### PR TITLE
✨ Restore assistant unification and add gesture visuals

### DIFF
--- a/app/Lattices.app/Contents/Info.plist
+++ b/app/Lattices.app/Contents/Info.plist
@@ -26,9 +26,9 @@
         </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>0.4.8</string>
+    <string>0.4.10</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.4.8</string>
+    <string>0.4.10</string>
     <key>LSMinimumSystemVersion</key>
     <string>13.0</string>
     <key>LSUIElement</key>

--- a/app/Sources/AppShell/AppDelegate.swift
+++ b/app/Sources/AppShell/AppDelegate.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 extension Notification.Name {
     static let latticesPopoverWillShow = Notification.Name("latticesPopoverWillShow")
+    static let latticesShowAssistantSettings = Notification.Name("latticesShowAssistantSettings")
 }
 
 /// Manages the NSStatusItem (menu bar icon), left-click popover, and right-click context menu.

--- a/app/Sources/AppShell/AppShellView.swift
+++ b/app/Sources/AppShell/AppShellView.swift
@@ -14,9 +14,9 @@ enum AppPage: String, CaseIterable {
     var label: String {
         switch self {
         case .home:             return "Home"
-        case .screenMap:        return "Screen Map"
+        case .screenMap:        return "Layout"
         case .desktopInventory: return "Desktop Inventory"
-        case .pi:               return "Pi"
+        case .pi:               return "Assistant"
         case .settings:         return "Settings"
         case .companionSettings:return "Settings"
         case .docs:             return "Docs"
@@ -28,7 +28,7 @@ enum AppPage: String, CaseIterable {
         case .home:             return "house"
         case .screenMap:        return "rectangle.3.group"
         case .desktopInventory: return "macwindow.on.rectangle"
-        case .pi:               return "terminal"
+        case .pi:               return "bubble.left.and.bubble.right"
         case .settings:         return "gearshape"
         case .companionSettings:return "ipad.and.iphone"
         case .docs:             return "book"

--- a/app/Sources/AppShell/SettingsView.swift
+++ b/app/Sources/AppShell/SettingsView.swift
@@ -90,6 +90,9 @@ struct SettingsContentView: View {
                 selectedTab = .companion
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .latticesShowAssistantSettings)) { _ in
+            selectedTab = .ai
+        }
     }
 
     // MARK: - Back Bar

--- a/app/Sources/AppShell/SettingsWindow.swift
+++ b/app/Sources/AppShell/SettingsWindow.swift
@@ -18,6 +18,13 @@ final class SettingsWindowController {
         ScreenMapWindowController.shared.showPage(.companionSettings)
     }
 
+    func showAssistant() {
+        ScreenMapWindowController.shared.showPage(.settings)
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .latticesShowAssistantSettings, object: nil)
+        }
+    }
+
     func close() {
         ScreenMapWindowController.shared.close()
     }

--- a/app/Sources/Core/Actions/IntentEngine.swift
+++ b/app/Sources/Core/Actions/IntentEngine.swift
@@ -845,6 +845,8 @@ struct ClaudeResolvedIntent {
     let slots: [String: JSON]
 }
 
+typealias ResolvedIntent = ClaudeResolvedIntent
+
 struct ClaudeAgentPlan {
     let steps: [ClaudeResolvedIntent]
     let reasoning: String

--- a/app/Sources/Core/Input/MouseGestureConfig.swift
+++ b/app/Sources/Core/Input/MouseGestureConfig.swift
@@ -6,10 +6,21 @@ enum MouseGestureDirection: String, CaseIterable, Codable, Equatable {
     case right
     case up
     case down
+
+    var displayLabel: String {
+        switch self {
+        case .left: return "Left"
+        case .right: return "Right"
+        case .up: return "Up"
+        case .down: return "Down"
+        }
+    }
 }
 
 enum MouseShortcutTriggerKind: String, Codable, Equatable {
     case drag
+    case click
+    case shape
 }
 
 enum MouseShortcutActionType: String, Codable, Equatable {
@@ -18,6 +29,7 @@ enum MouseShortcutActionType: String, Codable, Equatable {
     case screenMapToggle = "screenmap.toggle"
     case dictationStart = "dictation.start"
     case shortcutSend = "shortcut.send"
+    case appActivate = "app.activate"
 }
 
 enum MouseShortcutModifier: String, CaseIterable, Codable, Equatable {
@@ -46,6 +58,7 @@ enum MouseShortcutModifier: String, CaseIterable, Codable, Equatable {
 }
 
 enum MouseShortcutButton: Hashable, Codable, Equatable {
+    case right
     case middle
     case button4
     case button5
@@ -53,6 +66,7 @@ enum MouseShortcutButton: Hashable, Codable, Equatable {
 
     init(rawButtonNumber: Int) {
         switch rawButtonNumber {
+        case 1: self = .right
         case 2: self = .middle
         case 3: self = .button4
         case 4: self = .button5
@@ -69,11 +83,13 @@ enum MouseShortcutButton: Hashable, Codable, Equatable {
 
         let stringValue = try container.decode(String.self)
         switch stringValue.lowercased() {
+        case "right", "button.right":
+            self = .right
         case "middle", "button.middle":
             self = .middle
-        case "button4", "button.button4":
+        case "back", "button.back", "button4", "button.button4":
             self = .button4
-        case "button5", "button.button5":
+        case "forward", "button.forward", "button5", "button.button5":
             self = .button5
         default:
             if let raw = Int(stringValue.filter(\.isNumber)) {
@@ -91,6 +107,7 @@ enum MouseShortcutButton: Hashable, Codable, Equatable {
 
     var rawButtonNumber: Int {
         switch self {
+        case .right: return 1
         case .middle: return 2
         case .button4: return 3
         case .button5: return 4
@@ -100,27 +117,30 @@ enum MouseShortcutButton: Hashable, Codable, Equatable {
 
     var configValue: String {
         switch self {
+        case .right: return "right"
         case .middle: return "middle"
-        case .button4: return "button4"
-        case .button5: return "button5"
+        case .button4: return "back"
+        case .button5: return "forward"
         case .number(let value): return "button\(value)"
         }
     }
 
     var displayLabel: String {
         switch self {
+        case .right: return "Right Click"
         case .middle: return "Middle Click"
-        case .button4: return "Button 4"
-        case .button5: return "Button 5"
+        case .button4: return "Back Button"
+        case .button5: return "Forward Button"
         case .number(let value): return "Button \(value)"
         }
     }
 
     var triggerToken: String {
         switch self {
+        case .right: return "button.right"
         case .middle: return "button.middle"
-        case .button4: return "button.button4"
-        case .button5: return "button.button5"
+        case .button4: return "button.back"
+        case .button5: return "button.forward"
         case .number(let value): return "button.\(value)"
         }
     }
@@ -226,10 +246,37 @@ struct MouseShortcutDeviceSelector: Codable, Equatable {
 struct MouseShortcutTrigger: Codable, Equatable {
     var button: MouseShortcutButton
     var kind: MouseShortcutTriggerKind
-    var direction: MouseGestureDirection
+    var direction: MouseGestureDirection?
+    var shape: GestureShapeLabel?
 
     var triggerName: String {
-        "\(button.triggerToken).\(kind.rawValue).\(direction.rawValue)"
+        let detail: String?
+        switch kind {
+        case .drag:
+            detail = direction?.rawValue
+        case .shape:
+            detail = shape?.rawValue
+        case .click:
+            detail = nil
+        }
+        return ([button.triggerToken, kind.rawValue] + [detail].compactMap { $0 }).joined(separator: ".")
+    }
+
+    var displayLabel: String {
+        switch kind {
+        case .click:
+            return "\(button.displayLabel) click"
+        case .drag:
+            if let direction {
+                return "\(button.displayLabel) drag \(direction.displayLabel.lowercased())"
+            }
+            return "\(button.displayLabel) drag"
+        case .shape:
+            if let shape {
+                return "\(button.displayLabel) \(shape.displayName)"
+            }
+            return "\(button.displayLabel) shape"
+        }
     }
 }
 
@@ -248,6 +295,13 @@ struct MouseShortcutKeyStroke: Codable, Equatable {
 struct MouseShortcutActionDefinition: Codable, Equatable {
     var type: MouseShortcutActionType
     var shortcut: MouseShortcutKeyStroke?
+    var app: String?
+
+    init(type: MouseShortcutActionType, shortcut: MouseShortcutKeyStroke? = nil, app: String? = nil) {
+        self.type = type
+        self.shortcut = shortcut
+        self.app = app
+    }
 
     var label: String {
         switch type {
@@ -261,7 +315,47 @@ struct MouseShortcutActionDefinition: Codable, Equatable {
             return "Dictation"
         case .shortcutSend:
             return shortcut?.displayLabel ?? "Send Shortcut"
+        case .appActivate:
+            return app.map { "Activate \($0)" } ?? "Activate App"
         }
+    }
+}
+
+struct MouseShortcutVisualDefinition: Codable, Equatable {
+    var renderer: String
+    var asset: String?
+    var character: String?
+    var events: [String: String]?
+
+    init(
+        renderer: String = "native",
+        asset: String? = nil,
+        character: String? = nil,
+        events: [String: String]? = nil
+    ) {
+        self.renderer = renderer
+        self.asset = asset
+        self.character = character
+        self.events = events
+    }
+
+    var isLottiePOC: Bool {
+        renderer.localizedCaseInsensitiveCompare("lottie") == .orderedSame
+    }
+
+    func marker(phase: String, shape: GestureShapeLabel?, success: Bool?) -> String? {
+        let keys: [String] = [
+            success.map { "\(phase).\($0 ? "success" : "failure")" },
+            shape.map { "recognized:\($0.rawValue)" },
+            phase,
+        ].compactMap { $0 }
+
+        for key in keys {
+            if let marker = events?[key] {
+                return marker
+            }
+        }
+        return nil
     }
 }
 
@@ -271,6 +365,23 @@ struct MouseShortcutRule: Codable, Equatable, Identifiable {
     var device: MouseShortcutDeviceSelector
     var trigger: MouseShortcutTrigger
     var action: MouseShortcutActionDefinition
+    var visual: MouseShortcutVisualDefinition?
+
+    init(
+        id: String,
+        enabled: Bool,
+        device: MouseShortcutDeviceSelector,
+        trigger: MouseShortcutTrigger,
+        action: MouseShortcutActionDefinition,
+        visual: MouseShortcutVisualDefinition? = nil
+    ) {
+        self.id = id
+        self.enabled = enabled
+        self.device = device
+        self.trigger = trigger
+        self.action = action
+        self.visual = visual
+    }
 
     var summary: String {
         "\(trigger.triggerName) -> \(action.type.rawValue)"
@@ -302,29 +413,29 @@ struct MouseShortcutConfig: Codable, Equatable {
                 id: "space-previous",
                 enabled: true,
                 device: .any,
-                trigger: MouseShortcutTrigger(button: .middle, kind: .drag, direction: .left),
-                action: MouseShortcutActionDefinition(type: .spacePrevious, shortcut: nil)
+                trigger: MouseShortcutTrigger(button: .middle, kind: .drag, direction: .left, shape: nil),
+                action: MouseShortcutActionDefinition(type: .spacePrevious)
             ),
             MouseShortcutRule(
                 id: "space-next",
                 enabled: true,
                 device: .any,
-                trigger: MouseShortcutTrigger(button: .middle, kind: .drag, direction: .right),
-                action: MouseShortcutActionDefinition(type: .spaceNext, shortcut: nil)
+                trigger: MouseShortcutTrigger(button: .middle, kind: .drag, direction: .right, shape: nil),
+                action: MouseShortcutActionDefinition(type: .spaceNext)
             ),
             MouseShortcutRule(
                 id: "screenmap-overview",
                 enabled: true,
                 device: .any,
-                trigger: MouseShortcutTrigger(button: .middle, kind: .drag, direction: .down),
-                action: MouseShortcutActionDefinition(type: .screenMapToggle, shortcut: nil)
+                trigger: MouseShortcutTrigger(button: .middle, kind: .drag, direction: .down, shape: nil),
+                action: MouseShortcutActionDefinition(type: .screenMapToggle)
             ),
             MouseShortcutRule(
                 id: "dictation",
                 enabled: true,
                 device: .any,
-                trigger: MouseShortcutTrigger(button: .middle, kind: .drag, direction: .up),
-                action: MouseShortcutActionDefinition(type: .dictationStart, shortcut: nil)
+                trigger: MouseShortcutTrigger(button: .middle, kind: .drag, direction: .up, shape: nil),
+                action: MouseShortcutActionDefinition(type: .dictationStart)
             ),
         ]
     )
@@ -339,11 +450,26 @@ struct MouseShortcutMatchResult {
 struct MouseShortcutTriggerEvent {
     let button: MouseShortcutButton
     let kind: MouseShortcutTriggerKind
-    let direction: MouseGestureDirection
+    let direction: MouseGestureDirection?
+    let shape: GestureShapeLabel?
     let device: MouseInputDeviceInfo?
 
+    init(
+        button: MouseShortcutButton,
+        kind: MouseShortcutTriggerKind,
+        direction: MouseGestureDirection? = nil,
+        shape: GestureShapeLabel? = nil,
+        device: MouseInputDeviceInfo? = nil
+    ) {
+        self.button = button
+        self.kind = kind
+        self.direction = direction
+        self.shape = shape
+        self.device = device
+    }
+
     var triggerName: String {
-        MouseShortcutTrigger(button: button, kind: kind, direction: direction).triggerName
+        MouseShortcutTrigger(button: button, kind: kind, direction: direction, shape: shape).triggerName
     }
 }
 

--- a/app/Sources/Core/Input/MouseGestureController.swift
+++ b/app/Sources/Core/Input/MouseGestureController.swift
@@ -6,6 +6,35 @@ private enum MouseGestureAccessory {
     case mic
 }
 
+private enum MouseGestureOverlayStyle: Equatable {
+    case drawing
+    case thinLine
+    case thickLine
+}
+
+private enum MouseGestureVisualPhase: String {
+    case started
+    case updated
+    case recognized
+    case completed
+}
+
+private struct MouseGestureOverlayTheme {
+    let graphite: NSColor
+    let graphiteDark: NSColor
+    let accent: NSColor
+    let highlight: NSColor
+    let failure: NSColor
+
+    static let graffiti = MouseGestureOverlayTheme(
+        graphite: NSColor(calibratedRed: 0.66, green: 0.69, blue: 0.73, alpha: 1.0),
+        graphiteDark: NSColor(calibratedRed: 0.16, green: 0.17, blue: 0.19, alpha: 1.0),
+        accent: NSColor(calibratedRed: 0.34, green: 0.78, blue: 1.0, alpha: 1.0),
+        highlight: NSColor(calibratedRed: 0.82, green: 0.94, blue: 1.0, alpha: 1.0),
+        failure: NSColor(calibratedRed: 0.98, green: 0.52, blue: 0.42, alpha: 1.0)
+    )
+}
+
 final class MouseGestureController {
     static let shared = MouseGestureController()
 
@@ -21,6 +50,8 @@ final class MouseGestureController {
         let overlay: MouseGestureOverlay
         var currentPoint: CGPoint
         var lockedDirection: MouseGestureDirection?
+        var pathPoints: [GesturePathPoint]
+        var visual: MouseShortcutVisualDefinition?
 
         init(buttonNumber: Int64, startPoint: CGPoint, overlay: MouseGestureOverlay) {
             self.buttonNumber = buttonNumber
@@ -28,6 +59,19 @@ final class MouseGestureController {
             self.overlay = overlay
             self.currentPoint = startPoint
             self.lockedDirection = nil
+            self.pathPoints = [
+                GesturePathPoint(point: startPoint, timestamp: Date().timeIntervalSinceReferenceDate)
+            ]
+            self.visual = nil
+        }
+
+        func recordPoint(_ point: CGPoint) {
+            if let last = pathPoints.last {
+                let dx = point.x - last.x
+                let dy = point.y - last.y
+                guard sqrt(dx * dx + dy * dy) >= 2 else { return }
+            }
+            pathPoints.append(GesturePathPoint(point: point, timestamp: Date().timeIntervalSinceReferenceDate))
         }
     }
 
@@ -39,6 +83,7 @@ final class MouseGestureController {
     private var retainedOverlays: [ObjectIdentifier: MouseGestureOverlay] = [:]
     private var subscriptions: Set<AnyCancellable> = []
     private var installedObservers = false
+    private let shapeRecognizer = ShapeRecognizer()
 
     private init() {}
 
@@ -112,6 +157,7 @@ final class MouseGestureController {
         mask |= CGEventMask(1) << CGEventType.leftMouseDown.rawValue
         mask |= CGEventMask(1) << CGEventType.leftMouseUp.rawValue
         mask |= CGEventMask(1) << CGEventType.rightMouseDown.rawValue
+        mask |= CGEventMask(1) << CGEventType.rightMouseDragged.rawValue
         mask |= CGEventMask(1) << CGEventType.rightMouseUp.rawValue
         mask |= CGEventMask(1) << CGEventType.otherMouseDown.rawValue
         mask |= CGEventMask(1) << CGEventType.otherMouseDragged.rawValue
@@ -172,8 +218,14 @@ final class MouseGestureController {
         }
 
         switch type {
-        case .leftMouseDown, .leftMouseUp, .rightMouseDown, .rightMouseUp:
+        case .leftMouseDown, .leftMouseUp:
             return handlePassiveMouseButtonEvent(type: type, event: event)
+        case .rightMouseDown:
+            return handleMouseDown(event, buttonNumber: Int64(CGMouseButton.right.rawValue))
+        case .rightMouseDragged:
+            return handleMouseDragged(event, buttonNumber: Int64(CGMouseButton.right.rawValue))
+        case .rightMouseUp:
+            return handleMouseUp(event, buttonNumber: Int64(CGMouseButton.right.rawValue))
         default:
             break
         }
@@ -272,6 +324,7 @@ final class MouseGestureController {
             self.releaseOverlay(overlay)
         }
         let newSession = GestureSession(buttonNumber: buttonNumber, startPoint: point, overlay: overlay)
+        newSession.visual = MouseShortcutStore.shared.visualHint(for: button)
         session = newSession
         DiagnosticLog.shared.info("MouseGesture: began at \(format(point)) button=\(buttonNumber)")
         recordObservedEvent(
@@ -298,6 +351,8 @@ final class MouseGestureController {
         MouseShortcutStore.shared.reloadIfNeeded()
 
         session.currentPoint = event.location
+        session.recordPoint(event.location)
+        let button = MouseShortcutButton(rawButtonNumber: Int(buttonNumber))
         let delta = CGPoint(
             x: event.location.x - session.startPoint.x,
             y: event.location.y - session.startPoint.y
@@ -308,7 +363,6 @@ final class MouseGestureController {
         if direction != session.lockedDirection {
             session.lockedDirection = direction
             if let direction {
-                let button = MouseShortcutButton(rawButtonNumber: Int(buttonNumber))
                 let triggerEvent = MouseShortcutTriggerEvent(button: button, kind: .drag, direction: direction, device: nil)
                 let match = MouseShortcutStore.shared.match(for: triggerEvent)
                 DiagnosticLog.shared.info("MouseGesture: locked \(label(for: direction)) via \(triggerEvent.triggerName)")
@@ -336,10 +390,27 @@ final class MouseGestureController {
                 origin: session.startPoint,
                 direction: direction,
                 label: nil,
+                style: overlayStyle(for: button),
+                visual: session.visual,
+                visualPhase: .updated,
+                shape: nil,
+                success: nil,
+                pathPoints: session.pathPoints,
                 progress: previewProgress
             )
         } else {
-            session.overlay.track(origin: session.startPoint, direction: nil, label: nil, progress: 0)
+            session.overlay.track(
+                origin: session.startPoint,
+                direction: nil,
+                label: nil,
+                style: overlayStyle(for: MouseShortcutButton(rawButtonNumber: Int(buttonNumber))),
+                visual: session.visual,
+                visualPhase: .updated,
+                shape: nil,
+                success: nil,
+                pathPoints: session.pathPoints,
+                progress: 0
+            )
         }
 
         return nil
@@ -367,6 +438,8 @@ final class MouseGestureController {
         guard session.buttonNumber == buttonNumber else {
             return Unmanaged.passUnretained(event)
         }
+        session.currentPoint = event.location
+        session.recordPoint(event.location)
 
         let delta = CGPoint(
             x: event.location.x - session.startPoint.x,
@@ -376,7 +449,57 @@ final class MouseGestureController {
         let direction = Self.resolveDirection(delta: delta, threshold: tuning.dragThreshold, axisBias: tuning.axisBias)
         self.session = nil
 
+        let shapeResult = shapeRecognizer.recognize(points: session.pathPoints)
+        if let shape = shapeResult.shape {
+            let shapeTrigger = MouseShortcutTriggerEvent(button: button, kind: .shape, shape: shape)
+            let shapeMatch = MouseShortcutStore.shared.match(for: shapeTrigger)
+            if let shapeMatch {
+                let commitDirection = shapeResult.segments.last?.direction ?? direction ?? .right
+                let dismissBeforeAction = shouldDismissOverlayBeforeAction(match: shapeMatch)
+                if dismissBeforeAction {
+                    session.overlay.dismiss(immediately: true)
+                }
+
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { return }
+                    if !dismissBeforeAction {
+                        self.retainOverlay(session.overlay)
+                    }
+                    let outcome = self.performAction(match: shapeMatch, startPoint: session.startPoint)
+                    DiagnosticLog.shared.info("MouseGesture: \(shape.displayName) -> \(outcome.label) -> \(outcome.success ? "ok" : "blocked")")
+                    self.recordObservedEvent(
+                        phase: "up",
+                        button: button,
+                        location: event.location,
+                        delta: delta,
+                        modifiers: event.flags,
+                        candidate: shapeTrigger.triggerName,
+                        match: shapeMatch,
+                        note: "shape fired confidence=\(String(format: "%.2f", Double(shapeResult.confidence)))",
+                        appInfo: appInfo
+                    )
+                    if !dismissBeforeAction {
+                        session.overlay.commit(
+                            origin: session.startPoint,
+                            direction: commitDirection,
+                            label: outcome.label,
+                            success: outcome.success,
+                            style: self.overlayStyle(for: button),
+                            visual: shapeMatch.rule.visual ?? session.visual,
+                            visualPhase: .completed,
+                            shape: shape,
+                            pathPoints: session.pathPoints,
+                            accessory: outcome.accessory
+                        )
+                    }
+                }
+                return nil
+            }
+        }
+
         guard let direction else {
+            let clickTrigger = MouseShortcutTriggerEvent(button: button, kind: .click, direction: nil, device: nil)
+            let clickMatch = MouseShortcutStore.shared.match(for: clickTrigger)
             DiagnosticLog.shared.info("MouseGesture: released without a gesture at \(format(event.location))")
             recordObservedEvent(
                 phase: "up",
@@ -384,18 +507,27 @@ final class MouseGestureController {
                 location: event.location,
                 delta: delta,
                 modifiers: event.flags,
-                candidate: nil,
-                match: nil,
-                note: "replay click",
+                candidate: clickMatch != nil ? clickTrigger.triggerName : nil,
+                match: clickMatch,
+                note: clickMatch != nil ? "click action" : "replay click",
                 appInfo: appInfo
             )
-            DispatchQueue.main.async { [weak self] in
-                session.overlay.dismiss()
-                self?.replayMouseClick(
-                    buttonNumber: buttonNumber,
-                    at: session.startPoint,
-                    flags: event.flags
-                )
+            if let clickMatch {
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { return }
+                    session.overlay.dismiss(immediately: true)
+                    let outcome = self.performAction(match: clickMatch, startPoint: session.startPoint)
+                    DiagnosticLog.shared.info("MouseGesture: \(outcome.label) -> \(outcome.success ? "ok" : "blocked")")
+                }
+            } else {
+                DispatchQueue.main.async { [weak self] in
+                    session.overlay.dismiss()
+                    self?.replayMouseClick(
+                        buttonNumber: buttonNumber,
+                        at: session.startPoint,
+                        flags: event.flags
+                    )
+                }
             }
             return nil
         }
@@ -431,6 +563,11 @@ final class MouseGestureController {
                     direction: direction,
                     label: outcome.label,
                     success: outcome.success,
+                    style: self.overlayStyle(for: button),
+                    visual: match?.rule.visual ?? session.visual,
+                    visualPhase: .completed,
+                    shape: nil,
+                    pathPoints: session.pathPoints,
                     accessory: outcome.accessory
                 )
             }
@@ -473,6 +610,14 @@ final class MouseGestureController {
                 success: sent,
                 accessory: nil
             )
+        case .appActivate:
+            let activated = activateApplication(named: match.action.app)
+            let appLabel = match.action.app?.trimmingCharacters(in: .whitespacesAndNewlines)
+            return GestureOutcome(
+                label: activated ? "\(appLabel?.isEmpty == false ? appLabel! : "App") Focused" : "App Activation Blocked",
+                success: activated,
+                accessory: nil
+            )
         }
     }
 
@@ -489,13 +634,31 @@ final class MouseGestureController {
         }
     }
 
+    private func overlayStyle(for button: MouseShortcutButton) -> MouseGestureOverlayStyle {
+        switch button {
+        case .button4:
+            return .thinLine
+        case .button5:
+            return .thickLine
+        case .middle:
+            return .drawing
+        case .right, .number:
+            return .drawing
+        }
+    }
+
     private func clearSession() {
         session?.overlay.dismiss(immediately: true)
         session = nil
     }
 
     private func replayMouseClick(buttonNumber: Int64, at point: CGPoint, flags: CGEventFlags) {
-        let events: [CGEventType] = [.otherMouseDown, .otherMouseUp]
+        let events: [CGEventType]
+        if buttonNumber == Int64(CGMouseButton.right.rawValue) {
+            events = [.rightMouseDown, .rightMouseUp]
+        } else {
+            events = [.otherMouseDown, .otherMouseUp]
+        }
         for type in events {
             guard let mouseButton = CGMouseButton(rawValue: UInt32(buttonNumber)) else { continue }
             guard let event = CGEvent(
@@ -527,7 +690,7 @@ final class MouseGestureController {
         switch match.action.type {
         case .spacePrevious, .spaceNext, .screenMapToggle:
             return true
-        case .dictationStart, .shortcutSend:
+        case .dictationStart, .shortcutSend, .appActivate:
             return false
         }
     }
@@ -619,6 +782,40 @@ final class MouseGestureController {
             )
         )
     }
+
+    private func activateApplication(named appName: String?) -> Bool {
+        guard let appName, !appName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return false
+        }
+
+        if let running = NSWorkspace.shared.runningApplications.first(where: { app in
+            app.localizedName?.localizedCaseInsensitiveCompare(appName) == .orderedSame
+                || app.bundleIdentifier?.localizedCaseInsensitiveContains(appName) == true
+        }) {
+            return running.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+        }
+
+        let fileManager = FileManager.default
+        let trimmedName = appName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let appFilenames = trimmedName.hasSuffix(".app") ? [trimmedName] : [trimmedName + ".app", trimmedName]
+        let roots = [
+            "/Applications",
+            "/System/Applications",
+            fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Applications").path,
+        ]
+
+        for root in roots {
+            for filename in appFilenames {
+                let url = URL(fileURLWithPath: root).appendingPathComponent(filename)
+                guard fileManager.fileExists(atPath: url.path) else { continue }
+                NSWorkspace.shared.openApplication(at: url, configuration: NSWorkspace.OpenConfiguration())
+                return true
+            }
+        }
+
+        _ = ProcessQuery.shell(["/usr/bin/open", "-a", trimmedName])
+        return true
+    }
 }
 
 private final class MouseGestureOverlay {
@@ -653,14 +850,32 @@ private final class MouseGestureOverlay {
         window.orderFrontRegardless()
     }
 
-    func track(origin: CGPoint, direction: MouseGestureDirection?, label: String?, progress: CGFloat) {
+    func track(
+        origin: CGPoint,
+        direction: MouseGestureDirection?,
+        label: String?,
+        style: MouseGestureOverlayStyle,
+        visual: MouseShortcutVisualDefinition?,
+        visualPhase: MouseGestureVisualPhase,
+        shape: GestureShapeLabel?,
+        success: Bool?,
+        pathPoints: [GesturePathPoint],
+        progress: CGFloat
+    ) {
         fadeTimer?.invalidate()
         window.alphaValue = 1
-        if let direction {
+        let localPath = localPath(from: pathPoints)
+        if direction != nil || localPath.count > 1 {
             overlayView.state = .tracking(
                 origin: localPoint(from: origin),
                 direction: direction,
                 label: label,
+                style: style,
+                visual: visual,
+                visualPhase: visualPhase,
+                shape: shape,
+                success: success,
+                path: localPath,
                 progress: progress
             )
         } else {
@@ -674,6 +889,11 @@ private final class MouseGestureOverlay {
         direction: MouseGestureDirection,
         label: String,
         success: Bool,
+        style: MouseGestureOverlayStyle,
+        visual: MouseShortcutVisualDefinition?,
+        visualPhase: MouseGestureVisualPhase,
+        shape: GestureShapeLabel?,
+        pathPoints: [GesturePathPoint],
         accessory: MouseGestureAccessory?
     ) {
         fadeTimer?.invalidate()
@@ -683,6 +903,11 @@ private final class MouseGestureOverlay {
             direction: direction,
             label: label,
             success: success,
+            style: style,
+            visual: visual,
+            visualPhase: visualPhase,
+            shape: shape,
+            path: localPath(from: pathPoints),
             accessory: accessory,
             accessoryAnimationDuration: accessoryAnimationDuration
         )
@@ -722,6 +947,10 @@ private final class MouseGestureOverlay {
         return CGPoint(x: cgPoint.x - screen.frame.minX, y: nsY - screen.frame.minY)
     }
 
+    private func localPath(from pathPoints: [GesturePathPoint]) -> [CGPoint] {
+        pathPoints.map { localPoint(from: $0.cgPoint) }
+    }
+
     private func finishDismissal() {
         let callback = onDismiss
         onDismiss = nil
@@ -730,14 +959,32 @@ private final class MouseGestureOverlay {
 }
 
 private final class MouseGestureOverlayView: NSView {
+    private let theme = MouseGestureOverlayTheme.graffiti
+
     enum State {
         case idle
-        case tracking(origin: CGPoint, direction: MouseGestureDirection?, label: String?, progress: CGFloat)
+        case tracking(
+            origin: CGPoint,
+            direction: MouseGestureDirection?,
+            label: String?,
+            style: MouseGestureOverlayStyle,
+            visual: MouseShortcutVisualDefinition?,
+            visualPhase: MouseGestureVisualPhase,
+            shape: GestureShapeLabel?,
+            success: Bool?,
+            path: [CGPoint],
+            progress: CGFloat
+        )
         case committed(
             origin: CGPoint,
             direction: MouseGestureDirection,
             label: String,
             success: Bool,
+            style: MouseGestureOverlayStyle,
+            visual: MouseShortcutVisualDefinition?,
+            visualPhase: MouseGestureVisualPhase,
+            shape: GestureShapeLabel?,
+            path: [CGPoint],
             accessory: MouseGestureAccessory?,
             accessoryAnimationDuration: TimeInterval
         )
@@ -790,23 +1037,80 @@ private final class MouseGestureOverlayView: NSView {
         switch state {
         case .idle:
             break
-        case .tracking(let origin, let direction, let label, let progress):
+        case .tracking(let origin, let direction, let label, let style, let visual, let visualPhase, let shape, let success, let path, let progress):
             drawOrigin(at: origin, in: ctx, alpha: 0.88)
-            if let direction {
+            if path.count > 1 {
+                drawGesturePath(
+                    path,
+                    fallbackOrigin: origin,
+                    direction: direction,
+                    label: label,
+                    success: true,
+                    committed: false,
+                    style: style,
+                    accessory: nil,
+                    progressOverride: progress,
+                    in: ctx
+                )
+                drawVisualPOCIfNeeded(
+                    visual,
+                    phase: visualPhase,
+                    shape: shape,
+                    success: success,
+                    points: path,
+                    label: label,
+                    in: ctx
+                )
+            } else if let direction {
                 drawArrow(
                     from: origin,
                     direction: direction,
                     label: label,
                     success: true,
                     committed: false,
+                    style: style,
                     accessory: nil,
                     progressOverride: progress,
                     in: ctx
                 )
             }
-        case .committed(let origin, let direction, let label, let success, let accessory, _):
+        case .committed(let origin, let direction, let label, let success, let style, let visual, let visualPhase, let shape, let path, let accessory, _):
             drawOrigin(at: origin, in: ctx, alpha: 1.0)
-            drawArrow(from: origin, direction: direction, label: label, success: success, committed: true, accessory: accessory, progressOverride: nil, in: ctx)
+            if path.count > 1 {
+                drawGesturePath(
+                    path,
+                    fallbackOrigin: origin,
+                    direction: direction,
+                    label: label,
+                    success: success,
+                    committed: true,
+                    style: style,
+                    accessory: accessory,
+                    progressOverride: nil,
+                    in: ctx
+                )
+                drawVisualPOCIfNeeded(
+                    visual,
+                    phase: visualPhase,
+                    shape: shape,
+                    success: success,
+                    points: path,
+                    label: label,
+                    in: ctx
+                )
+            } else {
+                drawArrow(
+                    from: origin,
+                    direction: direction,
+                    label: label,
+                    success: success,
+                    committed: true,
+                    style: style,
+                    accessory: accessory,
+                    progressOverride: nil,
+                    in: ctx
+                )
+            }
         }
     }
 
@@ -824,6 +1128,7 @@ private final class MouseGestureOverlayView: NSView {
         label: String?,
         success: Bool,
         committed: Bool,
+        style: MouseGestureOverlayStyle,
         accessory: MouseGestureAccessory?,
         progressOverride: CGFloat?,
         in ctx: CGContext
@@ -839,6 +1144,7 @@ private final class MouseGestureOverlayView: NSView {
             : NSColor(calibratedRed: 0.98, green: 0.52, blue: 0.42, alpha: 1.0)
         let strokeAlpha = committed ? 0.92 : (0.48 + 0.44 * clampedProgress)
         let glowAlpha = committed ? 0.2 : (0.08 + 0.08 * clampedProgress)
+        let metrics = arrowMetrics(for: style)
 
         ctx.saveGState()
         ctx.setLineCap(.round)
@@ -847,7 +1153,7 @@ private final class MouseGestureOverlayView: NSView {
         glowPath.move(to: origin)
         glowPath.addLine(to: end)
         ctx.addPath(glowPath)
-        ctx.setLineWidth(16)
+        ctx.setLineWidth(metrics.glowWidth)
         ctx.setStrokeColor(accent.withAlphaComponent(glowAlpha).cgColor)
         ctx.strokePath()
 
@@ -855,11 +1161,11 @@ private final class MouseGestureOverlayView: NSView {
         linePath.move(to: origin)
         linePath.addLine(to: end)
         ctx.addPath(linePath)
-        ctx.setLineWidth(5)
+        ctx.setLineWidth(metrics.lineWidth)
         ctx.setStrokeColor(accent.withAlphaComponent(strokeAlpha).cgColor)
         ctx.strokePath()
 
-        drawArrowHead(at: end, direction: direction, color: accent)
+        drawArrowHead(at: end, direction: direction, color: accent, size: metrics.headSize)
         if let label, (!committed || clampedProgress >= labelRevealThreshold) {
             drawLabel(label, from: origin, to: end, direction: direction, color: accent)
         }
@@ -869,8 +1175,300 @@ private final class MouseGestureOverlayView: NSView {
         ctx.restoreGState()
     }
 
-    private func drawArrowHead(at end: CGPoint, direction: MouseGestureDirection, color: NSColor) {
-        let size: CGFloat = 15
+    private func drawGesturePath(
+        _ points: [CGPoint],
+        fallbackOrigin: CGPoint,
+        direction: MouseGestureDirection?,
+        label: String?,
+        success: Bool,
+        committed: Bool,
+        style: MouseGestureOverlayStyle,
+        accessory: MouseGestureAccessory?,
+        progressOverride: CGFloat?,
+        in ctx: CGContext
+    ) {
+        guard points.count > 1 else { return }
+        let accent = success ? theme.accent : theme.failure
+        let stroke = success ? theme.graphite : theme.failure
+        let metrics = arrowMetrics(for: style)
+        let pathProgress = progressOverride ?? currentArrowProgress(committed: committed)
+        let clampedProgress = min(1, max(0, pathProgress))
+        let strokeAlpha = committed ? 0.92 : (0.48 + 0.44 * clampedProgress)
+        let glowAlpha = committed ? 0.28 : (0.12 + 0.12 * clampedProgress)
+        let visiblePoints = visiblePathPoints(points, progress: committed ? clampedProgress : 1)
+        guard visiblePoints.count > 1 else { return }
+
+        let path = smoothedGesturePath(from: visiblePoints)
+
+        ctx.saveGState()
+        ctx.setLineCap(.round)
+        ctx.setLineJoin(.round)
+
+        drawGestureGuideDots(around: visiblePoints, accent: accent, in: ctx)
+
+        ctx.addPath(path)
+        ctx.setLineWidth(metrics.glowWidth + 10)
+        ctx.setStrokeColor(theme.graphiteDark.withAlphaComponent(committed ? 0.44 : 0.30).cgColor)
+        ctx.strokePath()
+
+        ctx.addPath(path)
+        ctx.setLineWidth(metrics.glowWidth)
+        ctx.setStrokeColor(accent.withAlphaComponent(glowAlpha).cgColor)
+        ctx.strokePath()
+
+        ctx.addPath(path)
+        ctx.setLineWidth(metrics.lineWidth)
+        ctx.setStrokeColor(stroke.withAlphaComponent(strokeAlpha).cgColor)
+        ctx.strokePath()
+
+        ctx.addPath(path)
+        ctx.setLineWidth(max(1, metrics.lineWidth * 0.28))
+        ctx.setStrokeColor((success ? theme.highlight : accent).withAlphaComponent(success ? strokeAlpha * 0.62 : strokeAlpha).cgColor)
+        ctx.strokePath()
+
+        let end = visiblePoints.last ?? fallbackOrigin
+        let resolvedDirection = direction ?? pathDirection(from: visiblePoints)
+        if let resolvedDirection {
+            drawArrowHead(at: end, direction: resolvedDirection, color: stroke, size: metrics.headSize)
+            if let label, (!committed || clampedProgress >= labelRevealThreshold) {
+                drawLabel(label, from: fallbackOrigin, to: end, direction: resolvedDirection, color: accent)
+            }
+            if committed, let accessory, clampedProgress >= labelRevealThreshold {
+                drawAccessory(accessory, from: fallbackOrigin, to: end, direction: resolvedDirection, color: accent, in: ctx)
+            }
+        }
+        ctx.restoreGState()
+    }
+
+    private func drawGestureGuideDots(around points: [CGPoint], accent: NSColor, in ctx: CGContext) {
+        guard !points.isEmpty else { return }
+        let minX = (points.map(\.x).min() ?? 0) - 34
+        let maxX = (points.map(\.x).max() ?? 0) + 34
+        let minY = (points.map(\.y).min() ?? 0) - 34
+        let maxY = (points.map(\.y).max() ?? 0) + 34
+        let spacing: CGFloat = 34
+        let dotRadius: CGFloat = 2.2
+        let startX = floor(minX / spacing) * spacing
+        let startY = floor(minY / spacing) * spacing
+
+        var y = startY
+        while y <= maxY {
+            var x = startX
+            while x <= maxX {
+                let point = CGPoint(x: x, y: y)
+                let distance = nearestDistance(from: point, to: points)
+                let closeness = max(0, 1 - min(distance / 96, 1))
+                let alpha = 0.08 + closeness * 0.20
+                let radius = dotRadius + closeness * 1.2
+                ctx.setFillColor(accent.withAlphaComponent(alpha).cgColor)
+                ctx.fillEllipse(in: CGRect(x: x - radius, y: y - radius, width: radius * 2, height: radius * 2))
+                x += spacing
+            }
+            y += spacing
+        }
+    }
+
+    private func nearestDistance(from point: CGPoint, to points: [CGPoint]) -> CGFloat {
+        points.reduce(CGFloat.greatestFiniteMagnitude) { nearest, candidate in
+            let dx = point.x - candidate.x
+            let dy = point.y - candidate.y
+            return min(nearest, sqrt(dx * dx + dy * dy))
+        }
+    }
+
+    private func drawVisualPOCIfNeeded(
+        _ visual: MouseShortcutVisualDefinition?,
+        phase: MouseGestureVisualPhase,
+        shape: GestureShapeLabel?,
+        success: Bool?,
+        points: [CGPoint],
+        label: String?,
+        in ctx: CGContext
+    ) {
+        guard let visual, visual.isLottiePOC, let end = points.last else { return }
+        let marker = visual.marker(phase: phase.rawValue, shape: shape, success: success) ?? fallbackMarker(phase: phase, success: success)
+        let previous = points.dropLast().last ?? end
+        let velocity = CGPoint(x: end.x - previous.x, y: end.y - previous.y)
+        let speed = min(1, sqrt(velocity.x * velocity.x + velocity.y * velocity.y) / 42)
+        let anchor = CGPoint(x: end.x + 28, y: end.y + 22 - speed * 8)
+        drawLottieCatPOC(marker: marker, at: anchor, velocity: velocity, label: label, in: ctx)
+    }
+
+    private func fallbackMarker(phase: MouseGestureVisualPhase, success: Bool?) -> String {
+        switch phase {
+        case .started:
+            return "curious"
+        case .updated:
+            return "follow"
+        case .recognized:
+            return "pounce"
+        case .completed:
+            return success == false ? "confused" : "celebrate"
+        }
+    }
+
+    private func drawLottieCatPOC(
+        marker: String,
+        at center: CGPoint,
+        velocity: CGPoint,
+        label: String?,
+        in ctx: CGContext
+    ) {
+        let mood = marker.lowercased()
+        let bodyColor = NSColor(calibratedRed: 0.13, green: 0.14, blue: 0.16, alpha: 0.92)
+        let faceColor = theme.highlight.withAlphaComponent(0.94)
+        let accent = mood.contains("confused") ? theme.failure : theme.accent
+        let tilt = max(-0.34, min(0.34, velocity.x / 160))
+        let hop: CGFloat = mood.contains("pounce") || mood.contains("celebrate") ? 7 : 0
+        let headCenter = CGPoint(x: center.x, y: center.y + hop)
+        let headRadius: CGFloat = mood.contains("pounce") ? 16 : 14
+
+        ctx.saveGState()
+        ctx.translateBy(x: headCenter.x, y: headCenter.y)
+        ctx.rotate(by: tilt)
+        ctx.translateBy(x: -headCenter.x, y: -headCenter.y)
+
+        ctx.setFillColor(theme.graphiteDark.withAlphaComponent(0.24).cgColor)
+        ctx.fillEllipse(in: CGRect(x: headCenter.x - 22, y: headCenter.y - 18, width: 44, height: 36))
+
+        let leftEar = CGMutablePath()
+        leftEar.move(to: CGPoint(x: headCenter.x - 12, y: headCenter.y + 9))
+        leftEar.addLine(to: CGPoint(x: headCenter.x - 7, y: headCenter.y + 25))
+        leftEar.addLine(to: CGPoint(x: headCenter.x - 1, y: headCenter.y + 11))
+        leftEar.closeSubpath()
+        ctx.addPath(leftEar)
+        ctx.setFillColor(bodyColor.cgColor)
+        ctx.fillPath()
+
+        let rightEar = CGMutablePath()
+        rightEar.move(to: CGPoint(x: headCenter.x + 12, y: headCenter.y + 9))
+        rightEar.addLine(to: CGPoint(x: headCenter.x + 7, y: headCenter.y + 25))
+        rightEar.addLine(to: CGPoint(x: headCenter.x + 1, y: headCenter.y + 11))
+        rightEar.closeSubpath()
+        ctx.addPath(rightEar)
+        ctx.setFillColor(bodyColor.cgColor)
+        ctx.fillPath()
+
+        ctx.setFillColor(bodyColor.cgColor)
+        ctx.fillEllipse(in: CGRect(x: headCenter.x - headRadius, y: headCenter.y - headRadius, width: headRadius * 2, height: headRadius * 2))
+        ctx.setStrokeColor(accent.withAlphaComponent(0.72).cgColor)
+        ctx.setLineWidth(1.4)
+        ctx.strokeEllipse(in: CGRect(x: headCenter.x - headRadius, y: headCenter.y - headRadius, width: headRadius * 2, height: headRadius * 2))
+
+        let eyeY = headCenter.y + 2
+        let blink = mood.contains("pounce") || mood.contains("celebrate")
+        drawCatEye(at: CGPoint(x: headCenter.x - 5, y: eyeY), blink: blink, color: faceColor, in: ctx)
+        drawCatEye(at: CGPoint(x: headCenter.x + 5, y: eyeY), blink: blink, color: faceColor, in: ctx)
+
+        ctx.setStrokeColor(faceColor.withAlphaComponent(0.82).cgColor)
+        ctx.setLineWidth(1)
+        let mouth = CGMutablePath()
+        mouth.move(to: CGPoint(x: headCenter.x - 3, y: headCenter.y - 5))
+        mouth.addQuadCurve(to: CGPoint(x: headCenter.x + 3, y: headCenter.y - 5), control: CGPoint(x: headCenter.x, y: headCenter.y - (mood.contains("confused") ? 2 : 8)))
+        ctx.addPath(mouth)
+        ctx.strokePath()
+
+        if mood.contains("celebrate"), let label {
+            drawCatToast(label, near: CGPoint(x: headCenter.x + 18, y: headCenter.y + 18), color: accent)
+        }
+
+        ctx.restoreGState()
+    }
+
+    private func drawCatEye(at point: CGPoint, blink: Bool, color: NSColor, in ctx: CGContext) {
+        ctx.setStrokeColor(color.cgColor)
+        ctx.setFillColor(color.cgColor)
+        if blink {
+            ctx.setLineWidth(1.4)
+            let path = CGMutablePath()
+            path.move(to: CGPoint(x: point.x - 2.4, y: point.y))
+            path.addLine(to: CGPoint(x: point.x + 2.4, y: point.y))
+            ctx.addPath(path)
+            ctx.strokePath()
+        } else {
+            ctx.fillEllipse(in: CGRect(x: point.x - 1.7, y: point.y - 1.7, width: 3.4, height: 3.4))
+        }
+    }
+
+    private func drawCatToast(_ label: String, near point: CGPoint, color: NSColor) {
+        let shortLabel = label.replacingOccurrences(of: " Focused", with: "!")
+        let font = NSFont.monospacedSystemFont(ofSize: 9, weight: .bold)
+        let attributed = NSAttributedString(
+            string: shortLabel,
+            attributes: [
+                .font: font,
+                .foregroundColor: theme.highlight.withAlphaComponent(0.96),
+            ]
+        )
+        let size = attributed.size()
+        let rect = CGRect(x: point.x, y: point.y, width: size.width + 12, height: size.height + 7)
+        let bubble = NSBezierPath(roundedRect: rect, xRadius: 8, yRadius: 8)
+        theme.graphiteDark.withAlphaComponent(0.72).setFill()
+        bubble.fill()
+        color.withAlphaComponent(0.5).setStroke()
+        bubble.lineWidth = 1
+        bubble.stroke()
+        attributed.draw(in: CGRect(x: rect.minX + 6, y: rect.minY + 3.5, width: size.width, height: size.height))
+    }
+
+    private func smoothedGesturePath(from points: [CGPoint]) -> CGPath {
+        let path = CGMutablePath()
+        guard let first = points.first else { return path }
+        path.move(to: first)
+
+        guard points.count > 2 else {
+            if let last = points.last {
+                path.addLine(to: last)
+            }
+            return path
+        }
+
+        for index in 0..<(points.count - 1) {
+            let previous = points[max(index - 1, 0)]
+            let current = points[index]
+            let next = points[index + 1]
+            let nextNext = points[min(index + 2, points.count - 1)]
+            let tension: CGFloat = 0.34
+            let control1 = CGPoint(
+                x: current.x + (next.x - previous.x) * tension,
+                y: current.y + (next.y - previous.y) * tension
+            )
+            let control2 = CGPoint(
+                x: next.x - (nextNext.x - current.x) * tension,
+                y: next.y - (nextNext.y - current.y) * tension
+            )
+            path.addCurve(to: next, control1: control1, control2: control2)
+        }
+        return path
+    }
+
+    private func visiblePathPoints(_ points: [CGPoint], progress: CGFloat) -> [CGPoint] {
+        guard progress < 1, points.count > 2 else { return points }
+        let clamped = min(1, max(0.04, progress))
+        let count = max(2, Int(ceil(CGFloat(points.count) * clamped)))
+        return Array(points.prefix(count))
+    }
+
+    private func pathDirection(from points: [CGPoint]) -> MouseGestureDirection? {
+        guard points.count >= 2 else { return nil }
+        let window = points.suffix(min(6, points.count))
+        guard let first = window.first, let last = window.last else { return nil }
+        let delta = CGPoint(x: last.x - first.x, y: last.y - first.y)
+        return MouseGestureController.resolveDirection(delta: delta, threshold: 4, axisBias: 1.0)
+    }
+
+    private func arrowMetrics(for style: MouseGestureOverlayStyle) -> (lineWidth: CGFloat, glowWidth: CGFloat, headSize: CGFloat) {
+        switch style {
+        case .thinLine:
+            return (2.4, 7, 10)
+        case .thickLine:
+            return (8.5, 20, 18)
+        case .drawing:
+            return (5, 16, 15)
+        }
+    }
+
+    private func drawArrowHead(at end: CGPoint, direction: MouseGestureDirection, color: NSColor, size: CGFloat) {
         let path = NSBezierPath()
 
         switch direction {
@@ -898,17 +1496,31 @@ private final class MouseGestureOverlayView: NSView {
     }
 
     private func drawLabel(_ label: String, from origin: CGPoint, to end: CGPoint, direction: MouseGestureDirection, color: NSColor) {
-        let font = NSFont.monospacedSystemFont(ofSize: 11, weight: .semibold)
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: font,
-            .foregroundColor: NSColor.white.withAlphaComponent(0.94),
+        let display = labelComponents(for: label)
+        let titleFont = NSFont.systemFont(ofSize: 15, weight: .heavy)
+        let kickerFont = NSFont.monospacedSystemFont(ofSize: 8, weight: .bold)
+        let titleAttributes: [NSAttributedString.Key: Any] = [
+            .font: titleFont,
+            .foregroundColor: theme.highlight.withAlphaComponent(0.98),
         ]
-        let attributed = NSAttributedString(string: label, attributes: attributes)
-        let textSize = attributed.size()
-        let paddingX: CGFloat = 10
-        let paddingY: CGFloat = 6
+        let kickerAttributes: [NSAttributedString.Key: Any] = [
+            .font: kickerFont,
+            .foregroundColor: color.withAlphaComponent(0.84),
+        ]
+        let title = NSAttributedString(string: display.title, attributes: titleAttributes)
+        let kicker = display.kicker.map { NSAttributedString(string: $0, attributes: kickerAttributes) }
+        let titleSize = title.size()
+        let kickerSize = kicker?.size() ?? .zero
+        let gap: CGFloat = kicker == nil ? 0 : 2
+        let textSize = CGSize(
+            width: max(titleSize.width, kickerSize.width),
+            height: titleSize.height + gap + kickerSize.height
+        )
+        let paddingX: CGFloat = 14
+        let paddingY: CGFloat = 8
+        let tickWidth: CGFloat = 6
         let bubbleSize = CGSize(
-            width: textSize.width + paddingX * 2,
+            width: textSize.width + paddingX * 2 + tickWidth,
             height: textSize.height + paddingY * 2
         )
         let bubbleOrigin = labelOrigin(from: origin, to: end, direction: direction, bubbleSize: bubbleSize)
@@ -919,22 +1531,66 @@ private final class MouseGestureOverlayView: NSView {
             height: bubbleSize.height
         )
 
-        let bg = NSBezierPath(roundedRect: rect, xRadius: 10, yRadius: 10)
-        NSColor.black.withAlphaComponent(0.42).setFill()
+        ctxSaveForLabel(rotationDegrees: -4, around: CGPoint(x: rect.midX, y: rect.midY))
+
+        let shadowRect = rect.insetBy(dx: -5, dy: -5)
+        let shadow = NSBezierPath(roundedRect: shadowRect, xRadius: 15, yRadius: 15)
+        theme.graphiteDark.withAlphaComponent(0.24).setFill()
+        shadow.fill()
+
+        let bg = NSBezierPath(roundedRect: rect, xRadius: 13, yRadius: 13)
+        theme.graphiteDark.withAlphaComponent(0.82).setFill()
         bg.fill()
 
-        let border = NSBezierPath(roundedRect: rect, xRadius: 10, yRadius: 10)
-        color.withAlphaComponent(0.26).setStroke()
-        border.lineWidth = 1
+        let border = NSBezierPath(roundedRect: rect, xRadius: 13, yRadius: 13)
+        theme.graphite.withAlphaComponent(0.46).setStroke()
+        border.lineWidth = 1.2
         border.stroke()
 
-        let textRect = CGRect(
-            x: rect.minX + paddingX,
-            y: rect.minY + paddingY,
-            width: textSize.width,
-            height: textSize.height
+        let tickRect = CGRect(
+            x: rect.minX + 8,
+            y: rect.midY - 7,
+            width: 3,
+            height: 14
         )
-        attributed.draw(in: textRect)
+        let tick = NSBezierPath(roundedRect: tickRect, xRadius: 1.5, yRadius: 1.5)
+        color.withAlphaComponent(0.82).setFill()
+        tick.fill()
+
+        let titleRect = CGRect(
+            x: rect.minX + paddingX + tickWidth,
+            y: rect.minY + paddingY + kickerSize.height + gap,
+            width: titleSize.width,
+            height: titleSize.height
+        )
+        title.draw(in: titleRect)
+
+        if let kicker {
+            let kickerRect = CGRect(
+                x: rect.minX + paddingX + tickWidth + 1,
+                y: rect.minY + paddingY,
+                width: kickerSize.width,
+                height: kickerSize.height
+            )
+            kicker.draw(in: kickerRect)
+        }
+
+        NSGraphicsContext.current?.cgContext.restoreGState()
+    }
+
+    private func labelComponents(for label: String) -> (title: String, kicker: String?) {
+        if label.hasSuffix(" Focused") {
+            return (String(label.dropLast(" Focused".count)), "FOCUSED")
+        }
+        return (label, nil)
+    }
+
+    private func ctxSaveForLabel(rotationDegrees: CGFloat, around center: CGPoint) {
+        guard let ctx = NSGraphicsContext.current?.cgContext else { return }
+        ctx.saveGState()
+        ctx.translateBy(x: center.x, y: center.y)
+        ctx.rotate(by: rotationDegrees * .pi / 180)
+        ctx.translateBy(x: -center.x, y: -center.y)
     }
 
     private func labelOrigin(from origin: CGPoint, to end: CGPoint, direction: MouseGestureDirection, bubbleSize: CGSize) -> CGPoint {
@@ -1045,7 +1701,7 @@ private final class MouseGestureOverlayView: NSView {
         accessoryAnimationDuration = 0
         accessoryAnimationDelay = 0
 
-        if case .committed(_, _, _, _, let accessory, let duration) = state, accessory != nil {
+        if case .committed(_, _, _, _, _, _, _, _, _, let accessory, let duration) = state, accessory != nil {
             accessoryAnimationStartedAt = Date()
             accessoryAnimationDuration = duration
             accessoryAnimationDelay = replayLeadInDuration * 0.86
@@ -1180,9 +1836,9 @@ private final class MouseGestureOverlayView: NSView {
         switch state {
         case .idle:
             return nil
-        case .tracking(_, let direction, _, _):
+        case .tracking(_, let direction, _, _, _, _, _, _, _, _):
             return direction
-        case .committed(_, let direction, _, _, _, _):
+        case .committed(_, let direction, _, _, _, _, _, _, _, _, _):
             return direction
         }
     }
@@ -1195,7 +1851,7 @@ private final class MouseGestureOverlayView: NSView {
     }
 
     private func trackingProgress(from state: State) -> CGFloat? {
-        if case .tracking(_, _, _, let progress) = state {
+        if case .tracking(_, _, _, _, _, _, _, _, _, let progress) = state {
             return progress
         }
         return nil

--- a/app/Sources/Core/Input/MouseShortcutStore.swift
+++ b/app/Sources/Core/Input/MouseShortcutStore.swift
@@ -36,6 +36,10 @@ final class MouseShortcutStore: ObservableObject {
         enabledRules.map { "\($0.trigger.triggerName) -> \($0.action.type.rawValue)" }
     }
 
+    func visualHint(for button: MouseShortcutButton) -> MouseShortcutVisualDefinition? {
+        enabledRules.first { $0.trigger.button == button && $0.visual != nil }?.visual
+    }
+
     func ensureConfigFile() {
         guard !FileManager.default.fileExists(atPath: configURL.path) else { return }
         write(config: .defaults)
@@ -77,9 +81,16 @@ final class MouseShortcutStore: ObservableObject {
         for rule in enabledRules {
             guard rule.trigger.kind == event.kind,
                   rule.trigger.button == event.button,
-                  rule.trigger.direction == event.direction,
                   rule.device.matches(event.device) else {
                 continue
+            }
+            switch event.kind {
+            case .drag:
+                guard rule.trigger.direction == event.direction else { continue }
+            case .shape:
+                guard rule.trigger.shape == event.shape else { continue }
+            case .click:
+                break
             }
 
             return MouseShortcutMatchResult(

--- a/app/Sources/Core/Input/ShapeRecognizer.swift
+++ b/app/Sources/Core/Input/ShapeRecognizer.swift
@@ -1,0 +1,607 @@
+import Foundation
+import CoreGraphics
+
+// MARK: - Path Point
+
+/// A single point in the captured mouse path with timestamp
+struct GesturePathPoint: Codable {
+    let x: CGFloat
+    let y: CGFloat
+    let timestamp: TimeInterval
+
+    var cgPoint: CGPoint {
+        CGPoint(x: x, y: y)
+    }
+
+    init(x: CGFloat, y: CGFloat, timestamp: TimeInterval) {
+        self.x = x
+        self.y = y
+        self.timestamp = timestamp
+    }
+
+    init(point: CGPoint, timestamp: TimeInterval) {
+        self.x = point.x
+        self.y = point.y
+        self.timestamp = timestamp
+    }
+}
+
+// MARK: - Direction Segment
+
+/// A detected direction segment in the path
+struct DirectionSegment {
+    let direction: MouseGestureDirection
+    let startIndex: Int
+    let endIndex: Int
+    let length: CGFloat
+
+    var label: String {
+        direction.rawValue
+    }
+}
+
+// MARK: - Shape Label
+
+/// Recognized shape label from the gesture
+enum GestureShapeLabel: String, Codable, CaseIterable {
+    // Single segment
+    case up = "up"
+    case down = "down"
+    case left = "left"
+    case right = "right"
+
+    // Two-segment shapes
+    case lShapeDownRight = "l-shape-down-right"
+    case lShapeDownLeft = "l-shape-down-left"
+    case lShapeUpRight = "l-shape-up-right"
+    case lShapeUpLeft = "l-shape-up-left"
+    case reverseLShapeRightDown = "reverse-l-right-down"
+    case reverseLShapeLeftDown = "reverse-l-left-down"
+    case vShape = "v-shape"
+    case reverseV = "reverse-v"
+    case zShape = "z-shape"
+    case reverseZ = "reverse-z"
+    case sShape = "s-shape"
+
+    // Three-segment shapes
+    case uShape = "u-shape"
+    case uShapeFlipped = "u-shape-flipped"
+    case nShape = "n-shape"
+    case mShape = "m-shape"
+
+    var displayName: String {
+        switch self {
+        case .up: return "Up"
+        case .down: return "Down"
+        case .left: return "Left"
+        case .right: return "Right"
+        case .lShapeDownRight: return "L (↓ then →)"
+        case .lShapeDownLeft: return "L (↓ then ←)"
+        case .lShapeUpRight: return "L (↑ then →)"
+        case .lShapeUpLeft: return "L (↑ then ←)"
+        case .reverseLShapeRightDown: return "Reverse L (→ then ↓)"
+        case .reverseLShapeLeftDown: return "Reverse L (← then ↓)"
+        case .vShape: return "V (↓ then ↑)"
+        case .reverseV: return "Reverse V (↑ then ↓)"
+        case .zShape: return "Z (→ then ↓ then →)"
+        case .reverseZ: return "Reverse Z (← then ↓ then ←)"
+        case .sShape: return "S (→ then ↑ then →)"
+        case .uShape: return "U (↓ then → then ↑)"
+        case .uShapeFlipped: return "U Flipped (↑ then → then ↓)"
+        case .nShape: return "N (↓ then ← then ↑)"
+        case .mShape: return "M (↑ then ← then ↓)"
+        }
+    }
+
+    var segmentCount: Int {
+        switch self {
+        case .up, .down, .left, .right:
+            return 1
+        case .lShapeDownRight, .lShapeDownLeft, .lShapeUpRight, .lShapeUpLeft,
+             .reverseLShapeRightDown, .reverseLShapeLeftDown, .vShape, .reverseV:
+            return 2
+        case .zShape, .reverseZ, .sShape:
+            return 3
+        case .uShape, .uShapeFlipped, .nShape, .mShape:
+            return 3
+        }
+    }
+
+    static func from(segments: [DirectionSegment]) -> GestureShapeLabel? {
+        guard !segments.isEmpty else { return nil }
+
+        let directions = segments.map { $0.direction }
+
+        // Single direction
+        if segments.count == 1 {
+            switch directions[0] {
+            case .up: return .up
+            case .down: return .down
+            case .left: return .left
+            case .right: return .right
+            }
+        }
+
+        // Two directions - L-shapes, V-shapes, etc.
+        if segments.count == 2 {
+            let first = directions[0]
+            let second = directions[1]
+
+            // L shapes
+            if first == .down && second == .right {
+                return .lShapeDownRight
+            }
+            if first == .down && second == .left {
+                return .lShapeDownLeft
+            }
+            if first == .up && second == .right {
+                return .lShapeUpRight
+            }
+            if first == .up && second == .left {
+                return .lShapeUpLeft
+            }
+
+            // Reverse L shapes (horizontal first)
+            if first == .right && second == .down {
+                return .reverseLShapeRightDown
+            }
+            if first == .left && second == .down {
+                return .reverseLShapeLeftDown
+            }
+
+            // V shapes (opposite vertical directions)
+            if first == .down && second == .up {
+                return .vShape
+            }
+            if first == .up && second == .down {
+                return .reverseV
+            }
+        }
+
+        // Three directions - Z-shapes, U-shapes, etc.
+        if segments.count == 3 {
+            let first = directions[0]
+            let second = directions[1]
+            let third = directions[2]
+
+            // Z shapes (horizontal, vertical, horizontal)
+            if first == .right && second == .down && third == .right {
+                return .zShape
+            }
+            if first == .left && second == .down && third == .left {
+                return .reverseZ
+            }
+            if first == .right && second == .up && third == .right {
+                return .sShape
+            }
+
+            // U shapes (down, right, up or similar)
+            if first == .down && second == .right && third == .up {
+                return .uShape
+            }
+            if first == .up && second == .right && third == .down {
+                return .uShapeFlipped
+            }
+            if first == .down && second == .left && third == .up {
+                return .nShape
+            }
+            if first == .up && second == .left && third == .down {
+                return .mShape
+            }
+        }
+
+        return nil
+    }
+}
+
+// MARK: - Recognition Result
+
+struct ShapeRecognitionResult {
+    let shape: GestureShapeLabel?
+    let segments: [DirectionSegment]
+    let confidence: CGFloat
+    let pathLength: CGFloat
+
+    var displayLabel: String {
+        if let shape {
+            return shape.displayName
+        }
+        if let first = segments.first {
+            return "Unknown (\(first.label))"
+        }
+        return "Unknown"
+    }
+
+    var shapeToken: String? {
+        shape?.rawValue
+    }
+}
+
+// MARK: - Shape Recognizer
+
+final class ShapeRecognizer {
+    // Configuration
+    private let minSegmentLength: CGFloat
+    private let angularThreshold: CGFloat  // radians, default ~45 degrees
+    private let minTotalPathLength: CGFloat
+    private let cornerSmoothRadius: Int     // points to consider around corners
+
+    init(
+        minSegmentLength: CGFloat = 40,
+        angularThreshold: CGFloat = .pi / 4,  // 45 degrees
+        minTotalPathLength: CGFloat = 80,
+        cornerSmoothRadius: Int = 3
+    ) {
+        self.minSegmentLength = minSegmentLength
+        self.angularThreshold = angularThreshold
+        self.minTotalPathLength = minTotalPathLength
+        self.cornerSmoothRadius = cornerSmoothRadius
+    }
+
+    // MARK: - Main Entry Point
+
+    func recognize(points: [GesturePathPoint]) -> ShapeRecognitionResult {
+        guard points.count >= 3 else {
+            return ShapeRecognitionResult(shape: nil, segments: [], confidence: 0, pathLength: 0)
+        }
+
+        // Calculate total path length
+        let totalLength = calculatePathLength(points)
+        guard totalLength >= minTotalPathLength else {
+            return ShapeRecognitionResult(shape: nil, segments: [], confidence: 0, pathLength: totalLength)
+        }
+
+        // Direction runs work better for mouse gestures than strict corner
+        // detection because real paths rarely contain one crisp corner sample.
+        let runSegments = buildDirectionRunSegments(points: points)
+        let corners = detectCorners(points: points)
+        let segments = runSegments.isEmpty ? buildSegments(points: points, corners: corners) : runSegments
+
+        // Classify shape
+        let shape = GestureShapeLabel.from(segments: segments)
+
+        // Calculate confidence based on segment clarity
+        let confidence = calculateConfidence(segments: segments, corners: corners.count, totalLength: totalLength)
+
+        return ShapeRecognitionResult(
+            shape: shape,
+            segments: segments,
+            confidence: confidence,
+            pathLength: totalLength
+        )
+    }
+
+    // MARK: - Corner Detection
+
+    private func detectCorners(points: [GesturePathPoint]) -> [Int] {
+        guard points.count > cornerSmoothRadius * 2 else { return [] }
+
+        var corners: [Int] = []
+        var lastSignificantDirection: MouseGestureDirection?
+
+        for i in cornerSmoothRadius..<(points.count - cornerSmoothRadius) {
+            let before = averageVector(in: points, from: i - cornerSmoothRadius, to: i)
+            let after = averageVector(in: points, from: i, to: i + cornerSmoothRadius)
+
+            // Skip if either vector is too short (near-zero movement)
+            guard vectorLength(before) > minSegmentLength / 4 else { continue }
+            guard vectorLength(after) > minSegmentLength / 4 else { continue }
+
+            let directionBefore = vectorToDirection(before)
+            let directionAfter = vectorToDirection(after)
+
+            guard let dirBefore = directionBefore, let dirAfter = directionAfter else { continue }
+
+            // Check if this is a meaningful direction change
+            if dirBefore != dirAfter {
+                // Verify it's not just noise - the change should be significant
+                let angle = angleBetween(before, after)
+                if angle >= angularThreshold {
+                    // Only add if it's a new direction (not rapid back-and-forth)
+                    if lastSignificantDirection != dirAfter {
+                        corners.append(i)
+                        lastSignificantDirection = dirAfter
+                    }
+                }
+            }
+        }
+
+        return corners
+    }
+
+    private func averageVector(in points: [GesturePathPoint], from start: Int, to end: Int) -> CGPoint {
+        guard end > start else { return .zero }
+        var sum = CGPoint.zero
+        var count = 0
+
+        for i in start..<min(end, points.count) {
+            if i > start {
+                let prev = points[i - 1]
+                let curr = points[i]
+                sum.x += curr.x - prev.x
+                sum.y += curr.y - prev.y
+                count += 1
+            }
+        }
+
+        return count > 0 ? CGPoint(x: sum.x / CGFloat(count), y: sum.y / CGFloat(count)) : .zero
+    }
+
+    private func vectorLength(_ v: CGPoint) -> CGFloat {
+        sqrt(v.x * v.x + v.y * v.y)
+    }
+
+    private func vectorToDirection(_ v: CGPoint) -> MouseGestureDirection? {
+        let length = vectorLength(v)
+        guard length > 5 else { return nil }  // minimum threshold
+
+        // Determine primary direction based on dominant axis
+        let absX = abs(v.x)
+        let absY = abs(v.y)
+
+        if absX > absY * 1.2 {  // axis bias
+            return v.x >= 0 ? .right : .left
+        } else if absY > absX * 1.2 {
+            return v.y >= 0 ? .down : .up
+        }
+
+        // If diagonal, use the dominant component
+        if absX >= absY {
+            return v.x >= 0 ? .right : .left
+        } else {
+            return v.y >= 0 ? .down : .up
+        }
+    }
+
+    private func angleBetween(_ a: CGPoint, _ b: CGPoint) -> CGFloat {
+        let dot = a.x * b.x + a.y * b.y
+        let lenA = vectorLength(a)
+        let lenB = vectorLength(b)
+        guard lenA > 0 && lenB > 0 else { return 0 }
+
+        let cosAngle = max(-1, min(1, dot / (lenA * lenB)))
+        return acos(cosAngle)
+    }
+
+    // MARK: - Segment Building
+
+    private func buildDirectionRunSegments(points: [GesturePathPoint]) -> [DirectionSegment] {
+        guard points.count >= 2 else { return [] }
+
+        var rawSegments: [DirectionSegment] = []
+        var currentDirection: MouseGestureDirection?
+        var currentStart = 0
+        var currentEnd = 0
+        var currentLength: CGFloat = 0
+
+        func flushCurrent() {
+            guard let currentDirection, currentLength > 0 else { return }
+            rawSegments.append(
+                DirectionSegment(
+                    direction: currentDirection,
+                    startIndex: currentStart,
+                    endIndex: currentEnd,
+                    length: currentLength
+                )
+            )
+        }
+
+        for index in 1..<points.count {
+            let previous = points[index - 1]
+            let current = points[index]
+            let delta = CGPoint(x: current.x - previous.x, y: current.y - previous.y)
+            let length = vectorLength(delta)
+            guard length >= 2, let direction = vectorToDirection(delta) else { continue }
+
+            if currentDirection == nil {
+                currentDirection = direction
+                currentStart = index - 1
+                currentEnd = index
+                currentLength = length
+                continue
+            }
+
+            if direction == currentDirection {
+                currentEnd = index
+                currentLength += length
+            } else {
+                flushCurrent()
+                currentDirection = direction
+                currentStart = index - 1
+                currentEnd = index
+                currentLength = length
+            }
+        }
+        flushCurrent()
+
+        let merged = mergeShortDirectionRuns(rawSegments)
+        let filtered = merged.filter { $0.length >= minSegmentLength }
+        return mergeAdjacentSegments(filtered)
+    }
+
+    private func mergeShortDirectionRuns(_ segments: [DirectionSegment]) -> [DirectionSegment] {
+        guard !segments.isEmpty else { return [] }
+
+        var result: [DirectionSegment] = []
+        for segment in segments {
+            guard segment.length < minSegmentLength / 2 else {
+                result.append(segment)
+                continue
+            }
+
+            if let last = result.last {
+                result[result.count - 1] = DirectionSegment(
+                    direction: last.direction,
+                    startIndex: last.startIndex,
+                    endIndex: segment.endIndex,
+                    length: last.length + segment.length
+                )
+            }
+        }
+
+        return result
+    }
+
+    private func mergeAdjacentSegments(_ segments: [DirectionSegment]) -> [DirectionSegment] {
+        guard !segments.isEmpty else { return [] }
+
+        var result: [DirectionSegment] = []
+        for segment in segments {
+            if let last = result.last, last.direction == segment.direction {
+                result[result.count - 1] = DirectionSegment(
+                    direction: last.direction,
+                    startIndex: last.startIndex,
+                    endIndex: segment.endIndex,
+                    length: last.length + segment.length
+                )
+            } else {
+                result.append(segment)
+            }
+        }
+
+        return result
+    }
+
+    private func buildSegments(points: [GesturePathPoint], corners: [Int]) -> [DirectionSegment] {
+        guard !points.isEmpty else { return [] }
+
+        // If no corners, use entire path as one segment
+        if corners.isEmpty {
+            let direction = overallDirection(points: points)
+            if let dir = direction {
+                let length = calculatePathLength(points)
+                return [DirectionSegment(direction: dir, startIndex: 0, endIndex: points.count - 1, length: length)]
+            }
+            return []
+        }
+
+        var segments: [DirectionSegment] = []
+
+        // First segment
+        let firstCorner = corners[0]
+        let firstDir = segmentDirection(points: points, from: 0, to: firstCorner)
+        if let dir = firstDir {
+            let length = segmentLength(points: points, from: 0, to: firstCorner)
+            if length >= minSegmentLength {
+                segments.append(DirectionSegment(direction: dir, startIndex: 0, endIndex: firstCorner, length: length))
+            }
+        }
+
+        // Middle segments (between corners)
+        for i in 0..<(corners.count - 1) {
+            let startIdx = corners[i]
+            let endIdx = corners[i + 1]
+            let dir = segmentDirection(points: points, from: startIdx, to: endIdx)
+            if let dir = dir {
+                let length = segmentLength(points: points, from: startIdx, to: endIdx)
+                if length >= minSegmentLength {
+                    segments.append(DirectionSegment(direction: dir, startIndex: startIdx, endIndex: endIdx, length: length))
+                }
+            }
+        }
+
+        // Last segment
+        let lastCorner = corners[corners.count - 1]
+        let lastDir = segmentDirection(points: points, from: lastCorner, to: points.count - 1)
+        if let dir = lastDir {
+            let length = segmentLength(points: points, from: lastCorner, to: points.count - 1)
+            if length >= minSegmentLength {
+                segments.append(DirectionSegment(direction: dir, startIndex: lastCorner, endIndex: points.count - 1, length: length))
+            }
+        }
+
+        return segments
+    }
+
+    private func overallDirection(points: [GesturePathPoint]) -> MouseGestureDirection? {
+        guard let first = points.first, let last = points.last else { return nil }
+        let delta = CGPoint(x: last.x - first.x, y: last.y - first.y)
+        return vectorToDirection(delta)
+    }
+
+    private func segmentDirection(points: [GesturePathPoint], from startIdx: Int, to endIdx: Int) -> MouseGestureDirection? {
+        guard startIdx < endIdx, endIdx < points.count else { return nil }
+        let start = points[startIdx]
+        let end = points[endIdx]
+        let delta = CGPoint(x: end.x - start.x, y: end.y - start.y)
+        return vectorToDirection(delta)
+    }
+
+    private func segmentLength(points: [GesturePathPoint], from startIdx: Int, to endIdx: Int) -> CGFloat {
+        guard startIdx < endIdx else { return 0 }
+        var length: CGFloat = 0
+        for i in (startIdx + 1)...endIdx {
+            if i < points.count {
+                let dx = points[i].x - points[i - 1].x
+                let dy = points[i].y - points[i - 1].y
+                length += sqrt(dx * dx + dy * dy)
+            }
+        }
+        return length
+    }
+
+    private func calculatePathLength(_ points: [GesturePathPoint]) -> CGFloat {
+        guard points.count >= 2 else { return 0 }
+        var length: CGFloat = 0
+        for i in 1..<points.count {
+            let dx = points[i].x - points[i - 1].x
+            let dy = points[i].y - points[i - 1].y
+            length += sqrt(dx * dx + dy * dy)
+        }
+        return length
+    }
+
+    // MARK: - Confidence Calculation
+
+    private func calculateConfidence(segments: [DirectionSegment], corners: Int, totalLength: CGFloat) -> CGFloat {
+        guard !segments.isEmpty else { return 0 }
+
+        var confidence: CGFloat = 1.0
+
+        // Penalize for many corners (noisy path)
+        if corners > 2 {
+            confidence -= CGFloat(corners - 2) * 0.1
+        }
+
+        // Penalize if segment lengths are very uneven (might be accidental)
+        if segments.count >= 2 {
+            let lengths = segments.map { $0.length }
+            let avgLength = lengths.reduce(0, +) / CGFloat(lengths.count)
+            let variance = lengths.map { abs($0 - avgLength) / avgLength }.reduce(0, +) / CGFloat(lengths.count)
+            confidence -= min(0.3, CGFloat(variance) * 0.5)
+        }
+
+        // Boost if path is long and smooth
+        if totalLength > 200 && corners == 0 {
+            confidence = min(1.0, confidence + 0.1)
+        }
+
+        return max(0, min(1, confidence))
+    }
+}
+
+// MARK: - Convenience Extensions
+
+extension ShapeRecognizer {
+    /// Recognize from raw CGPoints
+    func recognize(points: [CGPoint], timestamps: [TimeInterval]? = nil) -> ShapeRecognitionResult {
+        let gesturePoints: [GesturePathPoint]
+        if let ts = timestamps {
+            gesturePoints = zip(points, ts).map { GesturePathPoint(x: $0.0.x, y: $0.0.y, timestamp: $0.1) }
+        } else {
+            let now = Date().timeIntervalSinceReferenceDate
+            gesturePoints = points.enumerated().map { GesturePathPoint(x: $0.1.x, y: $0.1.y, timestamp: now + Double($0.0) * 0.01) }
+        }
+        return recognize(points: gesturePoints)
+    }
+
+    /// Quick check if path contains a corner
+    func hasCorner(at point: CGPoint, in points: [GesturePathPoint]) -> Bool {
+        // Simple check - find nearest point index and check context
+        guard let nearestIndex = points.firstIndex(where: { abs($0.x - point.x) < 5 && abs($0.y - point.y) < 5 }) else {
+            return false
+        }
+        let corners = detectCorners(points: points)
+        return corners.contains(nearestIndex)
+    }
+}

--- a/app/Sources/Core/Overlays/Voice/VoiceCommandWindow.swift
+++ b/app/Sources/Core/Overlays/Voice/VoiceCommandWindow.swift
@@ -968,15 +968,14 @@ struct VoiceCommandView: View {
         let slots = state.intentSlots.map { "\($0.key)=\($0.value)" }.joined(separator: ", ")
         let matchStr = slots.isEmpty ? matched : "\(matched)(\(slots))"
 
-        let haiku = AgentPool.shared.haiku
-        guard haiku.isReady else {
-            state.appendLog("AI not ready")
+        let assistant = PiChatSession.shared
+        guard assistant.isProviderInferenceReady else {
+            state.appendLog("Assistant provider not ready")
             return
         }
 
-        state.appendLog("Asking AI...")
-        let message = "Transcript: \"\(transcript)\"\nMatched: \(matchStr)"
-        haiku.send(message: message) { [weak state] response in
+        state.appendLog("Asking Assistant...")
+        assistant.askVoiceAdvisor(transcript: transcript, matched: matchStr) { [weak state] response in
             guard let state = state, let response = response else { return }
             state.agentResponse = response
         }
@@ -985,7 +984,7 @@ struct VoiceCommandView: View {
     private func executeSuggestion(_ suggestion: AgentResponse.AgentSuggestion) {
         var slotsDict = suggestion.slots
 
-        // If the intent needs a query slot and Haiku didn't include one,
+        // If the intent needs a query slot and the assistant did not include one,
         // try to extract it from the label or fall back to the original query
         if suggestion.intent == "search" && slotsDict["query"] == nil {
             // Try extracting from label: "Deep search Vox" → "Vox"
@@ -1124,7 +1123,7 @@ struct VoiceCommandView: View {
 
     // MARK: - AI Corner (bottom-right)
 
-    @ObservedObject private var haikuSession = AgentPool.shared.haiku
+    @ObservedObject private var assistantSession = PiChatSession.shared
 
     private var aiCorner: some View {
         VStack(spacing: 0) {
@@ -1139,20 +1138,9 @@ struct VoiceCommandView: View {
                     .tracking(1)
                 Spacer()
 
-                // Context usage indicator
-                let stats = haikuSession.sessionStats
-                if stats.contextWindow > 0 {
-                    let pct = Int(stats.contextUsage * 100)
-                    Text("\(pct)%")
-                        .font(Typo.geistMono(8))
-                        .foregroundColor(pct > 60 ? Palette.detach : Palette.textMuted.opacity(0.6))
-                }
-
-                if stats.costUSD > 0 {
-                    Text("$\(String(format: "%.3f", stats.costUSD))")
-                        .font(Typo.geistMono(8))
-                        .foregroundColor(Palette.textMuted.opacity(0.6))
-                }
+                Text(assistantSession.currentProvider.name)
+                    .font(Typo.geistMono(8))
+                    .foregroundColor(Palette.textMuted.opacity(0.65))
 
                 if state.agentResponse != nil {
                     Button(action: { copyAIResponse() }) {
@@ -1163,7 +1151,7 @@ struct VoiceCommandView: View {
                     .buttonStyle(.plain)
                 }
 
-                if haikuSession.isReady {
+                if assistantSession.isProviderInferenceReady {
                     Circle()
                         .fill(Palette.running.opacity(0.6))
                         .frame(width: 4, height: 4)

--- a/app/Sources/Core/Pi/PiChatDock.swift
+++ b/app/Sources/Core/Pi/PiChatDock.swift
@@ -16,18 +16,6 @@ struct PiChatDock: View {
         VStack(spacing: 0) {
             topHandle
 
-            if session.hasPiBinary && session.isAuthPanelVisible {
-                Rectangle()
-                    .fill(Palette.border)
-                    .frame(height: 0.5)
-
-                authPanel
-
-                Rectangle()
-                    .fill(Palette.border)
-                    .frame(height: 0.5)
-            }
-
             transcript
 
             Rectangle()
@@ -37,14 +25,7 @@ struct PiChatDock: View {
             if session.hasPiBinary && !session.needsProviderSetup {
                 composer
             } else if session.needsProviderSetup {
-                if session.isAuthPanelVisible {
-                    setupLockedBar
-                } else {
-                    PiProviderSetupCallout(session: session, compact: true)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 10)
-                        .background(Color.black.opacity(0.62))
-                }
+                providerSettingsBar
             } else {
                 PiInstallCallout(session: session, compact: true)
                     .padding(.horizontal, 10)
@@ -197,29 +178,54 @@ struct PiChatDock: View {
                     .fixedSize(horizontal: false, vertical: true)
 
                 if session.currentProvider.authMode == .apiKey {
-                    HStack(spacing: 8) {
-                        SecureField(session.currentProvider.tokenPlaceholder, text: $session.authToken)
-                            .textFieldStyle(.plain)
-                            .font(Typo.mono(11))
-                            .foregroundColor(Palette.text)
-                            .focused($authFieldFocused)
-                            .onSubmit {
-                                session.saveSelectedToken()
+                    if session.hasSelectedCredential && !session.isEditingStoredCredential {
+                        HStack(spacing: 8) {
+                            Circle()
+                                .fill(Palette.running)
+                                .frame(width: 6, height: 6)
+
+                            Text("credential saved")
+                                .font(Typo.mono(9))
+                                .foregroundColor(Palette.textDim)
+
+                            Spacer()
+
+                            footerButton("replace") {
+                                session.beginReplacingSelectedCredential()
                             }
 
-                        footerButton("save key") {
-                            session.saveSelectedToken()
-                        }
-
-                        if session.hasSelectedCredential {
                             footerButton("clear") {
                                 session.removeSelectedCredential()
                             }
                         }
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 8)
+                        .background(authCardBackground(tint: Palette.running))
+                    } else {
+                        HStack(spacing: 8) {
+                            SecureField(session.currentProvider.tokenPlaceholder, text: $session.authToken)
+                                .textFieldStyle(.plain)
+                                .font(Typo.mono(11))
+                                .foregroundColor(Palette.text)
+                                .focused($authFieldFocused)
+                                .onSubmit {
+                                    session.saveSelectedToken()
+                                }
+
+                            footerButton("save key") {
+                                session.saveSelectedToken()
+                            }
+
+                            if session.hasSelectedCredential {
+                                footerButton("cancel") {
+                                    session.cancelReplacingSelectedCredential()
+                                }
+                            }
+                        }
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 8)
+                        .background(authCardBackground(tint: Palette.running))
                     }
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 8)
-                    .background(authCardBackground(tint: Palette.running))
                 } else {
                     HStack(spacing: 8) {
                         footerButton("connect") {
@@ -347,7 +353,7 @@ struct PiChatDock: View {
                     .font(Typo.geistMonoBold(11))
                     .foregroundColor(Palette.running)
 
-                TextField("Ask Pi something lightweight...", text: $session.draft, axis: .vertical)
+                TextField("Ask about settings...", text: $session.draft, axis: .vertical)
                     .textFieldStyle(.plain)
                     .font(Typo.mono(11))
                     .foregroundColor(Palette.text)
@@ -384,7 +390,7 @@ struct PiChatDock: View {
                 .fill(session.hasPiBinary ? Palette.running : Palette.kill)
                 .frame(width: 6, height: 6)
 
-            Text("PI DOCK")
+            Text("ASSISTANT")
                 .font(Typo.geistMonoBold(9))
                 .foregroundColor(Palette.text)
 
@@ -395,10 +401,8 @@ struct PiChatDock: View {
 
             Spacer()
 
-            if session.hasPiBinary && !session.needsProviderSetup {
-                footerButton(session.isAuthPanelVisible ? "auth -" : "auth +") {
-                    session.toggleAuthPanel()
-                }
+            footerIconButton(systemName: "gearshape") {
+                SettingsWindowController.shared.showAssistant()
             }
 
             footerButton("reset") {
@@ -408,6 +412,34 @@ struct PiChatDock: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 7)
         .background(Color.white.opacity(0.015))
+    }
+
+    private var providerSettingsBar: some View {
+        HStack(alignment: .center, spacing: 8) {
+            Circle()
+                .fill(Palette.detach)
+                .frame(width: 6, height: 6)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("CONNECT A PROVIDER")
+                    .font(Typo.geistMonoBold(9))
+                    .foregroundColor(Palette.text)
+
+                Text("Choose a chat provider in Settings.")
+                    .font(Typo.mono(9))
+                    .foregroundColor(Palette.textDim)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer()
+
+            footerButton("settings", tint: Palette.running) {
+                SettingsWindowController.shared.showAssistant()
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 10)
+        .background(Color.black.opacity(0.62))
     }
 
     private var footerStatusText: String {
@@ -455,7 +487,7 @@ struct PiChatDock: View {
         switch role {
         case .system: return "system"
         case .user: return "you"
-        case .assistant: return "pi"
+        case .assistant: return "assistant"
         }
     }
 
@@ -504,6 +536,21 @@ struct PiChatDock: View {
             )
             .opacity(disabled ? 0.65 : 1)
             .disabled(disabled)
+    }
+
+    private func footerIconButton(systemName: String, tint: Color = Palette.textMuted, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(tint)
+                .frame(width: 24, height: 22)
+                .background(
+                    Capsule()
+                        .fill(Color.white.opacity(0.03))
+                        .overlay(Capsule().strokeBorder(Palette.border, lineWidth: 0.5))
+                )
+        }
+        .buttonStyle(.plain)
     }
 
     private func authCardBackground(tint: Color) -> some View {

--- a/app/Sources/Core/Pi/PiChatSession.swift
+++ b/app/Sources/Core/Pi/PiChatSession.swift
@@ -40,7 +40,7 @@ struct PiProvider: Identifiable, Equatable {
             authMode: .oauth,
             tokenLabel: "OAuth",
             tokenPlaceholder: "",
-            helpText: "Uses Pi's device-code login. Personal access tokens are not accepted on this path."
+            helpText: "Uses device-code login. Personal access tokens are not accepted on this path."
         ),
         PiProvider(
             id: "openai-codex",
@@ -48,7 +48,7 @@ struct PiProvider: Identifiable, Equatable {
             authMode: .oauth,
             tokenLabel: "OAuth",
             tokenPlaceholder: "",
-            helpText: "Uses Pi's browser login for ChatGPT Plus/Pro Codex access."
+            helpText: "Uses browser login for ChatGPT Plus/Pro Codex access."
         ),
         PiProvider(
             id: "openai",
@@ -56,7 +56,7 @@ struct PiProvider: Identifiable, Equatable {
             authMode: .apiKey,
             tokenLabel: "API key",
             tokenPlaceholder: "sk-...",
-            helpText: "Stores an OpenAI API key in Pi's auth.json for this app and Pi CLI to reuse."
+            helpText: "Stores an OpenAI API key for this app and the provider runtime to reuse."
         ),
         PiProvider(
             id: "anthropic",
@@ -64,7 +64,7 @@ struct PiProvider: Identifiable, Equatable {
             authMode: .apiKey,
             tokenLabel: "API key",
             tokenPlaceholder: "sk-ant-...",
-            helpText: "Stores an Anthropic API key for Pi. OAuth-capable Anthropic flows can be added later."
+            helpText: "Stores an Anthropic API key for provider-backed chat."
         ),
         PiProvider(
             id: "google",
@@ -72,7 +72,7 @@ struct PiProvider: Identifiable, Equatable {
             authMode: .apiKey,
             tokenLabel: "API key",
             tokenPlaceholder: "AIza...",
-            helpText: "Stores a Gemini API key for Pi's Google provider."
+            helpText: "Stores a Gemini API key for provider-backed chat."
         ),
         PiProvider(
             id: "openrouter",
@@ -80,7 +80,7 @@ struct PiProvider: Identifiable, Equatable {
             authMode: .apiKey,
             tokenLabel: "API key",
             tokenPlaceholder: "sk-or-...",
-            helpText: "Stores an OpenRouter API key for Pi."
+            helpText: "Stores an OpenRouter API key for provider-backed chat."
         ),
         PiProvider(
             id: "groq",
@@ -88,7 +88,7 @@ struct PiProvider: Identifiable, Equatable {
             authMode: .apiKey,
             tokenLabel: "API key",
             tokenPlaceholder: "gsk_...",
-            helpText: "Stores a Groq API key for Pi."
+            helpText: "Stores a Groq API key for provider-backed chat."
         ),
         PiProvider(
             id: "xai",
@@ -96,7 +96,7 @@ struct PiProvider: Identifiable, Equatable {
             authMode: .apiKey,
             tokenLabel: "API key",
             tokenPlaceholder: "xai-...",
-            helpText: "Stores an xAI API key for Pi."
+            helpText: "Stores an xAI API key for provider-backed chat."
         ),
         PiProvider(
             id: "mistral",
@@ -104,7 +104,7 @@ struct PiProvider: Identifiable, Equatable {
             authMode: .apiKey,
             tokenLabel: "API key",
             tokenPlaceholder: "",
-            helpText: "Stores a Mistral API key for Pi."
+            helpText: "Stores a Mistral API key for provider-backed chat."
         ),
         PiProvider(
             id: "minimax",
@@ -112,7 +112,7 @@ struct PiProvider: Identifiable, Equatable {
             authMode: .apiKey,
             tokenLabel: "API key",
             tokenPlaceholder: "",
-            helpText: "Stores a MiniMax API key for Pi."
+            helpText: "Stores a MiniMax API key for provider-backed chat."
         ),
     ]
 
@@ -128,7 +128,7 @@ final class PiChatSession: ObservableObject {
     @Published private(set) var messages: [PiChatMessage] = [
         PiChatMessage(
             role: .system,
-            text: "Pi dock ready. This is a lightweight in-app conversation surface, not a full terminal.",
+            text: "Assistant ready. This is a lightweight in-app conversation surface, not a full terminal.",
             timestamp: Date()
         )
     ]
@@ -151,6 +151,7 @@ final class PiChatSession: ObservableObject {
             }
             UserDefaults.standard.set(authProviderID, forKey: Self.selectedProviderDefaultsKey)
             authToken = ""
+            isEditingStoredCredential = false
             authPromptInput = ""
             pendingAuthPrompt = nil
             authNoticeText = nil
@@ -163,6 +164,7 @@ final class PiChatSession: ObservableObject {
         }
     }
     @Published var authToken: String = ""
+    @Published var isEditingStoredCredential: Bool = false
     @Published var authPromptInput: String = ""
     @Published private(set) var isAuthenticating: Bool = false
     @Published private(set) var authenticatingProviderID: String?
@@ -177,6 +179,8 @@ final class PiChatSession: ObservableObject {
 
     private let queue = DispatchQueue(label: "pi-chat-session", qos: .userInitiated)
     private let sessionFileURL: URL
+    private let voiceAdvisorSessionFileURL: URL
+    private let voiceResolverSessionFileURL: URL
     private let authFileURL: URL
     private var authProcess: Process?
     private var authProcessIdentifier: Int32?
@@ -198,6 +202,8 @@ final class PiChatSession: ObservableObject {
         let dir = base.appendingPathComponent("Lattices/pi-chat", isDirectory: true)
         try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
         sessionFileURL = dir.appendingPathComponent("session.jsonl")
+        voiceAdvisorSessionFileURL = dir.appendingPathComponent("voice-advisor.jsonl")
+        voiceResolverSessionFileURL = dir.appendingPathComponent("voice-resolver.jsonl")
         authFileURL = Self.piAgentDirURL().appendingPathComponent("auth.json")
 
         if let savedProvider = UserDefaults.standard.string(forKey: Self.selectedProviderDefaultsKey),
@@ -216,6 +222,10 @@ final class PiChatSession: ObservableObject {
 
     var hasPiBinary: Bool {
         piBinaryPath != nil
+    }
+
+    var isProviderInferenceReady: Bool {
+        hasPiBinary && !needsProviderSetup
     }
 
     var piInstallCommand: String {
@@ -288,7 +298,7 @@ final class PiChatSession: ObservableObject {
             return prompt.message
         }
         if latestAuthURL == nil {
-            return "Stay here for a second while Pi prepares the browser step."
+            return "Stay here for a second while the sign-in page is prepared."
         }
         if authVerificationCode != nil {
             return authVerificationCodeCopied
@@ -313,7 +323,7 @@ final class PiChatSession: ObservableObject {
 
     var setupStatusSummary: String {
         if !hasPiBinary {
-            return "Install Pi to enable the assistant"
+            return "Install the provider runtime to enable provider chat"
         }
         if isAuthenticating {
             return authStepShortText
@@ -389,12 +399,12 @@ final class PiChatSession: ObservableObject {
     func copyPiInstallCommand() {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(piInstallCommand, forType: .string)
-        appendSystemMessage("Copied the Pi install command to the clipboard.")
+        appendSystemMessage("Copied the provider runtime install command to the clipboard.")
     }
 
     func installPiInTerminal() {
         Preferences.shared.terminal.launch(command: piInstallCommand, in: NSHomeDirectory())
-        appendSystemMessage("Opened \(Preferences.shared.terminal.rawValue) and started the Pi install.")
+        appendSystemMessage("Opened \(Preferences.shared.terminal.rawValue) and started the provider runtime install.")
     }
 
     func sendDraft() {
@@ -409,6 +419,14 @@ final class PiChatSession: ObservableObject {
         guard !trimmed.isEmpty else { return }
         guard !isSending else { return }
 
+        messages.append(PiChatMessage(role: .user, text: trimmed, timestamp: Date()))
+
+        if let localResponse = handleLocalSettingsCommand(trimmed) {
+            messages.append(PiChatMessage(role: .assistant, text: localResponse, timestamp: Date()))
+            statusText = hasPiBinary ? (needsProviderSetup ? "setup ai" : "idle") : "missing pi"
+            return
+        }
+
         refreshBinaryAvailability()
 
         guard let piPath = piBinaryPath else {
@@ -422,11 +440,10 @@ final class PiChatSession: ObservableObject {
             return
         }
 
-        messages.append(PiChatMessage(role: .user, text: trimmed, timestamp: Date()))
-
         let provider = currentProvider
         isSending = true
         statusText = "thinking..."
+        let prompt = providerPrompt(for: trimmed)
 
         queue.async { [weak self] in
             guard let self else { return }
@@ -437,7 +454,7 @@ final class PiChatSession: ObservableObject {
                 "--provider", provider.id,
                 "-p",
                 "--session", self.sessionFileURL.path,
-                trimmed,
+                prompt,
             ]
 
             var env = ProcessInfo.processInfo.environment
@@ -469,7 +486,7 @@ final class PiChatSession: ObservableObject {
                 DispatchQueue.main.async {
                     self.isSending = false
                     self.statusText = "launch failed"
-                    self.appendSystemMessage("Failed to launch Pi: \(error.localizedDescription)")
+                    self.appendSystemMessage("Failed to launch the provider runtime: \(error.localizedDescription)")
                 }
                 return
             }
@@ -487,7 +504,7 @@ final class PiChatSession: ObservableObject {
                     return
                 }
 
-                let message = !stderr.isEmpty ? stderr : (stdout.isEmpty ? "Pi returned no output." : stdout)
+                let message = !stderr.isEmpty ? stderr : (stdout.isEmpty ? "The provider runtime returned no output." : stdout)
                 if let friendly = self.friendlyAuthFailureMessage(for: message) {
                     self.statusText = "setup ai"
                     self.authErrorText = friendly
@@ -501,6 +518,140 @@ final class PiChatSession: ObservableObject {
                     self.isAuthPanelVisible = true
                 }
             }
+        }
+    }
+
+    func askVoiceAdvisor(transcript: String, matched: String, callback: @escaping (AgentResponse?) -> Void) {
+        runProviderInference(
+            prompt: voiceAdvisorPrompt(transcript: transcript, matched: matched),
+            sessionURL: voiceAdvisorSessionFileURL,
+            label: "voice advisor"
+        ) { output in
+            guard let output, !output.isEmpty else {
+                callback(nil)
+                return
+            }
+            callback(AgentResponse.parse(text: output))
+        }
+    }
+
+    func answerVoiceQuestion(_ transcript: String, callback: @escaping (AgentResponse?) -> Void) {
+        runProviderInference(
+            prompt: voiceQuestionPrompt(transcript: transcript),
+            sessionURL: voiceAdvisorSessionFileURL,
+            label: "voice question"
+        ) { output in
+            guard let output, !output.isEmpty else {
+                callback(nil)
+                return
+            }
+            callback(AgentResponse(commentary: output, suggestion: nil, raw: output))
+        }
+    }
+
+    func resolveVoiceIntent(transcript: String, callback: @escaping (ResolvedIntent?) -> Void) {
+        runProviderInference(
+            prompt: voiceResolverPrompt(transcript: transcript),
+            sessionURL: voiceResolverSessionFileURL,
+            label: "voice resolver"
+        ) { output in
+            guard let output,
+                  let jsonStr = Self.extractJSON(from: output),
+                  let data = jsonStr.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let intent = json["intent"] as? String,
+                  intent != "unknown" else {
+                callback(nil)
+                return
+            }
+
+            var slots: [String: JSON] = [:]
+            if let rawSlots = json["slots"] as? [String: Any] {
+                for (key, value) in rawSlots {
+                    if let value = value as? String {
+                        slots[key] = .string(value)
+                    } else if let value = value as? Int {
+                        slots[key] = .int(value)
+                    } else if let value = value as? Bool {
+                        slots[key] = .bool(value)
+                    }
+                }
+            }
+            callback(ResolvedIntent(intent: intent, slots: slots))
+        }
+    }
+
+    private func runProviderInference(
+        prompt: String,
+        sessionURL: URL,
+        label: String,
+        callback: @escaping (String?) -> Void
+    ) {
+        refreshBinaryAvailability()
+
+        guard let piPath = piBinaryPath else {
+            DiagnosticLog.shared.info("Assistant inference[\(label)]: provider runtime not installed")
+            callback(nil)
+            return
+        }
+        guard !needsProviderSetup else {
+            DiagnosticLog.shared.info("Assistant inference[\(label)]: selected provider needs credentials")
+            callback(nil)
+            return
+        }
+
+        let provider = currentProvider
+        let hasStoredCredential = storedCredentialKinds[provider.id] != nil
+
+        queue.async {
+            let timer = DiagnosticLog.shared.startTimed("Assistant inference[\(label)] via \(provider.name)")
+
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: piPath)
+            proc.arguments = [
+                "--provider", provider.id,
+                "-p",
+                "--session", sessionURL.path,
+                prompt,
+            ]
+
+            var env = ProcessInfo.processInfo.environment
+            env.removeValue(forKey: "CLAUDECODE")
+            Self.sanitizeEnvironment(&env, for: provider.id, hasStoredCredential: hasStoredCredential)
+            proc.environment = env
+
+            let outPipe = Pipe()
+            let errPipe = Pipe()
+            proc.standardOutput = outPipe
+            proc.standardError = errPipe
+
+            do {
+                try proc.run()
+                proc.waitUntilExit()
+            } catch {
+                DiagnosticLog.shared.warn("Assistant inference[\(label)]: launch failed — \(error)")
+                DiagnosticLog.shared.finish(timer)
+                DispatchQueue.main.async { callback(nil) }
+                return
+            }
+
+            DiagnosticLog.shared.finish(timer)
+            let stdout = String(data: outPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let stderr = String(data: errPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if !stderr.isEmpty {
+                DiagnosticLog.shared.info("Assistant inference[\(label)] stderr: \(stderr.prefix(200))")
+            }
+
+            guard proc.terminationStatus == 0, !stdout.isEmpty else {
+                DiagnosticLog.shared.info("Assistant inference[\(label)]: empty/error response")
+                DispatchQueue.main.async { callback(nil) }
+                return
+            }
+
+            DispatchQueue.main.async { callback(stdout) }
         }
     }
 
@@ -519,10 +670,11 @@ final class PiChatSession: ObservableObject {
                 ]
             }
             authToken = ""
+            isEditingStoredCredential = false
             authNoticeText = "Saved \(currentProvider.tokenLabel.lowercased()) for \(currentProvider.name)."
             authErrorText = nil
             reloadAuthState()
-            appendSystemMessage("Saved \(currentProvider.name) credentials to Pi auth storage.")
+            appendSystemMessage("Saved \(currentProvider.name) credentials.")
             isAuthPanelVisible = false
             prepareForDisplay()
         } catch {
@@ -537,8 +689,9 @@ final class PiChatSession: ObservableObject {
             }
             authNoticeText = "Removed saved credentials for \(currentProvider.name)."
             authErrorText = nil
+            isEditingStoredCredential = true
             reloadAuthState()
-            appendSystemMessage("Removed saved \(currentProvider.name) credentials from Pi auth storage.")
+            appendSystemMessage("Removed saved \(currentProvider.name) credentials.")
             prepareForDisplay()
         } catch {
             authErrorText = "Failed to remove credentials: \(error.localizedDescription)"
@@ -554,6 +707,19 @@ final class PiChatSession: ObservableObject {
         startOAuthLogin(for: currentProvider)
     }
 
+    func beginReplacingSelectedCredential() {
+        authToken = ""
+        authErrorText = nil
+        authNoticeText = nil
+        isEditingStoredCredential = true
+    }
+
+    func cancelReplacingSelectedCredential() {
+        authToken = ""
+        authErrorText = nil
+        isEditingStoredCredential = false
+    }
+
     func submitAuthPrompt() {
         guard let prompt = pendingAuthPrompt else { return }
         let value = authPromptInput.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -563,7 +729,7 @@ final class PiChatSession: ObservableObject {
 
     private func submitAuthPromptValue(_ value: String) {
         guard let handle = authInputHandle else {
-            authErrorText = "Pi auth input pipe is no longer available."
+            authErrorText = "The auth input pipe is no longer available."
             return
         }
 
@@ -639,17 +805,17 @@ final class PiChatSession: ObservableObject {
         refreshBinaryAvailability()
 
         guard hasPiBinary else {
-            authErrorText = "Install Pi before starting auth."
+            authErrorText = "Install the provider runtime before starting auth."
             return
         }
 
         guard let nodePath = nodeBinaryPath else {
-            authErrorText = "Node.js is required for Pi OAuth login."
+            authErrorText = "Node.js is required for OAuth login."
             return
         }
 
         guard let oauthModuleURL = resolveOAuthModuleURL() else {
-            authErrorText = "Couldn't locate Pi's OAuth module next to the installed `pi` CLI."
+            authErrorText = "Couldn't locate the OAuth module next to the installed provider runtime."
             return
         }
 
@@ -783,11 +949,11 @@ final class PiChatSession: ObservableObject {
                 NSWorkspace.shared.open(url)
             }
             if authVerificationCode != nil {
-                appendSystemMessage("Pi auth is ready. The sign-in code is copied, and you can reopen the browser page here if needed.")
+                appendSystemMessage("Auth is ready. The sign-in code is copied, and you can reopen the browser page here if needed.")
             } else if let instructions, !instructions.isEmpty {
-                appendSystemMessage("Pi auth: \(instructions) If nothing opened, use OPEN AGAIN.")
+                appendSystemMessage("Auth: \(instructions) If nothing opened, use OPEN AGAIN.")
             } else {
-                appendSystemMessage("Pi auth is ready in your browser. If nothing opened, use OPEN AGAIN.")
+                appendSystemMessage("Auth is ready in your browser. If nothing opened, use OPEN AGAIN.")
             }
 
         case "progress":
@@ -795,7 +961,7 @@ final class PiChatSession: ObservableObject {
 
         case "success":
             guard var credentials = json["credentials"] as? [String: Any] else {
-                authErrorText = "Pi auth completed but returned no credentials."
+                authErrorText = "Auth completed but returned no credentials."
                 return
             }
             let providerID = authenticatingProviderID ?? authProviderID
@@ -808,7 +974,7 @@ final class PiChatSession: ObservableObject {
                 reloadAuthState()
                 authNoticeText = "Saved OAuth credentials for \(provider.name)."
                 authErrorText = nil
-                appendSystemMessage("Saved \(provider.name) OAuth credentials to Pi auth storage.")
+                appendSystemMessage("Saved \(provider.name) OAuth credentials.")
                 isAuthPanelVisible = false
                 prepareForDisplay()
             } catch {
@@ -816,9 +982,9 @@ final class PiChatSession: ObservableObject {
             }
 
         case "error":
-            let message = json["message"] as? String ?? "Unknown Pi auth error."
+            let message = json["message"] as? String ?? "Unknown auth error."
             authErrorText = message
-            appendSystemMessage("Pi auth failed: \(message)")
+            appendSystemMessage("Auth failed: \(message)")
 
         default:
             authNoticeText = line
@@ -886,9 +1052,9 @@ final class PiChatSession: ObservableObject {
     private func structuredWelcomeMessage() -> String {
         if !hasPiBinary {
             return """
-            Welcome to Pi Workspace.
+            Welcome to the Workspace Assistant.
 
-            Pi powers the in-app assistant. Install it first, then come back here and refresh.
+            I can manage app settings here. Install the provider runtime to unlock provider-backed chat for longer planning and coding prompts.
 
             Install command:
             \(piInstallCommand)
@@ -897,7 +1063,7 @@ final class PiChatSession: ObservableObject {
 
         if isAuthenticating {
             return """
-            Welcome to Pi Workspace.
+            Welcome to the Workspace Assistant.
 
             \(authStepTitle)
 
@@ -907,19 +1073,485 @@ final class PiChatSession: ObservableObject {
 
         if needsProviderSetup {
             return """
-            Welcome to Pi Workspace.
+            Welcome to the Workspace Assistant.
 
             Next step: connect \(currentProvider.name).
 
-            The setup panel above is open. Once you finish that one step, the chat box unlocks automatically.
+            Open Settings with the gear icon, choose a provider, and save its API key to unlock provider-backed chat.
             """
         }
 
         return """
-        Welcome to Pi Workspace.
+        Welcome to the Workspace Assistant.
 
-        You're connected with \(currentProvider.name). Ask for code help, planning, debugging, or a second opinion.
+        You're connected with \(currentProvider.name). I can manage Lattices settings locally, or use the provider for code help, planning, debugging, and second opinions.
         """
+    }
+
+    private func handleLocalSettingsCommand(_ text: String) -> String? {
+        let lower = text.lowercased()
+        let prefs = Preferences.shared
+
+        if lower.contains("open settings") || lower.contains("show settings") {
+            SettingsWindowController.shared.show()
+            return "Opened Settings."
+        }
+
+        if lower.contains("scan root") || lower.contains("project root") || lower.contains("project scan") {
+            if let root = extractPathValue(from: text) {
+                prefs.scanRoot = root
+                ProjectScanner.shared.updateRoot(root)
+                ProjectScanner.shared.scan()
+                return "Set project scan root to \(root) and started a rescan."
+            }
+            return nil
+        }
+
+        if lower.contains("terminal") {
+            if let terminal = parseTerminal(from: lower) {
+                guard terminal.isInstalled else {
+                    return "\(terminal.rawValue) is not installed, so I left the terminal set to \(prefs.terminal.rawValue)."
+                }
+                prefs.terminal = terminal
+                return "Set terminal to \(terminal.rawValue)."
+            }
+            return nil
+        }
+
+        if lower.contains("detach mode") || lower.contains("interaction mode") || lower.contains("learning mode") || lower.contains("auto mode") {
+            if lower.contains("auto") {
+                prefs.mode = .auto
+                return "Set detach mode to Auto."
+            }
+            if lower.contains("learning") {
+                prefs.mode = .learning
+                return "Set detach mode to Learning."
+            }
+            return nil
+        }
+
+        if lower.contains("drag") && lower.contains("snap") {
+            if let enabled = parseBooleanIntent(from: lower) {
+                prefs.dragSnapEnabled = enabled
+                return "\(enabled ? "Enabled" : "Disabled") drag-to-snap."
+            }
+            return nil
+        }
+
+        if lower.contains("mouse") && (lower.contains("gesture") || lower.contains("shortcut")) {
+            if let enabled = parseBooleanIntent(from: lower) {
+                prefs.mouseGesturesEnabled = enabled
+                return "\(enabled ? "Enabled" : "Disabled") mouse gestures."
+            }
+            return nil
+        }
+
+        if lower.contains("companion") && lower.contains("bridge") {
+            if let enabled = parseBooleanIntent(from: lower) {
+                prefs.companionBridgeEnabled = enabled
+                return "\(enabled ? "Enabled" : "Disabled") the companion bridge."
+            }
+            return nil
+        }
+
+        if lower.contains("companion") && lower.contains("trackpad") {
+            if let enabled = parseBooleanIntent(from: lower) {
+                prefs.companionTrackpadEnabled = enabled
+                return "\(enabled ? "Enabled" : "Disabled") companion trackpad."
+            }
+            return nil
+        }
+
+        if lower.contains("ocr") || lower.contains("screen text") || lower.contains("text recognition") {
+            if lower.contains("accuracy") {
+                if lower.contains("fast") {
+                    prefs.ocrAccuracy = "fast"
+                    return "Set OCR accuracy to Fast."
+                }
+                if lower.contains("accurate") {
+                    prefs.ocrAccuracy = "accurate"
+                    return "Set OCR accuracy to Accurate."
+                }
+                return nil
+            }
+
+            if let enabled = parseBooleanIntent(from: lower) {
+                OcrModel.shared.setEnabled(enabled)
+                return "\(enabled ? "Enabled" : "Disabled") screen text recognition."
+            }
+            return nil
+        }
+
+        if lower.contains("advisor") || lower.contains("voice advisor") {
+            return nil
+        }
+
+        if lower.contains("open assistant settings") || lower.contains("show assistant settings") {
+            SettingsWindowController.shared.showAssistant()
+            return "Opened Assistant settings."
+        }
+
+        return nil
+    }
+
+    private func providerPrompt(for userText: String) -> String {
+        """
+        You are the Workspace Assistant, the in-app assistant for Lattices.
+
+        Use the structured context as ground truth. Answer naturally and concretely. For informational questions, explain what is currently configured and what the available choices mean. For setting changes, describe what should change; the host app is responsible for applying supported changes.
+
+        Structured context:
+        \(assistantKnowledgeBrief())
+
+        User request:
+        \(userText)
+        """
+    }
+
+    private func voiceAdvisorPrompt(transcript: String, matched: String) -> String {
+        """
+        You are the same Workspace Assistant used by Lattices chat, responding through the voice command surface.
+
+        Use the shared structured context below as ground truth. The voice surface needs terse commentary and optional next actions, not a chatty answer.
+
+        Structured context:
+        \(assistantKnowledgeBrief())
+
+        Voice transcript:
+        "\(transcript)"
+
+        Local match already handled:
+        \(matched)
+
+        Respond with ONLY a JSON object:
+        {"commentary": "short observation or null", "suggestion": {"label": "button text", "intent": "intent_name", "slots": {"key": "value"}} or null}
+
+        Rules:
+        - commentary: 1 sentence max. null if the matched command fully covers the request.
+        - suggestion: a follow-up action. null if none needed.
+        - Never suggest what was already executed.
+        - Suggestions MUST include all required slots.
+        - Be terse and useful.
+        """
+    }
+
+    private func voiceQuestionPrompt(transcript: String) -> String {
+        """
+        You are the same Workspace Assistant used by Lattices chat, responding through the voice surface.
+
+        This is an informational question, not necessarily a command. Use the shared structured context below, answer naturally, and include concrete current settings when relevant. Keep it short enough for voice, but do not give a clipped yes/no answer.
+
+        Structured context:
+        \(assistantKnowledgeBrief())
+
+        User said:
+        "\(transcript)"
+        """
+    }
+
+    private func voiceResolverPrompt(transcript: String) -> String {
+        let windowList = DesktopModel.shared.windows.values
+            .prefix(20)
+            .map { "\($0.app): \($0.title)" }
+            .joined(separator: "\n")
+
+        var intentList = ""
+        if case .array(let intents) = PhraseMatcher.shared.catalog() {
+            intentList = intents.compactMap { intent -> String? in
+                guard let name = intent["intent"]?.stringValue else { return nil }
+                var slotNames: [String] = []
+                if case .array(let slots) = intent["slots"] {
+                    slotNames = slots.compactMap { $0["name"]?.stringValue }
+                }
+                return slotNames.isEmpty ? name : "\(name)(\(slotNames.joined(separator: ",")))"
+            }.joined(separator: ", ")
+        }
+
+        return """
+        You are the same Workspace Assistant used by Lattices chat, resolving a spoken command into one executable Lattices intent.
+
+        Structured context:
+        \(assistantKnowledgeBrief())
+
+        Voice transcript, possibly with transcription errors:
+        "\(transcript)"
+
+        Available intents:
+        \(intentList)
+
+        Current windows:
+        \(windowList)
+
+        Return ONLY a JSON object like:
+        {"intent":"search","slots":{"query":"dewey"},"reasoning":"user wants to find dewey windows"}
+
+        Rules:
+        - Use intent "unknown" if the request cannot be mapped confidently.
+        - Include all required slots.
+        - For search, extract the key term.
+        - Use app/window names from the current windows list when targeting windows.
+        """
+    }
+
+    private func assistantKnowledgeBrief() -> String {
+        assistantContextJSON()
+    }
+
+    private func assistantContextJSON() -> String {
+        let payload = assistantContextPayload()
+        guard JSONSerialization.isValidJSONObject(payload),
+              let data = try? JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys]),
+              let text = String(data: data, encoding: .utf8) else {
+            return #"{"error":"context unavailable"}"#
+        }
+        return text
+    }
+
+    private func assistantContextPayload() -> [String: Any] {
+        let prefs = Preferences.shared
+        MouseShortcutStore.shared.reloadIfNeeded()
+
+        return [
+            "assistant": [
+                "name": "Workspace Assistant",
+                "selectedProvider": [
+                    "id": authProviderID,
+                    "name": currentProvider.name,
+                    "credential": selectedCredentialSummary,
+                ],
+                "providerRuntime": [
+                    "binary": (piBinaryPath as Any?) ?? NSNull(),
+                    "node": (nodeBinaryPath as Any?) ?? NSNull(),
+                    "authFile": authFileURL.path,
+                    "chatSession": sessionFileURL.path,
+                ],
+            ],
+            "currentSettings": [
+                "terminal": prefs.terminal.rawValue,
+                "detachMode": prefs.mode.rawValue,
+                "scanRoot": prefs.scanRoot.isEmpty ? NSNull() : prefs.scanRoot,
+                "dragToSnap": prefs.dragSnapEnabled,
+                "companionBridge": prefs.companionBridgeEnabled,
+                "companionTrackpad": prefs.companionTrackpadEnabled,
+                "ocr": [
+                    "enabled": prefs.ocrEnabled,
+                    "accuracy": prefs.ocrAccuracy,
+                    "quickIntervalSeconds": prefs.ocrQuickInterval,
+                    "deepIntervalSeconds": prefs.ocrDeepInterval,
+                    "quickWindowLimit": prefs.ocrQuickLimit,
+                    "deepWindowLimit": prefs.ocrDeepLimit,
+                    "deepScanBudget": prefs.ocrDeepBudget,
+                ],
+                "mouseShortcuts": mouseShortcutContextPayload(),
+            ],
+            "settingsCatalog": [
+                [
+                    "id": "terminal",
+                    "type": "enum",
+                    "choices": Terminal.allCases.map(\.rawValue),
+                    "installedChoices": Terminal.installed.map(\.rawValue),
+                    "description": "Terminal app used when Lattices launches workspaces.",
+                ],
+                [
+                    "id": "detachMode",
+                    "type": "enum",
+                    "choices": ["learning", "auto"],
+                    "description": "Learning mode shows tmux hints; auto mode stays quieter.",
+                ],
+                [
+                    "id": "scanRoot",
+                    "type": "path",
+                    "description": "Root directory scanned for projects containing .lattices.json.",
+                ],
+                [
+                    "id": "dragToSnap",
+                    "type": "boolean",
+                    "description": "Enables drag-to-snap window zones.",
+                ],
+                [
+                    "id": "mouseShortcuts",
+                    "type": "boolean-plus-json-rules",
+                    "description": "Middle-click and drag gesture shortcuts controlled by mouseGestures.enabled plus ~/.lattices/mouse-shortcuts.json.",
+                ],
+                [
+                    "id": "ocr",
+                    "type": "object",
+                    "description": "Screen text recognition settings, including enablement, cadence, and accuracy.",
+                ],
+                [
+                    "id": "assistantProvider",
+                    "type": "enum-plus-api-key",
+                    "choices": ["openai", "groq", "openrouter", "minimax"],
+                    "description": "Provider-backed inference for chat and voice.",
+                ],
+            ],
+            "settingsFiles": [
+                "workspace": "\(NSHomeDirectory())/.lattices/workspace.json",
+                "mouseShortcuts": MouseShortcutStore.shared.configURL.path,
+                "snapZones": "\(NSHomeDirectory())/.lattices/snap-zones.json",
+                "ocrDatabase": "\(NSHomeDirectory())/.lattices/ocr.db",
+                "diagnostics": "\(NSHomeDirectory())/.lattices/lattices.log",
+            ],
+            "cliCommands": [
+                "lattices",
+                "lattices init",
+                "lattices sync",
+                "lattices restart [pane]",
+                "lattices tile <position>",
+                "lattices group [id]",
+                "lattices layer [name|index]",
+                "lattices windows --json",
+                "lattices search <query>",
+                "lattices app restart",
+            ],
+            "runtimeSnapshot": [
+                "installedTerminals": Terminal.installed.map(\.rawValue),
+                "discoveredProjectCount": ProjectScanner.shared.projects.count,
+            ],
+        ]
+    }
+
+    private func mouseShortcutContextPayload() -> [String: Any] {
+        let prefs = Preferences.shared
+        let store = MouseShortcutStore.shared
+        store.reloadIfNeeded()
+
+        return [
+            "enabled": prefs.mouseGesturesEnabled,
+            "configFile": store.configURL.path,
+            "tuning": [
+                "dragThresholdPx": Double(store.tuning.dragThreshold),
+                "holdTolerancePx": Double(store.tuning.holdTolerance),
+                "axisBias": Double(store.tuning.axisBias),
+            ],
+            "activeMappings": store.enabledRules.map { rule in
+                [
+                    "id": rule.id,
+                    "trigger": rule.trigger.displayLabel,
+                    "action": rule.action.label,
+                    "summary": rule.summary,
+                ]
+            },
+        ]
+    }
+
+    private func settingsSummary() -> String {
+        let prefs = Preferences.shared
+        return """
+        Current settings:
+        Terminal: \(prefs.terminal.rawValue)
+        Detach mode: \(prefs.mode.rawValue)
+        Scan root: \(prefs.scanRoot.isEmpty ? "not set" : prefs.scanRoot)
+        Drag-to-snap: \(prefs.dragSnapEnabled ? "on" : "off")
+        Mouse gestures: \(prefs.mouseGesturesEnabled ? "on" : "off")
+        Companion bridge: \(prefs.companionBridgeEnabled ? "on" : "off")
+        Companion trackpad: \(prefs.companionTrackpadEnabled ? "on" : "off")
+        OCR: \(prefs.ocrEnabled ? "on" : "off"), \(prefs.ocrAccuracy)
+        Voice assistant: same provider as chat, \(currentProvider.name)
+
+        \(mouseShortcutSummary())
+        """
+    }
+
+    private func mouseShortcutSummary() -> String {
+        let prefs = Preferences.shared
+        let store = MouseShortcutStore.shared
+        store.reloadIfNeeded()
+        let mappings = store.summaryLines
+        let mappingText = mappings.isEmpty
+            ? "- No active mouse shortcut mappings."
+            : mappings.map { "- \($0)" }.joined(separator: "\n")
+
+        return """
+        Mouse shortcuts:
+        - Middle-click shortcuts are \(prefs.mouseGesturesEnabled ? "enabled" : "disabled").
+        - Config file: \(store.configURL.path)
+        - Drag threshold: \(Int(store.tuning.dragThreshold)) px; hold tolerance: \(Int(store.tuning.holdTolerance)) px; axis bias: \(String(format: "%.1f", Double(store.tuning.axisBias))).
+        Active mappings:
+        \(mappingText)
+        """
+    }
+
+    private static func extractJSON(from text: String) -> String? {
+        let cleaned = text
+            .replacingOccurrences(of: "```json", with: "")
+            .replacingOccurrences(of: "```", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let start = cleaned.firstIndex(of: "{"),
+              let end = cleaned.lastIndex(of: "}") else { return nil }
+        return String(cleaned[start...end])
+    }
+
+    private func settingsHelpText() -> String {
+        """
+        I can manage Lattices settings from chat. Try:
+        - set terminal to Ghostty
+        - set scan root to ~/dev
+        - turn OCR off
+        - set OCR accuracy to fast
+        - enable drag snap
+        - disable mouse gestures
+        - set detach mode to auto
+        - open assistant settings
+        - open settings
+        """
+    }
+
+    private func parseTerminal(from lower: String) -> Terminal? {
+        let aliases: [(Terminal, [String])] = [
+            (.iterm2, ["iterm2", "iterm"]),
+            (.warp, ["warp"]),
+            (.ghostty, ["ghostty"]),
+            (.kitty, ["kitty"]),
+            (.alacritty, ["alacritty"]),
+            (.terminal, ["terminal.app", "apple terminal", "terminal"]),
+        ]
+
+        return aliases.first { _, names in
+            names.contains { lower.contains($0) }
+        }?.0
+    }
+
+    private func parseBooleanIntent(from lower: String) -> Bool? {
+        let offTokens = ["turn off", "disable", "disabled", "off", "false", "stop"]
+        if offTokens.contains(where: lower.contains) {
+            return false
+        }
+
+        let onTokens = ["turn on", "enable", "enabled", "on", "true", "start"]
+        if onTokens.contains(where: lower.contains) {
+            return true
+        }
+
+        return nil
+    }
+
+    private func extractPathValue(from text: String) -> String? {
+        let markers = [" to ", " at ", " root "]
+        let lower = text.lowercased()
+
+        for marker in markers {
+            guard let range = lower.range(of: marker) else { continue }
+            let raw = text[range.upperBound...]
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .trimmingCharacters(in: CharacterSet(charactersIn: "\"'`"))
+            guard !raw.isEmpty else { continue }
+            return (raw as NSString).expandingTildeInPath
+        }
+
+        return nil
+    }
+
+    private func extractFirstNumber(from text: String) -> Double? {
+        let pattern = #"(?<![A-Za-z0-9_])\$?([0-9]+(?:\.[0-9]+)?)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let nsRange = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let match = regex.firstMatch(in: text, range: nsRange),
+              match.numberOfRanges > 1,
+              let range = Range(match.range(at: 1), in: text) else {
+            return nil
+        }
+        return Double(text[range])
     }
 
     private func friendlyAuthFailureMessage(for message: String) -> String? {
@@ -937,10 +1569,10 @@ final class PiChatSession: ObservableObject {
         guard authHints.contains(where: lowercased.contains) else { return nil }
 
         if currentProvider.authMode == .oauth {
-            return "This provider is not connected yet. Use the setup panel to sign in with \(currentProvider.name), then come back and send your first prompt."
+            return "This provider is not connected yet. Open Settings with the gear icon, connect \(currentProvider.name), then come back and send your first prompt."
         }
 
-        return "This provider still needs an API key. Paste your \(currentProvider.tokenLabel.lowercased()) into the setup panel above, save it, and then try again."
+        return "This provider still needs an API key. Open Settings with the gear icon, save your \(currentProvider.tokenLabel.lowercased()), and then try again."
     }
 
     private func shouldAutoSubmitPrompt(_ prompt: PiAuthPrompt) -> Bool {

--- a/app/Sources/Core/Pi/PiWorkspaceView.swift
+++ b/app/Sources/Core/Pi/PiWorkspaceView.swift
@@ -19,14 +19,6 @@ struct PiWorkspaceView: View {
                 .fill(Palette.border)
                 .frame(height: 0.5)
 
-            if session.hasPiBinary && session.isAuthPanelVisible {
-                authPanel
-
-                Rectangle()
-                    .fill(Palette.border)
-                    .frame(height: 0.5)
-            }
-
             transcript
 
             Rectangle()
@@ -36,14 +28,7 @@ struct PiWorkspaceView: View {
             if session.hasPiBinary && !session.needsProviderSetup {
                 composer
             } else if session.needsProviderSetup {
-                if session.isAuthPanelVisible {
-                    setupLockedPanel
-                } else {
-                    PiProviderSetupCallout(session: session, compact: false)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 14)
-                        .background(Palette.surface.opacity(0.22))
-                }
+                providerSettingsPrompt
             } else {
                 PiInstallCallout(session: session, compact: false)
                     .padding(.horizontal, 16)
@@ -70,7 +55,7 @@ struct PiWorkspaceView: View {
                         .fill(session.hasPiBinary ? Palette.running : Palette.kill)
                         .frame(width: 7, height: 7)
 
-                    Text("WORKSPACE CHAT")
+                    Text("WORKSPACE ASSISTANT")
                         .font(Typo.geistMonoBold(11))
                         .foregroundColor(Palette.text)
 
@@ -89,8 +74,8 @@ struct PiWorkspaceView: View {
                         ? session.authStepDescription
                         : (session.needsProviderSetup
                             ? "Next step: connect a provider to unlock chat."
-                            : "Full conversation surface for longer prompts, auth, and provider switching."))
-                    : "Install Pi to unlock longer prompts, provider auth, and the full in-app assistant surface.")
+                            : "Full conversation surface for settings, longer prompts, planning, debugging, and second opinions."))
+                    : "Settings chat is ready here. Install the provider runtime to unlock longer prompts and provider-backed chat.")
                     .font(Typo.mono(10))
                     .foregroundColor(Palette.textDim)
             }
@@ -98,13 +83,7 @@ struct PiWorkspaceView: View {
             Spacer()
 
             HStack(spacing: 6) {
-                capsuleLabel(session.currentProvider.name.uppercased(), tint: Palette.textDim)
-
-                if session.hasPiBinary && !session.needsProviderSetup {
-                    actionChip(session.isAuthPanelVisible ? "AUTH -" : "AUTH +") {
-                        session.toggleAuthPanel()
-                    }
-                }
+                settingsGearButton
 
                 if session.hasConversationHistory {
                     actionChip("RESET") {
@@ -115,6 +94,51 @@ struct PiWorkspaceView: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 14)
+    }
+
+    private var settingsGearButton: some View {
+        Button {
+            SettingsWindowController.shared.showAssistant()
+        } label: {
+            Image(systemName: "gearshape")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(Palette.textMuted)
+                .frame(width: 26, height: 24)
+                .background(
+                    Capsule()
+                        .fill(Color.white.opacity(0.03))
+                        .overlay(Capsule().strokeBorder(Palette.border, lineWidth: 0.5))
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var providerSettingsPrompt: some View {
+        HStack(alignment: .center, spacing: 10) {
+            Circle()
+                .fill(Palette.detach)
+                .frame(width: 7, height: 7)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text("CONNECT A PROVIDER")
+                    .font(Typo.geistMonoBold(10))
+                    .foregroundColor(Palette.text)
+
+                Text("Choose OpenAI, Groq, OpenRouter, or MiniMax in Settings to unlock provider-backed chat.")
+                    .font(Typo.mono(10))
+                    .foregroundColor(Palette.textDim)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer()
+
+            actionChip("SETTINGS", tint: Palette.running) {
+                SettingsWindowController.shared.showAssistant()
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .background(Palette.surface.opacity(0.22))
     }
 
     private var authPanel: some View {
@@ -184,29 +208,54 @@ struct PiWorkspaceView: View {
                     .fixedSize(horizontal: false, vertical: true)
 
                 if session.currentProvider.authMode == .apiKey {
-                    HStack(spacing: 8) {
-                        SecureField(session.currentProvider.tokenPlaceholder, text: $session.authToken)
-                            .textFieldStyle(.plain)
-                            .font(Typo.mono(11))
-                            .foregroundColor(Palette.text)
-                            .focused($authFieldFocused)
-                            .onSubmit {
-                                session.saveSelectedToken()
+                    if session.hasSelectedCredential && !session.isEditingStoredCredential {
+                        HStack(spacing: 8) {
+                            Circle()
+                                .fill(Palette.running)
+                                .frame(width: 6, height: 6)
+
+                            Text("\(session.currentProvider.name) credential saved")
+                                .font(Typo.mono(10))
+                                .foregroundColor(Palette.textDim)
+
+                            Spacer()
+
+                            actionChip("REPLACE") {
+                                session.beginReplacingSelectedCredential()
                             }
 
-                        actionChip("SAVE KEY") {
-                            session.saveSelectedToken()
-                        }
-
-                        if session.hasSelectedCredential {
                             actionChip("CLEAR") {
                                 session.removeSelectedCredential()
                             }
                         }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 10)
+                        .background(authCardBackground(tint: Palette.running))
+                    } else {
+                        HStack(spacing: 8) {
+                            SecureField(session.currentProvider.tokenPlaceholder, text: $session.authToken)
+                                .textFieldStyle(.plain)
+                                .font(Typo.mono(11))
+                                .foregroundColor(Palette.text)
+                                .focused($authFieldFocused)
+                                .onSubmit {
+                                    session.saveSelectedToken()
+                                }
+
+                            actionChip("SAVE KEY") {
+                                session.saveSelectedToken()
+                            }
+
+                            if session.hasSelectedCredential {
+                                actionChip("CANCEL") {
+                                    session.cancelReplacingSelectedCredential()
+                                }
+                            }
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 10)
+                        .background(authCardBackground(tint: Palette.running))
                     }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 10)
-                    .background(authCardBackground(tint: Palette.running))
                 } else {
                     HStack(spacing: 8) {
                         actionChip("CONNECT") {
@@ -343,7 +392,7 @@ struct PiWorkspaceView: View {
                     .font(Typo.geistMonoBold(12))
                     .foregroundColor(Palette.running)
 
-                TextField("Ask Pi something heavier...", text: $session.draft, axis: .vertical)
+                TextField("Ask about settings or planning...", text: $session.draft, axis: .vertical)
                     .textFieldStyle(.plain)
                     .font(Typo.mono(12))
                     .foregroundColor(Palette.text)
@@ -395,7 +444,7 @@ struct PiWorkspaceView: View {
         switch role {
         case .system: return "system"
         case .user: return "you"
-        case .assistant: return "pi"
+        case .assistant: return "assistant"
         }
     }
 

--- a/app/Sources/Core/Voice/AudioProvider.swift
+++ b/app/Sources/Core/Voice/AudioProvider.swift
@@ -130,6 +130,16 @@ final class AudioLayer: ObservableObject {
         // Clear previous agent response
         agentResponse = nil
 
+        if shouldAnswerWithAssistant(transcription.text) {
+            DiagnosticLog.shared.info("AudioLayer: question-like voice request, asking Assistant provider")
+            matchedIntent = nil
+            matchedSlots = [:]
+            executionResult = "thinking..."
+            executionData = nil
+            assistantQuestion(transcription: transcription)
+            return
+        }
+
         if let match = matcher.match(text: transcription.text) {
             matchedIntent = match.intentName
             matchConfidence = match.confidence
@@ -144,91 +154,130 @@ final class AudioLayer: ObservableObject {
                 executionData = result
                 DiagnosticLog.shared.info("AudioLayer: executed '\(match.intentName)' → ok")
             } catch {
-                DiagnosticLog.shared.info("AudioLayer: intent error — \(error.localizedDescription), falling back to Claude")
+                DiagnosticLog.shared.info("AudioLayer: intent error — \(error.localizedDescription), asking Assistant provider")
                 executionResult = "thinking..."
                 executionData = nil
-                claudeFallback(transcription: transcription)
+                assistantFallback(transcription: transcription)
             }
 
-            // Fire parallel Haiku advisor for 5+ word utterances
+            // Fire parallel provider-backed advisor for 5+ word utterances.
             fireAdvisor(transcript: transcription.text, matched: "\(match.intentName)(\(matchedSlots))")
 
         } else {
-            // No local match — Claude fallback
-            DiagnosticLog.shared.info("AudioLayer: no phrase match for '\(transcription.text)', falling back to Claude")
+            // No local match — ask the selected Assistant provider.
+            DiagnosticLog.shared.info("AudioLayer: no phrase match for '\(transcription.text)', asking Assistant provider")
             matchedIntent = nil
             matchedSlots = [:]
             executionResult = "thinking..."
             executionData = nil
-            claudeFallback(transcription: transcription)
+            assistantFallback(transcription: transcription)
         }
     }
 
-    /// Fire the Haiku advisor in parallel — non-blocking, result arrives later.
+    /// Fire the selected Assistant provider in parallel — non-blocking, result arrives later.
     private func fireAdvisor(transcript: String, matched: String) {
-        let haiku = AgentPool.shared.haiku
-        guard haiku.isReady else {
-            DiagnosticLog.shared.info("AudioLayer: advisor skipped (haiku not ready)")
+        let assistant = PiChatSession.shared
+        guard assistant.isProviderInferenceReady else {
+            DiagnosticLog.shared.info("AudioLayer: advisor skipped (Assistant provider not ready)")
             return
         }
 
-        let message = "Transcript: \"\(transcript)\"\nMatched: \(matched)"
-        DiagnosticLog.shared.info("AudioLayer: firing haiku advisor")
+        DiagnosticLog.shared.info("AudioLayer: firing Assistant advisor via \(assistant.currentProvider.name)")
 
-        haiku.send(message: message) { [weak self] response in
+        assistant.askVoiceAdvisor(transcript: transcript, matched: matched) { [weak self] response in
             guard let self = self, let response = response else { return }
             self.agentResponse = response
             if let commentary = response.commentary {
-                DiagnosticLog.shared.info("AudioLayer: haiku says — \(commentary)")
+                DiagnosticLog.shared.info("AudioLayer: Assistant advisor says — \(commentary)")
             }
             if let suggestion = response.suggestion {
-                DiagnosticLog.shared.info("AudioLayer: haiku suggests — \(suggestion.label) → \(suggestion.intent)")
+                DiagnosticLog.shared.info("AudioLayer: Assistant advisor suggests — \(suggestion.label) → \(suggestion.intent)")
             }
         }
     }
 
-    private func claudeFallback(transcription: Transcription) {
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            guard let self else { return }
+    private func assistantFallback(transcription: Transcription) {
+        let assistant = PiChatSession.shared
+        guard assistant.isProviderInferenceReady else {
+            executionResult = "Connect an Assistant provider in Settings"
+            DiagnosticLog.shared.info("AudioLayer: Assistant provider not ready")
+            return
+        }
 
-            let result = ClaudeFallback.resolve(
-                transcript: transcription.text,
-                windows: DesktopModel.shared.windows.values.map { $0 },
-                intentCatalog: PhraseMatcher.shared.catalog()
+        assistant.resolveVoiceIntent(transcript: transcription.text) { [weak self] resolved in
+            guard let self else { return }
+            guard let resolved else {
+                self.executionResult = "Assistant couldn't resolve intent"
+                DiagnosticLog.shared.info("AudioLayer: Assistant provider returned no intent")
+                return
+            }
+
+            DiagnosticLog.shared.info("AudioLayer: Assistant resolved → \(resolved.intent) \(resolved.slots)")
+            self.matchedIntent = resolved.intent
+            self.matchedSlots = resolved.slots.reduce(into: [:]) { dict, pair in
+                dict[pair.key] = pair.value.stringValue ?? "\(pair.value)"
+            }
+
+            let intentMatch = IntentMatch(
+                intentName: resolved.intent,
+                slots: resolved.slots,
+                confidence: 0.8,
+                matchedPhrase: "assistant-provider"
             )
 
-            DispatchQueue.main.async {
-                guard let resolved = result else {
-                    self.executionResult = "Claude couldn't resolve intent"
-                    DiagnosticLog.shared.info("AudioLayer: Claude fallback returned nil")
-                    return
-                }
-
-                DiagnosticLog.shared.info("AudioLayer: Claude resolved → \(resolved.intent) \(resolved.slots)")
-                self.matchedIntent = resolved.intent
-                self.matchedSlots = resolved.slots.reduce(into: [:]) { dict, pair in
-                    dict[pair.key] = pair.value.stringValue ?? "\(pair.value)"
-                }
-
-                let intentMatch = IntentMatch(
-                    intentName: resolved.intent,
-                    slots: resolved.slots,
-                    confidence: 0.8,
-                    matchedPhrase: "claude-fallback"
-                )
-
-                do {
-                    let execResult = try PhraseMatcher.shared.execute(intentMatch)
-                    self.executionResult = "ok"
-                    self.executionData = execResult
-                    DiagnosticLog.shared.info("AudioLayer: Claude-resolved executed → \(execResult)")
-                } catch {
-                    self.executionResult = error.localizedDescription
-                    self.executionData = nil
-                    DiagnosticLog.shared.info("AudioLayer: Claude-resolved execution error — \(error.localizedDescription)")
-                }
+            do {
+                let execResult = try PhraseMatcher.shared.execute(intentMatch)
+                self.executionResult = "ok"
+                self.executionData = execResult
+                DiagnosticLog.shared.info("AudioLayer: Assistant-resolved executed → \(execResult)")
+            } catch {
+                self.executionResult = error.localizedDescription
+                self.executionData = nil
+                DiagnosticLog.shared.info("AudioLayer: Assistant-resolved execution error — \(error.localizedDescription)")
             }
         }
+    }
+
+    private func assistantQuestion(transcription: Transcription) {
+        let assistant = PiChatSession.shared
+        guard assistant.isProviderInferenceReady else {
+            executionResult = "Connect an Assistant provider in Settings"
+            DiagnosticLog.shared.info("AudioLayer: Assistant provider not ready for question")
+            return
+        }
+
+        assistant.answerVoiceQuestion(transcription.text) { [weak self] response in
+            guard let self else { return }
+            guard let response else {
+                self.executionResult = "Assistant couldn't answer"
+                DiagnosticLog.shared.info("AudioLayer: Assistant provider returned no answer")
+                return
+            }
+            self.agentResponse = response
+            self.executionResult = "ok"
+            self.executionData = nil
+            if let commentary = response.commentary {
+                DiagnosticLog.shared.info("AudioLayer: Assistant answered — \(commentary.prefix(160))")
+            }
+        }
+    }
+
+    private func shouldAnswerWithAssistant(_ text: String) -> Bool {
+        let lower = text.lowercased()
+        let questionStarters = [
+            "what", "how", "why", "where", "when", "who",
+            "can you tell", "tell me about", "explain", "summarize", "describe"
+        ]
+        let asksQuestion = text.contains("?") || questionStarters.contains(where: lower.hasPrefix)
+        guard asksQuestion else { return false }
+
+        let assistantTopics = [
+            "setting", "settings", "configured", "enabled", "disabled",
+            "mouse", "shortcut", "shortcuts", "gesture", "gestures",
+            "ocr", "terminal", "scan root", "assistant", "provider",
+            "lattices", "workspace"
+        ]
+        return assistantTopics.contains(where: lower.contains)
     }
 }
 

--- a/docs/gesture-customization-proposal.md
+++ b/docs/gesture-customization-proposal.md
@@ -1,0 +1,520 @@
+# LAT-001: Gesture Visual Customization and Renderer Hooks
+
+## Status
+
+Proposal for maintainers.
+
+This is the first Lattices engineering proposal in the `LAT-00n` series, following the same proposal-numbering spirit as the `SCO-00n` documents used for Scout/OpenScout planning.
+
+This document covers how to productize the recent mouse gesture and visual customization prototypes without letting decoration leak into the recognition or action-dispatch fast path.
+
+## Summary
+
+Lattices now has the bones of a gesture system that feels unusually alive for a macOS workspace tool: low-level mouse capture, shape recognition, shortcut matching, immediate native action dispatch, and a fallback overlay that can draw paths, markers, and result labels.
+
+The next question is whether customization should become a supported product surface. The answer proposed here is yes, but with a hard boundary:
+
+- gesture recognition and action dispatch remain native, synchronous, and fast
+- custom rendering is declarative, best-effort, and optional
+- user assets and external renderers never block or decide actions
+- normal customization should not require recompiling the app
+
+The first supported model should be a declarative `visual` block on mouse shortcut rules, backed by native theme presets and marker-to-animation mappings. Real Lottie playback can follow once the configuration model is stable. A plugin or XPC renderer can come later, after the native path has proven the contract.
+
+## Current Gesture Pipeline
+
+The gesture pipeline lives mainly in:
+
+- `app/Sources/Core/Input/MouseGestureController.swift`
+- `app/Sources/Core/Input/MouseGestureConfig.swift`
+- `app/Sources/Core/Input/MouseShortcutStore.swift`
+- `app/Sources/Core/Input/ShapeRecognizer.swift`
+
+The current/prototyped flow is:
+
+1. A CG event tap captures mouse button and movement events.
+2. `MouseGestureController` starts and updates gesture sessions, tracking button state, phase, and path points.
+3. Movement points are fed to `ShapeRecognizer`, which compresses raw motion into direction runs.
+4. Recognized shapes such as `l-shape-down-right` become trigger facts.
+5. `MouseShortcutStore` matches a `MouseShortcutTriggerEvent` against enabled `MouseShortcutRule` entries.
+6. The matched rule dispatches its native action immediately.
+7. `MouseGestureOverlay` and `MouseGestureOverlayView`, currently nested in `MouseGestureController.swift`, render the fallback/native gesture feedback.
+
+The important split is already visible: input capture, recognition, rule matching, and action dispatch form the control path. Overlay drawing is feedback.
+
+## What Was Prototyped
+
+Recent prototype work explored both input semantics and visual expression.
+
+Input and matching:
+
+- shape triggers
+- right, back, forward, and middle button handling
+- MX back/forward aliases
+- a back-button L shape that activates iTerm
+- native action dispatch that stays immediate
+
+Visual feedback:
+
+- path drawing instead of a single direction arrow
+- Bezier/graffiti trail rendering
+- guide dots inspired by Android pattern lock
+- satisfying result labels such as `iTerm FOCUSED`
+- a `visual` block on shortcut rules
+- a native stand-in for a custom animated character
+
+The visual customization proof of concept added optional rule metadata:
+
+```json
+{
+  "visual": {
+    "renderer": "lottie",
+    "asset": "~/.lattices/gesture-assets/cat.json",
+    "character": "cat",
+    "events": {
+      "updated": "follow",
+      "recognized:l-shape-down-right": "pounce",
+      "completed.success": "celebrate",
+      "completed.failure": "confused"
+    }
+  }
+}
+```
+
+Today, `renderer: "lottie"` is a shim/POC name, not a real Lottie dependency. The native renderer draws a small reactive cat/avatar as a stand-in for an eventual Lottie asset.
+
+That is a good prototype shape because it tests the user-facing contract without prematurely committing to a rendering engine.
+
+## Architecture Principle
+
+Recognition and action dispatch are the fast path. They must never wait on:
+
+- custom rendering
+- scripts
+- Lottie playback
+- XPC processes
+- user-provided assets
+- filesystem reads after gesture start
+- network access
+
+Visual customization is decorative. It can make gestures more legible, delightful, and personal, but it cannot become part of whether a gesture succeeds.
+
+In practical terms:
+
+- if a renderer fails, the action still runs
+- if an asset is missing, the native fallback overlay appears
+- if an external renderer is slow, it drops frames or misses the gesture
+- if config is invalid, the rule can still match using native trigger/action fields
+- action success/failure is reported from the action layer, not inferred from animation state
+
+This boundary should be visible in the code. The gesture controller can emit visual events, but renderers should consume snapshots or markers asynchronously. They should not own recognition state.
+
+## Proposed Customization Model
+
+### 1. Declarative `visual` block first
+
+Mouse shortcut rules should support a stable optional `visual` block:
+
+```json
+{
+  "id": "back-l-iterm",
+  "enabled": true,
+  "device": "any",
+  "trigger": {
+    "button": "back",
+    "kind": "shape",
+    "shape": "l-shape-down-right"
+  },
+  "action": {
+    "type": "app.activate",
+    "app": "iTerm"
+  },
+  "visual": {
+    "renderer": "native",
+    "theme": "graffiti",
+    "markers": {
+      "updated": "follow",
+      "recognized:l-shape-down-right": "commit",
+      "completed.success": "success",
+      "completed.failure": "error"
+    }
+  }
+}
+```
+
+The `visual` block should be optional and ignored by older versions where possible. Its first stable fields should be:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `renderer` | string | Selects renderer family: `native`, later `lottie`, later `external` |
+| `theme` | string? | Native preset name such as `minimal`, `graffiti`, `pattern`, `avatar` |
+| `asset` | string? | Local asset reference for renderer families that need it |
+| `character` | string? | Optional named character/avatar inside a renderer or asset pack |
+| `markers` or `events` | object | Maps gesture markers to renderer actions |
+
+The POC uses `events`; the product model should choose one name. `markers` is slightly clearer because the keys are not all raw system events. They are renderer-facing semantic markers derived from gesture state.
+
+### 2. Theme presets
+
+Before exposing arbitrary assets as the main path, ship native presets:
+
+- `minimal`: simple path and endpoint feedback
+- `graffiti`: Bezier trail with energetic completion burst
+- `pattern`: guide dots and shape lock-in feedback
+- `avatar`: native character-style feedback, similar to the POC cat
+- `quiet`: subtle feedback for users who want confirmation without flourish
+
+Presets give users customization without loading code or assets. They also give maintainers a reference for the renderer contract.
+
+### 3. Marker mapping
+
+Renderer-facing markers should be small, named, and phase-based:
+
+| Marker | Meaning |
+|---|---|
+| `started` | Gesture session began |
+| `updated` | Path changed |
+| `recognized:<shape>` | Recognizer has a likely shape |
+| `matched:<rule-id>` | Rule matched |
+| `completed.success` | Action completed successfully |
+| `completed.failure` | Action failed or no rule matched |
+| `cancelled` | Gesture was cancelled |
+
+Renderers can map these to animation names, effects, or state transitions:
+
+```json
+{
+  "markers": {
+    "started": "wake",
+    "updated": "follow",
+    "recognized:l-shape-down-right": "pounce",
+    "completed.success": "celebrate",
+    "completed.failure": "confused",
+    "cancelled": "hide"
+  }
+}
+```
+
+The control path emits facts. The renderer interprets those facts.
+
+### 4. Asset references
+
+Asset references should be local file paths or app-bundled names:
+
+```json
+{
+  "visual": {
+    "renderer": "lottie",
+    "asset": "~/.lattices/gesture-assets/cat.json",
+    "markers": {
+      "updated": "follow",
+      "completed.success": "celebrate"
+    }
+  }
+}
+```
+
+Rules:
+
+- expand `~` explicitly
+- resolve relative paths relative to `~/.lattices/`, not the current project
+- do not fetch remote URLs
+- validate extension and size before loading
+- cache parsed assets outside the gesture hot path
+- fall back to `native` if loading fails
+
+### 5. Real Lottie player later
+
+The current native shim should not pretend to be production Lottie. The roadmap should be:
+
+1. stabilize the rule schema and marker model
+2. ship native presets
+3. add a real Lottie player behind the same renderer protocol
+4. keep Lottie playback isolated from recognition and action dispatch
+
+This avoids coupling the configuration surface to the first graphics library chosen.
+
+### 6. Optional external renderer or XPC later
+
+External renderers are powerful, but they are also where latency, crash, and security complexity enters. They should be a later feature, probably via XPC rather than arbitrary process execution.
+
+The contract should look like a one-way visual event stream:
+
+- Lattices sends gesture snapshots and markers.
+- The renderer returns nothing that affects recognition or actions.
+- The renderer may request drawing surfaces only through a narrow API.
+- Timeouts and crashes are expected and non-fatal.
+
+The open source nature of Lattices means users can always recompile experiments. Product customization should be easier and safer than that.
+
+## Config Examples
+
+### Back Button L to iTerm with Native Visual Markers
+
+```json
+{
+  "id": "back-l-iterm",
+  "enabled": true,
+  "device": "any",
+  "trigger": {
+    "button": "back",
+    "kind": "shape",
+    "shape": "l-shape-down-right"
+  },
+  "action": {
+    "type": "app.activate",
+    "app": "iTerm"
+  },
+  "visual": {
+    "renderer": "native",
+    "theme": "pattern",
+    "markers": {
+      "started": "show-guides",
+      "updated": "draw-path",
+      "recognized:l-shape-down-right": "lock-shape",
+      "completed.success": "success-label",
+      "completed.failure": "miss-label"
+    }
+  }
+}
+```
+
+### Back Button L to iTerm with Future Lottie Asset
+
+```json
+{
+  "id": "back-l-iterm",
+  "enabled": true,
+  "device": "any",
+  "trigger": {
+    "button": "back",
+    "kind": "shape",
+    "shape": "l-shape-down-right"
+  },
+  "action": {
+    "type": "app.activate",
+    "app": "iTerm"
+  },
+  "visual": {
+    "renderer": "lottie",
+    "asset": "~/.lattices/gesture-assets/cat.json",
+    "character": "cat",
+    "markers": {
+      "started": "wake",
+      "updated": "follow",
+      "recognized:l-shape-down-right": "pounce",
+      "completed.success": "celebrate",
+      "completed.failure": "confused",
+      "cancelled": "hide"
+    }
+  }
+}
+```
+
+### Quiet Native Preset
+
+```json
+{
+  "id": "middle-l-palette",
+  "enabled": true,
+  "trigger": {
+    "button": "middle",
+    "kind": "shape",
+    "shape": "l-shape-down-right"
+  },
+  "action": {
+    "type": "palette.open"
+  },
+  "visual": {
+    "renderer": "native",
+    "theme": "quiet"
+  }
+}
+```
+
+## Latency Considerations
+
+Gesture UX is latency-sensitive in two places:
+
+- recognition should keep up with pointer movement
+- action dispatch should happen as soon as the gesture commits
+
+Renderer latency is allowed to be worse than action latency. The user should never feel that an animation is in charge of the system.
+
+Implementation guidelines:
+
+- use immutable gesture snapshots for renderer updates
+- throttle rendering updates independently from event capture
+- pre-load and validate assets when config changes, not when the gesture begins
+- cap path point history passed to renderers
+- drop visual frames under pressure
+- keep completion labels tied to action receipts, not animation callbacks
+
+Target behavior:
+
+- action dispatch remains effectively immediate after match
+- native visual feedback tracks the pointer smoothly
+- custom renderer failure is invisible except for fallback visuals or debug logs
+
+## Stability Considerations
+
+The gesture system sits near global input, so failure modes must be boring.
+
+Renderer failures should not:
+
+- disable the event tap
+- wedge gesture state
+- prevent shortcut matching
+- crash the app
+- leave persistent overlay windows stuck on screen
+
+Recommended boundaries:
+
+- a `GestureVisualRenderer` protocol with small methods such as `start`, `update`, `mark`, `complete`, `cancel`
+- a native fallback renderer that is always available
+- renderer selection that can fail closed to `native`
+- defensive validation of unknown marker names
+- debug logging for invalid visuals, but no noisy user-facing alerts during gestures
+
+## Security Considerations
+
+Even though Lattices is open source, normal customization should not require recompilation. That means configuration and assets become part of the product surface and need constraints.
+
+For MVP:
+
+- no remote asset URLs
+- no shell commands in `visual`
+- no arbitrary scripts
+- no executable plugins
+- local assets only
+- size limits for loaded assets
+- clear fallback when assets are missing or invalid
+
+For a future external renderer:
+
+- prefer XPC over raw process execution
+- use a narrow, documented message protocol
+- treat renderer output as pixels or visual state only
+- never accept action decisions from the renderer
+- add a user-visible trust/install flow if third-party renderer bundles are supported
+
+## Proposed Internal Shape
+
+The implementation should keep the current architecture but name the boundary more explicitly.
+
+Possible types:
+
+```swift
+struct GestureVisualConfig {
+    let renderer: GestureVisualRendererID
+    let theme: String?
+    let asset: String?
+    let character: String?
+    let markers: [String: String]
+}
+
+struct GestureVisualSnapshot {
+    let sessionID: UUID
+    let phase: GesturePhase
+    let button: MouseShortcutButton
+    let points: [CGPoint]
+    let recognizedShape: String?
+    let matchedRuleID: String?
+}
+
+protocol GestureVisualRenderer {
+    func start(_ snapshot: GestureVisualSnapshot, config: GestureVisualConfig)
+    func update(_ snapshot: GestureVisualSnapshot)
+    func mark(_ marker: String, snapshot: GestureVisualSnapshot)
+    func complete(_ marker: String, snapshot: GestureVisualSnapshot)
+    func cancel(_ snapshot: GestureVisualSnapshot)
+}
+```
+
+The exact Swift names can differ. The important part is that renderers consume snapshots and markers; they do not mutate recognition state or decide actions.
+
+## Phased Roadmap
+
+### Phase 0: POC Cleanup
+
+Goal: make the prototype understandable and safe to keep iterating.
+
+- keep native avatar/Lottie shim clearly labeled as POC
+- document current supported marker keys
+- ensure missing or invalid visual config falls back to native overlay
+- verify back/forward button aliases and shape matching remain independent from visuals
+
+### Phase 1: MVP Native Customization
+
+Goal: support real user customization without external dependencies.
+
+- stabilize the `visual` schema
+- support `renderer: "native"`
+- ship a small set of native themes
+- support marker mapping for native themes
+- load visual config from normal shortcut config
+- add diagnostics for invalid visuals
+- keep existing native overlay as fallback
+
+### Phase 2: Real Lottie Integration
+
+Goal: make `renderer: "lottie"` honest.
+
+- add a real Lottie player dependency or embedded playback implementation
+- validate and cache Lottie assets outside the gesture hot path
+- map markers to animation segments or named states
+- enforce size and complexity limits
+- provide at least one bundled example asset
+
+### Phase 3: Renderer Hooks and XPC
+
+Goal: enable deeper experiments without compromising the app.
+
+- define a one-way renderer event protocol
+- run external renderers out of process
+- add crash and timeout handling
+- add user trust/install UX for third-party renderers
+- keep all action decisions inside Lattices
+
+## Open Questions
+
+- Should the field be named `events` to match the prototype, or `markers` to better describe the stable concept?
+- Should visual config live only on individual rules, or should users be able to define reusable named visual profiles?
+- How much of `MouseGestureOverlay` should become a renderer implementation versus remaining a fallback shell?
+- Should marker names be fully free-form, or should unknown keys be rejected during config validation?
+- Do we want app-level theme defaults, per-device defaults, or only per-rule visuals for MVP?
+- Should `completed.failure` mean "no rule matched", "action failed", or both with more specific submarkers?
+- Where should user assets live: `~/.lattices/gesture-assets/`, app support, or both?
+
+## Acceptance Criteria
+
+For the MVP:
+
+- A shortcut rule can include a `visual` block without changing trigger or action behavior.
+- A back-button `l-shape-down-right` rule can activate iTerm and show native marker-based feedback.
+- Invalid visual config falls back to the native overlay and does not prevent the action.
+- Missing assets do not crash the app or delay gesture completion.
+- Recognition and action dispatch do not wait on renderer work.
+- Native themes can render started, updated, recognized, success, failure, and cancelled states.
+- The config format is documented with at least one complete example.
+- Debug diagnostics make renderer fallback understandable to maintainers.
+
+For later Lottie support:
+
+- `renderer: "lottie"` uses a real Lottie player, not the native shim.
+- Lottie assets are validated and cached before gesture start.
+- Marker mappings can target named animations or segments.
+- Lottie renderer failure falls back to native rendering without affecting actions.
+
+## Recommendation
+
+Productize visual customization, but productize it as a renderer contract rather than as a graphics feature.
+
+The useful product surface is not "play a cat animation." It is:
+
+- gestures have stable semantic markers
+- users can bind visual feedback to those markers
+- Lattices keeps input and action dispatch fast
+- renderers are replaceable decoration
+
+That gives maintainers room to ship the fun parts without letting them become load-bearing.


### PR DESCRIPTION
## Summary

- **Mouse gestures**: adds `click` and `shape` trigger kinds alongside `drag`, fixing a decode failure caused by the existing `mouse-shortcuts.json` paste rule (`"kind": "click"`). Middle-click without dragging now fires the matched click rule (e.g. Cmd+V paste) instead of always replaying the raw click.
- **Gesture visuals**: new drawing-style overlay with `graffiti` theme (graphite/accent/highlight/failure colors), shape recognizer for free-form gesture input, and visual phase tracking (started → updated → recognized → completed).
- **Assistant / Pi**: restored assistant unification in `PiChatSession`, updated `PiChatDock` and `PiWorkspaceView` layouts, refreshed `VoiceCommandWindow` and `AudioProvider`.

## Test plan

- [ ] Verify `mouse-shortcuts.json` loads without errors on app launch (no `failed to decode` in diagnostic log)
- [ ] Middle-click without dragging triggers the paste rule (Cmd+V sent to frontmost app)
- [ ] Middle-drag gestures (left/right/up/down) still fire correctly with the graffiti overlay
- [ ] Shape-based gesture rules decode and match without errors
- [ ] Pi assistant session opens and responds correctly
- [ ] Voice command window appears and audio capture works