### PR TITLE
Add Caps Lock Hyper remapping

### DIFF
--- a/app/Sources/AppShell/AppDelegate.swift
+++ b/app/Sources/AppShell/AppDelegate.swift
@@ -124,6 +124,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         store.register(action: .omniSearch) { OmniSearchWindow.shared.toggle() }
         WindowDragSnapController.shared.start()
         MouseGestureController.shared.start()
+        KeyboardRemapController.shared.start()
 
         // Session layer cycling
         store.register(action: .layerNext) { SessionLayerStore.shared.cycleNext() }
@@ -203,6 +204,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        KeyboardRemapController.shared.stop()
         LatticesCompanionBridgeServer.shared.stop()
         DaemonServer.shared.stop()
     }

--- a/app/Sources/AppShell/Preferences.swift
+++ b/app/Sources/AppShell/Preferences.swift
@@ -41,6 +41,10 @@ class Preferences: ObservableObject {
         didSet { UserDefaults.standard.set(mouseGesturesEnabled, forKey: "mouseGestures.enabled") }
     }
 
+    @Published var keyboardRemapsEnabled: Bool {
+        didSet { UserDefaults.standard.set(keyboardRemapsEnabled, forKey: "keyboardRemaps.enabled") }
+    }
+
     // MARK: - AI / Claude
 
     @Published var claudePath: String {
@@ -166,6 +170,12 @@ class Preferences: ObservableObject {
             self.mouseGesturesEnabled = UserDefaults.standard.bool(forKey: "mouseGestures.enabled")
         } else {
             self.mouseGesturesEnabled = false
+        }
+
+        if UserDefaults.standard.object(forKey: "keyboardRemaps.enabled") != nil {
+            self.keyboardRemapsEnabled = UserDefaults.standard.bool(forKey: "keyboardRemaps.enabled")
+        } else {
+            self.keyboardRemapsEnabled = true
         }
         // AI / Claude
         self.claudePath = UserDefaults.standard.string(forKey: "claude.path") ?? ""

--- a/app/Sources/AppShell/SettingsView.swift
+++ b/app/Sources/AppShell/SettingsView.swift
@@ -60,6 +60,7 @@ struct SettingsContentView: View {
     @ObservedObject var workspaceManager: WorkspaceManager = .shared
     @ObservedObject var appUpdater: AppUpdater = .shared
     @ObservedObject var mouseShortcutStore: MouseShortcutStore = .shared
+    @ObservedObject var keyboardRemapStore: KeyboardRemapStore = .shared
     var onBack: (() -> Void)? = nil
 
     @State private var selectedTab: SettingsSection = .general
@@ -588,6 +589,83 @@ struct SettingsContentView: View {
                         Text("Use Event Viewer to discover what your mouse emits on this machine. The config schema already accepts device selectors, but live gesture matching currently falls back to global rules when macOS doesn't expose the source device.")
                             .font(Typo.caption(9))
                             .foregroundColor(Palette.textMuted.opacity(0.7))
+                    }
+                }
+
+                settingsCard {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("Keyboard remaps")
+                            .font(Typo.mono(11))
+                            .foregroundColor(Palette.text)
+
+                        HStack {
+                            Text("Caps Lock as Hyper")
+                                .font(Typo.mono(10))
+                                .foregroundColor(Palette.textDim)
+                            Spacer()
+                            Toggle("", isOn: $prefs.keyboardRemapsEnabled)
+                                .toggleStyle(.switch)
+                                .controlSize(.small)
+                                .labelsHidden()
+                        }
+
+                        Text("Rules live in ~/.lattices/keyboard-remaps.json. The default maps hold Caps Lock to Hyper and tap Caps Lock to Escape, so the existing Hyper shortcuts work on the laptop keyboard.")
+                            .font(Typo.caption(9))
+                            .foregroundColor(Palette.textMuted.opacity(0.7))
+
+                        cardDivider
+
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Active remaps")
+                                .font(Typo.mono(10))
+                                .foregroundColor(Palette.textDim)
+
+                            ForEach(keyboardRemapStore.summaryLines.prefix(4), id: \.self) { line in
+                                Text(line)
+                                    .font(Typo.caption(9))
+                                    .foregroundColor(Palette.textMuted.opacity(0.78))
+                            }
+
+                            if keyboardRemapStore.summaryLines.isEmpty {
+                                Text("No active remaps")
+                                    .font(Typo.caption(9))
+                                    .foregroundColor(Palette.textMuted.opacity(0.6))
+                            }
+                        }
+
+                        HStack(spacing: 8) {
+                            Button {
+                                keyboardRemapStore.openConfiguration()
+                            } label: {
+                                Text("Configure...")
+                                    .font(Typo.monoBold(10))
+                                    .foregroundColor(Palette.text)
+                                    .padding(.horizontal, 12)
+                                    .padding(.vertical, 4)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 4)
+                                            .fill(Palette.surfaceHov)
+                                            .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.borderLit, lineWidth: 0.5))
+                                    )
+                            }
+                            .buttonStyle(.plain)
+
+                            Button {
+                                keyboardRemapStore.restoreDefaults()
+                            } label: {
+                                Text("Restore Defaults")
+                                    .font(Typo.monoBold(10))
+                                    .foregroundColor(Palette.text)
+                                    .padding(.horizontal, 12)
+                                    .padding(.vertical, 4)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 4)
+                                            .fill(Palette.surfaceHov)
+                                            .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.borderLit, lineWidth: 0.5))
+                                    )
+                            }
+                            .buttonStyle(.plain)
+                        }
                     }
                 }
             }

--- a/app/Sources/Core/Input/KeyboardRemapConfig.swift
+++ b/app/Sources/Core/Input/KeyboardRemapConfig.swift
@@ -1,0 +1,69 @@
+import CoreGraphics
+import Foundation
+
+enum KeyboardRemapKey: String, Codable, Equatable {
+    case capsLock = "caps_lock"
+
+    var keyCode: Int64 {
+        switch self {
+        case .capsLock: return 57
+        }
+    }
+
+    var displayLabel: String {
+        switch self {
+        case .capsLock: return "Caps Lock"
+        }
+    }
+}
+
+enum KeyboardRemapAction: String, Codable, Equatable {
+    case escape
+    case hyper
+
+    var displayLabel: String {
+        switch self {
+        case .escape: return "Escape"
+        case .hyper: return "Hyper"
+        }
+    }
+}
+
+struct KeyboardRemapRule: Codable, Equatable, Identifiable {
+    var id: String
+    var enabled: Bool
+    var from: KeyboardRemapKey
+    var toIfHeld: KeyboardRemapAction
+    var toIfAlone: KeyboardRemapAction?
+
+    var summaryLine: String {
+        let held = "hold \(from.displayLabel) -> \(toIfHeld.displayLabel)"
+        guard let alone = toIfAlone else { return held }
+        return "\(held), tap -> \(alone.displayLabel)"
+    }
+}
+
+struct KeyboardRemapConfig: Codable, Equatable {
+    var rules: [KeyboardRemapRule]
+
+    static let defaults = KeyboardRemapConfig(
+        rules: [
+            KeyboardRemapRule(
+                id: "caps_lock_hyper_escape",
+                enabled: true,
+                from: .capsLock,
+                toIfHeld: .hyper,
+                toIfAlone: .escape
+            )
+        ]
+    )
+}
+
+extension CGEventFlags {
+    static let latticesHyper: CGEventFlags = [
+        .maskCommand,
+        .maskControl,
+        .maskAlternate,
+        .maskShift,
+    ]
+}

--- a/app/Sources/Core/Input/KeyboardRemapController.swift
+++ b/app/Sources/Core/Input/KeyboardRemapController.swift
@@ -1,0 +1,184 @@
+import AppKit
+import Combine
+import CoreGraphics
+
+final class KeyboardRemapController {
+    static let shared = KeyboardRemapController()
+
+    private static let syntheticMarker: Int64 = 0x4C4B524D
+
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+    private var subscriptions: Set<AnyCancellable> = []
+    private var installedObservers = false
+    private var capsLayerActive = false
+    private var capsUsedAsModifier = false
+
+    private init() {}
+
+    func start() {
+        installObserversIfNeeded()
+        refresh()
+    }
+
+    func stop() {
+        removeEventTap()
+        capsLayerActive = false
+        capsUsedAsModifier = false
+    }
+
+    private func installObserversIfNeeded() {
+        guard !installedObservers else { return }
+        installedObservers = true
+
+        Preferences.shared.$keyboardRemapsEnabled
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.refresh() }
+            .store(in: &subscriptions)
+
+        PermissionChecker.shared.$accessibility
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.refresh() }
+            .store(in: &subscriptions)
+    }
+
+    private func refresh() {
+        guard Preferences.shared.keyboardRemapsEnabled,
+              PermissionChecker.shared.accessibility else {
+            removeEventTap()
+            return
+        }
+
+        KeyboardRemapStore.shared.ensureConfigFile()
+        if eventTap == nil {
+            installEventTap()
+        } else if let eventTap {
+            CGEvent.tapEnable(tap: eventTap, enable: true)
+        }
+    }
+
+    private func installEventTap() {
+        var mask = CGEventMask(0)
+        mask |= CGEventMask(1) << CGEventType.keyDown.rawValue
+        mask |= CGEventMask(1) << CGEventType.keyUp.rawValue
+        mask |= CGEventMask(1) << CGEventType.flagsChanged.rawValue
+
+        let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: mask,
+            callback: Self.eventTapCallback,
+            userInfo: UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
+        )
+
+        guard let tap else {
+            DiagnosticLog.shared.warn("KeyboardRemap: failed to install keyboard event tap")
+            return
+        }
+
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        eventTap = tap
+        runLoopSource = source
+
+        if let source {
+            CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        }
+        CGEvent.tapEnable(tap: tap, enable: true)
+        DiagnosticLog.shared.info("KeyboardRemap: keyboard event tap installed")
+    }
+
+    private func removeEventTap() {
+        if let source = runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+        }
+        runLoopSource = nil
+        if let tap = eventTap {
+            CFMachPortInvalidate(tap)
+        }
+        eventTap = nil
+    }
+
+    private static let eventTapCallback: CGEventTapCallBack = { _, type, event, userInfo in
+        guard let userInfo else { return Unmanaged.passUnretained(event) }
+        let controller = Unmanaged<KeyboardRemapController>.fromOpaque(userInfo).takeUnretainedValue()
+        return controller.handleEvent(type: type, event: event)
+    }
+
+    private func handleEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            if let eventTap {
+                CGEvent.tapEnable(tap: eventTap, enable: true)
+            }
+            return Unmanaged.passUnretained(event)
+        }
+
+        if event.getIntegerValueField(.eventSourceUserData) == Self.syntheticMarker {
+            return Unmanaged.passUnretained(event)
+        }
+
+        KeyboardRemapStore.shared.reloadIfNeeded()
+        guard let rule = KeyboardRemapStore.shared.capsLockRule,
+              rule.toIfHeld == .hyper else {
+            return Unmanaged.passUnretained(event)
+        }
+
+        let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+        if type == .flagsChanged, keyCode == rule.from.keyCode {
+            return handleCapsLockFlagsChanged(event, rule: rule)
+        }
+
+        guard capsLayerActive else {
+            return Unmanaged.passUnretained(event)
+        }
+
+        switch type {
+        case .keyDown:
+            capsUsedAsModifier = true
+            event.flags = normalizedFlags(event.flags).union(.latticesHyper)
+            return Unmanaged.passUnretained(event)
+        case .keyUp:
+            event.flags = normalizedFlags(event.flags).union(.latticesHyper)
+            return Unmanaged.passUnretained(event)
+        default:
+            return Unmanaged.passUnretained(event)
+        }
+    }
+
+    private func handleCapsLockFlagsChanged(_ event: CGEvent, rule: KeyboardRemapRule) -> Unmanaged<CGEvent>? {
+        let isDown = event.flags.contains(.maskAlphaShift)
+        if isDown {
+            capsLayerActive = true
+            capsUsedAsModifier = false
+            DiagnosticLog.shared.info("KeyboardRemap: Caps Lock layer active")
+        } else {
+            let shouldTap = capsLayerActive && !capsUsedAsModifier && rule.toIfAlone == .escape
+            capsLayerActive = false
+            capsUsedAsModifier = false
+            if shouldTap {
+                postKeyTap(keyCode: 53)
+            }
+            DiagnosticLog.shared.info("KeyboardRemap: Caps Lock layer inactive")
+        }
+
+        return nil
+    }
+
+    private func normalizedFlags(_ flags: CGEventFlags) -> CGEventFlags {
+        var normalized = flags
+        normalized.remove(.maskAlphaShift)
+        return normalized
+    }
+
+    private func postKeyTap(keyCode: CGKeyCode) {
+        guard let source = CGEventSource(stateID: .combinedSessionState),
+              let down = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true),
+              let up = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false) else {
+            return
+        }
+        down.setIntegerValueField(.eventSourceUserData, value: Self.syntheticMarker)
+        up.setIntegerValueField(.eventSourceUserData, value: Self.syntheticMarker)
+        down.post(tap: .cghidEventTap)
+        up.post(tap: .cghidEventTap)
+    }
+}

--- a/app/Sources/Core/Input/KeyboardRemapStore.swift
+++ b/app/Sources/Core/Input/KeyboardRemapStore.swift
@@ -1,0 +1,84 @@
+import AppKit
+import Combine
+import Foundation
+
+final class KeyboardRemapStore: ObservableObject {
+    static let shared = KeyboardRemapStore()
+
+    @Published private(set) var config: KeyboardRemapConfig
+
+    let configURL: URL
+    private var lastLoadedModifiedDate: Date?
+
+    private init() {
+        let dir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".lattices")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        self.configURL = dir.appendingPathComponent("keyboard-remaps.json")
+        self.config = .defaults
+        ensureConfigFile()
+        reload()
+    }
+
+    var enabledRules: [KeyboardRemapRule] {
+        config.rules.filter(\.enabled)
+    }
+
+    var summaryLines: [String] {
+        enabledRules.map(\.summaryLine)
+    }
+
+    var capsLockRule: KeyboardRemapRule? {
+        enabledRules.first { $0.from == .capsLock }
+    }
+
+    func ensureConfigFile() {
+        guard !FileManager.default.fileExists(atPath: configURL.path) else { return }
+        write(config: .defaults)
+    }
+
+    func reload() {
+        guard let data = FileManager.default.contents(atPath: configURL.path) else {
+            config = .defaults
+            return
+        }
+
+        do {
+            config = try JSONDecoder().decode(KeyboardRemapConfig.self, from: data)
+            lastLoadedModifiedDate = modifiedDate()
+        } catch {
+            DiagnosticLog.shared.error("KeyboardRemapStore: failed to decode keyboard-remaps.json - \(error.localizedDescription)")
+            config = .defaults
+        }
+    }
+
+    func reloadIfNeeded() {
+        let currentModifiedDate = modifiedDate()
+        guard currentModifiedDate != lastLoadedModifiedDate else { return }
+        reload()
+    }
+
+    func restoreDefaults() {
+        write(config: .defaults)
+        reload()
+        DiagnosticLog.shared.info("Keyboard remaps restored to defaults")
+    }
+
+    func openConfiguration() {
+        ensureConfigFile()
+        NSWorkspace.shared.open(configURL)
+    }
+
+    private func write(config: KeyboardRemapConfig) {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        guard let data = try? encoder.encode(config) else { return }
+        try? data.write(to: configURL, options: .atomic)
+        lastLoadedModifiedDate = modifiedDate()
+    }
+
+    private func modifiedDate() -> Date? {
+        let attrs = try? FileManager.default.attributesOfItem(atPath: configURL.path)
+        return attrs?[.modificationDate] as? Date
+    }
+}

--- a/docs/app.md
+++ b/docs/app.md
@@ -169,12 +169,24 @@ The settings window has four tabs:
 | Mode       | `learning` or `auto` (see below)                     |
 | Scan Root  | Directory to scan for .lattices.json configs (type a path or click Browse) |
 | Updates    | Download the latest release and relaunch the app     |
+| Keyboard Remaps | Optional Caps Lock layer that maps hold to Hyper and tap to Escape |
 
 **Mode** controls how the app handles session interaction:
 
 - **Learning** — shows tmux keybinding hints when you detach
   (helpful while getting used to tmux)
 - **Auto** — detaches sessions automatically (fewer prompts)
+
+### Keyboard Remaps
+
+**Keyboard remaps** are enabled by default for the laptop-friendly rule:
+
+- hold Caps Lock -> Hyper (`Control` + `Option` + `Shift` + `Command`)
+- tap Caps Lock -> Escape
+
+Rules live in `~/.lattices/keyboard-remaps.json`, and the Settings toggle
+can turn the layer off. Keyboard remaps require Accessibility permission
+because they use a local event tap.
 
 ### AI
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -161,6 +161,29 @@ Run `lattices init` in your project directory to generate a starter
 Aliases: `ls`/`list`, `kill`/`rm`, `sync`/`reconcile`,
 `restart`/`respawn`, `tile`/`t`.
 
+## Keyboard remaps
+
+The menu bar app can create a lightweight keyboard layer from
+`~/.lattices/keyboard-remaps.json`. The default config is:
+
+```json
+{
+  "rules": [
+    {
+      "enabled": true,
+      "from": "caps_lock",
+      "id": "caps_lock_hyper_escape",
+      "toIfAlone": "escape",
+      "toIfHeld": "hyper"
+    }
+  ]
+}
+```
+
+It is enabled by default and can be turned off from Settings -> General ->
+Keyboard remaps. Hold Caps Lock to send Hyper (`Control` + `Option` +
+`Shift` + `Command`), or tap Caps Lock alone to send Escape.
+
 ## Machine-readable output
 
 ### `--json` flag


### PR DESCRIPTION
## Summary
- add a keyboard remap event-tap controller for Caps Lock
- default Caps Lock hold to Hyper and tap to Escape
- add Settings controls plus docs for ~/.lattices/keyboard-remaps.json

## Verification
- swift build
- bun bin/lattices.ts app restart
- swift build in clean PR worktree