### PR TITLE
Release 0.4.7 with mouse shortcut and companion bridge updates

### DIFF
--- a/app/Info.plist
+++ b/app/Info.plist
@@ -15,9 +15,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleVersion</key>
-    <string>0.4.6</string>
+    <string>0.4.7</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.4.6</string>
+    <string>0.4.7</string>
     <key>LSMinimumSystemVersion</key>
     <string>13.0</string>
     <key>LSUIElement</key>

--- a/app/Lattices.app/Contents/Info.plist
+++ b/app/Lattices.app/Contents/Info.plist
@@ -15,9 +15,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleVersion</key>
-    <string>0.4.6</string>
+    <string>0.4.7</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.4.6</string>
+    <string>0.4.7</string>
     <key>LSMinimumSystemVersion</key>
     <string>13.0</string>
     <key>LSUIElement</key>

--- a/app/Package.swift
+++ b/app/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
         ),
         .testTarget(
             name: "LatticesTests",
+            dependencies: ["Lattices"],
             path: "Tests"
         )
     ]

--- a/app/Sources/AppShell/AppDelegate.swift
+++ b/app/Sources/AppShell/AppDelegate.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import SwiftUI
 
 extension Notification.Name {
@@ -13,6 +14,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var statusItem: NSStatusItem!
     private var popover: NSPopover?
     private var contextMenu: NSMenu!
+    private var companionBridgePreferenceCancellable: AnyCancellable?
 
     /// 3×3 grid icon for the menu bar — L-shape bright, rest dim (template for auto light/dark)
     private static let menuBarIcon: NSImage = {
@@ -183,7 +185,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         ProcessModel.shared.start()
         LatticesApi.setup()
         DaemonServer.shared.start()
-        LatticesCompanionBridgeServer.shared.start()
+        companionBridgePreferenceCancellable = Preferences.shared.$companionBridgeEnabled
+            .removeDuplicates()
+            .sink { enabled in
+                if enabled {
+                    LatticesCompanionBridgeServer.shared.start()
+                } else {
+                    LatticesCompanionBridgeServer.shared.stop()
+                }
+            }
         AgentPool.shared.start()
         diag.finish(tBoot)
 

--- a/app/Sources/AppShell/Preferences.swift
+++ b/app/Sources/AppShell/Preferences.swift
@@ -10,6 +10,7 @@ class Preferences: ObservableObject {
     static let shared = Preferences()
 
     private enum CompanionDefaultsKey {
+        static let bridgeEnabled = "companion.bridge.enabled"
         static let trackpadEnabled = "companion.trackpad.enabled"
         static let cockpitLayout = "companion.cockpit.layout"
     }
@@ -28,6 +29,10 @@ class Preferences: ObservableObject {
 
     @Published var dragSnapEnabled: Bool {
         didSet { UserDefaults.standard.set(dragSnapEnabled, forKey: "windowSnap.enabled") }
+    }
+
+    @Published var companionBridgeEnabled: Bool {
+        didSet { UserDefaults.standard.set(companionBridgeEnabled, forKey: CompanionDefaultsKey.bridgeEnabled) }
     }
 
     @Published var companionTrackpadEnabled: Bool {
@@ -153,6 +158,14 @@ class Preferences: ObservableObject {
             self.dragSnapEnabled = UserDefaults.standard.bool(forKey: "windowSnap.enabled")
         } else {
             self.dragSnapEnabled = true
+        }
+
+        if UserDefaults.standard.object(forKey: CompanionDefaultsKey.bridgeEnabled) != nil {
+            self.companionBridgeEnabled = UserDefaults.standard.bool(forKey: CompanionDefaultsKey.bridgeEnabled)
+        } else {
+            let hadLegacyTrackpadPreference = UserDefaults.standard.object(forKey: CompanionDefaultsKey.trackpadEnabled) != nil
+            let hasTrustedCompanionDevices = !LatticesCompanionSecurityCoordinator.shared.trustedDeviceSummaries().isEmpty
+            self.companionBridgeEnabled = hadLegacyTrackpadPreference || hasTrustedCompanionDevices
         }
 
         if UserDefaults.standard.object(forKey: CompanionDefaultsKey.trackpadEnabled) != nil {

--- a/app/Sources/AppShell/SettingsView.swift
+++ b/app/Sources/AppShell/SettingsView.swift
@@ -501,7 +501,7 @@ struct SettingsContentView: View {
                             .foregroundColor(Palette.text)
 
                         HStack {
-                            Text("Middle-click gestures")
+                            Text("Middle-click shortcuts")
                                 .font(Typo.mono(10))
                                 .foregroundColor(Palette.textDim)
                             Spacer()
@@ -511,18 +511,18 @@ struct SettingsContentView: View {
                                 .labelsHidden()
                         }
 
-                        Text("Rules live in ~/.lattices/mouse-shortcuts.json. The current defaults preserve the working setup: middle-click drag left/right switches Spaces and drag down opens the Screen Map overview.")
+                        Text("Rules live in ~/.lattices/mouse-shortcuts.json. The defaults now give middle-click a real paste on click, while drag left/right switches Spaces, drag down opens Screen Map overview, and drag up starts Dictation.")
                             .font(Typo.caption(9))
                             .foregroundColor(Palette.textMuted.opacity(0.7))
 
                         cardDivider
 
                         VStack(alignment: .leading, spacing: 6) {
-                            Text("Active drag mappings")
+                            Text("Active mappings")
                                 .font(Typo.mono(10))
                                 .foregroundColor(Palette.textDim)
 
-                            ForEach(mouseShortcutStore.summaryLines.prefix(4), id: \.self) { line in
+                            ForEach(mouseShortcutStore.summaryLines.prefix(5), id: \.self) { line in
                                 Text(line)
                                     .font(Typo.caption(9))
                                     .foregroundColor(Palette.textMuted.opacity(0.78))
@@ -1254,9 +1254,37 @@ struct SettingsContentView: View {
         return shortcutSectionCard(
             title: "Companion Cockpit",
             eyebrow: "iPad & iPhone",
-            summary: "Define the Mac-authored command deck here, then let the companion app render it. Trackpad proxy runs through the same bridge."
+            summary: "Define the Mac-authored command deck here, then let the companion app render it. Local network access stays off until you explicitly enable the bridge."
         ) {
             VStack(alignment: .leading, spacing: 14) {
+                HStack(alignment: .top, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 5) {
+                        Text("Companion Access")
+                            .font(Typo.monoBold(11))
+                            .foregroundColor(Palette.text)
+                        Text("Advertise a secure local-network bridge for paired iPad and iPhone devices. Leave this off to avoid the macOS local network permission prompt until you actually want companion features.")
+                            .font(Typo.caption(10.5))
+                            .foregroundColor(Palette.textMuted)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    Spacer()
+
+                    Toggle("", isOn: $prefs.companionBridgeEnabled)
+                        .toggleStyle(.switch)
+                        .labelsHidden()
+                }
+
+                if !prefs.companionBridgeEnabled {
+                    Text("The companion bridge is currently off. Turn it on when you're ready to pair an iPad or iPhone.")
+                        .font(Typo.caption(10.5))
+                        .foregroundColor(Palette.textMuted)
+                        .padding(12)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(shortcutsInsetPanel)
+                }
+
+                VStack(alignment: .leading, spacing: 14) {
                 HStack(alignment: .top, spacing: 12) {
                     VStack(alignment: .leading, spacing: 5) {
                         Text("Trackpad Proxy")
@@ -1382,6 +1410,9 @@ struct SettingsContentView: View {
                     .font(Typo.caption(10.5))
                     .foregroundColor(Palette.textDim)
                 }
+                }
+                .disabled(!prefs.companionBridgeEnabled)
+                .opacity(prefs.companionBridgeEnabled ? 1 : 0.55)
             }
         }
     }

--- a/app/Sources/Core/Input/MouseGestureConfig.swift
+++ b/app/Sources/Core/Input/MouseGestureConfig.swift
@@ -9,6 +9,7 @@ enum MouseGestureDirection: String, CaseIterable, Codable, Equatable {
 }
 
 enum MouseShortcutTriggerKind: String, Codable, Equatable {
+    case click
     case drag
 }
 
@@ -226,10 +227,25 @@ struct MouseShortcutDeviceSelector: Codable, Equatable {
 struct MouseShortcutTrigger: Codable, Equatable {
     var button: MouseShortcutButton
     var kind: MouseShortcutTriggerKind
-    var direction: MouseGestureDirection
+    var direction: MouseGestureDirection?
 
     var triggerName: String {
-        "\(button.triggerToken).\(kind.rawValue).\(direction.rawValue)"
+        if let direction {
+            return "\(button.triggerToken).\(kind.rawValue).\(direction.rawValue)"
+        }
+        return "\(button.triggerToken).\(kind.rawValue)"
+    }
+
+    var displayLabel: String {
+        switch kind {
+        case .click:
+            return button.displayLabel
+        case .drag:
+            if let direction {
+                return "\(button.displayLabel) drag \(direction.rawValue)"
+            }
+            return "\(button.displayLabel) drag"
+        }
     }
 }
 
@@ -273,7 +289,7 @@ struct MouseShortcutRule: Codable, Equatable, Identifiable {
     var action: MouseShortcutActionDefinition
 
     var summary: String {
-        "\(trigger.triggerName) -> \(action.type.rawValue)"
+        "\(trigger.displayLabel) -> \(action.label)"
     }
 }
 
@@ -294,10 +310,26 @@ struct MouseShortcutConfig: Codable, Equatable {
     var tuning: MouseShortcutTuning
     var rules: [MouseShortcutRule]
 
+    static let currentVersion = 2
+
     static let defaults = MouseShortcutConfig(
-        version: 1,
+        version: currentVersion,
         tuning: .defaults,
         rules: [
+            MouseShortcutRule(
+                id: "paste",
+                enabled: true,
+                device: .any,
+                trigger: MouseShortcutTrigger(button: .middle, kind: .click, direction: nil),
+                action: MouseShortcutActionDefinition(
+                    type: .shortcutSend,
+                    shortcut: MouseShortcutKeyStroke(
+                        key: "v",
+                        keyCode: nil,
+                        modifiers: [.command]
+                    )
+                )
+            ),
             MouseShortcutRule(
                 id: "space-previous",
                 enabled: true,
@@ -328,6 +360,20 @@ struct MouseShortcutConfig: Codable, Equatable {
             ),
         ]
     )
+
+    func normalizedForCurrentVersion() -> MouseShortcutConfig {
+        guard version < Self.currentVersion else { return self }
+
+        var normalized = self
+        normalized.version = Self.currentVersion
+
+        let existingRuleIDs = Set(normalized.rules.map(\.id))
+        for rule in Self.defaults.rules where !existingRuleIDs.contains(rule.id) {
+            normalized.rules.append(rule)
+        }
+
+        return normalized
+    }
 }
 
 struct MouseShortcutMatchResult {
@@ -339,7 +385,7 @@ struct MouseShortcutMatchResult {
 struct MouseShortcutTriggerEvent {
     let button: MouseShortcutButton
     let kind: MouseShortcutTriggerKind
-    let direction: MouseGestureDirection
+    let direction: MouseGestureDirection?
     let device: MouseInputDeviceInfo?
 
     var triggerName: String {

--- a/app/Sources/Core/Input/MouseGestureController.swift
+++ b/app/Sources/Core/Input/MouseGestureController.swift
@@ -377,6 +377,38 @@ final class MouseGestureController {
         self.session = nil
 
         guard let direction else {
+            let clickDistance = max(abs(delta.x), abs(delta.y))
+            let clickTriggerEvent = MouseShortcutTriggerEvent(
+                button: button,
+                kind: .click,
+                direction: nil,
+                device: nil
+            )
+            let clickMatch = clickDistance <= tuning.holdTolerance
+                ? MouseShortcutStore.shared.match(for: clickTriggerEvent)
+                : nil
+
+            if let clickMatch {
+                DispatchQueue.main.async { [weak self] in
+                    session.overlay.dismiss(immediately: true)
+                    guard let self else { return }
+                    let outcome = self.performAction(match: clickMatch, startPoint: session.startPoint)
+                    DiagnosticLog.shared.info("MouseGesture: \(outcome.label) -> \(outcome.success ? "ok" : "blocked")")
+                    self.recordObservedEvent(
+                        phase: "up",
+                        button: button,
+                        location: event.location,
+                        delta: delta,
+                        modifiers: event.flags,
+                        candidate: clickTriggerEvent.triggerName,
+                        match: clickMatch,
+                        note: outcome.success ? "click fired" : "click blocked",
+                        appInfo: appInfo
+                    )
+                }
+                return nil
+            }
+
             DiagnosticLog.shared.info("MouseGesture: released without a gesture at \(format(event.location))")
             recordObservedEvent(
                 phase: "up",
@@ -384,9 +416,9 @@ final class MouseGestureController {
                 location: event.location,
                 delta: delta,
                 modifiers: event.flags,
-                candidate: nil,
-                match: nil,
-                note: "replay click",
+                candidate: clickDistance <= tuning.holdTolerance ? clickTriggerEvent.triggerName : nil,
+                match: clickMatch,
+                note: clickDistance <= tuning.holdTolerance ? "replay click" : "movement below drag threshold",
                 appInfo: appInfo
             )
             DispatchQueue.main.async { [weak self] in

--- a/app/Sources/Core/Input/MouseInputEventViewer.swift
+++ b/app/Sources/Core/Input/MouseInputEventViewer.swift
@@ -152,7 +152,7 @@ private struct MouseInputEventViewerView: View {
                 Text("Mouse Shortcut Event Viewer")
                     .font(.system(size: 14, weight: .semibold, design: .monospaced))
                     .foregroundColor(.white.opacity(0.95))
-                Text("Watching extra mouse buttons and drag candidates for configurable shortcuts.")
+                Text("Watching extra mouse buttons plus click and drag candidates for configurable shortcuts.")
                     .font(.system(size: 11))
                     .foregroundColor(.white.opacity(0.6))
             }

--- a/app/Sources/Core/Input/MouseShortcutStore.swift
+++ b/app/Sources/Core/Input/MouseShortcutStore.swift
@@ -33,7 +33,7 @@ final class MouseShortcutStore: ObservableObject {
     }
 
     var summaryLines: [String] {
-        enabledRules.map { "\($0.trigger.triggerName) -> \($0.action.type.rawValue)" }
+        enabledRules.map(\.summary)
     }
 
     func ensureConfigFile() {
@@ -48,8 +48,14 @@ final class MouseShortcutStore: ObservableObject {
         }
 
         do {
-            config = try JSONDecoder().decode(MouseShortcutConfig.self, from: data)
-            lastLoadedModifiedDate = modifiedDate()
+            let decoded = try JSONDecoder().decode(MouseShortcutConfig.self, from: data)
+            let normalized = decoded.normalizedForCurrentVersion()
+            config = normalized
+            if normalized != decoded {
+                write(config: normalized)
+            } else {
+                lastLoadedModifiedDate = modifiedDate()
+            }
         } catch {
             DiagnosticLog.shared.error("MouseShortcutStore: failed to decode mouse-shortcuts.json - \(error.localizedDescription)")
             config = .defaults

--- a/app/Tests/MouseShortcutConfigTests.swift
+++ b/app/Tests/MouseShortcutConfigTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import Lattices
+
+final class MouseShortcutConfigTests: XCTestCase {
+    func testDefaultsIncludeMiddleClickPaste() throws {
+        let pasteRule = try XCTUnwrap(MouseShortcutConfig.defaults.rules.first(where: { $0.id == "paste" }))
+
+        XCTAssertEqual(MouseShortcutConfig.defaults.version, MouseShortcutConfig.currentVersion)
+        XCTAssertTrue(pasteRule.enabled)
+        XCTAssertEqual(pasteRule.trigger.button, .middle)
+        XCTAssertEqual(pasteRule.trigger.kind, .click)
+        XCTAssertNil(pasteRule.trigger.direction)
+        XCTAssertEqual(pasteRule.action.type, .shortcutSend)
+        XCTAssertEqual(pasteRule.action.shortcut?.key, "v")
+        XCTAssertEqual(pasteRule.action.shortcut?.modifiers, [.command])
+    }
+
+    func testLegacyConfigMigrationAppendsPasteRule() {
+        let legacy = MouseShortcutConfig(
+            version: 1,
+            tuning: .defaults,
+            rules: [
+                MouseShortcutRule(
+                    id: "space-next",
+                    enabled: true,
+                    device: .any,
+                    trigger: MouseShortcutTrigger(button: .middle, kind: .drag, direction: .right),
+                    action: MouseShortcutActionDefinition(type: .spaceNext, shortcut: nil)
+                ),
+                MouseShortcutRule(
+                    id: "custom",
+                    enabled: true,
+                    device: .any,
+                    trigger: MouseShortcutTrigger(button: .button4, kind: .drag, direction: .left),
+                    action: MouseShortcutActionDefinition(type: .spacePrevious, shortcut: nil)
+                ),
+            ]
+        )
+
+        let migrated = legacy.normalizedForCurrentVersion()
+
+        XCTAssertEqual(migrated.version, MouseShortcutConfig.currentVersion)
+        XCTAssertEqual(migrated.rules.prefix(2).map { $0.id }, ["space-next", "custom"])
+        XCTAssertTrue(migrated.rules.contains(where: { $0.id == "paste" }))
+        XCTAssertEqual(migrated.rules.filter { $0.id == "space-next" }.count, 1)
+        XCTAssertEqual(migrated.rules.filter { $0.id == "custom" }.count, 1)
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lattices/cli",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Agentic window manager for macOS — programmable workspace, smart layouts, managed tmux sessions, and a 35+-method agent API",
   "bin": {
     "lattices": "./bin/lattices.ts",


### PR DESCRIPTION
## Summary
- bump package/app metadata to 0.4.7
- add middle-click paste shortcut support with config migration
- add companion bridge access toggle so local-network advertising stays off until enabled
- add tests for mouse shortcut defaults and migration

## Tests
- env CLANG_MODULE_CACHE_PATH=/tmp/lattices-clang-cache SWIFTPM_TESTS_MODULECACHE=/tmp/lattices-swiftpm-cache swift test