### PR TITLE
Add configurable mouse shortcuts and smart tiling

### DIFF
--- a/app/Sources/AppDelegate.swift
+++ b/app/Sources/AppDelegate.swift
@@ -119,6 +119,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
         store.register(action: .omniSearch) { OmniSearchWindow.shared.toggle() }
         WindowDragSnapController.shared.start()
+        MouseGestureController.shared.start()
 
         // Session layer cycling
         store.register(action: .layerNext) { SessionLayerStore.shared.cycleNext() }

--- a/app/Sources/MouseGestureConfig.swift
+++ b/app/Sources/MouseGestureConfig.swift
@@ -1,0 +1,364 @@
+import AppKit
+import Foundation
+
+enum MouseGestureDirection: String, CaseIterable, Codable, Equatable {
+    case left
+    case right
+    case up
+    case down
+}
+
+enum MouseShortcutTriggerKind: String, Codable, Equatable {
+    case drag
+}
+
+enum MouseShortcutActionType: String, Codable, Equatable {
+    case spaceNext = "space.next"
+    case spacePrevious = "space.previous"
+    case screenMapToggle = "screenmap.toggle"
+    case dictationStart = "dictation.start"
+    case shortcutSend = "shortcut.send"
+}
+
+enum MouseShortcutModifier: String, CaseIterable, Codable, Equatable {
+    case command
+    case control
+    case option
+    case shift
+
+    var appleScriptToken: String {
+        switch self {
+        case .command: return "command down"
+        case .control: return "control down"
+        case .option: return "option down"
+        case .shift: return "shift down"
+        }
+    }
+
+    var displayLabel: String {
+        switch self {
+        case .command: return "Cmd"
+        case .control: return "Ctrl"
+        case .option: return "Option"
+        case .shift: return "Shift"
+        }
+    }
+}
+
+enum MouseShortcutButton: Hashable, Codable, Equatable {
+    case middle
+    case button4
+    case button5
+    case number(Int)
+
+    init(rawButtonNumber: Int) {
+        switch rawButtonNumber {
+        case 2: self = .middle
+        case 3: self = .button4
+        case 4: self = .button5
+        default: self = .number(rawButtonNumber)
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let intValue = try? container.decode(Int.self) {
+            self = MouseShortcutButton(rawButtonNumber: intValue)
+            return
+        }
+
+        let stringValue = try container.decode(String.self)
+        switch stringValue.lowercased() {
+        case "middle", "button.middle":
+            self = .middle
+        case "button4", "button.button4":
+            self = .button4
+        case "button5", "button.button5":
+            self = .button5
+        default:
+            if let raw = Int(stringValue.filter(\.isNumber)) {
+                self = MouseShortcutButton(rawButtonNumber: raw)
+            } else {
+                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported mouse button '\(stringValue)'")
+            }
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(configValue)
+    }
+
+    var rawButtonNumber: Int {
+        switch self {
+        case .middle: return 2
+        case .button4: return 3
+        case .button5: return 4
+        case .number(let value): return value
+        }
+    }
+
+    var configValue: String {
+        switch self {
+        case .middle: return "middle"
+        case .button4: return "button4"
+        case .button5: return "button5"
+        case .number(let value): return "button\(value)"
+        }
+    }
+
+    var displayLabel: String {
+        switch self {
+        case .middle: return "Middle Click"
+        case .button4: return "Button 4"
+        case .button5: return "Button 5"
+        case .number(let value): return "Button \(value)"
+        }
+    }
+
+    var triggerToken: String {
+        switch self {
+        case .middle: return "button.middle"
+        case .button4: return "button.button4"
+        case .button5: return "button.button5"
+        case .number(let value): return "button.\(value)"
+        }
+    }
+}
+
+struct MouseShortcutDeviceSelector: Codable, Equatable {
+    private enum CodingKeys: String, CodingKey {
+        case match
+        case vendorId
+        case productId
+        case locationId
+        case product
+        case manufacturer
+        case transport
+    }
+
+    var match: String?
+    var vendorId: Int?
+    var productId: Int?
+    var locationId: Int?
+    var product: String?
+    var manufacturer: String?
+    var transport: String?
+
+    static let any = MouseShortcutDeviceSelector(match: "any")
+
+    init(
+        match: String? = "any",
+        vendorId: Int? = nil,
+        productId: Int? = nil,
+        locationId: Int? = nil,
+        product: String? = nil,
+        manufacturer: String? = nil,
+        transport: String? = nil
+    ) {
+        self.match = match
+        self.vendorId = vendorId
+        self.productId = productId
+        self.locationId = locationId
+        self.product = product
+        self.manufacturer = manufacturer
+        self.transport = transport
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let stringValue = try? container.decode(String.self) {
+            self = MouseShortcutDeviceSelector(match: stringValue)
+            return
+        }
+
+        let object = try decoder.container(keyedBy: CodingKeys.self)
+        match = try object.decodeIfPresent(String.self, forKey: .match)
+        vendorId = try object.decodeIfPresent(Int.self, forKey: .vendorId)
+        productId = try object.decodeIfPresent(Int.self, forKey: .productId)
+        locationId = try object.decodeIfPresent(Int.self, forKey: .locationId)
+        product = try object.decodeIfPresent(String.self, forKey: .product)
+        manufacturer = try object.decodeIfPresent(String.self, forKey: .manufacturer)
+        transport = try object.decodeIfPresent(String.self, forKey: .transport)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        if isAny {
+            var container = encoder.singleValueContainer()
+            try container.encode("any")
+            return
+        }
+
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(match, forKey: .match)
+        try container.encodeIfPresent(vendorId, forKey: .vendorId)
+        try container.encodeIfPresent(productId, forKey: .productId)
+        try container.encodeIfPresent(locationId, forKey: .locationId)
+        try container.encodeIfPresent(product, forKey: .product)
+        try container.encodeIfPresent(manufacturer, forKey: .manufacturer)
+        try container.encodeIfPresent(transport, forKey: .transport)
+    }
+
+    var isAny: Bool {
+        let normalized = (match ?? "any").lowercased()
+        return normalized == "any"
+            && vendorId == nil
+            && productId == nil
+            && locationId == nil
+            && product == nil
+            && manufacturer == nil
+            && transport == nil
+    }
+
+    func matches(_ device: MouseInputDeviceInfo?) -> Bool {
+        if isAny { return true }
+        guard let device else { return false }
+        if let vendorId, vendorId != device.vendorId { return false }
+        if let productId, productId != device.productId { return false }
+        if let locationId, locationId != device.locationId { return false }
+        if let product, device.product?.localizedCaseInsensitiveContains(product) != true { return false }
+        if let manufacturer, device.manufacturer?.localizedCaseInsensitiveContains(manufacturer) != true { return false }
+        if let transport, device.transport?.localizedCaseInsensitiveContains(transport) != true { return false }
+        return true
+    }
+}
+
+struct MouseShortcutTrigger: Codable, Equatable {
+    var button: MouseShortcutButton
+    var kind: MouseShortcutTriggerKind
+    var direction: MouseGestureDirection
+
+    var triggerName: String {
+        "\(button.triggerToken).\(kind.rawValue).\(direction.rawValue)"
+    }
+}
+
+struct MouseShortcutKeyStroke: Codable, Equatable {
+    var key: String?
+    var keyCode: Int?
+    var modifiers: [MouseShortcutModifier]
+
+    var displayLabel: String {
+        let keyLabel = key?.uppercased() ?? "KeyCode \(keyCode ?? -1)"
+        let parts = modifiers.map(\.displayLabel) + [keyLabel]
+        return parts.joined(separator: "+")
+    }
+}
+
+struct MouseShortcutActionDefinition: Codable, Equatable {
+    var type: MouseShortcutActionType
+    var shortcut: MouseShortcutKeyStroke?
+
+    var label: String {
+        switch type {
+        case .spaceNext:
+            return "Next Space"
+        case .spacePrevious:
+            return "Previous Space"
+        case .screenMapToggle:
+            return "Screen Map Overview"
+        case .dictationStart:
+            return "Dictation"
+        case .shortcutSend:
+            return shortcut?.displayLabel ?? "Send Shortcut"
+        }
+    }
+}
+
+struct MouseShortcutRule: Codable, Equatable, Identifiable {
+    var id: String
+    var enabled: Bool
+    var device: MouseShortcutDeviceSelector
+    var trigger: MouseShortcutTrigger
+    var action: MouseShortcutActionDefinition
+
+    var summary: String {
+        "\(trigger.triggerName) -> \(action.type.rawValue)"
+    }
+}
+
+struct MouseShortcutTuning: Codable, Equatable {
+    var dragThreshold: CGFloat
+    var holdTolerance: CGFloat
+    var axisBias: CGFloat
+
+    static let defaults = MouseShortcutTuning(
+        dragThreshold: 68,
+        holdTolerance: 10,
+        axisBias: 1.2
+    )
+}
+
+struct MouseShortcutConfig: Codable, Equatable {
+    var version: Int
+    var tuning: MouseShortcutTuning
+    var rules: [MouseShortcutRule]
+
+    static let defaults = MouseShortcutConfig(
+        version: 1,
+        tuning: .defaults,
+        rules: [
+            MouseShortcutRule(
+                id: "space-previous",
+                enabled: true,
+                device: .any,
+                trigger: MouseShortcutTrigger(button: .middle, kind: .drag, direction: .left),
+                action: MouseShortcutActionDefinition(type: .spacePrevious, shortcut: nil)
+            ),
+            MouseShortcutRule(
+                id: "space-next",
+                enabled: true,
+                device: .any,
+                trigger: MouseShortcutTrigger(button: .middle, kind: .drag, direction: .right),
+                action: MouseShortcutActionDefinition(type: .spaceNext, shortcut: nil)
+            ),
+            MouseShortcutRule(
+                id: "screenmap-overview",
+                enabled: true,
+                device: .any,
+                trigger: MouseShortcutTrigger(button: .middle, kind: .drag, direction: .down),
+                action: MouseShortcutActionDefinition(type: .screenMapToggle, shortcut: nil)
+            ),
+            MouseShortcutRule(
+                id: "dictation",
+                enabled: true,
+                device: .any,
+                trigger: MouseShortcutTrigger(button: .middle, kind: .drag, direction: .up),
+                action: MouseShortcutActionDefinition(type: .dictationStart, shortcut: nil)
+            ),
+        ]
+    )
+}
+
+struct MouseShortcutMatchResult {
+    let rule: MouseShortcutRule
+    let action: MouseShortcutActionDefinition
+    let triggerName: String
+}
+
+struct MouseShortcutTriggerEvent {
+    let button: MouseShortcutButton
+    let kind: MouseShortcutTriggerKind
+    let direction: MouseGestureDirection
+    let device: MouseInputDeviceInfo?
+
+    var triggerName: String {
+        MouseShortcutTrigger(button: button, kind: kind, direction: direction).triggerName
+    }
+}
+
+struct MouseShortcutObservedEvent {
+    let timestamp: Date
+    let phase: String
+    let buttonNumber: Int
+    let location: CGPoint
+    let delta: CGPoint
+    let modifiers: NSEvent.ModifierFlags
+    let frontmostAppName: String?
+    let frontmostBundleId: String?
+    let candidateTrigger: String?
+    let device: MouseInputDeviceInfo?
+    let matchedRuleSummary: String?
+    let willFire: Bool
+    let note: String?
+}

--- a/app/Sources/MouseGestureController.swift
+++ b/app/Sources/MouseGestureController.swift
@@ -391,7 +391,11 @@ final class MouseGestureController {
             )
             DispatchQueue.main.async { [weak self] in
                 session.overlay.dismiss()
-                self?.replayMouseClick(buttonNumber: buttonNumber, at: session.startPoint)
+                self?.replayMouseClick(
+                    buttonNumber: buttonNumber,
+                    at: session.startPoint,
+                    flags: event.flags
+                )
             }
             return nil
         }
@@ -490,7 +494,7 @@ final class MouseGestureController {
         session = nil
     }
 
-    private func replayMouseClick(buttonNumber: Int64, at point: CGPoint) {
+    private func replayMouseClick(buttonNumber: Int64, at point: CGPoint, flags: CGEventFlags) {
         let events: [CGEventType] = [.otherMouseDown, .otherMouseUp]
         for type in events {
             guard let mouseButton = CGMouseButton(rawValue: UInt32(buttonNumber)) else { continue }
@@ -503,6 +507,7 @@ final class MouseGestureController {
 
             event.setIntegerValueField(CGEventField.mouseEventButtonNumber, value: buttonNumber)
             event.setIntegerValueField(CGEventField.eventSourceUserData, value: Self.syntheticMarker)
+            event.flags = flags
             event.post(tap: CGEventTapLocation.cghidEventTap)
         }
     }

--- a/app/Sources/MouseGestureController.swift
+++ b/app/Sources/MouseGestureController.swift
@@ -1,0 +1,562 @@
+import AppKit
+import Combine
+import CoreGraphics
+
+enum MouseGestureDirection: Equatable {
+    case left
+    case right
+    case down
+}
+
+final class MouseGestureController {
+    static let shared = MouseGestureController()
+
+    private struct GestureOutcome {
+        let label: String
+        let success: Bool
+    }
+
+    private final class GestureSession {
+        let startPoint: CGPoint
+        let overlay: MouseGestureOverlay
+        var currentPoint: CGPoint
+
+        init(startPoint: CGPoint, overlay: MouseGestureOverlay) {
+            self.startPoint = startPoint
+            self.overlay = overlay
+            self.currentPoint = startPoint
+        }
+    }
+
+    private static let syntheticMarker: Int64 = 0x4C474D47
+
+    private let minimumDistance: CGFloat = 68
+    private let axisBias: CGFloat = 1.2
+    private let middleButtonNumber: Int64 = 2
+
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+    private var session: GestureSession?
+    private var subscriptions: Set<AnyCancellable> = []
+    private var installedObservers = false
+
+    private init() {}
+
+    func start() {
+        installObserversIfNeeded()
+        refresh()
+    }
+
+    func stop() {
+        clearSession()
+        removeEventTap()
+    }
+
+    static func resolveDirection(
+        delta: CGPoint,
+        threshold: CGFloat = 68,
+        axisBias: CGFloat = 1.2
+    ) -> MouseGestureDirection? {
+        let absX = abs(delta.x)
+        let absY = abs(delta.y)
+        guard max(absX, absY) >= threshold else { return nil }
+
+        if absX >= absY * axisBias {
+            return delta.x >= 0 ? .right : .left
+        }
+
+        if absY >= absX * axisBias, delta.y > 0 {
+            return .down
+        }
+
+        return nil
+    }
+
+    private func installObserversIfNeeded() {
+        guard !installedObservers else { return }
+        installedObservers = true
+
+        Preferences.shared.$mouseGesturesEnabled
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.refresh() }
+            .store(in: &subscriptions)
+
+        PermissionChecker.shared.$accessibility
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.refresh() }
+            .store(in: &subscriptions)
+    }
+
+    private func refresh() {
+        guard Preferences.shared.mouseGesturesEnabled, PermissionChecker.shared.accessibility else {
+            clearSession()
+            removeEventTap()
+            return
+        }
+
+        if eventTap == nil {
+            installEventTap()
+        } else if let eventTap {
+            CGEvent.tapEnable(tap: eventTap, enable: true)
+        }
+    }
+
+    private func installEventTap() {
+        var mask = CGEventMask(0)
+        mask |= CGEventMask(1) << CGEventType.otherMouseDown.rawValue
+        mask |= CGEventMask(1) << CGEventType.otherMouseDragged.rawValue
+        mask |= CGEventMask(1) << CGEventType.otherMouseUp.rawValue
+
+        let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: mask,
+            callback: Self.eventTapCallback,
+            userInfo: UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
+        )
+
+        guard let tap else {
+            DiagnosticLog.shared.warn("MouseGesture: failed to install middle-click event tap")
+            return
+        }
+
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        eventTap = tap
+        runLoopSource = source
+
+        if let source {
+            CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        }
+        CGEvent.tapEnable(tap: tap, enable: true)
+        DiagnosticLog.shared.info("MouseGesture: middle-click event tap installed")
+    }
+
+    private func removeEventTap() {
+        if let source = runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+        }
+        runLoopSource = nil
+        if let tap = eventTap {
+            CFMachPortInvalidate(tap)
+        }
+        eventTap = nil
+    }
+
+    private static let eventTapCallback: CGEventTapCallBack = { _, type, event, userInfo in
+        guard let userInfo else { return Unmanaged.passUnretained(event) }
+        let controller = Unmanaged<MouseGestureController>.fromOpaque(userInfo).takeUnretainedValue()
+        return controller.handleEvent(type: type, event: event)
+    }
+
+    private func handleEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            if let eventTap {
+                CGEvent.tapEnable(tap: eventTap, enable: true)
+            }
+            return Unmanaged.passUnretained(event)
+        }
+
+        if event.getIntegerValueField(.eventSourceUserData) == Self.syntheticMarker {
+            return Unmanaged.passUnretained(event)
+        }
+
+        guard event.getIntegerValueField(.mouseEventButtonNumber) == middleButtonNumber else {
+            return Unmanaged.passUnretained(event)
+        }
+
+        switch type {
+        case .otherMouseDown:
+            return handleMouseDown(event)
+        case .otherMouseDragged:
+            return handleMouseDragged(event)
+        case .otherMouseUp:
+            return handleMouseUp(event)
+        default:
+            return Unmanaged.passUnretained(event)
+        }
+    }
+
+    private func handleMouseDown(_ event: CGEvent) -> Unmanaged<CGEvent>? {
+        let point = event.location
+        guard let screen = desktopScreen(containing: point) else {
+            clearSession()
+            return Unmanaged.passUnretained(event)
+        }
+
+        clearSession()
+        let overlay = MouseGestureOverlay(screen: screen)
+        let newSession = GestureSession(startPoint: point, overlay: overlay)
+        session = newSession
+        overlay.track(origin: point, direction: nil, label: nil)
+        return nil
+    }
+
+    private func handleMouseDragged(_ event: CGEvent) -> Unmanaged<CGEvent>? {
+        guard let session else {
+            return Unmanaged.passUnretained(event)
+        }
+
+        session.currentPoint = event.location
+        let delta = CGPoint(
+            x: event.location.x - session.startPoint.x,
+            y: event.location.y - session.startPoint.y
+        )
+        let direction = Self.resolveDirection(delta: delta, threshold: minimumDistance, axisBias: axisBias)
+
+        if let direction {
+            session.overlay.track(origin: session.startPoint, direction: direction, label: label(for: direction))
+        } else {
+            session.overlay.track(origin: session.startPoint, direction: nil, label: nil)
+        }
+
+        return nil
+    }
+
+    private func handleMouseUp(_ event: CGEvent) -> Unmanaged<CGEvent>? {
+        guard let session else {
+            return Unmanaged.passUnretained(event)
+        }
+
+        let delta = CGPoint(
+            x: event.location.x - session.startPoint.x,
+            y: event.location.y - session.startPoint.y
+        )
+        let direction = Self.resolveDirection(delta: delta, threshold: minimumDistance, axisBias: axisBias)
+        self.session = nil
+
+        guard let direction else {
+            session.overlay.dismiss()
+            replayMiddleClick(at: session.startPoint)
+            return nil
+        }
+
+        let outcome = performAction(for: direction, startPoint: session.startPoint)
+        session.overlay.commit(origin: session.startPoint, direction: direction, label: outcome.label, success: outcome.success)
+        return nil
+    }
+
+    private func performAction(for direction: MouseGestureDirection, startPoint: CGPoint) -> GestureOutcome {
+        switch direction {
+        case .left:
+            let switched = WindowTiler.switchToAdjacentSpace(offset: -1, from: startPoint)
+            return GestureOutcome(label: switched ? "Previous Space" : "No Previous Space", success: switched)
+        case .right:
+            let switched = WindowTiler.switchToAdjacentSpace(offset: 1, from: startPoint)
+            return GestureOutcome(label: switched ? "Next Space" : "No Next Space", success: switched)
+        case .down:
+            ScreenMapWindowController.shared.showScreenMapOverview()
+            return GestureOutcome(label: "Screen Map Overview", success: true)
+        }
+    }
+
+    private func label(for direction: MouseGestureDirection) -> String {
+        switch direction {
+        case .left:
+            return "Previous Space"
+        case .right:
+            return "Next Space"
+        case .down:
+            return "Screen Map Overview"
+        }
+    }
+
+    private func clearSession() {
+        session?.overlay.dismiss(immediately: true)
+        session = nil
+    }
+
+    private func replayMiddleClick(at point: CGPoint) {
+        let events: [CGEventType] = [.otherMouseDown, .otherMouseUp]
+        for type in events {
+            guard let event = CGEvent(
+                mouseEventSource: nil,
+                mouseType: type,
+                mouseCursorPosition: point,
+                mouseButton: .center
+            ) else { continue }
+
+            event.setIntegerValueField(.mouseEventButtonNumber, value: middleButtonNumber)
+            event.setIntegerValueField(.eventSourceUserData, value: Self.syntheticMarker)
+            event.post(tap: .cghidEventTap)
+        }
+    }
+
+    private func desktopScreen(containing cgPoint: CGPoint) -> NSScreen? {
+        guard let screen = screen(containing: cgPoint) else { return nil }
+        guard cgVisibleRect(for: screen).contains(cgPoint) else { return nil }
+        guard !hasWindowAtPoint(cgPoint) else { return nil }
+        return screen
+    }
+
+    private func screen(containing cgPoint: CGPoint) -> NSScreen? {
+        let primaryHeight = NSScreen.screens.first?.frame.height ?? 0
+        let nsPoint = NSPoint(x: cgPoint.x, y: primaryHeight - cgPoint.y)
+        return NSScreen.screens.first(where: { $0.frame.contains(nsPoint) }) ?? NSScreen.main ?? NSScreen.screens.first
+    }
+
+    private func cgVisibleRect(for screen: NSScreen) -> CGRect {
+        let primaryHeight = NSScreen.screens.first?.frame.height ?? screen.frame.height
+        let visible = screen.visibleFrame
+        return CGRect(
+            x: visible.minX,
+            y: primaryHeight - visible.maxY,
+            width: visible.width,
+            height: visible.height
+        )
+    }
+
+    private func hasWindowAtPoint(_ point: CGPoint) -> Bool {
+        guard let windows = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements],
+            kCGNullWindowID
+        ) as? [[String: Any]] else {
+            return false
+        }
+
+        for info in windows {
+            guard let owner = info[kCGWindowOwnerName as String] as? String,
+                  owner != "Lattices",
+                  let boundsDict = info[kCGWindowBounds as String] as? NSDictionary else {
+                continue
+            }
+
+            let layer = info[kCGWindowLayer as String] as? Int ?? 0
+            let alpha = info[kCGWindowAlpha as String] as? Double ?? 1.0
+            let isOnScreen = info[kCGWindowIsOnscreen as String] as? Bool ?? true
+            guard layer == 0, alpha > 0.01, isOnScreen else { continue }
+
+            var rect = CGRect.zero
+            guard CGRectMakeWithDictionaryRepresentation(boundsDict, &rect) else { continue }
+            guard rect.width >= 8, rect.height >= 8 else { continue }
+
+            if rect.contains(point) {
+                return true
+            }
+        }
+
+        return false
+    }
+}
+
+private final class MouseGestureOverlay {
+    private let screen: NSScreen
+    private let window: NSWindow
+    private let overlayView: MouseGestureOverlayView
+    private var fadeTimer: Timer?
+
+    init(screen: NSScreen) {
+        self.screen = screen
+        self.window = NSWindow(
+            contentRect: screen.frame,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        self.overlayView = MouseGestureOverlayView(frame: NSRect(origin: .zero, size: screen.frame.size))
+
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.maximumWindow)))
+        window.hasShadow = false
+        window.ignoresMouseEvents = true
+        window.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
+        window.contentView = overlayView
+        window.orderFrontRegardless()
+    }
+
+    func track(origin: CGPoint, direction: MouseGestureDirection?, label: String?) {
+        fadeTimer?.invalidate()
+        window.alphaValue = 1
+        overlayView.state = .tracking(origin: localPoint(from: origin), direction: direction, label: label)
+        overlayView.needsDisplay = true
+    }
+
+    func commit(origin: CGPoint, direction: MouseGestureDirection, label: String, success: Bool) {
+        fadeTimer?.invalidate()
+        window.alphaValue = 1
+        overlayView.state = .committed(origin: localPoint(from: origin), direction: direction, label: label, success: success)
+        overlayView.needsDisplay = true
+
+        fadeTimer = Timer.scheduledTimer(withTimeInterval: 0.38, repeats: false) { [weak self] _ in
+            self?.dismiss()
+        }
+    }
+
+    func dismiss(immediately: Bool = false) {
+        fadeTimer?.invalidate()
+        fadeTimer = nil
+
+        if immediately {
+            window.orderOut(nil)
+            return
+        }
+
+        NSAnimationContext.runAnimationGroup({ ctx in
+            ctx.duration = 0.18
+            window.animator().alphaValue = 0
+        }, completionHandler: { [weak self] in
+            self?.window.orderOut(nil)
+        })
+    }
+
+    private func localPoint(from cgPoint: CGPoint) -> CGPoint {
+        let primaryHeight = NSScreen.screens.first?.frame.height ?? screen.frame.height
+        let nsY = primaryHeight - cgPoint.y
+        return CGPoint(x: cgPoint.x - screen.frame.minX, y: nsY - screen.frame.minY)
+    }
+}
+
+private final class MouseGestureOverlayView: NSView {
+    enum State {
+        case tracking(origin: CGPoint, direction: MouseGestureDirection?, label: String?)
+        case committed(origin: CGPoint, direction: MouseGestureDirection, label: String, success: Bool)
+    }
+
+    var state: State = .tracking(origin: .zero, direction: nil, label: nil)
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let ctx = NSGraphicsContext.current?.cgContext else { return }
+        ctx.clear(bounds)
+
+        switch state {
+        case .tracking(let origin, let direction, let label):
+            drawOrigin(at: origin, in: ctx, alpha: 0.88)
+            if let direction, let label {
+                drawArrow(from: origin, direction: direction, label: label, success: true, committed: false, in: ctx)
+            }
+        case .committed(let origin, let direction, let label, let success):
+            drawOrigin(at: origin, in: ctx, alpha: 1.0)
+            drawArrow(from: origin, direction: direction, label: label, success: success, committed: true, in: ctx)
+        }
+    }
+
+    private func drawOrigin(at point: CGPoint, in ctx: CGContext, alpha: CGFloat) {
+        ctx.setFillColor(NSColor(calibratedRed: 0.48, green: 0.76, blue: 1.0, alpha: alpha * 0.18).cgColor)
+        ctx.fillEllipse(in: CGRect(x: point.x - 18, y: point.y - 18, width: 36, height: 36))
+
+        ctx.setFillColor(NSColor(calibratedRed: 0.62, green: 0.84, blue: 1.0, alpha: alpha * 0.95).cgColor)
+        ctx.fillEllipse(in: CGRect(x: point.x - 5, y: point.y - 5, width: 10, height: 10))
+    }
+
+    private func drawArrow(
+        from origin: CGPoint,
+        direction: MouseGestureDirection,
+        label: String,
+        success: Bool,
+        committed: Bool,
+        in ctx: CGContext
+    ) {
+        let length: CGFloat = committed ? 136 : 118
+        let vector = arrowVector(for: direction, length: length)
+        let end = CGPoint(x: origin.x + vector.x, y: origin.y + vector.y)
+        let accent = success
+            ? NSColor(calibratedRed: 0.45, green: 0.80, blue: 1.0, alpha: 1.0)
+            : NSColor(calibratedRed: 0.98, green: 0.52, blue: 0.42, alpha: 1.0)
+
+        ctx.saveGState()
+        ctx.setLineCap(.round)
+
+        let glowPath = CGMutablePath()
+        glowPath.move(to: origin)
+        glowPath.addLine(to: end)
+        ctx.addPath(glowPath)
+        ctx.setLineWidth(committed ? 20 : 16)
+        ctx.setStrokeColor(accent.withAlphaComponent(committed ? 0.22 : 0.16).cgColor)
+        ctx.strokePath()
+
+        let linePath = CGMutablePath()
+        linePath.move(to: origin)
+        linePath.addLine(to: end)
+        ctx.addPath(linePath)
+        ctx.setLineWidth(committed ? 7 : 5)
+        ctx.setStrokeColor(accent.withAlphaComponent(0.92).cgColor)
+        ctx.strokePath()
+
+        drawArrowHead(at: end, direction: direction, color: accent, committed: committed)
+        drawLabel(label, near: end, direction: direction, color: accent)
+        ctx.restoreGState()
+    }
+
+    private func drawArrowHead(at end: CGPoint, direction: MouseGestureDirection, color: NSColor, committed: Bool) {
+        let size: CGFloat = committed ? 18 : 15
+        let path = NSBezierPath()
+
+        switch direction {
+        case .left:
+            path.move(to: CGPoint(x: end.x - size, y: end.y))
+            path.line(to: CGPoint(x: end.x + size * 0.2, y: end.y + size * 0.72))
+            path.line(to: CGPoint(x: end.x + size * 0.2, y: end.y - size * 0.72))
+        case .right:
+            path.move(to: CGPoint(x: end.x + size, y: end.y))
+            path.line(to: CGPoint(x: end.x - size * 0.2, y: end.y + size * 0.72))
+            path.line(to: CGPoint(x: end.x - size * 0.2, y: end.y - size * 0.72))
+        case .down:
+            path.move(to: CGPoint(x: end.x, y: end.y - size))
+            path.line(to: CGPoint(x: end.x - size * 0.72, y: end.y + size * 0.2))
+            path.line(to: CGPoint(x: end.x + size * 0.72, y: end.y + size * 0.2))
+        }
+
+        path.close()
+        color.withAlphaComponent(0.96).setFill()
+        path.fill()
+    }
+
+    private func drawLabel(_ label: String, near end: CGPoint, direction: MouseGestureDirection, color: NSColor) {
+        let font = NSFont.monospacedSystemFont(ofSize: 11, weight: .semibold)
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor.white.withAlphaComponent(0.94),
+        ]
+        let attributed = NSAttributedString(string: label, attributes: attributes)
+        let textSize = attributed.size()
+        let origin = labelOrigin(near: end, direction: direction, textSize: textSize)
+        let paddingX: CGFloat = 10
+        let paddingY: CGFloat = 6
+        let rect = CGRect(
+            x: origin.x,
+            y: origin.y,
+            width: textSize.width + paddingX * 2,
+            height: textSize.height + paddingY * 2
+        )
+
+        let bg = NSBezierPath(roundedRect: rect, xRadius: 10, yRadius: 10)
+        NSColor.black.withAlphaComponent(0.42).setFill()
+        bg.fill()
+
+        let border = NSBezierPath(roundedRect: rect, xRadius: 10, yRadius: 10)
+        color.withAlphaComponent(0.26).setStroke()
+        border.lineWidth = 1
+        border.stroke()
+
+        let textRect = CGRect(
+            x: rect.minX + paddingX,
+            y: rect.minY + paddingY,
+            width: textSize.width,
+            height: textSize.height
+        )
+        attributed.draw(in: textRect)
+    }
+
+    private func labelOrigin(near end: CGPoint, direction: MouseGestureDirection, textSize: CGSize) -> CGPoint {
+        switch direction {
+        case .left:
+            return CGPoint(x: end.x - textSize.width - 42, y: end.y + 12)
+        case .right:
+            return CGPoint(x: end.x + 16, y: end.y + 12)
+        case .down:
+            return CGPoint(x: end.x - textSize.width / 2 - 10, y: end.y - textSize.height - 42)
+        }
+    }
+
+    private func arrowVector(for direction: MouseGestureDirection, length: CGFloat) -> CGPoint {
+        switch direction {
+        case .left:
+            return CGPoint(x: -length, y: 0)
+        case .right:
+            return CGPoint(x: length, y: 0)
+        case .down:
+            return CGPoint(x: 0, y: -length)
+        }
+    }
+}

--- a/app/Sources/MouseGestureController.swift
+++ b/app/Sources/MouseGestureController.swift
@@ -2,10 +2,8 @@ import AppKit
 import Combine
 import CoreGraphics
 
-enum MouseGestureDirection: Equatable {
-    case left
-    case right
-    case down
+private enum MouseGestureAccessory {
+    case mic
 }
 
 final class MouseGestureController {
@@ -14,29 +12,31 @@ final class MouseGestureController {
     private struct GestureOutcome {
         let label: String
         let success: Bool
+        let accessory: MouseGestureAccessory?
     }
 
     private final class GestureSession {
+        let buttonNumber: Int64
         let startPoint: CGPoint
         let overlay: MouseGestureOverlay
         var currentPoint: CGPoint
+        var lockedDirection: MouseGestureDirection?
 
-        init(startPoint: CGPoint, overlay: MouseGestureOverlay) {
+        init(buttonNumber: Int64, startPoint: CGPoint, overlay: MouseGestureOverlay) {
+            self.buttonNumber = buttonNumber
             self.startPoint = startPoint
             self.overlay = overlay
             self.currentPoint = startPoint
+            self.lockedDirection = nil
         }
     }
 
     private static let syntheticMarker: Int64 = 0x4C474D47
 
-    private let minimumDistance: CGFloat = 68
-    private let axisBias: CGFloat = 1.2
-    private let middleButtonNumber: Int64 = 2
-
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
     private var session: GestureSession?
+    private var retainedOverlays: [ObjectIdentifier: MouseGestureOverlay] = [:]
     private var subscriptions: Set<AnyCancellable> = []
     private var installedObservers = false
 
@@ -65,8 +65,8 @@ final class MouseGestureController {
             return delta.x >= 0 ? .right : .left
         }
 
-        if absY >= absX * axisBias, delta.y > 0 {
-            return .down
+        if absY >= absX * axisBias {
+            return delta.y >= 0 ? .down : .up
         }
 
         return nil
@@ -85,10 +85,16 @@ final class MouseGestureController {
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in self?.refresh() }
             .store(in: &subscriptions)
+
+        MouseInputEventViewer.shared.$isCaptureActive
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.refresh() }
+            .store(in: &subscriptions)
     }
 
     private func refresh() {
-        guard Preferences.shared.mouseGesturesEnabled, PermissionChecker.shared.accessibility else {
+        let shouldCapture = MouseInputEventViewer.shared.isCaptureActive || Preferences.shared.mouseGesturesEnabled
+        guard shouldCapture, PermissionChecker.shared.accessibility else {
             clearSession()
             removeEventTap()
             return
@@ -103,6 +109,10 @@ final class MouseGestureController {
 
     private func installEventTap() {
         var mask = CGEventMask(0)
+        mask |= CGEventMask(1) << CGEventType.leftMouseDown.rawValue
+        mask |= CGEventMask(1) << CGEventType.leftMouseUp.rawValue
+        mask |= CGEventMask(1) << CGEventType.rightMouseDown.rawValue
+        mask |= CGEventMask(1) << CGEventType.rightMouseUp.rawValue
         mask |= CGEventMask(1) << CGEventType.otherMouseDown.rawValue
         mask |= CGEventMask(1) << CGEventType.otherMouseDragged.rawValue
         mask |= CGEventMask(1) << CGEventType.otherMouseUp.rawValue
@@ -117,7 +127,7 @@ final class MouseGestureController {
         )
 
         guard let tap else {
-            DiagnosticLog.shared.warn("MouseGesture: failed to install middle-click event tap")
+            DiagnosticLog.shared.warn("MouseGesture: failed to install mouse shortcut event tap")
             return
         }
 
@@ -129,7 +139,7 @@ final class MouseGestureController {
             CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
         }
         CGEvent.tapEnable(tap: tap, enable: true)
-        DiagnosticLog.shared.info("MouseGesture: middle-click event tap installed")
+        DiagnosticLog.shared.info("MouseGesture: mouse shortcut event tap installed")
     }
 
     private func removeEventTap() {
@@ -161,60 +171,200 @@ final class MouseGestureController {
             return Unmanaged.passUnretained(event)
         }
 
-        guard event.getIntegerValueField(.mouseEventButtonNumber) == middleButtonNumber else {
+        switch type {
+        case .leftMouseDown, .leftMouseUp, .rightMouseDown, .rightMouseUp:
+            return handlePassiveMouseButtonEvent(type: type, event: event)
+        default:
+            break
+        }
+
+        let buttonNumber = event.getIntegerValueField(.mouseEventButtonNumber)
+        if buttonNumber < 2 {
             return Unmanaged.passUnretained(event)
         }
 
         switch type {
         case .otherMouseDown:
-            return handleMouseDown(event)
+            return handleMouseDown(event, buttonNumber: buttonNumber)
         case .otherMouseDragged:
-            return handleMouseDragged(event)
+            return handleMouseDragged(event, buttonNumber: buttonNumber)
         case .otherMouseUp:
-            return handleMouseUp(event)
+            return handleMouseUp(event, buttonNumber: buttonNumber)
         default:
             return Unmanaged.passUnretained(event)
         }
     }
 
-    private func handleMouseDown(_ event: CGEvent) -> Unmanaged<CGEvent>? {
+    private func handlePassiveMouseButtonEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        guard MouseInputEventViewer.shared.isCaptureActive else {
+            return Unmanaged.passUnretained(event)
+        }
+
+        let phase: String
+        switch type {
+        case .leftMouseDown, .rightMouseDown:
+            phase = "down"
+        case .leftMouseUp, .rightMouseUp:
+            phase = "up"
+        default:
+            return Unmanaged.passUnretained(event)
+        }
+
+        let buttonNumber = Int(event.getIntegerValueField(.mouseEventButtonNumber))
+        let appInfo = currentAppInfo()
+        recordObservedEvent(
+            phase: phase,
+            button: MouseShortcutButton(rawButtonNumber: buttonNumber),
+            location: event.location,
+            delta: .zero,
+            modifiers: event.flags,
+            candidate: nil,
+            match: nil,
+            note: "pass-through primary button",
+            appInfo: appInfo
+        )
+        return Unmanaged.passUnretained(event)
+    }
+
+    private func handleMouseDown(_ event: CGEvent, buttonNumber: Int64) -> Unmanaged<CGEvent>? {
+        MouseShortcutStore.shared.reloadIfNeeded()
         let point = event.location
-        guard let screen = desktopScreen(containing: point) else {
+        let button = MouseShortcutButton(rawButtonNumber: Int(buttonNumber))
+        let appInfo = currentAppInfo()
+        let canRecognize = Preferences.shared.mouseGesturesEnabled && MouseShortcutStore.shared.watchedButtonNumbers.contains(buttonNumber)
+
+        guard let screen = screen(containing: point) else {
+            DiagnosticLog.shared.info("MouseGesture: ignored click at \(format(point)) (off-screen)")
+            recordObservedEvent(
+                phase: "down",
+                button: button,
+                location: point,
+                delta: .zero,
+                modifiers: event.flags,
+                candidate: nil,
+                match: nil,
+                note: "off-screen",
+                appInfo: appInfo
+            )
             clearSession()
+            return Unmanaged.passUnretained(event)
+        }
+
+        guard canRecognize else {
+            recordObservedEvent(
+                phase: "down",
+                button: button,
+                location: point,
+                delta: .zero,
+                modifiers: event.flags,
+                candidate: nil,
+                match: nil,
+                note: "button not mapped",
+                appInfo: appInfo
+            )
             return Unmanaged.passUnretained(event)
         }
 
         clearSession()
         let overlay = MouseGestureOverlay(screen: screen)
-        let newSession = GestureSession(startPoint: point, overlay: overlay)
+        overlay.onDismiss = { [weak self, weak overlay] in
+            guard let self, let overlay else { return }
+            self.releaseOverlay(overlay)
+        }
+        let newSession = GestureSession(buttonNumber: buttonNumber, startPoint: point, overlay: overlay)
         session = newSession
-        overlay.track(origin: point, direction: nil, label: nil)
+        DiagnosticLog.shared.info("MouseGesture: began at \(format(point)) button=\(buttonNumber)")
+        recordObservedEvent(
+            phase: "down",
+            button: button,
+            location: point,
+            delta: .zero,
+            modifiers: event.flags,
+            candidate: nil,
+            match: nil,
+            note: "tracking",
+            appInfo: appInfo
+        )
         return nil
     }
 
-    private func handleMouseDragged(_ event: CGEvent) -> Unmanaged<CGEvent>? {
+    private func handleMouseDragged(_ event: CGEvent, buttonNumber: Int64) -> Unmanaged<CGEvent>? {
         guard let session else {
             return Unmanaged.passUnretained(event)
         }
+        guard session.buttonNumber == buttonNumber else {
+            return Unmanaged.passUnretained(event)
+        }
+        MouseShortcutStore.shared.reloadIfNeeded()
 
         session.currentPoint = event.location
         let delta = CGPoint(
             x: event.location.x - session.startPoint.x,
             y: event.location.y - session.startPoint.y
         )
-        let direction = Self.resolveDirection(delta: delta, threshold: minimumDistance, axisBias: axisBias)
+        let tuning = MouseShortcutStore.shared.tuning
+        let direction = Self.resolveDirection(delta: delta, threshold: tuning.dragThreshold, axisBias: tuning.axisBias)
+
+        if direction != session.lockedDirection {
+            session.lockedDirection = direction
+            if let direction {
+                let button = MouseShortcutButton(rawButtonNumber: Int(buttonNumber))
+                let triggerEvent = MouseShortcutTriggerEvent(button: button, kind: .drag, direction: direction, device: nil)
+                let match = MouseShortcutStore.shared.match(for: triggerEvent)
+                DiagnosticLog.shared.info("MouseGesture: locked \(label(for: direction)) via \(triggerEvent.triggerName)")
+                recordObservedEvent(
+                    phase: "drag",
+                    button: button,
+                    location: event.location,
+                    delta: delta,
+                    modifiers: event.flags,
+                    candidate: triggerEvent.triggerName,
+                    match: match,
+                    note: match == nil ? "no rule" : "candidate",
+                    appInfo: currentAppInfo()
+                )
+            }
+        }
 
         if let direction {
-            session.overlay.track(origin: session.startPoint, direction: direction, label: label(for: direction))
+            let dominantDistance = max(abs(delta.x), abs(delta.y))
+            let previewProgress = previewProgress(
+                dominantDistance: dominantDistance,
+                threshold: tuning.dragThreshold
+            )
+            session.overlay.track(
+                origin: session.startPoint,
+                direction: direction,
+                label: nil,
+                progress: previewProgress
+            )
         } else {
-            session.overlay.track(origin: session.startPoint, direction: nil, label: nil)
+            session.overlay.track(origin: session.startPoint, direction: nil, label: nil, progress: 0)
         }
 
         return nil
     }
 
-    private func handleMouseUp(_ event: CGEvent) -> Unmanaged<CGEvent>? {
+    private func handleMouseUp(_ event: CGEvent, buttonNumber: Int64) -> Unmanaged<CGEvent>? {
+        MouseShortcutStore.shared.reloadIfNeeded()
+        let button = MouseShortcutButton(rawButtonNumber: Int(buttonNumber))
+        let appInfo = currentAppInfo()
+
         guard let session else {
+            recordObservedEvent(
+                phase: "up",
+                button: button,
+                location: event.location,
+                delta: .zero,
+                modifiers: event.flags,
+                candidate: nil,
+                match: nil,
+                note: "no active session",
+                appInfo: appInfo
+            )
+            return Unmanaged.passUnretained(event)
+        }
+        guard session.buttonNumber == buttonNumber else {
             return Unmanaged.passUnretained(event)
         }
 
@@ -222,31 +372,103 @@ final class MouseGestureController {
             x: event.location.x - session.startPoint.x,
             y: event.location.y - session.startPoint.y
         )
-        let direction = Self.resolveDirection(delta: delta, threshold: minimumDistance, axisBias: axisBias)
+        let tuning = MouseShortcutStore.shared.tuning
+        let direction = Self.resolveDirection(delta: delta, threshold: tuning.dragThreshold, axisBias: tuning.axisBias)
         self.session = nil
 
         guard let direction else {
-            session.overlay.dismiss()
-            replayMiddleClick(at: session.startPoint)
+            DiagnosticLog.shared.info("MouseGesture: released without a gesture at \(format(event.location))")
+            recordObservedEvent(
+                phase: "up",
+                button: button,
+                location: event.location,
+                delta: delta,
+                modifiers: event.flags,
+                candidate: nil,
+                match: nil,
+                note: "replay click",
+                appInfo: appInfo
+            )
+            DispatchQueue.main.async { [weak self] in
+                session.overlay.dismiss()
+                self?.replayMouseClick(buttonNumber: buttonNumber, at: session.startPoint)
+            }
             return nil
         }
 
-        let outcome = performAction(for: direction, startPoint: session.startPoint)
-        session.overlay.commit(origin: session.startPoint, direction: direction, label: outcome.label, success: outcome.success)
+        let triggerEvent = MouseShortcutTriggerEvent(button: button, kind: .drag, direction: direction, device: nil)
+        let match = MouseShortcutStore.shared.match(for: triggerEvent)
+        let dismissBeforeAction = shouldDismissOverlayBeforeAction(match: match)
+        if dismissBeforeAction {
+            session.overlay.dismiss(immediately: true)
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            if !dismissBeforeAction {
+                self.retainOverlay(session.overlay)
+            }
+            let outcome = self.performAction(match: match, startPoint: session.startPoint)
+            DiagnosticLog.shared.info("MouseGesture: \(outcome.label) -> \(outcome.success ? "ok" : "blocked")")
+            self.recordObservedEvent(
+                phase: "up",
+                button: button,
+                location: event.location,
+                delta: delta,
+                modifiers: event.flags,
+                candidate: triggerEvent.triggerName,
+                match: match,
+                note: outcome.success ? "fired" : "blocked",
+                appInfo: appInfo
+            )
+            if !dismissBeforeAction {
+                session.overlay.commit(
+                    origin: session.startPoint,
+                    direction: direction,
+                    label: outcome.label,
+                    success: outcome.success,
+                    accessory: outcome.accessory
+                )
+            }
+        }
         return nil
     }
 
-    private func performAction(for direction: MouseGestureDirection, startPoint: CGPoint) -> GestureOutcome {
-        switch direction {
-        case .left:
+    private func performAction(match: MouseShortcutMatchResult?, startPoint: CGPoint) -> GestureOutcome {
+        guard let match else {
+            return GestureOutcome(label: "No Shortcut Assigned", success: false, accessory: nil)
+        }
+
+        switch match.action.type {
+        case .spacePrevious:
+            guard WindowTiler.adjacentSpaceTarget(offset: -1, from: startPoint) != nil else {
+                return GestureOutcome(label: "No Previous Space", success: false, accessory: nil)
+            }
             let switched = WindowTiler.switchToAdjacentSpace(offset: -1, from: startPoint)
-            return GestureOutcome(label: switched ? "Previous Space" : "No Previous Space", success: switched)
-        case .right:
+            return GestureOutcome(label: switched ? "Previous Space" : "Previous Space Blocked", success: switched, accessory: nil)
+        case .spaceNext:
+            guard WindowTiler.adjacentSpaceTarget(offset: 1, from: startPoint) != nil else {
+                return GestureOutcome(label: "No Next Space", success: false, accessory: nil)
+            }
             let switched = WindowTiler.switchToAdjacentSpace(offset: 1, from: startPoint)
-            return GestureOutcome(label: switched ? "Next Space" : "No Next Space", success: switched)
-        case .down:
+            return GestureOutcome(label: switched ? "Next Space" : "Next Space Blocked", success: switched, accessory: nil)
+        case .screenMapToggle:
             ScreenMapWindowController.shared.showScreenMapOverview()
-            return GestureOutcome(label: "Screen Map Overview", success: true)
+            return GestureOutcome(label: "Screen Map Overview", success: true, accessory: nil)
+        case .dictationStart:
+            let sent = sendDictationShortcut()
+            return GestureOutcome(
+                label: sent ? "Dictation" : "Dictation Blocked",
+                success: sent,
+                accessory: sent ? .mic : nil
+            )
+        case .shortcutSend:
+            let sent = sendShortcut(match.action.shortcut)
+            return GestureOutcome(
+                label: sent ? match.action.label : "Shortcut Blocked",
+                success: sent,
+                accessory: nil
+            )
         }
     }
 
@@ -256,6 +478,8 @@ final class MouseGestureController {
             return "Previous Space"
         case .right:
             return "Next Space"
+        case .up:
+            return "Up"
         case .down:
             return "Screen Map Overview"
         }
@@ -266,27 +490,21 @@ final class MouseGestureController {
         session = nil
     }
 
-    private func replayMiddleClick(at point: CGPoint) {
+    private func replayMouseClick(buttonNumber: Int64, at point: CGPoint) {
         let events: [CGEventType] = [.otherMouseDown, .otherMouseUp]
         for type in events {
+            guard let mouseButton = CGMouseButton(rawValue: UInt32(buttonNumber)) else { continue }
             guard let event = CGEvent(
                 mouseEventSource: nil,
                 mouseType: type,
                 mouseCursorPosition: point,
-                mouseButton: .center
+                mouseButton: mouseButton
             ) else { continue }
 
-            event.setIntegerValueField(.mouseEventButtonNumber, value: middleButtonNumber)
-            event.setIntegerValueField(.eventSourceUserData, value: Self.syntheticMarker)
-            event.post(tap: .cghidEventTap)
+            event.setIntegerValueField(CGEventField.mouseEventButtonNumber, value: buttonNumber)
+            event.setIntegerValueField(CGEventField.eventSourceUserData, value: Self.syntheticMarker)
+            event.post(tap: CGEventTapLocation.cghidEventTap)
         }
-    }
-
-    private func desktopScreen(containing cgPoint: CGPoint) -> NSScreen? {
-        guard let screen = screen(containing: cgPoint) else { return nil }
-        guard cgVisibleRect(for: screen).contains(cgPoint) else { return nil }
-        guard !hasWindowAtPoint(cgPoint) else { return nil }
-        return screen
     }
 
     private func screen(containing cgPoint: CGPoint) -> NSScreen? {
@@ -295,55 +513,120 @@ final class MouseGestureController {
         return NSScreen.screens.first(where: { $0.frame.contains(nsPoint) }) ?? NSScreen.main ?? NSScreen.screens.first
     }
 
-    private func cgVisibleRect(for screen: NSScreen) -> CGRect {
-        let primaryHeight = NSScreen.screens.first?.frame.height ?? screen.frame.height
-        let visible = screen.visibleFrame
-        return CGRect(
-            x: visible.minX,
-            y: primaryHeight - visible.maxY,
-            width: visible.width,
-            height: visible.height
+    private func format(_ point: CGPoint) -> String {
+        "\(Int(point.x)),\(Int(point.y))"
+    }
+
+    private func shouldDismissOverlayBeforeAction(match: MouseShortcutMatchResult?) -> Bool {
+        guard let match else { return false }
+        switch match.action.type {
+        case .spacePrevious, .spaceNext, .screenMapToggle:
+            return true
+        case .dictationStart, .shortcutSend:
+            return false
+        }
+    }
+
+    private func previewProgress(dominantDistance: CGFloat, threshold: CGFloat) -> CGFloat {
+        guard dominantDistance > threshold else { return 0 }
+        let overshoot = dominantDistance - threshold
+        let normalized = min(1, max(0, overshoot / 90))
+        return 0.32 + normalized * 0.68
+    }
+
+    private func retainOverlay(_ overlay: MouseGestureOverlay) {
+        retainedOverlays[ObjectIdentifier(overlay)] = overlay
+    }
+
+    private func releaseOverlay(_ overlay: MouseGestureOverlay) {
+        retainedOverlays.removeValue(forKey: ObjectIdentifier(overlay))
+    }
+
+    private func currentAppInfo() -> (name: String?, bundleId: String?) {
+        let app = NSWorkspace.shared.frontmostApplication
+        return (app?.localizedName, app?.bundleIdentifier)
+    }
+
+    private func recordObservedEvent(
+        phase: String,
+        button: MouseShortcutButton,
+        location: CGPoint,
+        delta: CGPoint,
+        modifiers: CGEventFlags,
+        candidate: String?,
+        match: MouseShortcutMatchResult?,
+        note: String?,
+        appInfo: (name: String?, bundleId: String?)
+    ) {
+        guard MouseInputEventViewer.shared.isCaptureActive else { return }
+        let sourceState = Int(modifiers.rawValue)
+        MouseInputEventViewer.shared.record(
+            MouseShortcutObservedEvent(
+                timestamp: Date(),
+                phase: phase,
+                buttonNumber: button.rawButtonNumber,
+                location: location,
+                delta: delta,
+                modifiers: NSEvent.ModifierFlags(rawValue: UInt(modifiers.rawValue)),
+                frontmostAppName: appInfo.name,
+                frontmostBundleId: appInfo.bundleId,
+                candidateTrigger: candidate,
+                device: nil,
+                matchedRuleSummary: match?.rule.summary,
+                willFire: match != nil,
+                note: note.map { "\($0) | flags=\(sourceState)" } ?? "flags=\(sourceState)"
+            )
         )
     }
 
-    private func hasWindowAtPoint(_ point: CGPoint) -> Bool {
-        guard let windows = CGWindowListCopyWindowInfo(
-            [.optionOnScreenOnly, .excludeDesktopElements],
-            kCGNullWindowID
-        ) as? [[String: Any]] else {
+    private func sendShortcut(_ shortcut: MouseShortcutKeyStroke?) -> Bool {
+        guard let shortcut else { return false }
+        let modifiers = shortcut.modifiers.map(\.appleScriptToken).joined(separator: ", ")
+        let command: String
+
+        if let keyCode = shortcut.keyCode {
+            command = modifiers.isEmpty
+                ? "key code \(keyCode)"
+                : "key code \(keyCode) using {\(modifiers)}"
+        } else if let key = shortcut.key {
+            command = modifiers.isEmpty
+                ? "keystroke \"\(key)\""
+                : "keystroke \"\(key)\" using {\(modifiers)}"
+        } else {
             return false
         }
 
-        for info in windows {
-            guard let owner = info[kCGWindowOwnerName as String] as? String,
-                  owner != "Lattices",
-                  let boundsDict = info[kCGWindowBounds as String] as? NSDictionary else {
-                continue
-            }
+        let script = """
+        tell application "System Events"
+            \(command)
+        end tell
+        return "ok"
+        """
+        return ProcessQuery.shell(["/usr/bin/osascript", "-e", script]) == "ok"
+    }
 
-            let layer = info[kCGWindowLayer as String] as? Int ?? 0
-            let alpha = info[kCGWindowAlpha as String] as? Double ?? 1.0
-            let isOnScreen = info[kCGWindowIsOnscreen as String] as? Bool ?? true
-            guard layer == 0, alpha > 0.01, isOnScreen else { continue }
-
-            var rect = CGRect.zero
-            guard CGRectMakeWithDictionaryRepresentation(boundsDict, &rect) else { continue }
-            guard rect.width >= 8, rect.height >= 8 else { continue }
-
-            if rect.contains(point) {
-                return true
-            }
-        }
-
-        return false
+    private func sendDictationShortcut() -> Bool {
+        sendShortcut(
+            MouseShortcutKeyStroke(
+                key: "a",
+                keyCode: nil,
+                modifiers: [.command, .shift]
+            )
+        )
     }
 }
 
 private final class MouseGestureOverlay {
+    private let committedHoldDuration: TimeInterval = 0.0
+    private let fadeDuration: TimeInterval = 0.03
+    private let accessoryCommittedHoldDuration: TimeInterval = 0.0
+    private let accessoryAnimationDuration: TimeInterval = 0.10
+
     private let screen: NSScreen
     private let window: NSWindow
     private let overlayView: MouseGestureOverlayView
     private var fadeTimer: Timer?
+    var onDismiss: (() -> Void)?
 
     init(screen: NSScreen) {
         self.screen = screen
@@ -365,22 +648,48 @@ private final class MouseGestureOverlay {
         window.orderFrontRegardless()
     }
 
-    func track(origin: CGPoint, direction: MouseGestureDirection?, label: String?) {
+    func track(origin: CGPoint, direction: MouseGestureDirection?, label: String?, progress: CGFloat) {
         fadeTimer?.invalidate()
         window.alphaValue = 1
-        overlayView.state = .tracking(origin: localPoint(from: origin), direction: direction, label: label)
+        if let direction {
+            overlayView.state = .tracking(
+                origin: localPoint(from: origin),
+                direction: direction,
+                label: label,
+                progress: progress
+            )
+        } else {
+            overlayView.state = .idle
+        }
         overlayView.needsDisplay = true
     }
 
-    func commit(origin: CGPoint, direction: MouseGestureDirection, label: String, success: Bool) {
+    func commit(
+        origin: CGPoint,
+        direction: MouseGestureDirection,
+        label: String,
+        success: Bool,
+        accessory: MouseGestureAccessory?
+    ) {
         fadeTimer?.invalidate()
         window.alphaValue = 1
-        overlayView.state = .committed(origin: localPoint(from: origin), direction: direction, label: label, success: success)
+        overlayView.state = .committed(
+            origin: localPoint(from: origin),
+            direction: direction,
+            label: label,
+            success: success,
+            accessory: accessory,
+            accessoryAnimationDuration: accessoryAnimationDuration
+        )
         overlayView.needsDisplay = true
 
-        fadeTimer = Timer.scheduledTimer(withTimeInterval: 0.38, repeats: false) { [weak self] _ in
+        let postReplayHoldDuration = accessory == nil ? committedHoldDuration : accessoryCommittedHoldDuration
+        let totalVisibleDuration = overlayView.replayLeadInDuration + postReplayHoldDuration
+        let timer = Timer(timeInterval: totalVisibleDuration, repeats: false) { [weak self] _ in
             self?.dismiss()
         }
+        fadeTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
     }
 
     func dismiss(immediately: Bool = false) {
@@ -389,14 +698,16 @@ private final class MouseGestureOverlay {
 
         if immediately {
             window.orderOut(nil)
+            finishDismissal()
             return
         }
 
         NSAnimationContext.runAnimationGroup({ ctx in
-            ctx.duration = 0.18
+            ctx.duration = fadeDuration
             window.animator().alphaValue = 0
         }, completionHandler: { [weak self] in
             self?.window.orderOut(nil)
+            self?.finishDismissal()
         })
     }
 
@@ -405,29 +716,92 @@ private final class MouseGestureOverlay {
         let nsY = primaryHeight - cgPoint.y
         return CGPoint(x: cgPoint.x - screen.frame.minX, y: nsY - screen.frame.minY)
     }
+
+    private func finishDismissal() {
+        let callback = onDismiss
+        onDismiss = nil
+        callback?()
+    }
 }
 
 private final class MouseGestureOverlayView: NSView {
     enum State {
-        case tracking(origin: CGPoint, direction: MouseGestureDirection?, label: String?)
-        case committed(origin: CGPoint, direction: MouseGestureDirection, label: String, success: Bool)
+        case idle
+        case tracking(origin: CGPoint, direction: MouseGestureDirection?, label: String?, progress: CGFloat)
+        case committed(
+            origin: CGPoint,
+            direction: MouseGestureDirection,
+            label: String,
+            success: Bool,
+            accessory: MouseGestureAccessory?,
+            accessoryAnimationDuration: TimeInterval
+        )
     }
 
-    var state: State = .tracking(origin: .zero, direction: nil, label: nil)
+    var state: State = .idle {
+        didSet {
+            updateArrowAnimation(from: oldValue, to: state)
+            updateAccessoryAnimation()
+        }
+    }
+    private var accessoryAnimationTimer: Timer?
+    private var accessoryAnimationStartedAt: Date?
+    private var accessoryAnimationDuration: TimeInterval = 0
+    private var arrowAnimationTimer: Timer?
+    private var arrowAnimationStartedAt: Date?
+    private var arrowAnimationDuration: TimeInterval = 0
+    private var committedStartProgress: CGFloat = 0
+    private var accessoryAnimationDelay: TimeInterval = 0
+    private let committedArrowAnimationDuration: TimeInterval = 0.06
+    private let arrowAnimationDelay: TimeInterval = 0.012
+    private let labelRevealThreshold: CGFloat = 0.8
+
+    var replayLeadInDuration: TimeInterval {
+        if committedStartProgress >= labelRevealThreshold {
+            return 0
+        }
+        let remainingProgress = max(0, 1 - committedStartProgress)
+        return arrowAnimationDelay + committedArrowAnimationDuration * remainingProgress
+    }
+
+    override var isFlipped: Bool {
+        false
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window == nil {
+            arrowAnimationTimer?.invalidate()
+            arrowAnimationTimer = nil
+            accessoryAnimationTimer?.invalidate()
+            accessoryAnimationTimer = nil
+        }
+    }
 
     override func draw(_ dirtyRect: NSRect) {
         guard let ctx = NSGraphicsContext.current?.cgContext else { return }
         ctx.clear(bounds)
 
         switch state {
-        case .tracking(let origin, let direction, let label):
+        case .idle:
+            break
+        case .tracking(let origin, let direction, let label, let progress):
             drawOrigin(at: origin, in: ctx, alpha: 0.88)
-            if let direction, let label {
-                drawArrow(from: origin, direction: direction, label: label, success: true, committed: false, in: ctx)
+            if let direction {
+                drawArrow(
+                    from: origin,
+                    direction: direction,
+                    label: label,
+                    success: true,
+                    committed: false,
+                    accessory: nil,
+                    progressOverride: progress,
+                    in: ctx
+                )
             }
-        case .committed(let origin, let direction, let label, let success):
+        case .committed(let origin, let direction, let label, let success, let accessory, _):
             drawOrigin(at: origin, in: ctx, alpha: 1.0)
-            drawArrow(from: origin, direction: direction, label: label, success: success, committed: true, in: ctx)
+            drawArrow(from: origin, direction: direction, label: label, success: success, committed: true, accessory: accessory, progressOverride: nil, in: ctx)
         }
     }
 
@@ -442,17 +816,24 @@ private final class MouseGestureOverlayView: NSView {
     private func drawArrow(
         from origin: CGPoint,
         direction: MouseGestureDirection,
-        label: String,
+        label: String?,
         success: Bool,
         committed: Bool,
+        accessory: MouseGestureAccessory?,
+        progressOverride: CGFloat?,
         in ctx: CGContext
     ) {
-        let length: CGFloat = committed ? 136 : 118
+        let baseLength: CGFloat = 118
+        let arrowProgress = progressOverride ?? currentArrowProgress(committed: committed)
+        let clampedProgress = min(1, max(0, arrowProgress))
+        let length = baseLength * (committed ? max(0.14, clampedProgress) : (0.34 + 0.66 * clampedProgress))
         let vector = arrowVector(for: direction, length: length)
         let end = CGPoint(x: origin.x + vector.x, y: origin.y + vector.y)
         let accent = success
             ? NSColor(calibratedRed: 0.45, green: 0.80, blue: 1.0, alpha: 1.0)
             : NSColor(calibratedRed: 0.98, green: 0.52, blue: 0.42, alpha: 1.0)
+        let strokeAlpha = committed ? 0.92 : (0.48 + 0.44 * clampedProgress)
+        let glowAlpha = committed ? 0.2 : (0.08 + 0.08 * clampedProgress)
 
         ctx.saveGState()
         ctx.setLineCap(.round)
@@ -461,25 +842,30 @@ private final class MouseGestureOverlayView: NSView {
         glowPath.move(to: origin)
         glowPath.addLine(to: end)
         ctx.addPath(glowPath)
-        ctx.setLineWidth(committed ? 20 : 16)
-        ctx.setStrokeColor(accent.withAlphaComponent(committed ? 0.22 : 0.16).cgColor)
+        ctx.setLineWidth(16)
+        ctx.setStrokeColor(accent.withAlphaComponent(glowAlpha).cgColor)
         ctx.strokePath()
 
         let linePath = CGMutablePath()
         linePath.move(to: origin)
         linePath.addLine(to: end)
         ctx.addPath(linePath)
-        ctx.setLineWidth(committed ? 7 : 5)
-        ctx.setStrokeColor(accent.withAlphaComponent(0.92).cgColor)
+        ctx.setLineWidth(5)
+        ctx.setStrokeColor(accent.withAlphaComponent(strokeAlpha).cgColor)
         ctx.strokePath()
 
-        drawArrowHead(at: end, direction: direction, color: accent, committed: committed)
-        drawLabel(label, near: end, direction: direction, color: accent)
+        drawArrowHead(at: end, direction: direction, color: accent)
+        if let label, (!committed || clampedProgress >= labelRevealThreshold) {
+            drawLabel(label, from: origin, to: end, direction: direction, color: accent)
+        }
+        if committed, let accessory, clampedProgress >= labelRevealThreshold {
+            drawAccessory(accessory, from: origin, to: end, direction: direction, color: accent, in: ctx)
+        }
         ctx.restoreGState()
     }
 
-    private func drawArrowHead(at end: CGPoint, direction: MouseGestureDirection, color: NSColor, committed: Bool) {
-        let size: CGFloat = committed ? 18 : 15
+    private func drawArrowHead(at end: CGPoint, direction: MouseGestureDirection, color: NSColor) {
+        let size: CGFloat = 15
         let path = NSBezierPath()
 
         switch direction {
@@ -491,6 +877,10 @@ private final class MouseGestureOverlayView: NSView {
             path.move(to: CGPoint(x: end.x + size, y: end.y))
             path.line(to: CGPoint(x: end.x - size * 0.2, y: end.y + size * 0.72))
             path.line(to: CGPoint(x: end.x - size * 0.2, y: end.y - size * 0.72))
+        case .up:
+            path.move(to: CGPoint(x: end.x, y: end.y + size))
+            path.line(to: CGPoint(x: end.x - size * 0.72, y: end.y - size * 0.2))
+            path.line(to: CGPoint(x: end.x + size * 0.72, y: end.y - size * 0.2))
         case .down:
             path.move(to: CGPoint(x: end.x, y: end.y - size))
             path.line(to: CGPoint(x: end.x - size * 0.72, y: end.y + size * 0.2))
@@ -502,7 +892,7 @@ private final class MouseGestureOverlayView: NSView {
         path.fill()
     }
 
-    private func drawLabel(_ label: String, near end: CGPoint, direction: MouseGestureDirection, color: NSColor) {
+    private func drawLabel(_ label: String, from origin: CGPoint, to end: CGPoint, direction: MouseGestureDirection, color: NSColor) {
         let font = NSFont.monospacedSystemFont(ofSize: 11, weight: .semibold)
         let attributes: [NSAttributedString.Key: Any] = [
             .font: font,
@@ -510,14 +900,18 @@ private final class MouseGestureOverlayView: NSView {
         ]
         let attributed = NSAttributedString(string: label, attributes: attributes)
         let textSize = attributed.size()
-        let origin = labelOrigin(near: end, direction: direction, textSize: textSize)
         let paddingX: CGFloat = 10
         let paddingY: CGFloat = 6
-        let rect = CGRect(
-            x: origin.x,
-            y: origin.y,
+        let bubbleSize = CGSize(
             width: textSize.width + paddingX * 2,
             height: textSize.height + paddingY * 2
+        )
+        let bubbleOrigin = labelOrigin(from: origin, to: end, direction: direction, bubbleSize: bubbleSize)
+        let rect = CGRect(
+            x: bubbleOrigin.x,
+            y: bubbleOrigin.y,
+            width: bubbleSize.width,
+            height: bubbleSize.height
         )
 
         let bg = NSBezierPath(roundedRect: rect, xRadius: 10, yRadius: 10)
@@ -538,15 +932,26 @@ private final class MouseGestureOverlayView: NSView {
         attributed.draw(in: textRect)
     }
 
-    private func labelOrigin(near end: CGPoint, direction: MouseGestureDirection, textSize: CGSize) -> CGPoint {
+    private func labelOrigin(from origin: CGPoint, to end: CGPoint, direction: MouseGestureDirection, bubbleSize: CGSize) -> CGPoint {
+        let midpoint = CGPoint(x: (origin.x + end.x) / 2, y: (origin.y + end.y) / 2)
+        let proposedOrigin: CGPoint
+
         switch direction {
-        case .left:
-            return CGPoint(x: end.x - textSize.width - 42, y: end.y + 12)
-        case .right:
-            return CGPoint(x: end.x + 16, y: end.y + 12)
-        case .down:
-            return CGPoint(x: end.x - textSize.width / 2 - 10, y: end.y - textSize.height - 42)
+        case .left, .right:
+            proposedOrigin = CGPoint(x: midpoint.x - bubbleSize.width / 2, y: midpoint.y + 18)
+        case .up, .down:
+            proposedOrigin = CGPoint(x: midpoint.x + 20, y: midpoint.y - bubbleSize.height / 2)
         }
+
+        let minX: CGFloat = 12
+        let minY: CGFloat = 12
+        let maxX = max(minX, bounds.width - bubbleSize.width - 12)
+        let maxY = max(minY, bounds.height - bubbleSize.height - 12)
+
+        return CGPoint(
+            x: min(max(proposedOrigin.x, minX), maxX),
+            y: min(max(proposedOrigin.y, minY), maxY)
+        )
     }
 
     private func arrowVector(for direction: MouseGestureDirection, length: CGFloat) -> CGPoint {
@@ -555,8 +960,239 @@ private final class MouseGestureOverlayView: NSView {
             return CGPoint(x: -length, y: 0)
         case .right:
             return CGPoint(x: length, y: 0)
+        case .up:
+            return CGPoint(x: 0, y: length)
         case .down:
             return CGPoint(x: 0, y: -length)
         }
+    }
+
+    private func updateArrowAnimation(from oldState: State, to newState: State) {
+        let oldDirection = stateDirection(from: oldState)
+        let newDirection = stateDirection(from: newState)
+        let oldCommitted = isCommitted(state: oldState)
+        let newCommitted = isCommitted(state: newState)
+
+        if newCommitted, newDirection != nil {
+            let shouldRestart = oldDirection != newDirection || !oldCommitted
+            if shouldRestart {
+                let previousProgress = trackingProgress(from: oldState)
+                committedStartProgress = max(0, min(1, previousProgress ?? 0))
+                if committedStartProgress >= 0.94 {
+                    arrowAnimationTimer?.invalidate()
+                    arrowAnimationTimer = nil
+                    arrowAnimationStartedAt = nil
+                    arrowAnimationDuration = 0
+                    committedStartProgress = 1
+                } else {
+                    startArrowAnimation(duration: committedArrowAnimationDuration)
+                }
+            }
+            return
+        }
+
+        arrowAnimationTimer?.invalidate()
+        arrowAnimationTimer = nil
+        arrowAnimationStartedAt = nil
+        arrowAnimationDuration = 0
+        committedStartProgress = 0
+    }
+
+    private func startArrowAnimation(duration: TimeInterval) {
+        arrowAnimationTimer?.invalidate()
+        arrowAnimationStartedAt = Date()
+        arrowAnimationDuration = duration
+
+        let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak self] timer in
+            guard let self else {
+                timer.invalidate()
+                return
+            }
+            self.needsDisplay = true
+            let elapsed = Date().timeIntervalSince(self.arrowAnimationStartedAt ?? Date())
+            if elapsed >= self.replayLeadInDuration {
+                timer.invalidate()
+                self.arrowAnimationTimer = nil
+            }
+        }
+        arrowAnimationTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
+    }
+
+    private func currentArrowProgress(committed: Bool) -> CGFloat {
+        guard committed,
+              let startedAt = arrowAnimationStartedAt,
+              arrowAnimationDuration > 0 else {
+            return committed ? (committedStartProgress > 0 ? committedStartProgress : 1) : 1
+        }
+
+        let delayedElapsed = Date().timeIntervalSince(startedAt) - arrowAnimationDelay
+        guard delayedElapsed > 0 else { return committedStartProgress }
+        let normalized = min(1, max(0, delayedElapsed / arrowAnimationDuration))
+        let animated = easeOut(normalized)
+        return committedStartProgress + (1 - committedStartProgress) * animated
+    }
+
+    private func updateAccessoryAnimation() {
+        accessoryAnimationTimer?.invalidate()
+        accessoryAnimationTimer = nil
+        accessoryAnimationStartedAt = nil
+        accessoryAnimationDuration = 0
+        accessoryAnimationDelay = 0
+
+        if case .committed(_, _, _, _, let accessory, let duration) = state, accessory != nil {
+            accessoryAnimationStartedAt = Date()
+            accessoryAnimationDuration = duration
+            accessoryAnimationDelay = replayLeadInDuration * 0.86
+            let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak self] timer in
+                guard let self else {
+                    timer.invalidate()
+                    return
+                }
+                self.needsDisplay = true
+                let elapsed = Date().timeIntervalSince(self.accessoryAnimationStartedAt ?? Date())
+                if elapsed >= self.accessoryAnimationDelay + self.accessoryAnimationDuration {
+                    timer.invalidate()
+                    self.accessoryAnimationTimer = nil
+                }
+            }
+            accessoryAnimationTimer = timer
+            RunLoop.main.add(timer, forMode: .common)
+        }
+    }
+
+    private func drawAccessory(
+        _ accessory: MouseGestureAccessory,
+        from origin: CGPoint,
+        to end: CGPoint,
+        direction: MouseGestureDirection,
+        color: NSColor,
+        in ctx: CGContext
+    ) {
+        guard let startedAt = accessoryAnimationStartedAt, accessoryAnimationDuration > 0 else { return }
+        let delayedElapsed = Date().timeIntervalSince(startedAt) - accessoryAnimationDelay
+        guard delayedElapsed > 0 else { return }
+        let progress = min(1, max(0, delayedElapsed / accessoryAnimationDuration))
+        let scale = 0.82 + 0.18 * easeOut(progress)
+        let fadeStart: CGFloat = 0.58
+        let alphaProgress = progress <= fadeStart ? 1 : 1 - ((progress - fadeStart) / (1 - fadeStart))
+        let alpha = max(0, min(1, alphaProgress))
+        guard alpha > 0 else { return }
+
+        let center = accessoryCenter(from: end, direction: direction)
+        let badgeDiameter: CGFloat = 34 * scale
+        let badgeRect = CGRect(
+            x: center.x - badgeDiameter / 2,
+            y: center.y - badgeDiameter / 2,
+            width: badgeDiameter,
+            height: badgeDiameter
+        )
+
+        let badge = NSBezierPath(ovalIn: badgeRect)
+        NSColor.black.withAlphaComponent(0.46 * alpha).setFill()
+        badge.fill()
+
+        color.withAlphaComponent(0.32 * alpha).setStroke()
+        badge.lineWidth = 1
+        badge.stroke()
+
+        switch accessory {
+        case .mic:
+            drawMicGlyph(in: badgeRect.insetBy(dx: badgeDiameter * 0.26, dy: badgeDiameter * 0.2), color: color.withAlphaComponent(0.96 * alpha), in: ctx)
+        }
+    }
+
+    private func accessoryCenter(from end: CGPoint, direction: MouseGestureDirection) -> CGPoint {
+        switch direction {
+        case .up:
+            return CGPoint(x: end.x, y: end.y + 34)
+        case .down:
+            return CGPoint(x: end.x, y: end.y - 34)
+        case .left:
+            return CGPoint(x: end.x - 34, y: end.y)
+        case .right:
+            return CGPoint(x: end.x + 34, y: end.y)
+        }
+    }
+
+    private func drawMicGlyph(in rect: CGRect, color: NSColor, in ctx: CGContext) {
+        ctx.saveGState()
+        color.setStroke()
+        color.withAlphaComponent(0.22).setFill()
+
+        let bodyWidth = rect.width * 0.42
+        let bodyHeight = rect.height * 0.54
+        let bodyRect = CGRect(
+            x: rect.midX - bodyWidth / 2,
+            y: rect.maxY - bodyHeight,
+            width: bodyWidth,
+            height: bodyHeight
+        )
+        let body = NSBezierPath(roundedRect: bodyRect, xRadius: bodyWidth / 2, yRadius: bodyWidth / 2)
+        body.lineWidth = 1.6
+        body.fill()
+        body.stroke()
+
+        let stem = NSBezierPath()
+        stem.move(to: CGPoint(x: rect.midX, y: bodyRect.minY))
+        stem.line(to: CGPoint(x: rect.midX, y: rect.minY + rect.height * 0.24))
+        stem.lineWidth = 1.8
+        stem.lineCapStyle = .round
+        stem.stroke()
+
+        let arcRect = CGRect(
+            x: rect.midX - rect.width * 0.28,
+            y: rect.minY + rect.height * 0.18,
+            width: rect.width * 0.56,
+            height: rect.height * 0.42
+        )
+        let arc = NSBezierPath()
+        arc.appendArc(
+            withCenter: CGPoint(x: arcRect.midX, y: arcRect.midY + arcRect.height * 0.08),
+            radius: arcRect.width / 2,
+            startAngle: 200,
+            endAngle: -20,
+            clockwise: true
+        )
+        arc.lineWidth = 1.6
+        arc.lineCapStyle = .round
+        arc.stroke()
+
+        let base = NSBezierPath()
+        base.move(to: CGPoint(x: rect.midX - rect.width * 0.22, y: rect.minY + rect.height * 0.14))
+        base.line(to: CGPoint(x: rect.midX + rect.width * 0.22, y: rect.minY + rect.height * 0.14))
+        base.lineWidth = 1.6
+        base.lineCapStyle = .round
+        base.stroke()
+        ctx.restoreGState()
+    }
+
+    private func easeOut(_ t: CGFloat) -> CGFloat {
+        1 - pow(1 - t, 3)
+    }
+
+    private func stateDirection(from state: State) -> MouseGestureDirection? {
+        switch state {
+        case .idle:
+            return nil
+        case .tracking(_, let direction, _, _):
+            return direction
+        case .committed(_, let direction, _, _, _, _):
+            return direction
+        }
+    }
+
+    private func isCommitted(state: State) -> Bool {
+        if case .committed = state {
+            return true
+        }
+        return false
+    }
+
+    private func trackingProgress(from state: State) -> CGFloat? {
+        if case .tracking(_, _, _, let progress) = state {
+            return progress
+        }
+        return nil
     }
 }

--- a/app/Sources/MouseInputDeviceStore.swift
+++ b/app/Sources/MouseInputDeviceStore.swift
@@ -1,0 +1,98 @@
+import Foundation
+import IOKit.hid
+
+struct MouseInputDeviceInfo: Identifiable, Equatable {
+    var id: String
+    var vendorId: Int?
+    var productId: Int?
+    var locationId: Int?
+    var product: String?
+    var manufacturer: String?
+    var transport: String?
+
+    var summary: String {
+        var parts: [String] = []
+        if let product, !product.isEmpty {
+            parts.append(product)
+        }
+        if let manufacturer, !manufacturer.isEmpty, parts.isEmpty {
+            parts.append(manufacturer)
+        }
+        if let vendorId { parts.append("vid:\(vendorId)") }
+        if let productId { parts.append("pid:\(productId)") }
+        if let locationId { parts.append("loc:\(locationId)") }
+        if let transport, !transport.isEmpty { parts.append(transport) }
+        return parts.isEmpty ? "Unknown pointer device" : parts.joined(separator: " | ")
+    }
+}
+
+final class MouseInputDeviceStore: ObservableObject {
+    static let shared = MouseInputDeviceStore()
+
+    @Published private(set) var devices: [MouseInputDeviceInfo] = []
+
+    private init() {
+        refresh()
+    }
+
+    func refresh() {
+        let manager = IOHIDManagerCreate(kCFAllocatorDefault, IOOptionBits(kIOHIDOptionsTypeNone))
+        let matches: [[String: Any]] = [
+            [
+                kIOHIDDeviceUsagePageKey as String: kHIDPage_GenericDesktop,
+                kIOHIDDeviceUsageKey as String: kHIDUsage_GD_Mouse,
+            ],
+            [
+                kIOHIDDeviceUsagePageKey as String: kHIDPage_GenericDesktop,
+                kIOHIDDeviceUsageKey as String: kHIDUsage_GD_Pointer,
+            ],
+        ]
+        IOHIDManagerSetDeviceMatchingMultiple(manager, matches as CFArray)
+        IOHIDManagerOpen(manager, IOOptionBits(kIOHIDOptionsTypeNone))
+
+        let resolved: [MouseInputDeviceInfo]
+        if let rawDevices = IOHIDManagerCopyDevices(manager) as? Set<IOHIDDevice> {
+            resolved = rawDevices.compactMap(Self.deviceInfo(for:))
+                .sorted { $0.summary.localizedCaseInsensitiveCompare($1.summary) == .orderedAscending }
+        } else {
+            resolved = []
+        }
+
+        DispatchQueue.main.async {
+            self.devices = resolved
+        }
+    }
+
+    private static func deviceInfo(for device: IOHIDDevice) -> MouseInputDeviceInfo? {
+        let vendorId = integerProperty(kIOHIDVendorIDKey as CFString, from: device)
+        let productId = integerProperty(kIOHIDProductIDKey as CFString, from: device)
+        let locationId = integerProperty(kIOHIDLocationIDKey as CFString, from: device)
+        let product = stringProperty(kIOHIDProductKey as CFString, from: device)
+        let manufacturer = stringProperty(kIOHIDManufacturerKey as CFString, from: device)
+        let transport = stringProperty(kIOHIDTransportKey as CFString, from: device)
+
+        let vendorToken = vendorId.map(String.init) ?? "vid"
+        let productToken = productId.map(String.init) ?? "pid"
+        let locationToken = locationId.map(String.init) ?? "loc"
+        let id = [product ?? "mouse", vendorToken, productToken, locationToken].joined(separator: ":")
+
+        return MouseInputDeviceInfo(
+            id: id,
+            vendorId: vendorId,
+            productId: productId,
+            locationId: locationId,
+            product: product,
+            manufacturer: manufacturer,
+            transport: transport
+        )
+    }
+
+    private static func integerProperty(_ key: CFString, from device: IOHIDDevice) -> Int? {
+        guard let value = IOHIDDeviceGetProperty(device, key) else { return nil }
+        return (value as? NSNumber)?.intValue
+    }
+
+    private static func stringProperty(_ key: CFString, from device: IOHIDDevice) -> String? {
+        IOHIDDeviceGetProperty(device, key) as? String
+    }
+}

--- a/app/Sources/MouseInputEventViewer.swift
+++ b/app/Sources/MouseInputEventViewer.swift
@@ -1,0 +1,272 @@
+import AppKit
+import SwiftUI
+
+final class MouseInputEventViewer: ObservableObject {
+    static let shared = MouseInputEventViewer()
+
+    struct Entry: Identifiable {
+        let id = UUID()
+        let timestamp: Date
+        let phase: String
+        let appName: String
+        let bundleId: String
+        let buttonNumber: Int
+        let triggerCandidate: String
+        let deltaText: String
+        let modifiersText: String
+        let deviceText: String
+        let matchText: String
+        let note: String
+    }
+
+    @Published private(set) var entries: [Entry] = []
+    @Published private(set) var isCaptureActive = false
+
+    private let maxEntries = 120
+    private var window: NSWindow?
+    private var closeObserver: Any?
+
+    private init() {}
+
+    func show() {
+        if let window {
+            isCaptureActive = true
+            window.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        let view = MouseInputEventViewerView()
+        let window = AppWindowShell.makeWindow(
+            config: .init(
+                title: "Mouse Shortcut Event Viewer",
+                initialSize: NSSize(width: 980, height: 620),
+                minSize: NSSize(width: 840, height: 460),
+                maxSize: NSSize(width: 1500, height: 1000)
+            ),
+            rootView: view
+        )
+        AppWindowShell.positionCentered(window)
+        AppWindowShell.present(window)
+
+        closeObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            self?.teardownWindow()
+        }
+
+        self.window = window
+        isCaptureActive = true
+        DiagnosticLog.shared.info("Mouse shortcuts event viewer opened")
+    }
+
+    func dismiss() {
+        window?.close()
+        teardownWindow()
+    }
+
+    func clear() {
+        entries.removeAll()
+    }
+
+    func record(_ observedEvent: MouseShortcutObservedEvent) {
+        let entry = Entry(
+            timestamp: observedEvent.timestamp,
+            phase: observedEvent.phase,
+            appName: observedEvent.frontmostAppName ?? "Unknown App",
+            bundleId: observedEvent.frontmostBundleId ?? "unknown.bundle",
+            buttonNumber: observedEvent.buttonNumber,
+            triggerCandidate: observedEvent.candidateTrigger ?? "--",
+            deltaText: "\(Int(observedEvent.delta.x)), \(Int(observedEvent.delta.y))",
+            modifiersText: Self.modifierLabels(for: observedEvent.modifiers).joined(separator: "+").ifEmpty("--"),
+            deviceText: observedEvent.device?.summary ?? "Unresolved device",
+            matchText: observedEvent.matchedRuleSummary ?? (observedEvent.willFire ? "Would fire" : "No match"),
+            note: observedEvent.note ?? ""
+        )
+
+        DispatchQueue.main.async {
+            self.entries.append(entry)
+            if self.entries.count > self.maxEntries {
+                self.entries.removeFirst(self.entries.count - self.maxEntries)
+            }
+        }
+    }
+
+    private func teardownWindow() {
+        if let closeObserver {
+            NotificationCenter.default.removeObserver(closeObserver)
+            self.closeObserver = nil
+        }
+        window = nil
+        isCaptureActive = false
+    }
+
+    private static func modifierLabels(for flags: NSEvent.ModifierFlags) -> [String] {
+        var labels: [String] = []
+        if flags.contains(.control) { labels.append("Ctrl") }
+        if flags.contains(.option) { labels.append("Option") }
+        if flags.contains(.shift) { labels.append("Shift") }
+        if flags.contains(.command) { labels.append("Cmd") }
+        return labels
+    }
+}
+
+private struct MouseInputEventViewerView: View {
+    @ObservedObject private var viewer = MouseInputEventViewer.shared
+    @ObservedObject private var devices = MouseInputDeviceStore.shared
+
+    private static let timestampFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss.SSS"
+        return formatter
+    }()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+                .overlay(Color.white.opacity(0.08))
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 8) {
+                    if devices.devices.isEmpty {
+                        deviceStrip(text: "Devices: none detected")
+                    } else {
+                        deviceStrip(text: "Devices: " + devices.devices.map(\.summary).joined(separator: "  |  "))
+                    }
+
+                    ForEach(viewer.entries) { entry in
+                        entryRow(entry)
+                    }
+                }
+                .padding(14)
+            }
+            .background(Color.black.opacity(0.16))
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Mouse Shortcut Event Viewer")
+                    .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.95))
+                Text("Watching extra mouse buttons and drag candidates for configurable shortcuts.")
+                    .font(.system(size: 11))
+                    .foregroundColor(.white.opacity(0.6))
+            }
+
+            Spacer()
+
+            Button("Copy") {
+                let text = viewer.entries.map { entry in
+                    [
+                        Self.timestampFormatter.string(from: entry.timestamp),
+                        entry.phase,
+                        entry.appName,
+                        entry.bundleId,
+                        "button=\(entry.buttonNumber)",
+                        "candidate=\(entry.triggerCandidate)",
+                        "delta=\(entry.deltaText)",
+                        "mods=\(entry.modifiersText)",
+                        "device=\(entry.deviceText)",
+                        "match=\(entry.matchText)",
+                        entry.note,
+                    ].filter { !$0.isEmpty }.joined(separator: " | ")
+                }.joined(separator: "\n")
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(text, forType: .string)
+            }
+            .buttonStyle(.plain)
+            .foregroundColor(.white.opacity(0.72))
+
+            Button("Clear") {
+                viewer.clear()
+            }
+            .buttonStyle(.plain)
+            .foregroundColor(.white.opacity(0.72))
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(Color.white.opacity(0.04))
+    }
+
+    private func deviceStrip(text: String) -> some View {
+        Text(text)
+            .font(.system(size: 10, weight: .medium, design: .monospaced))
+            .foregroundColor(.white.opacity(0.6))
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color.white.opacity(0.04))
+            )
+    }
+
+    private func entryRow(_ entry: MouseInputEventViewer.Entry) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Text(Self.timestampFormatter.string(from: entry.timestamp))
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.82))
+
+                Text(entry.phase.uppercased())
+                    .font(.system(size: 10, weight: .bold, design: .monospaced))
+                    .foregroundColor(Color(red: 0.62, green: 0.84, blue: 1.0))
+
+                Text(entry.triggerCandidate)
+                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.94))
+
+                Spacer()
+
+                Text(entry.matchText)
+                    .font(.system(size: 10, weight: .medium, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.68))
+            }
+
+            HStack(spacing: 14) {
+                metadataPill("App", "\(entry.appName) (\(entry.bundleId))")
+                metadataPill("Button", "\(entry.buttonNumber)")
+                metadataPill("Delta", entry.deltaText)
+                metadataPill("Mods", entry.modifiersText)
+            }
+
+            HStack(spacing: 14) {
+                metadataPill("Device", entry.deviceText)
+                if !entry.note.isEmpty {
+                    metadataPill("Note", entry.note)
+                }
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.white.opacity(0.04))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.white.opacity(0.06), lineWidth: 0.5)
+                )
+        )
+    }
+
+    private func metadataPill(_ label: String, _ value: String) -> some View {
+        HStack(spacing: 6) {
+            Text(label.uppercased())
+                .font(.system(size: 9, weight: .bold, design: .monospaced))
+                .foregroundColor(.white.opacity(0.42))
+            Text(value)
+                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                .foregroundColor(.white.opacity(0.82))
+        }
+    }
+}
+
+private extension String {
+    func ifEmpty(_ replacement: String) -> String {
+        isEmpty ? replacement : self
+    }
+}

--- a/app/Sources/MouseShortcutStore.swift
+++ b/app/Sources/MouseShortcutStore.swift
@@ -1,0 +1,107 @@
+import AppKit
+import Combine
+import Foundation
+
+final class MouseShortcutStore: ObservableObject {
+    static let shared = MouseShortcutStore()
+
+    @Published private(set) var config: MouseShortcutConfig
+
+    let configURL: URL
+    private var lastLoadedModifiedDate: Date?
+
+    private init() {
+        let dir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".lattices")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        self.configURL = dir.appendingPathComponent("mouse-shortcuts.json")
+        self.config = .defaults
+        ensureConfigFile()
+        reload()
+    }
+
+    var tuning: MouseShortcutTuning {
+        config.tuning
+    }
+
+    var enabledRules: [MouseShortcutRule] {
+        config.rules.filter(\.enabled)
+    }
+
+    var watchedButtonNumbers: Set<Int64> {
+        Set(enabledRules.map { Int64($0.trigger.button.rawButtonNumber) })
+    }
+
+    var summaryLines: [String] {
+        enabledRules.map { "\($0.trigger.triggerName) -> \($0.action.type.rawValue)" }
+    }
+
+    func ensureConfigFile() {
+        guard !FileManager.default.fileExists(atPath: configURL.path) else { return }
+        write(config: .defaults)
+    }
+
+    func reload() {
+        guard let data = FileManager.default.contents(atPath: configURL.path) else {
+            config = .defaults
+            return
+        }
+
+        do {
+            config = try JSONDecoder().decode(MouseShortcutConfig.self, from: data)
+            lastLoadedModifiedDate = modifiedDate()
+        } catch {
+            DiagnosticLog.shared.error("MouseShortcutStore: failed to decode mouse-shortcuts.json - \(error.localizedDescription)")
+            config = .defaults
+        }
+    }
+
+    func reloadIfNeeded() {
+        let currentModifiedDate = modifiedDate()
+        guard currentModifiedDate != lastLoadedModifiedDate else { return }
+        reload()
+    }
+
+    func restoreDefaults() {
+        write(config: .defaults)
+        reload()
+        DiagnosticLog.shared.info("Mouse shortcuts restored to defaults")
+    }
+
+    func openConfiguration() {
+        ensureConfigFile()
+        NSWorkspace.shared.open(configURL)
+    }
+
+    func match(for event: MouseShortcutTriggerEvent) -> MouseShortcutMatchResult? {
+        for rule in enabledRules {
+            guard rule.trigger.kind == event.kind,
+                  rule.trigger.button == event.button,
+                  rule.trigger.direction == event.direction,
+                  rule.device.matches(event.device) else {
+                continue
+            }
+
+            return MouseShortcutMatchResult(
+                rule: rule,
+                action: rule.action,
+                triggerName: rule.trigger.triggerName
+            )
+        }
+
+        return nil
+    }
+
+    private func write(config: MouseShortcutConfig) {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        guard let data = try? encoder.encode(config) else { return }
+        try? data.write(to: configURL, options: .atomic)
+        lastLoadedModifiedDate = modifiedDate()
+    }
+
+    private func modifiedDate() -> Date? {
+        let attrs = try? FileManager.default.attributesOfItem(atPath: configURL.path)
+        return attrs?[.modificationDate] as? Date
+    }
+}

--- a/app/Sources/Preferences.swift
+++ b/app/Sources/Preferences.swift
@@ -38,6 +38,10 @@ class Preferences: ObservableObject {
         didSet { persistCompanionCockpitLayout() }
     }
 
+    @Published var mouseGesturesEnabled: Bool {
+        didSet { UserDefaults.standard.set(mouseGesturesEnabled, forKey: "mouseGestures.enabled") }
+    }
+
     // MARK: - AI / Claude
 
     @Published var claudePath: String {
@@ -160,6 +164,11 @@ class Preferences: ObservableObject {
 
         self.companionCockpitLayout = Self.loadCompanionCockpitLayout()
 
+        if UserDefaults.standard.object(forKey: "mouseGestures.enabled") != nil {
+            self.mouseGesturesEnabled = UserDefaults.standard.bool(forKey: "mouseGestures.enabled")
+        } else {
+            self.mouseGesturesEnabled = false
+        }
         // AI / Claude
         self.claudePath = UserDefaults.standard.string(forKey: "claude.path") ?? ""
         self.advisorModel = UserDefaults.standard.string(forKey: "claude.advisorModel") ?? "haiku"

--- a/app/Sources/ScreenMapWindowController.swift
+++ b/app/Sources/ScreenMapWindowController.swift
@@ -78,6 +78,14 @@ final class ScreenMapWindowController: ObservableObject {
         show()
     }
 
+    func showScreenMapOverview() {
+        activePage = .screenMap
+        show()
+        DispatchQueue.main.async { [weak self] in
+            self?.controller?.focusViewportPreset(.overview)
+        }
+    }
+
     /// Open screen map focused on a specific window.
     func showWindow(wid: UInt32) {
         activePage = .screenMap

--- a/app/Sources/SettingsView.swift
+++ b/app/Sources/SettingsView.swift
@@ -469,6 +469,29 @@ struct SettingsContentView: View {
                             .foregroundColor(Palette.textMuted.opacity(0.7))
                     }
                 }
+
+                settingsCard {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("Mouse gestures")
+                            .font(Typo.mono(11))
+                            .foregroundColor(Palette.text)
+
+                        HStack {
+                            Text("Middle-click gestures")
+                                .font(Typo.mono(10))
+                                .foregroundColor(Palette.textDim)
+                            Spacer()
+                            Toggle("", isOn: $prefs.mouseGesturesEnabled)
+                                .toggleStyle(.switch)
+                                .controlSize(.small)
+                                .labelsHidden()
+                        }
+
+                        Text("On empty desktop space only: drag left for the previous Space, right for the next Space, and down for the Screen Map overview. A stylized arrow preview appears once the direction locks in. Requires Accessibility permission.")
+                            .font(Typo.caption(9))
+                            .foregroundColor(Palette.textMuted.opacity(0.7))
+                    }
+                }
             }
             .padding(16)
             .frame(maxWidth: 760, alignment: .leading)

--- a/app/Sources/SettingsView.swift
+++ b/app/Sources/SettingsView.swift
@@ -58,6 +58,7 @@ struct SettingsContentView: View {
     @ObservedObject var scanner: ProjectScanner
     @ObservedObject var hotkeyStore: HotkeyStore = .shared
     @ObservedObject var appUpdater: AppUpdater = .shared
+    @ObservedObject var mouseShortcutStore: MouseShortcutStore = .shared
     var onBack: (() -> Void)? = nil
 
     @State private var selectedTab: SettingsSection = .general
@@ -487,7 +488,81 @@ struct SettingsContentView: View {
                                 .labelsHidden()
                         }
 
-                        Text("On empty desktop space only: drag left for the previous Space, right for the next Space, and down for the Screen Map overview. A stylized arrow preview appears once the direction locks in. Requires Accessibility permission.")
+                        Text("Rules live in ~/.lattices/mouse-shortcuts.json. The current defaults preserve the working setup: middle-click drag left/right switches Spaces and drag down opens the Screen Map overview.")
+                            .font(Typo.caption(9))
+                            .foregroundColor(Palette.textMuted.opacity(0.7))
+
+                        cardDivider
+
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Active drag mappings")
+                                .font(Typo.mono(10))
+                                .foregroundColor(Palette.textDim)
+
+                            ForEach(mouseShortcutStore.summaryLines.prefix(4), id: \.self) { line in
+                                Text(line)
+                                    .font(Typo.caption(9))
+                                    .foregroundColor(Palette.textMuted.opacity(0.78))
+                            }
+
+                            if mouseShortcutStore.summaryLines.isEmpty {
+                                Text("No active mappings")
+                                    .font(Typo.caption(9))
+                                    .foregroundColor(Palette.textMuted.opacity(0.6))
+                            }
+                        }
+
+                        HStack(spacing: 8) {
+                            Button {
+                                mouseShortcutStore.openConfiguration()
+                            } label: {
+                                Text("Configure...")
+                                    .font(Typo.monoBold(10))
+                                    .foregroundColor(Palette.text)
+                                    .padding(.horizontal, 12)
+                                    .padding(.vertical, 4)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 4)
+                                            .fill(Palette.surfaceHov)
+                                            .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.borderLit, lineWidth: 0.5))
+                                    )
+                            }
+                            .buttonStyle(.plain)
+
+                            Button {
+                                MouseInputEventViewer.shared.show()
+                            } label: {
+                                Text("Open Event Viewer")
+                                    .font(Typo.monoBold(10))
+                                    .foregroundColor(Palette.text)
+                                    .padding(.horizontal, 12)
+                                    .padding(.vertical, 4)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 4)
+                                            .fill(Palette.surfaceHov)
+                                            .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.borderLit, lineWidth: 0.5))
+                                    )
+                            }
+                            .buttonStyle(.plain)
+
+                            Button {
+                                mouseShortcutStore.restoreDefaults()
+                            } label: {
+                                Text("Restore Defaults")
+                                    .font(Typo.monoBold(10))
+                                    .foregroundColor(Palette.text)
+                                    .padding(.horizontal, 12)
+                                    .padding(.vertical, 4)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 4)
+                                            .fill(Palette.surfaceHov)
+                                            .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.borderLit, lineWidth: 0.5))
+                                    )
+                            }
+                            .buttonStyle(.plain)
+                        }
+
+                        Text("Use Event Viewer to discover what your mouse emits on this machine. Device-specific rules are supported in the schema now, with global fallback when the source device cannot be resolved from the event stream.")
                             .font(Typo.caption(9))
                             .foregroundColor(Palette.textMuted.opacity(0.7))
                     }

--- a/app/Sources/SettingsView.swift
+++ b/app/Sources/SettingsView.swift
@@ -562,7 +562,7 @@ struct SettingsContentView: View {
                             .buttonStyle(.plain)
                         }
 
-                        Text("Use Event Viewer to discover what your mouse emits on this machine. Device-specific rules are supported in the schema now, with global fallback when the source device cannot be resolved from the event stream.")
+                        Text("Use Event Viewer to discover what your mouse emits on this machine. The config schema already accepts device selectors, but live gesture matching currently falls back to global rules when macOS doesn't expose the source device.")
                             .font(Typo.caption(9))
                             .foregroundColor(Palette.textMuted.opacity(0.7))
                     }

--- a/app/Sources/WindowTiler.swift
+++ b/app/Sources/WindowTiler.swift
@@ -601,14 +601,72 @@ enum WindowTiler {
         return spaces[targetIndex]
     }
 
+    private struct AdjacentSpaceContext {
+        let point: CGPoint
+        let display: DisplaySpaces
+        let activeSpaceId: Int
+        let currentSpaceId: Int
+        let target: SpaceInfo?
+    }
+
+    private static func adjacentSpaceContext(offset: Int, from cgPoint: CGPoint? = nil) -> AdjacentSpaceContext? {
+        let point = cgPoint ?? currentMouseCGPoint()
+        guard let display = displaySpaces(containing: point) else { return nil }
+        let activeSpaceId = getCurrentSpace()
+        let currentSpaceId = resolvedCurrentSpaceId(for: display, activeSpaceId: activeSpaceId)
+        let target = adjacentSpace(in: display.spaces, currentSpaceId: currentSpaceId, offset: offset)
+        return AdjacentSpaceContext(
+            point: point,
+            display: display,
+            activeSpaceId: activeSpaceId,
+            currentSpaceId: currentSpaceId,
+            target: target
+        )
+    }
+
+    static func adjacentSpaceTarget(offset: Int, from cgPoint: CGPoint? = nil) -> SpaceInfo? {
+        adjacentSpaceContext(offset: offset, from: cgPoint)?.target
+    }
+
     @discardableResult
     static func switchToAdjacentSpace(offset: Int, from cgPoint: CGPoint? = nil) -> Bool {
-        guard let display = displaySpaces(containing: cgPoint ?? currentMouseCGPoint()) else { return false }
-        guard let target = adjacentSpace(in: display.spaces, currentSpaceId: display.currentSpaceId, offset: offset) else {
+        guard let context = adjacentSpaceContext(offset: offset, from: cgPoint) else {
+            DiagnosticLog.shared.warn("switchToAdjacentSpace: no adjacent space for offset \(offset) from \(formatCGPoint(cgPoint ?? currentMouseCGPoint()))")
             return false
         }
-        switchToSpace(spaceId: target.id)
-        return true
+
+        let spaces = context.display.spaces.map(\.id)
+        let targetText = context.target.map { String($0.id) } ?? "none"
+        DiagnosticLog.shared.info(
+            "switchToAdjacentSpace: offset=\(offset) point=\(formatCGPoint(context.point)) displayId=\(context.display.displayId) active=\(context.activeSpaceId) displayCurrent=\(context.display.currentSpaceId) resolved=\(context.currentSpaceId) target=\(targetText) spaces=\(spaces)"
+        )
+
+        if getDisplaySpaces().count == 1 {
+            if let finalSpaceId = switchToAdjacentSpaceViaSystemShortcut(
+                offset: offset,
+                displayId: context.display.displayId,
+                initialSpaceId: context.currentSpaceId
+            ) {
+                if let target = context.target, finalSpaceId != target.id {
+                    DiagnosticLog.shared.info("switchToAdjacentSpace: system shortcut changed \(context.currentSpaceId) → \(finalSpaceId) (expected \(target.id))")
+                } else {
+                    DiagnosticLog.shared.info("switchToAdjacentSpace: system shortcut changed \(context.currentSpaceId) → \(finalSpaceId)")
+                }
+                return true
+            }
+
+            guard let target = context.target else {
+                DiagnosticLog.shared.info("switchToAdjacentSpace: system shortcut stayed on \(context.currentSpaceId) and there is no adjacent space")
+                return false
+            }
+
+            DiagnosticLog.shared.warn("switchToAdjacentSpace: system shortcut stayed on \(context.currentSpaceId), falling back to SkyLight target \(target.id)")
+        }
+
+        guard let target = context.target else { return false }
+        let switched = switchToSpace(spaceId: target.id)
+        DiagnosticLog.shared.info("switchToAdjacentSpace: SkyLight \(switched ? "reached" : "missed") target \(target.id)")
+        return switched
     }
 
     /// Find a window by its title tag and return its CGWindowID and owner PID
@@ -637,10 +695,12 @@ enum WindowTiler {
         return result.map { $0.intValue }
     }
 
-    /// Switch a display to a specific Space
-    static func switchToSpace(spaceId: Int) {
+    /// Switch a display to a specific Space.
+    /// Returns true once the requested Space becomes current.
+    @discardableResult
+    static func switchToSpace(spaceId: Int, verify: Bool = true) -> Bool {
         guard let mainConn = CGS.mainConnectionID,
-              let setSpace = CGS.setCurrentSpace else { return }
+              let setSpace = CGS.setCurrentSpace else { return false }
 
         let cid = mainConn()
 
@@ -648,10 +708,37 @@ enum WindowTiler {
         let allDisplays = getDisplaySpaces()
         for display in allDisplays {
             if display.spaces.contains(where: { $0.id == spaceId }) {
+                let initialSpace = display.currentSpaceId
+                if initialSpace == spaceId {
+                    DiagnosticLog.shared.info("switchToSpace: display \(display.displayIndex) already on target \(spaceId)")
+                    return true
+                }
+
+                DiagnosticLog.shared.info(
+                    "switchToSpace: requesting \(spaceId) on display \(display.displayIndex) id=\(display.displayId) from \(initialSpace)"
+                )
                 setSpace(cid, display.displayId as CFString, UInt64(spaceId))
-                return
+                guard verify else { return true }
+
+                let deadline = Date().addingTimeInterval(0.45)
+                while Date() < deadline {
+                    usleep(30_000)
+                    let current = getDisplaySpaces().first(where: { $0.displayId == display.displayId })?.currentSpaceId ?? 0
+                    if current == spaceId {
+                        DiagnosticLog.shared.info("switchToSpace: display \(display.displayIndex) confirmed target \(spaceId)")
+                        return true
+                    }
+                }
+
+                DiagnosticLog.shared.warn(
+                    "switchToSpace: requested \(spaceId) on display \(display.displayIndex) from \(initialSpace), but current Space did not change"
+                )
+                return false
             }
         }
+
+        DiagnosticLog.shared.warn("switchToSpace: couldn't resolve display for space \(spaceId)")
+        return false
     }
 
     // MARK: - Move Window Between Spaces
@@ -2089,9 +2176,47 @@ enum WindowTiler {
         return CGPoint(x: mouseLocation.x, y: primaryHeight - mouseLocation.y)
     }
 
+    private static func switchToAdjacentSpaceViaSystemShortcut(offset: Int, displayId: String, initialSpaceId: Int) -> Int? {
+        let keyCode: CGKeyCode = offset < 0 ? 123 : 124
+        let script = """
+        tell application "System Events"
+            key code \(keyCode) using control down
+        end tell
+        return "ok"
+        """
+        let result = ProcessQuery.shell(["/usr/bin/osascript", "-e", script])
+        if result != "ok" {
+            DiagnosticLog.shared.warn("switchToAdjacentSpace: system shortcut script did not complete for offset \(offset)")
+        }
+        return waitForSpaceChange(displayId: displayId, initialSpaceId: initialSpaceId, timeout: 1.2)
+    }
+
+    private static func waitForSpaceChange(displayId: String, initialSpaceId: Int, timeout: TimeInterval) -> Int? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            usleep(30_000)
+            let current = getDisplaySpaces().first(where: { $0.displayId == displayId })?.currentSpaceId ?? 0
+            if current != 0, current != initialSpaceId {
+                return current
+            }
+        }
+        return nil
+    }
+
     private static func displaySpaces(containing cgPoint: CGPoint) -> DisplaySpaces? {
         guard let screenIndex = screenIndex(for: cgPoint) else { return nil }
         return getDisplaySpaces().first(where: { $0.displayIndex == screenIndex })
+    }
+
+    private static func resolvedCurrentSpaceId(for display: DisplaySpaces, activeSpaceId: Int) -> Int {
+        if display.spaces.contains(where: { $0.id == activeSpaceId }) {
+            return activeSpaceId
+        }
+        return display.currentSpaceId
+    }
+
+    private static func formatCGPoint(_ point: CGPoint) -> String {
+        "\(Int(point.x)),\(Int(point.y))"
     }
 
     private static func screenIndex(for cgPoint: CGPoint) -> Int? {

--- a/app/Sources/WindowTiler.swift
+++ b/app/Sources/WindowTiler.swift
@@ -594,6 +594,23 @@ enum WindowTiler {
         return Int(getActive(mainConn()))
     }
 
+    static func adjacentSpace(in spaces: [SpaceInfo], currentSpaceId: Int, offset: Int) -> SpaceInfo? {
+        guard let currentIndex = spaces.firstIndex(where: { $0.id == currentSpaceId }) else { return nil }
+        let targetIndex = currentIndex + offset
+        guard spaces.indices.contains(targetIndex) else { return nil }
+        return spaces[targetIndex]
+    }
+
+    @discardableResult
+    static func switchToAdjacentSpace(offset: Int, from cgPoint: CGPoint? = nil) -> Bool {
+        guard let display = displaySpaces(containing: cgPoint ?? currentMouseCGPoint()) else { return false }
+        guard let target = adjacentSpace(in: display.spaces, currentSpaceId: display.currentSpaceId, offset: offset) else {
+            return false
+        }
+        switchToSpace(spaceId: target.id)
+        return true
+    }
+
     /// Find a window by its title tag and return its CGWindowID and owner PID
     static func findWindow(tag: String) -> (wid: UInt32, pid: pid_t)? {
         guard let windowList = CGWindowListCopyWindowInfo([.optionAll, .excludeDesktopElements], kCGNullWindowID) as? [[String: Any]] else {
@@ -2064,6 +2081,24 @@ enum WindowTiler {
         return NSScreen.screens.first(where: {
             $0.frame.contains(NSPoint(x: centerX, y: nsCenterY))
         }) ?? NSScreen.main ?? primaryScreen
+    }
+
+    private static func currentMouseCGPoint() -> CGPoint {
+        let mouseLocation = NSEvent.mouseLocation
+        let primaryHeight = NSScreen.screens.first?.frame.height ?? 0
+        return CGPoint(x: mouseLocation.x, y: primaryHeight - mouseLocation.y)
+    }
+
+    private static func displaySpaces(containing cgPoint: CGPoint) -> DisplaySpaces? {
+        guard let screenIndex = screenIndex(for: cgPoint) else { return nil }
+        return getDisplaySpaces().first(where: { $0.displayIndex == screenIndex })
+    }
+
+    private static func screenIndex(for cgPoint: CGPoint) -> Int? {
+        let primaryHeight = NSScreen.screens.first?.frame.height ?? 0
+        let nsPoint = NSPoint(x: cgPoint.x, y: primaryHeight - cgPoint.y)
+        return NSScreen.screens.firstIndex(where: { $0.frame.contains(nsPoint) })
+            ?? (NSScreen.main != nil ? 0 : nil)
     }
 
     // MARK: - Private

--- a/bin/lattices.ts
+++ b/bin/lattices.ts
@@ -47,7 +47,7 @@ function hasTmux(): boolean {
 const tmuxRequiredCommands = new Set([
   "init", "ls", "list", "kill", "rm", "sync", "reconcile",
   "restart", "respawn", "group", "groups", "tab", "status",
-  "inventory", "distribute", "sessions",
+  "inventory", "sessions",
 ]);
 
 function requireTmux(command: string | undefined): void {
@@ -1430,14 +1430,14 @@ async function diagCommand(limit?: string): Promise<void> {
   }
 }
 
-async function distributeCommand(): Promise<void> {
-  try {
-    const { daemonCall } = await getDaemonClient();
-    await daemonCall("space.optimize", { scope: "visible", strategy: "balanced" });
-    console.log("Distributed visible windows into grid");
-  } catch {
-    console.log("Daemon not running. Start with: lattices app");
-  }
+async function distributeCommand(rawArgs: string[] = []): Promise<void> {
+  const request = parseSpaceOptimizeArgs(rawArgs, "visible");
+  await optimizeWindowsCommand(request, "Distributed");
+}
+
+async function tileFamilyCommand(rawArgs: string[]): Promise<void> {
+  const request = parseSpaceOptimizeArgs(rawArgs, "active-app");
+  await optimizeWindowsCommand(request, "Smart-tiled");
 }
 
 async function daemonLsCommand(): Promise<boolean> {
@@ -1740,7 +1740,8 @@ Usage:
   lattices windows [--json]   List all desktop windows (daemon required)
   lattices sessions [--json]  List active tmux sessions via daemon
   lattices tile <position>    Tile the frontmost window (left, right, top, etc.)
-  lattices distribute         Smart-grid all visible windows (daemon required)
+  lattices tile family [app] [region]  Smart-grid the frontmost app family, or a named app
+  lattices distribute [app] [region]   Smart-grid visible windows or just one app (daemon required)
   lattices layer [name|index]  List layers or switch by name/index (daemon required)
   lattices layer create <name> [wid:N ...] [--json '<specs>']  Create a session layer
   lattices layer snap [name]   Snapshot visible windows into a session layer
@@ -1931,6 +1932,69 @@ const tilePresets: Record<string, (s: ScreenBounds) => number[]> = {
   "center-third": (s) => [s.x + Math.round(s.w * 0.333), s.y, s.x + Math.round(s.w * 0.667), s.y + s.h],
   "right-third":  (s) => [s.x + Math.round(s.w * 0.667), s.y, s.x + s.w, s.y + s.h],
 };
+
+type SpaceOptimizeScope = "visible" | "active-app" | "app";
+
+interface SpaceOptimizeRequest {
+  scope: SpaceOptimizeScope;
+  app?: string;
+  region?: string;
+}
+
+function isPlacementToken(value?: string): boolean {
+  if (!value) return false;
+  const normalized = value.toLowerCase();
+  return normalized in tilePresets || /^grid:\d+x\d+:\d+,\d+$/i.test(normalized);
+}
+
+function parseSpaceOptimizeArgs(rawArgs: string[], defaultScope: SpaceOptimizeScope): SpaceOptimizeRequest {
+  const parts = rawArgs.filter(Boolean);
+  if (!parts.length) return { scope: defaultScope };
+
+  const last = parts[parts.length - 1];
+  const region = isPlacementToken(last) ? last : undefined;
+  const appParts = region ? parts.slice(0, -1) : parts;
+  const app = appParts.length ? appParts.join(" ") : undefined;
+
+  if (app) return { scope: "app", app, region };
+  return { scope: defaultScope, region };
+}
+
+function formatOptimizeTarget(request: SpaceOptimizeRequest): string {
+  if (request.app) return `"${request.app}"`;
+  return request.scope === "active-app" ? "the frontmost app" : "all visible windows";
+}
+
+async function optimizeWindowsCommand(
+  request: SpaceOptimizeRequest,
+  successVerb: string
+): Promise<void> {
+  try {
+    const { daemonCall } = await getDaemonClient();
+    const params: Record<string, unknown> = {
+      scope: request.scope,
+      strategy: "balanced",
+    };
+    if (request.app) params.app = request.app;
+    if (request.region) params.region = request.region;
+
+    const result = await daemonCall("space.optimize", params) as any;
+    const count = result?.windowCount ?? 0;
+    const target = formatOptimizeTarget(request);
+    const regionSuffix = request.region ? ` in the ${request.region} region` : "";
+
+    if (count === 0) {
+      console.log(`No eligible windows found for ${target}${regionSuffix}.`);
+      return;
+    }
+
+    console.log(
+      `${successVerb} ${count} window${count === 1 ? "" : "s"} for ${target}${regionSuffix}.`
+    );
+  } catch {
+    console.log("Daemon not running. Start with: lattices app");
+  }
+}
 
 function tileWindow(position: string): void {
   const preset = tilePresets[position];
@@ -2129,14 +2193,27 @@ switch (command) {
     }
     break;
   case "distribute":
-    await distributeCommand();
+    await distributeCommand(args.slice(1));
     break;
   case "tile":
   case "t":
-    if (args[1]) {
+    if (args[1] === "family" || args[1] === "app") {
+      await tileFamilyCommand(args.slice(2));
+    } else if (args[1] === "all") {
+      await distributeCommand(args.slice(2));
+    } else if (args[1]) {
       tileWindow(args[1]);
     } else {
-      console.log("Usage: lattices tile <position>\n");
+      console.log("Usage:");
+      console.log("  lattices tile <position>");
+      console.log("  lattices tile family [app-name] [region]");
+      console.log("  lattices tile all [app-name] [region]\n");
+      console.log("Examples:");
+      console.log("  lattices tile left");
+      console.log("  lattices tile family");
+      console.log("  lattices tile family right");
+      console.log("  lattices tile family iTerm2");
+      console.log("  lattices tile all Google Chrome left\n");
       console.log("Positions: left, right, top, bottom, top-left, top-right,");
       console.log("           bottom-left, bottom-right, maximize, center,");
       console.log("           left-third, center-third, right-third");

--- a/docs/config.md
+++ b/docs/config.md
@@ -131,6 +131,8 @@ Run `lattices init` in your project directory to generate a starter
 | `lattices sync`              | Reconcile session to match declared config        |
 | `lattices restart [pane]`    | Restart a pane's process (by name or index)       |
 | `lattices tile <position>`   | Tile the frontmost window to a screen position    |
+| `lattices tile family [app] [region]` | Smart-grid the frontmost app family, or a named app |
+| `lattices distribute [app] [region]` | Smart-grid visible windows or just one app      |
 | `lattices group [id]`        | List tab groups or launch/attach a group          |
 | `lattices groups`            | List all tab groups with status                   |
 | `lattices tab <group> [tab]` | Switch tab within a group (by label or index)     |
@@ -249,3 +251,24 @@ Aliases: `left-half`/`left`, `right-half`/`right`, `top-half`/`top`,
 
 Tiling respects the menu bar and dock. It uses the visible desktop
 area, not the full screen.
+
+### Smart app tiling
+
+Use `lattices tile family` when you want lattices to arrange a whole
+window family instead of just moving the frontmost window.
+
+Examples:
+
+```bash
+lattices tile family
+lattices tile family right
+lattices tile family iTerm2
+lattices tile family "Google Chrome" left
+```
+
+- With no app name, `family` means the **frontmost app**. If iTerm is
+  frontmost, lattices grids your visible iTerm windows.
+- If you pass a region (`left`, `right`, `top`, `bottom`, etc.), the
+  smart grid is constrained to that part of the screen.
+- `lattices distribute` uses the same smart grid engine, but defaults to
+  **all visible windows** instead of the current app family.

--- a/docs/tiling-reference.md
+++ b/docs/tiling-reference.md
@@ -196,6 +196,11 @@ These are composed from multiple `tile_window` actions:
 | Eight-up (4×2) | All eight `*-*-fourth` positions |
 | Distribute | Single `distribute` intent (auto-grid) |
 
+CLI shortcuts compile into the same distributor:
+
+- `lattices tile family` → smart-grid the frontmost app's visible windows
+- `lattices distribute iTerm2 right` → smart-grid visible iTerm windows inside the right half
+
 ## HandsOff Smart Distribution
 
 When the LLM sends multiple `tile_window` actions targeting the **same position**, `HandsOffSession.distributeTileActions()` subdivides:


### PR DESCRIPTION
## Summary
- add configurable mouse gesture rules and an event viewer in the menu bar companion
- keep the default middle-click drag behavior for Space switching and Screen Map overview
- add smart tiling CLI entry points for app-family tiling and visible-window distribution
- preserve modifier flags when replaying plain middle-clicks and tighten the settings copy around device selectors

## Verification
- `swift build -c release` in `app/`
- `swift test` in `app/`
- `npm run typecheck`
