### PR TITLE
Companion cockpit + iPad Home + mouse gesture controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ iOS/LatticesCompanion/.device-id.local
 
 # Swift package local build state
 swift/.build/
+swift/.swiftpm/
+
+# Xcode per-user state
+iOS/LatticesCompanion/LatticesCompanion.xcodeproj/xcuserdata/
+iOS/LatticesCompanion/LatticesCompanion.xcodeproj/project.xcworkspace/xcuserdata/

--- a/app/Sources/MouseGestureController.swift
+++ b/app/Sources/MouseGestureController.swift
@@ -1,0 +1,731 @@
+import AppKit
+import CoreGraphics
+
+// MARK: - Gesture Direction
+
+enum GestureDirection: String, Codable {
+    case up, left, right, down, none
+
+    var arrow: String {
+        switch self {
+        case .up:    return "↑"
+        case .down:  return "↓"
+        case .left:  return "←"
+        case .right: return "→"
+        case .none:  return ""
+        }
+    }
+}
+
+// MARK: - Action Types
+
+/// Supported gesture actions — extend this enum as capabilities grow.
+enum MouseGestureAction: String, Codable, CaseIterable {
+    // Tile actions
+    case tileMaximize   // 1×1 full cell
+    case tileLeft
+    case tileRight
+    case tileTop
+    case tileBottom
+    case tileTopLeft
+    case tileTopRight
+    case tileBottomLeft
+    case tileBottomRight
+
+    // Grid distributions
+    case grid2x2
+    case grid3x3
+    case grid4x4
+
+    var label: String {
+        switch self {
+        case .tileMaximize:  return "Maximize"
+        case .tileLeft:      return "Tile Left"
+        case .tileRight:     return "Tile Right"
+        case .tileTop:       return "Tile Top"
+        case .tileBottom:    return "Tile Bottom"
+        case .tileTopLeft:   return "Top Left"
+        case .tileTopRight:  return "Top Right"
+        case .tileBottomLeft:  return "Bottom Left"
+        case .tileBottomRight: return "Bottom Right"
+        case .grid2x2:       return "2×2 Grid"
+        case .grid3x3:       return "3×3 Grid"
+        case .grid4x4:       return "4×4 Grid"
+        }
+    }
+}
+
+// MARK: - Config Models
+
+struct MouseShortcutConfig: Codable {
+    var rules: [MouseShortcutRule]
+    var tuning: GestureTuning?
+    var version: Int?
+
+    struct MouseShortcutRule: Codable {
+        var id: String
+        var device: String  // "any", "MX Master", specific device name
+        var enabled: Bool?
+        var trigger: Trigger
+        var action: Action
+
+        struct Trigger: Codable {
+            var button: String       // "button3", "button4", "middle", etc.
+            var direction: String    // "up", "down", "left", "right"
+            var kind: String        // "drag", "hold", "tap"
+        }
+
+        struct Action: Codable {
+            var type: String         // e.g. "tile.left", "grid.3x3", "resize.grow.left"
+            var options: [String: String]?  // optional params
+        }
+    }
+
+    struct GestureTuning: Codable {
+        var dragThreshold: Double?
+        var holdTolerance: Double?
+        var axisBias: Double?
+    }
+
+    static func load() -> MouseShortcutConfig? {
+        let path = NSHomeDirectory() + "/.lattices/mouse-shortcuts.json"
+        guard let data = FileManager.default.contents(atPath: path) else {
+            DiagnosticLog.shared.warn("MouseGestureController: no config at ~/.lattices/mouse-shortcuts.json")
+            return nil
+        }
+        do {
+            let config = try JSONDecoder().decode(MouseShortcutConfig.self, from: data)
+            DiagnosticLog.shared.info("MouseGestureController: loaded \(config.rules.count) rules from config")
+            return config
+        } catch {
+            DiagnosticLog.shared.error("MouseGestureController: failed to parse config: \(error)")
+            return nil
+        }
+    }
+}
+
+// MARK: - Resolved Rule
+
+struct ResolvedRule {
+    let action: MouseGestureAction
+    let direction: GestureDirection
+    let buttonLabel: String
+}
+
+// MARK: - MouseGestureController
+
+/// Listens for held mouse buttons + drag gestures, executes window actions.
+/// Configuration comes from ~/.lattices/mouse-shortcuts.json — no hardcoded paths.
+/// Falls back to built-in defaults only when the config is absent or missing rules.
+final class MouseGestureController {
+    static let shared = MouseGestureController()
+
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+
+    // Tracking state
+    private var activeButtonLabel: String?
+    private var startPoint: CGPoint = .zero
+    private var accumulatedDelta: CGPoint = .zero
+    private var committedDirection: GestureDirection = .none
+    private var isTracking = false
+
+    // Config
+    private var rules: [String: ResolvedRule] = [:]  // "button3:up" → rule
+    private var tuning: MouseShortcutConfig.GestureTuning = .init()
+    private var defaultRules: [String: MouseGestureAction] = [:]  // fallbacks
+
+    // HUD feedback
+    private var feedbackWindow: NSWindow?
+    private var feedbackTimer: Timer?
+
+    // Self-healing circuit breaker
+    private struct BreakerState {
+        var trips: [Date] = []
+        var cooldownUntil: Date?
+        var permanentlyOpen: Bool = false
+    }
+    private var breaker = BreakerState()
+    private let breakerLock = NSLock()
+
+    private init() {
+        loadConfig()
+        setupEventTap()
+    }
+
+    deinit { stop() }
+
+    // MARK: - Config Loading
+
+    private func loadConfig() {
+        // Build default fallback rules
+        defaultRules = [
+            "button3:up":   .tileMaximize,
+            "button3:left": .grid2x2,
+            "button3:right": .grid3x3,
+            "button3:down": .grid4x4,
+        ]
+
+        guard let config = MouseShortcutConfig.load() else {
+            // Use defaults
+            buildRuleMap(from: defaultRules)
+            return
+        }
+
+        // Tuning
+        tuning = config.tuning ?? MouseShortcutConfig.GestureTuning()
+
+        // Build rule map from config
+        var resolved: [String: MouseGestureAction] = [:]
+        for rule in config.rules {
+            guard rule.enabled != false else { continue }
+
+            let key = "\(rule.trigger.button):\(rule.trigger.direction)"
+            let action = parseActionType(rule.action.type)
+            if let action {
+                resolved[key] = action
+                DiagnosticLog.shared.info("MouseGestureController: config rule \(rule.id) → \(key) = \(rule.action.type)")
+            }
+        }
+
+        buildRuleMap(from: resolved.isEmpty ? defaultRules : resolved)
+    }
+
+    private func buildRuleMap(from source: [String: MouseGestureAction]) {
+        rules = source.mapValues { action in
+            let parts = action.rawValue.split(separator: ".").map(String.init)
+            let dir: GestureDirection
+            switch parts.last ?? "" {
+            case "up":    dir = .up
+            case "down":  dir = .down
+            case "left":  dir = .left
+            case "right": dir = .right
+            default:      dir = .none
+            }
+            let button = source.first { $0.value == action }?.key.components(separatedBy: ":").first ?? ""
+            return ResolvedRule(action: action, direction: dir, buttonLabel: button)
+        }
+
+        // Simpler: store raw actions
+        rawRules = source
+    }
+
+    private var rawRules: [String: MouseGestureAction] = [:]
+
+    private func parseActionType(_ type: String) -> MouseGestureAction? {
+        switch type {
+        // Tile
+        case "tile.maximize", "tile.max":    return .tileMaximize
+        case "tile.left":                      return .tileLeft
+        case "tile.right":                     return .tileRight
+        case "tile.top":                       return .tileTop
+        case "tile.bottom":                    return .tileBottom
+        case "tile.top-left", "tile.topLeft":  return .tileTopLeft
+        case "tile.top-right", "tile.topRight": return .tileTopRight
+        case "tile.bottom-left", "tile.bottomLeft": return .tileBottomLeft
+        case "tile.bottom-right", "tile.bottomRight": return .tileBottomRight
+        // Grid
+        case "grid.2x2", "grid2x2":           return .grid2x2
+        case "grid.3x3", "grid3x3":           return .grid3x3
+        case "grid.4x4", "grid4x4":           return .grid4x4
+        default:
+            return nil
+        }
+    }
+
+    func reloadConfig() {
+        rules.removeAll()
+        rawRules.removeAll()
+        loadConfig()
+    }
+
+    // MARK: - Event Tap
+
+    private func setupEventTap() {
+        let downMask: CGEventMask = (
+            (1 << CGEventType.leftMouseDown.rawValue) |
+            (1 << CGEventType.rightMouseDown.rawValue) |
+            (1 << CGEventType.otherMouseDown.rawValue)
+        )
+        let upMask: CGEventMask = (
+            (1 << CGEventType.leftMouseUp.rawValue) |
+            (1 << CGEventType.rightMouseUp.rawValue) |
+            (1 << CGEventType.otherMouseUp.rawValue)
+        )
+        let dragMask: CGEventMask = (
+            (1 << CGEventType.leftMouseDragged.rawValue) |
+            (1 << CGEventType.rightMouseDragged.rawValue) |
+            (1 << CGEventType.otherMouseDragged.rawValue)
+        )
+        let eventMask = downMask | upMask | dragMask
+
+        let selfPtr = Unmanaged.passUnretained(self).toOpaque()
+
+        eventTap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: eventMask,
+            callback: { (proxy, type, event, refcon) -> Unmanaged<CGEvent>? in
+                guard let refcon = refcon else { return Unmanaged.passUnretained(event) }
+                let controller = Unmanaged<MouseGestureController>.fromOpaque(refcon).takeUnretainedValue()
+                return controller.handleEvent(proxy: proxy, type: type, event: event)
+            },
+            userInfo: selfPtr
+        )
+
+        guard let tap = eventTap else {
+            DiagnosticLog.shared.error("MouseGestureController: failed to create event tap — needs Accessibility permission?")
+            return
+        }
+
+        runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
+        DiagnosticLog.shared.info("MouseGestureController: event tap installed")
+    }
+
+    private func handleEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        if type == .tapDisabledByTimeout {
+            // OS detected our callback was too slow — let the breaker decide whether to back off.
+            tripBreaker(reason: "tap disabled by OS timeout")
+            return Unmanaged.passUnretained(event)
+        }
+        if type == .tapDisabledByUserInput {
+            if let tap = eventTap { CGEvent.tapEnable(tap: tap, enable: true) }
+            return Unmanaged.passUnretained(event)
+        }
+
+        let buttonNumber = Int(event.getIntegerValueField(.mouseEventButtonNumber))
+
+        switch type {
+        case .leftMouseDown, .rightMouseDown, .otherMouseDown:
+            handleButtonDown(buttonNumber: buttonNumber, event: event)
+        case .leftMouseUp, .rightMouseUp, .otherMouseUp:
+            handleButtonUp(buttonNumber: buttonNumber, event: event)
+        case .leftMouseDragged, .rightMouseDragged, .otherMouseDragged:
+            handleMouseDragged(event: event)
+        default:
+            break
+        }
+
+        return Unmanaged.passUnretained(event)
+    }
+
+    // MARK: - Event Handlers
+
+    private func handleButtonDown(buttonNumber: Int, event: CGEvent) {
+        let label = buttonLabel(for: buttonNumber)
+        guard rawRules.keys.contains(where: { $0.hasPrefix(label) }) else { return }
+
+        activeButtonLabel = label
+        startPoint = event.location
+        accumulatedDelta = .zero
+        committedDirection = .none
+        isTracking = true
+
+        DiagnosticLog.shared.info("MouseGestureController: tracking button=\(label)")
+    }
+
+    private func handleMouseDragged(event: CGEvent) {
+        guard isTracking, let button = activeButtonLabel else { return }
+
+        let currentPoint = event.location
+        let delta = CGPoint(
+            x: currentPoint.x - startPoint.x,
+            y: currentPoint.y - startPoint.y
+        )
+        accumulatedDelta = delta
+
+        let threshold = CGFloat(tuning.dragThreshold ?? 30)
+
+        if committedDirection == .none {
+            let dx = abs(delta.x)
+            let dy = abs(delta.y)
+
+            if max(dx, dy) > threshold {
+                committedDirection = dx > dy
+                    ? (delta.x > 0 ? .right : .left)
+                    : (delta.y > 0 ? .down : .up)
+
+                let key = "\(button):\(committedDirection.rawValue)"
+                let action = rawRules[key]
+                showFeedback(action: action, direction: committedDirection)
+                DiagnosticLog.shared.info("MouseGestureController: committed \(key) → \(action?.label ?? "nil")")
+            }
+        }
+    }
+
+    private func handleButtonUp(buttonNumber: Int, event: CGEvent) {
+        guard isTracking, let button = activeButtonLabel else { return }
+
+        hideFeedback()
+
+        if let direction = commitDirection() {
+            let key = "\(button):\(direction.rawValue)"
+            if let action = rawRules[key], !breakerTripped {
+                dispatchAction(action, direction: direction)
+            }
+        }
+
+        resetTracking()
+    }
+
+    /// Run an action off the event tap callback. Tap callback returns immediately;
+    /// AX/window work runs on the main queue. Duration is measured — if it exceeds
+    /// the budget, the circuit breaker trips and gestures pause.
+    private func dispatchAction(_ action: MouseGestureAction, direction: GestureDirection) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self, !self.breakerTripped else { return }
+            let start = Date()
+            self.executeAction(action, direction: direction)
+            let elapsedMs = Int(Date().timeIntervalSince(start) * 1000)
+            if elapsedMs > 500 {
+                self.tripBreaker(reason: "slow action \(action.label) (\(elapsedMs)ms)")
+            }
+        }
+    }
+
+    // MARK: - Direction Logic
+
+    private func commitDirection() -> GestureDirection? {
+        guard committedDirection != .none else { return nil }
+
+        let dx = abs(accumulatedDelta.x)
+        let dy = abs(accumulatedDelta.y)
+
+        // Confirm dominant axis
+        let bias = tuning.axisBias ?? 1.0
+        if dx > dy * bias || dy > dx * bias {
+            return committedDirection
+        }
+
+        // Too short = cancel
+        let threshold = CGFloat(tuning.dragThreshold ?? 30)
+        if max(dx, dy) < threshold * 0.5 {
+            return nil
+        }
+
+        return committedDirection
+    }
+
+    // MARK: - Action Execution
+
+    private func executeAction(_ action: MouseGestureAction, direction: GestureDirection) {
+        DiagnosticLog.shared.info("MouseGestureController: executing \(action.label)")
+
+        switch action {
+        // Tile actions
+        case .tileMaximize:
+            WindowTiler.tileFrontmostViaAX(to: .maximize)
+        case .tileLeft:
+            WindowTiler.tileFrontmostViaAX(to: .left)
+        case .tileRight:
+            WindowTiler.tileFrontmostViaAX(to: .right)
+        case .tileTop:
+            WindowTiler.tileFrontmostViaAX(to: .top)
+        case .tileBottom:
+            WindowTiler.tileFrontmostViaAX(to: .bottom)
+        case .tileTopLeft:
+            WindowTiler.tileFrontmostViaAX(to: .topLeft)
+        case .tileTopRight:
+            WindowTiler.tileFrontmostViaAX(to: .topRight)
+        case .tileBottomLeft:
+            WindowTiler.tileFrontmostViaAX(to: .bottomLeft)
+        case .tileBottomRight:
+            WindowTiler.tileFrontmostViaAX(to: .bottomRight)
+
+        // Grid distributions
+        case .grid2x2:
+            applyGrid(columns: 2, rows: 2)
+        case .grid3x3:
+            applyGrid(columns: 3, rows: 3)
+        case .grid4x4:
+            applyGrid(columns: 4, rows: 4)
+        }
+    }
+
+    private func applyGrid(columns: Int, rows: Int) {
+        let windows = DesktopModel.shared.allWindows()
+            .filter { $0.isOnScreen && $0.app != "Lattices" && !$0.title.isEmpty }
+            .prefix(columns * rows)
+            .map { (wid: $0.wid, pid: $0.pid) }
+
+        guard !windows.isEmpty else { return }
+
+        let screen = mouseScreen()
+        let sf = screen.visibleFrame
+        let primaryH = NSScreen.screens.first?.frame.height ?? 900
+        let screenCGX = sf.origin.x
+        let screenCGY = primaryH - sf.origin.y - sf.height
+
+        let cellW = sf.width / CGFloat(columns)
+        let cellH = sf.height / CGFloat(rows)
+        let gap: CGFloat = 2
+
+        var moves: [(wid: UInt32, pid: Int32, frame: CGRect)] = []
+        for (i, win) in windows.enumerated() {
+            let col = i % columns
+            let row = i / columns
+            let frame = CGRect(
+                x: screenCGX + CGFloat(col) * cellW + gap,
+                y: screenCGY + CGFloat(row) * cellH + gap,
+                width: cellW - gap * 2,
+                height: cellH - gap * 2
+            )
+            moves.append((win.wid, win.pid, frame))
+        }
+
+        WindowTiler.batchMoveAndRaiseWindows(moves)
+    }
+
+    // MARK: - Feedback HUD
+
+    private func showFeedback(action: MouseGestureAction?, direction: GestureDirection) {
+        DispatchQueue.main.async { [weak self] in
+            self?.displayFeedbackBadge(action: action, direction: direction)
+        }
+    }
+
+    private func displayFeedbackBadge(action: MouseGestureAction?, direction: GestureDirection) {
+        hideFeedback()
+
+        let badge = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 140, height: 50),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        badge.isOpaque = false
+        badge.backgroundColor = .clear
+        badge.level = .floating
+        badge.hasShadow = true
+        badge.ignoresMouseEvents = true
+        badge.collectionBehavior = [.canJoinAllSpaces, .stationary]
+
+        let contentView = NSView(frame: NSRect(x: 0, y: 0, width: 140, height: 50))
+        contentView.wantsLayer = true
+        contentView.layer?.backgroundColor = NSColor.black.withAlphaComponent(0.8).cgColor
+        contentView.layer?.cornerRadius = 12
+
+        let arrowLabel = NSTextField(labelWithString: direction.arrow)
+        arrowLabel.font = NSFont.systemFont(ofSize: 20, weight: .bold)
+        arrowLabel.textColor = .white
+        arrowLabel.frame = NSRect(x: 12, y: 8, width: 30, height: 34)
+        arrowLabel.alignment = .center
+
+        let actionLabel = NSTextField(labelWithString: action?.label ?? "—")
+        actionLabel.font = NSFont.systemFont(ofSize: 13, weight: .medium)
+        actionLabel.textColor = NSColor.white.withAlphaComponent(0.9)
+        actionLabel.frame = NSRect(x: 42, y: 8, width: 90, height: 34)
+        actionLabel.lineBreakMode = .byTruncatingTail
+
+        contentView.addSubview(arrowLabel)
+        contentView.addSubview(actionLabel)
+        badge.contentView = contentView
+
+        let mouseLoc = NSEvent.mouseLocation
+        let badgeFrame = NSRect(x: mouseLoc.x + 20, y: mouseLoc.y - 25, width: 140, height: 50)
+        badge.setFrame(badgeFrame, display: false)
+        badge.alphaValue = 0
+        badge.orderFront(nil)
+
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = 0.1
+            badge.animator().alphaValue = 1
+        }
+
+        feedbackWindow = badge
+
+        feedbackTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: false) { [weak self] _ in
+            self?.hideFeedback()
+        }
+    }
+
+    private func hideFeedback() {
+        feedbackTimer?.invalidate()
+        feedbackTimer = nil
+
+        guard let window = feedbackWindow else { return }
+
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = 0.15
+            window.animator().alphaValue = 0
+        } completionHandler: {
+            window.orderOut(nil)
+        }
+
+        feedbackWindow = nil
+    }
+
+    private func resetTracking() {
+        activeButtonLabel = nil
+        startPoint = .zero
+        accumulatedDelta = .zero
+        committedDirection = .none
+        isTracking = false
+    }
+
+    // MARK: - Utilities
+
+    private func buttonLabel(for number: Int) -> String {
+        switch number {
+        case 2:  return "middle"
+        case 3:  return "button3"
+        case 4:  return "button4"
+        default: return "button\(number)"
+        }
+    }
+
+    private func mouseScreen() -> NSScreen {
+        let loc = NSEvent.mouseLocation
+        return NSScreen.screens.first(where: { $0.frame.contains(loc) })
+            ?? NSScreen.main ?? NSScreen.screens.first!
+    }
+
+    // MARK: - Self-healing Circuit Breaker
+
+    /// True when the breaker has tripped — actions should not be dispatched.
+    private var breakerTripped: Bool {
+        breakerLock.lock()
+        defer { breakerLock.unlock() }
+        if breaker.permanentlyOpen { return true }
+        if let until = breaker.cooldownUntil, Date() < until { return true }
+        return false
+    }
+
+    /// Trip the breaker. Disables the tap, shows a status badge, schedules recovery.
+    /// Cooldown grows with repeated trips: 30s → 2min → permanent (until reload/restart).
+    private func tripBreaker(reason: String) {
+        breakerLock.lock()
+        let now = Date()
+        breaker.trips = breaker.trips.filter { now.timeIntervalSince($0) < 600 }
+        breaker.trips.append(now)
+        let count = breaker.trips.count
+
+        let cooldown: TimeInterval
+        let isPermanent: Bool
+        if count >= 3 {
+            cooldown = 0
+            isPermanent = true
+            breaker.permanentlyOpen = true
+        } else if count >= 2 {
+            cooldown = 120
+            isPermanent = false
+            breaker.cooldownUntil = now.addingTimeInterval(cooldown)
+        } else {
+            cooldown = 30
+            isPermanent = false
+            breaker.cooldownUntil = now.addingTimeInterval(cooldown)
+        }
+        breakerLock.unlock()
+
+        DiagnosticLog.shared.warn("MouseGestureController: breaker tripped (\(reason)) — trips=\(count), \(isPermanent ? "permanent" : "cooldown=\(Int(cooldown))s")")
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            if let tap = self.eventTap {
+                CGEvent.tapEnable(tap: tap, enable: false)
+            }
+            let message = isPermanent
+                ? "Mouse gestures disabled — too many stalls"
+                : "Mouse gestures paused — resuming in \(Int(cooldown))s"
+            self.showStatusBadge(message: message)
+
+            if !isPermanent {
+                DispatchQueue.main.asyncAfter(deadline: .now() + cooldown) { [weak self] in
+                    self?.recoverBreaker()
+                }
+            }
+        }
+    }
+
+    /// Re-enable the tap after cooldown, unless the breaker has been permanently opened.
+    private func recoverBreaker() {
+        breakerLock.lock()
+        let stillPermanent = breaker.permanentlyOpen
+        if !stillPermanent {
+            breaker.cooldownUntil = nil
+        }
+        breakerLock.unlock()
+
+        guard !stillPermanent else { return }
+
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: true)
+        }
+        DiagnosticLog.shared.info("MouseGestureController: breaker recovered — tap re-enabled")
+        showStatusBadge(message: "Mouse gestures resumed")
+    }
+
+    private func showStatusBadge(message: String) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.hideFeedback()
+
+            let width: CGFloat = 280
+            let height: CGFloat = 44
+            let badge = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: width, height: height),
+                styleMask: [.borderless],
+                backing: .buffered,
+                defer: false
+            )
+            badge.isOpaque = false
+            badge.backgroundColor = .clear
+            badge.level = .floating
+            badge.hasShadow = true
+            badge.ignoresMouseEvents = true
+            badge.collectionBehavior = [.canJoinAllSpaces, .stationary]
+
+            let contentView = NSView(frame: NSRect(x: 0, y: 0, width: width, height: height))
+            contentView.wantsLayer = true
+            contentView.layer?.backgroundColor = NSColor.black.withAlphaComponent(0.85).cgColor
+            contentView.layer?.cornerRadius = 12
+
+            let label = NSTextField(labelWithString: message)
+            label.font = NSFont.systemFont(ofSize: 13, weight: .medium)
+            label.textColor = .white
+            label.frame = NSRect(x: 14, y: 0, width: width - 28, height: height)
+            label.alignment = .center
+            label.lineBreakMode = .byTruncatingTail
+            contentView.addSubview(label)
+            badge.contentView = contentView
+
+            let screen = self.mouseScreen()
+            let sf = screen.visibleFrame
+            let badgeFrame = NSRect(
+                x: sf.midX - width / 2,
+                y: sf.midY - height / 2,
+                width: width,
+                height: height
+            )
+            badge.setFrame(badgeFrame, display: false)
+            badge.alphaValue = 0
+            badge.orderFront(nil)
+
+            NSAnimationContext.runAnimationGroup { ctx in
+                ctx.duration = 0.15
+                badge.animator().alphaValue = 1
+            }
+
+            self.feedbackWindow = badge
+            self.feedbackTimer = Timer.scheduledTimer(withTimeInterval: 2.5, repeats: false) { [weak self] _ in
+                self?.hideFeedback()
+            }
+        }
+    }
+
+    // MARK: - Start/Stop
+
+    func start() {
+        if let tap = eventTap { CGEvent.tapEnable(tap: tap, enable: true) }
+        DiagnosticLog.shared.info("MouseGestureController: started")
+    }
+
+    func stop() {
+        if let tap = eventTap { CGEvent.tapEnable(tap: tap, enable: false) }
+        hideFeedback()
+        DiagnosticLog.shared.info("MouseGestureController: stopped")
+    }
+}

--- a/bin/lattices-app.ts
+++ b/bin/lattices-app.ts
@@ -370,7 +370,10 @@ if (cmd === "build") {
     console.error("Swift is required. Install with: xcode-select --install");
     process.exit(1);
   }
-  buildFromSource();
+  if (!buildFromSource()) {
+    console.error("Build failed.");
+    process.exit(1);
+  }
 } else if (cmd === "quit") {
   if (quit()) {
     console.log("lattices app stopped.");

--- a/bin/lattices-dev
+++ b/bin/lattices-dev
@@ -166,6 +166,31 @@ cmd_clear_logs() {
     fi
 }
 
+cmd_link() {
+    if ! command -v bun >/dev/null 2>&1; then
+        red "bun not found. Install: curl -fsSL https://bun.sh/install | bash"
+        exit 1
+    fi
+    cd "$ROOT"
+    bun link
+    bun link @lattices/cli
+    if command -v lattices >/dev/null 2>&1; then
+        green "Linked. \`lattices\` -> $(command -v lattices)"
+    else
+        red "Linked, but \`lattices\` is not on PATH. Add bun's global bin to PATH:"
+        dim "  export PATH=\"\$HOME/.bun/bin:\$PATH\""
+    fi
+}
+
+cmd_unlink() {
+    if ! command -v bun >/dev/null 2>&1; then
+        red "bun not found."
+        exit 1
+    fi
+    bun remove -g @lattices/cli >/dev/null 2>&1 || true
+    green "Unlinked."
+}
+
 cmd_status() {
     if pgrep -x Lattices >/dev/null 2>&1; then
         local pid=$(pgrep -x Lattices)
@@ -187,6 +212,8 @@ cmd_status() {
 cmd_help() {
     echo "lattices-dev — Lattices development commands"
     echo ""
+    echo "  link         Symlink \`lattices\` to this checkout (bun link)"
+    echo "  unlink       Remove the bun link"
     echo "  restart      Quit + rebuild + relaunch"
     echo "  build        Build release binary"
     echo "  quit         Stop the running app"
@@ -199,6 +226,8 @@ cmd_help() {
 }
 
 case "${1:-help}" in
+    link)       cmd_link ;;
+    unlink)     cmd_unlink ;;
     restart)    cmd_restart ;;
     build)      cmd_build ;;
     quit|stop)  cmd_quit ;;

--- a/iOS/LatticesCompanion/LatticesCompanion.xcodeproj/project.pbxproj
+++ b/iOS/LatticesCompanion/LatticesCompanion.xcodeproj/project.pbxproj
@@ -7,20 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		015334E9F01E2EC8CE7C6C77 /* DeckStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11238FFB50336470B6A97CE0 /* DeckStore.swift */; };
 		02DFEEC584B5BE76F4E0EF59 /* Icon-App-29x29@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = AB70174A80BDBEF97964B1D1 /* Icon-App-29x29@3x.png */; };
 		0B62E8780B2EF68BB75DCB77 /* DeckKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1D4FCB5C53FAA6DC26531C63 /* DeckKit */; };
-		2495F9FA74E60FE3935AF9AB /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6008CE13AA2719DE4CFEFBA5 /* ContentView.swift */; };
-		303C0ED6FF5A801009E72EBD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E0A62477A93C15EBE3917B2E /* LaunchScreen.storyboard */; };
-		39910639463B85C88940415F /* DeckBridgeClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B31BBB86BC2F6969B6F8C6AC /* DeckBridgeClient.swift */; };
 		3CD5F4319B4419DA9ACCA70A /* Icon-App-60x60@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = D6A573A92276901B84AA3EE4 /* Icon-App-60x60@2x.png */; };
-		477B603FA482CD0AF55BC9C7 /* DeckBridgeSecurityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D303982A361559374D4ECAF /* DeckBridgeSecurityStore.swift */; };
 		48AB2F1093E08D5F972BEF57 /* Icon-App-76x76@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 2008FE641E08A7EA3F1142D8 /* Icon-App-76x76@2x.png */; };
 		49328530140603E31D3C44C4 /* Icon-App-29x29@1x.png in Resources */ = {isa = PBXBuildFile; fileRef = 763E58A4536019D1C0D225B5 /* Icon-App-29x29@1x.png */; };
-		4932E64B0E7CF7E4C48DB05E /* LatsDeckScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE37E6C4302786080981EE9 /* LatsDeckScreen.swift */; };
 		58104483ED43F7B6EADEDD47 /* Icon-App-29x29@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 5E31C91E44E310ECB2F450E6 /* Icon-App-29x29@2x.png */; };
-		84F9131A8649EB980EC5A378 /* BridgeDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4603482511D3BE1F2132C82 /* BridgeDiscovery.swift */; };
-		8509FE10337BF9B4286C77DF /* LatticesCompanionApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BAB98213FEF0182FB2EA32 /* LatticesCompanionApp.swift */; };
 		890DFAA5138BB9EFA7C21D8C /* Icon-App-20x20@1x.png in Resources */ = {isa = PBXBuildFile; fileRef = D91400AA758EB6C7BDEFA067 /* Icon-App-20x20@1x.png */; };
 		89AB5D05E905F1A23A38C4F3 /* Icon-App-40x40@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 742860D211F50B7F0B23A4DB /* Icon-App-40x40@3x.png */; };
 		AE392FBE93D051B87EF6EB52 /* Icon-App-40x40@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 65151992218EDBCB6BFC8518 /* Icon-App-40x40@2x.png */; };
@@ -30,68 +22,27 @@
 		D087EC7E9542F2EB5989500F /* Icon-App-1024x1024@1x.png in Resources */ = {isa = PBXBuildFile; fileRef = 2484AA38E059AA293C768446 /* Icon-App-1024x1024@1x.png */; };
 		D22111B43C6A48912D6E5A96 /* Icon-App-20x20@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 2569702CC7CAC0677B8C6524 /* Icon-App-20x20@3x.png */; };
 		D34392C35E4145D4262AC87F /* Icon-App-83.5x83.5@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = BCF0269F9663D59AA5D8BEF6 /* Icon-App-83.5x83.5@2x.png */; };
-		E7EC416CD4478DCF4FEBB4FC /* CompanionTrackpadSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2C2E756959812A344E33FA /* CompanionTrackpadSurface.swift */; };
-		EC49AAE0FD658F4D651D6CB1 /* LatsDesignSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5BE58AB3627168981D1D91F /* LatsDesignSystem.swift */; };
 		FD675D5F19359E6AA5DC41AB /* Icon-App-76x76@1x.png in Resources */ = {isa = PBXBuildFile; fileRef = 924A59FEB2399ED0CF09A4B5 /* Icon-App-76x76@1x.png */; };
-		389783C39A96A0C6040E3D18 /* HomeMockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30519DB14393D18A74E57E5B /* HomeMockData.swift */; };
-		3B524C6E337D9959BF1BE8FE /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C0606BE3D76578604B9CBD /* HomeView.swift */; };
-		3345DF34E18FB311421B2457 /* HomeTopBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5321ED84ACB164F46D2934B /* HomeTopBar.swift */; };
-		C6451DBFD579F34A327E81BF /* HomeTargetsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBAE0DE923F39F2BF45E3E1B /* HomeTargetsRow.swift */; };
-		B9C0507422A8734A914A0D30 /* HomeOverflowGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDF0B8863E06CF3EB482FBA /* HomeOverflowGrid.swift */; };
-		68B80BF5CD2C40BA2A059F8E /* HomeScenesGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8215EE258557D16AA38B3085 /* HomeScenesGrid.swift */; };
-		5BBCE0043B3533C707C8E672 /* HomeRoutinesList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C03F974076CB5E3C7E3587F /* HomeRoutinesList.swift */; };
-		FEEE84C4D01FA5FEF0781729 /* HomeRecentTape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78455880A83F3B59BA98BF37 /* HomeRecentTape.swift */; };
-		8213187280F129984B01C42C /* HomeSyncSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0AF528B55EB38C5E54DFBF /* HomeSyncSection.swift */; };
-		B608495202DFA2A819A411A2 /* HomeCloudStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89ACC1F3EE158DE33127A06F /* HomeCloudStrip.swift */; };
-		C08E8053E76ECAE40E56BC31 /* HomeBottomBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3DA7D87C159F5D6AC0C544C /* HomeBottomBar.swift */; };
-		76A8011A09CC97845FD62341 /* HomeZeroState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D54988DB36C3ED3DD1CBF066 /* HomeZeroState.swift */; };
-		27F65A5D6B42CBFF48C61B5D /* HomeVoiceOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1042450AFBDFADBC000EC79 /* HomeVoiceOverlay.swift */; };
-		2C6AA52F856780E09FBEC4F0 /* HomeDataAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 126FA09AC8E4CB185422ED57 /* HomeDataAdapter.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		003766AC268BAEEC8D05E9E8 /* swift */ = {isa = PBXFileReference; lastKnownFileType = folder; name = swift; path = ../../swift; sourceTree = SOURCE_ROOT; };
-		0A0454EF94BCB42389D5B90B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		0AE37E6C4302786080981EE9 /* LatsDeckScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatsDeckScreen.swift; sourceTree = "<group>"; };
-		11238FFB50336470B6A97CE0 /* DeckStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeckStore.swift; sourceTree = "<group>"; };
 		2008FE641E08A7EA3F1142D8 /* Icon-App-76x76@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-76x76@2x.png"; sourceTree = "<group>"; };
 		2484AA38E059AA293C768446 /* Icon-App-1024x1024@1x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-1024x1024@1x.png"; sourceTree = "<group>"; };
 		2569702CC7CAC0677B8C6524 /* Icon-App-20x20@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-20x20@3x.png"; sourceTree = "<group>"; };
-		31BAB98213FEF0182FB2EA32 /* LatticesCompanionApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatticesCompanionApp.swift; sourceTree = "<group>"; };
 		358CE7599268D7E37739DA40 /* Icon-App-20x20@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-20x20@2x.png"; sourceTree = "<group>"; };
 		5E31C91E44E310ECB2F450E6 /* Icon-App-29x29@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-29x29@2x.png"; sourceTree = "<group>"; };
-		6008CE13AA2719DE4CFEFBA5 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		65151992218EDBCB6BFC8518 /* Icon-App-40x40@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-40x40@2x.png"; sourceTree = "<group>"; };
 		742860D211F50B7F0B23A4DB /* Icon-App-40x40@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-40x40@3x.png"; sourceTree = "<group>"; };
 		763E58A4536019D1C0D225B5 /* Icon-App-29x29@1x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-29x29@1x.png"; sourceTree = "<group>"; };
-		7D303982A361559374D4ECAF /* DeckBridgeSecurityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeckBridgeSecurityStore.swift; sourceTree = "<group>"; };
 		924A59FEB2399ED0CF09A4B5 /* Icon-App-76x76@1x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-76x76@1x.png"; sourceTree = "<group>"; };
 		977D8E982F70B14D99DF82FE /* LatticesCompanion.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = LatticesCompanion.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB70174A80BDBEF97964B1D1 /* Icon-App-29x29@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-29x29@3x.png"; sourceTree = "<group>"; };
-		B31BBB86BC2F6969B6F8C6AC /* DeckBridgeClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeckBridgeClient.swift; sourceTree = "<group>"; };
-		B4603482511D3BE1F2132C82 /* BridgeDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeDiscovery.swift; sourceTree = "<group>"; };
 		B9B6EE50773DB75253F67837 /* Icon-App-40x40@1x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-40x40@1x.png"; sourceTree = "<group>"; };
-		BA2C2E756959812A344E33FA /* CompanionTrackpadSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionTrackpadSurface.swift; sourceTree = "<group>"; };
 		BCF0269F9663D59AA5D8BEF6 /* Icon-App-83.5x83.5@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-83.5x83.5@2x.png"; sourceTree = "<group>"; };
 		D0A784E5230CF4A1207A5B63 /* Icon-App-60x60@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-60x60@3x.png"; sourceTree = "<group>"; };
 		D6A573A92276901B84AA3EE4 /* Icon-App-60x60@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-60x60@2x.png"; sourceTree = "<group>"; };
 		D91400AA758EB6C7BDEFA067 /* Icon-App-20x20@1x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-20x20@1x.png"; sourceTree = "<group>"; };
-		E0A62477A93C15EBE3917B2E /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
-		E5BE58AB3627168981D1D91F /* LatsDesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatsDesignSystem.swift; sourceTree = "<group>"; };
-		30519DB14393D18A74E57E5B /* HomeMockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HomeMockData.swift; path = Home/HomeMockData.swift; sourceTree = "<group>"; };
-		B0C0606BE3D76578604B9CBD /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HomeView.swift; path = Home/HomeView.swift; sourceTree = "<group>"; };
-		C5321ED84ACB164F46D2934B /* HomeTopBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HomeTopBar.swift; path = Home/HomeTopBar.swift; sourceTree = "<group>"; };
-		DBAE0DE923F39F2BF45E3E1B /* HomeTargetsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HomeTargetsRow.swift; path = Home/HomeTargetsRow.swift; sourceTree = "<group>"; };
-		BEDF0B8863E06CF3EB482FBA /* HomeOverflowGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HomeOverflowGrid.swift; path = Home/HomeOverflowGrid.swift; sourceTree = "<group>"; };
-		8215EE258557D16AA38B3085 /* HomeScenesGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HomeScenesGrid.swift; path = Home/HomeScenesGrid.swift; sourceTree = "<group>"; };
-		7C03F974076CB5E3C7E3587F /* HomeRoutinesList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HomeRoutinesList.swift; path = Home/HomeRoutinesList.swift; sourceTree = "<group>"; };
-		78455880A83F3B59BA98BF37 /* HomeRecentTape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HomeRecentTape.swift; path = Home/HomeRecentTape.swift; sourceTree = "<group>"; };
-		8D0AF528B55EB38C5E54DFBF /* HomeSyncSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HomeSyncSection.swift; path = Home/HomeSyncSection.swift; sourceTree = "<group>"; };
-		89ACC1F3EE158DE33127A06F /* HomeCloudStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HomeCloudStrip.swift; path = Home/HomeCloudStrip.swift; sourceTree = "<group>"; };
-		F3DA7D87C159F5D6AC0C544C /* HomeBottomBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HomeBottomBar.swift; path = Home/HomeBottomBar.swift; sourceTree = "<group>"; };
-		D54988DB36C3ED3DD1CBF066 /* HomeZeroState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HomeZeroState.swift; path = Home/HomeZeroState.swift; sourceTree = "<group>"; };
-		E1042450AFBDFADBC000EC79 /* HomeVoiceOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HomeVoiceOverlay.swift; path = Home/HomeVoiceOverlay.swift; sourceTree = "<group>"; };
-		126FA09AC8E4CB185422ED57 /* HomeDataAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HomeDataAdapter.swift; path = Home/HomeDataAdapter.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -163,38 +114,27 @@
 			sourceTree = "<group>";
 		};
 		F83FF26ABEBD47CFB79371F9 /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-				B4603482511D3BE1F2132C82 /* BridgeDiscovery.swift */,
-				BA2C2E756959812A344E33FA /* CompanionTrackpadSurface.swift */,
-				6008CE13AA2719DE4CFEFBA5 /* ContentView.swift */,
-				B31BBB86BC2F6969B6F8C6AC /* DeckBridgeClient.swift */,
-				7D303982A361559374D4ECAF /* DeckBridgeSecurityStore.swift */,
-				11238FFB50336470B6A97CE0 /* DeckStore.swift */,
-				0A0454EF94BCB42389D5B90B /* Info.plist */,
-				0AE37E6C4302786080981EE9 /* LatsDeckScreen.swift */,
-				E5BE58AB3627168981D1D91F /* LatsDesignSystem.swift */,
-				126FA09AC8E4CB185422ED57 /* HomeDataAdapter.swift */,
-				E1042450AFBDFADBC000EC79 /* HomeVoiceOverlay.swift */,
-				30519DB14393D18A74E57E5B /* HomeMockData.swift */,
-				B0C0606BE3D76578604B9CBD /* HomeView.swift */,
-				C5321ED84ACB164F46D2934B /* HomeTopBar.swift */,
-				DBAE0DE923F39F2BF45E3E1B /* HomeTargetsRow.swift */,
-				BEDF0B8863E06CF3EB482FBA /* HomeOverflowGrid.swift */,
-				8215EE258557D16AA38B3085 /* HomeScenesGrid.swift */,
-				7C03F974076CB5E3C7E3587F /* HomeRoutinesList.swift */,
-				78455880A83F3B59BA98BF37 /* HomeRecentTape.swift */,
-				8D0AF528B55EB38C5E54DFBF /* HomeSyncSection.swift */,
-				89ACC1F3EE158DE33127A06F /* HomeCloudStrip.swift */,
-				F3DA7D87C159F5D6AC0C544C /* HomeBottomBar.swift */,
-				D54988DB36C3ED3DD1CBF066 /* HomeZeroState.swift */,
-				31BAB98213FEF0182FB2EA32 /* LatticesCompanionApp.swift */,
-				E0A62477A93C15EBE3917B2E /* LaunchScreen.storyboard */,
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				ACDF33FE680000000000D003 /* Exceptions for "Sources" folder in "LatticesCompanion" target */,
+			);
+			explicitFileTypes = {};
+			explicitFolders = (
 			);
 			path = Sources;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		ACDF33FE680000000000D003 /* Exceptions for "Sources" folder in "LatticesCompanion" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = C19FFDF279AEA0AB229D2532 /* LatticesCompanion */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXNativeTarget section */
 		C19FFDF279AEA0AB229D2532 /* LatticesCompanion */ = {
@@ -208,6 +148,9 @@
 			buildRules = (
 			);
 			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				F83FF26ABEBD47CFB79371F9 /* Sources */,
 			);
 			name = LatticesCompanion;
 			packageProductDependencies = (
@@ -274,7 +217,6 @@
 				FD675D5F19359E6AA5DC41AB /* Icon-App-76x76@1x.png in Resources */,
 				48AB2F1093E08D5F972BEF57 /* Icon-App-76x76@2x.png in Resources */,
 				D34392C35E4145D4262AC87F /* Icon-App-83.5x83.5@2x.png in Resources */,
-				303C0ED6FF5A801009E72EBD /* LaunchScreen.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -285,29 +227,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				84F9131A8649EB980EC5A378 /* BridgeDiscovery.swift in Sources */,
-				E7EC416CD4478DCF4FEBB4FC /* CompanionTrackpadSurface.swift in Sources */,
-				2495F9FA74E60FE3935AF9AB /* ContentView.swift in Sources */,
-				39910639463B85C88940415F /* DeckBridgeClient.swift in Sources */,
-				477B603FA482CD0AF55BC9C7 /* DeckBridgeSecurityStore.swift in Sources */,
-				015334E9F01E2EC8CE7C6C77 /* DeckStore.swift in Sources */,
-				4932E64B0E7CF7E4C48DB05E /* LatsDeckScreen.swift in Sources */,
-				EC49AAE0FD658F4D651D6CB1 /* LatsDesignSystem.swift in Sources */,
-				2C6AA52F856780E09FBEC4F0 /* HomeDataAdapter.swift in Sources */,
-				27F65A5D6B42CBFF48C61B5D /* HomeVoiceOverlay.swift in Sources */,
-				389783C39A96A0C6040E3D18 /* HomeMockData.swift in Sources */,
-				3B524C6E337D9959BF1BE8FE /* HomeView.swift in Sources */,
-				3345DF34E18FB311421B2457 /* HomeTopBar.swift in Sources */,
-				C6451DBFD579F34A327E81BF /* HomeTargetsRow.swift in Sources */,
-				B9C0507422A8734A914A0D30 /* HomeOverflowGrid.swift in Sources */,
-				68B80BF5CD2C40BA2A059F8E /* HomeScenesGrid.swift in Sources */,
-				5BBCE0043B3533C707C8E672 /* HomeRoutinesList.swift in Sources */,
-				FEEE84C4D01FA5FEF0781729 /* HomeRecentTape.swift in Sources */,
-				8213187280F129984B01C42C /* HomeSyncSection.swift in Sources */,
-				B608495202DFA2A819A411A2 /* HomeCloudStrip.swift in Sources */,
-				C08E8053E76ECAE40E56BC31 /* HomeBottomBar.swift in Sources */,
-				76A8011A09CC97845FD62341 /* HomeZeroState.swift in Sources */,
-				8509FE10337BF9B4286C77DF /* LatticesCompanionApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS/LatticesCompanion/Sources/ContentView.swift
+++ b/iOS/LatticesCompanion/Sources/ContentView.swift
@@ -103,6 +103,14 @@ struct ContentView: View {
                 LatsSettingsView(store: store)
                     .preferredColorScheme(.dark)
             }
+            // Adaptive polling: speed up while the user is in the cockpit
+            // (Deck or settings) — Home alone runs in ambient mode.
+            .onChange(of: showLatsDeck) { _, isOpen in
+                store.setUIPriority(isOpen ? .fast : .ambient)
+            }
+            .onChange(of: showSettings) { _, isOpen in
+                store.setUIPriority(isOpen ? .fast : .ambient)
+            }
         }
         .preferredColorScheme(.dark)
     }

--- a/iOS/LatticesCompanion/Sources/DeckStore.swift
+++ b/iOS/LatticesCompanion/Sources/DeckStore.swift
@@ -1,6 +1,15 @@
 import DeckKit
 import Foundation
 
+/// How aggressively the store should pull snapshots from the Mac. Two
+/// presets, mapped to interval values inside `DeckStore`:
+/// - `.fast`    → ~1s (active engagement: Deck open, voice in flight)
+/// - `.ambient` → ~5s (passive observation: Home idle)
+enum DeckPollPriority {
+    case fast
+    case ambient
+}
+
 @MainActor
 final class DeckStore: ObservableObject {
     @Published private(set) var discoveredBridges: [BridgeEndpoint] = []
@@ -21,6 +30,13 @@ final class DeckStore: ObservableObject {
     private let client = DeckBridgeClient()
     private let discovery = BridgeDiscovery()
     private var pollingTask: Task<Void, Never>?
+
+    /// UI hint for how aggressively to poll. Hosts flip this to `.fast` when
+    /// the user is actively engaged (Deck open, voice panel open, recording)
+    /// and back to `.ambient` when they're just looking at Home idle.
+    /// The store will *also* go fast on its own if the snapshot reports voice
+    /// activity or pending questions, so callers don't have to be exhaustive.
+    private var uiPriority: DeckPollPriority = .ambient
 
     var connectionLabel: String {
         // Prefer human-readable names (Bonjour service name / health-reported name)
@@ -114,6 +130,15 @@ final class DeckStore: ObservableObject {
         Task {
             await refreshSnapshot(endpoint: endpoint)
         }
+    }
+
+    /// Tell the store the user is actively engaged (or no longer engaged)
+    /// so it can speed up / slow down snapshot polling. Idempotent — call as
+    /// often as needed from `.onAppear` / `.onChange` hooks. The store will
+    /// independently go fast for in-snapshot signals (voice, attention) so
+    /// callers don't need to be perfect.
+    func setUIPriority(_ priority: DeckPollPriority) {
+        uiPriority = priority
     }
 
     func perform(
@@ -256,11 +281,26 @@ private extension DeckStore {
         pollingTask?.cancel()
         pollingTask = Task { [weak self] in
             while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(1))
+                let interval = self?.currentPollInterval ?? 5.0
+                try? await Task.sleep(for: .seconds(interval))
                 guard let self else { return }
                 await self.refreshSnapshot(endpoint: endpoint)
             }
         }
+    }
+
+    /// Decide the next poll interval based on UI hint + last snapshot.
+    /// Voice activity, pending attention, or an explicit `.fast` UI hint
+    /// pull us into 1s mode; otherwise we sip at 5s. Intervals are
+    /// re-evaluated each tick so the loop adapts as state changes.
+    private var currentPollInterval: TimeInterval {
+        if uiPriority == .fast { return 1.0 }
+        if let voice = snapshot?.voice {
+            if voice.phase != .idle { return 1.0 }
+            if voice.error != nil   { return 1.0 }
+        }
+        if !(snapshot?.questions.isEmpty ?? true) { return 1.0 }
+        return 5.0
     }
 
     func preferredEndpoint(fallback: BridgeEndpoint? = nil) -> BridgeEndpoint? {

--- a/iOS/LatticesCompanion/Sources/Home/HomeActivityFeed.swift
+++ b/iOS/LatticesCompanion/Sources/Home/HomeActivityFeed.swift
@@ -1,0 +1,251 @@
+import SwiftUI
+
+/// Combined activity log — folds three signal streams into a single card so
+/// the user gets one place to look instead of three half-empty sections:
+///   1. Attention (pending decisions)            → amber, pinned at top
+///   2. Recent    (history: command/voice/agent) → per-kind dot + ago
+///   3. Agent     (narration / tool log)         → violet glyph, dim text
+///
+/// Each block keeps its own visual prominence; they're stacked inside one
+/// LatsCard rather than fully homogenized so the kind of each row is still
+/// legible at a glance.
+struct HomeActivityFeed: View {
+    let recent: [HomeRecentEntry]
+    let agentFeed: [HomeAgentFeedEntry]
+    let attention: [HomeAttentionItem]
+    var onReplay: ((HomeRecentEntry) -> Void)? = nil
+
+    private var hasAny: Bool {
+        !recent.isEmpty || !agentFeed.isEmpty || !attention.isEmpty
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                LatsSectionLabel(text: "Activity")
+                Spacer()
+                Text(metaLine)
+                    .font(LatsFont.mono(9))
+                    .tracking(0.5)
+                    .foregroundStyle(LatsPalette.textFaint)
+            }
+
+            LatsCard(padding: 0) {
+                if !hasAny {
+                    Text("no activity yet")
+                        .font(LatsFont.mono(10))
+                        .foregroundStyle(LatsPalette.textFaint)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 14)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else {
+                    VStack(spacing: 0) {
+                        if !attention.isEmpty {
+                            block(of: attention) { item, isLast in
+                                ActivityAttentionRow(item: item)
+                                if !isLast { LatsHairlineDivider() }
+                            }
+                            if !recent.isEmpty || !agentFeed.isEmpty {
+                                LatsHairlineDivider()
+                            }
+                        }
+
+                        if !recent.isEmpty {
+                            block(of: recent) { entry, isLast in
+                                Button { onReplay?(entry) } label: {
+                                    ActivityRecentRow(entry: entry)
+                                }
+                                .buttonStyle(.plain)
+                                .disabled(onReplay == nil)
+                                if !isLast { LatsHairlineDivider() }
+                            }
+                            if !agentFeed.isEmpty {
+                                LatsHairlineDivider()
+                            }
+                        }
+
+                        if !agentFeed.isEmpty {
+                            block(of: agentFeed) { entry, isLast in
+                                ActivityAgentRow(entry: entry)
+                                if !isLast { LatsHairlineDivider() }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var metaLine: String {
+        var parts: [String] = []
+        if !attention.isEmpty { parts.append("\(attention.count) pending") }
+        if !recent.isEmpty    { parts.append("\(recent.count) recent") }
+        if !agentFeed.isEmpty { parts.append("\(agentFeed.count) agent") }
+        return parts.isEmpty ? "last 24h" : parts.joined(separator: " · ")
+    }
+
+    @ViewBuilder
+    private func block<Item: Identifiable, RowContent: View>(
+        of items: [Item],
+        @ViewBuilder row: @escaping (Item, Bool) -> RowContent
+    ) -> some View {
+        ForEach(Array(items.enumerated()), id: \.element.id) { idx, item in
+            row(item, idx == items.count - 1)
+        }
+    }
+}
+
+// MARK: - Attention row (pinned, amber prominence)
+
+private struct ActivityAttentionRow: View {
+    let item: HomeAttentionItem
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: item.icon)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(item.tint.color)
+                .frame(width: 14)
+
+            Text("ATTENTION")
+                .font(LatsFont.mono(9, weight: .bold))
+                .tracking(0.9)
+                .foregroundStyle(LatsPalette.amber.opacity(0.85))
+                .frame(width: 64, alignment: .leading)
+
+            Text(item.label)
+                .font(LatsFont.ui(12, weight: .semibold))
+                .foregroundStyle(LatsPalette.text)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .frame(minHeight: 38)
+        .background(LatsPalette.amber.opacity(0.05))
+        .contentShape(Rectangle())
+    }
+}
+
+// MARK: - Recent row (history, kind-colored dot + ago)
+
+private struct ActivityRecentRow: View {
+    let entry: HomeRecentEntry
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Circle()
+                .fill(entry.kind.dotColor)
+                .frame(width: 6, height: 6)
+                .frame(width: 14)
+
+            Text(entry.kind.label.uppercased())
+                .font(LatsFont.mono(9, weight: .semibold))
+                .tracking(0.9)
+                .foregroundStyle(LatsPalette.textFaint)
+                .frame(width: 64, alignment: .leading)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(entry.title)
+                    .font(LatsFont.ui(12, weight: .medium))
+                    .foregroundStyle(LatsPalette.text)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                if let subtitle = entry.subtitle {
+                    Text(subtitle)
+                        .font(LatsFont.mono(10))
+                        .foregroundStyle(LatsPalette.textDim)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            if let target = entry.target {
+                LatsBadge(text: target, tint: LatsPalette.textDim)
+            }
+
+            Text(entry.agoLabel)
+                .font(LatsFont.mono(10))
+                .foregroundStyle(LatsPalette.textFaint)
+                .frame(width: 56, alignment: .trailing)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .frame(minHeight: 38)
+        .contentShape(Rectangle())
+    }
+}
+
+// MARK: - Agent narration row (violet glyph, dim text)
+
+private struct ActivityAgentRow: View {
+    let entry: HomeAgentFeedEntry
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Text(entry.glyph)
+                .font(LatsFont.mono(11, weight: .semibold))
+                .foregroundStyle(entry.tint.color)
+                .frame(width: 14)
+
+            Text("AGENT")
+                .font(LatsFont.mono(9, weight: .semibold))
+                .tracking(0.9)
+                .foregroundStyle(LatsPalette.violet.opacity(0.7))
+                .frame(width: 64, alignment: .leading)
+
+            Text(entry.text)
+                .font(LatsFont.mono(11))
+                .foregroundStyle(LatsPalette.textDim)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .frame(minHeight: 38)
+        .contentShape(Rectangle())
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Activity · all sources") {
+    LatsBackground {
+        ScrollView {
+            HomeActivityFeed(
+                recent: HomeMock.recent,
+                agentFeed: HomeMock.agentFeed,
+                attention: HomeMock.attention
+            )
+            .padding(14)
+        }
+    }
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Activity · attention only") {
+    LatsBackground {
+        ScrollView {
+            HomeActivityFeed(
+                recent: [],
+                agentFeed: [],
+                attention: HomeMock.attention
+            )
+            .padding(14)
+        }
+    }
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Activity · empty") {
+    LatsBackground {
+        ScrollView {
+            HomeActivityFeed(recent: [], agentFeed: [], attention: [])
+                .padding(14)
+        }
+    }
+    .preferredColorScheme(.dark)
+}

--- a/iOS/LatticesCompanion/Sources/Home/HomeDataAdapter.swift
+++ b/iOS/LatticesCompanion/Sources/Home/HomeDataAdapter.swift
@@ -168,7 +168,20 @@ private extension HomeDataAdapter {
             lastActionAgo: firstHistory.map { agoLabel(from: $0.createdAt) },
             agentState: agentState(for: voice),
             attentionCount: snapshot?.questions.count ?? 0,
-            latencyMs: nil
+            latencyMs: nil,
+            metrics: metrics(from: snapshot?.telemetry)
+        )
+    }
+
+    /// Map `DeckSystemTelemetry` onto the gauge struct. Returns nil if no
+    /// telemetry sample exists, so the card hides its gauge cluster.
+    static func metrics(from tel: DeckSystemTelemetry?) -> HomeMachineMetrics? {
+        guard let tel else { return nil }
+        return HomeMachineMetrics(
+            cpuPercent: tel.cpuLoadPercent,
+            gpuPercent: tel.gpuLoadPercent,
+            memoryPercent: tel.memoryUsedPercent,
+            thermalPercent: tel.thermalPressurePercent
         )
     }
 

--- a/iOS/LatticesCompanion/Sources/Home/HomeMachineGauges.swift
+++ b/iOS/LatticesCompanion/Sources/Home/HomeMachineGauges.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+
+/// Per-machine load gauges. Renders 3-4 vertical bar meters showing the
+/// telemetry the daemon already publishes (CPU, GPU, memory, thermal).
+/// Lives inside the machine card so the live signal sits next to the
+/// thing it describes instead of in a detached status bar.
+///
+/// `compact` shrinks the bar dimensions so the cluster slots into the
+/// body row of a target card without growing the card height. The
+/// non-compact (full) form is for places with vertical room — e.g. a
+/// dedicated telemetry detail view.
+struct HomeMachineGauges: View {
+    let metrics: HomeMachineMetrics
+    /// Height of the bar fill area. Default is the standalone-view size;
+    /// in-card uses pass a value tuned to the right-column height.
+    var barHeight: CGFloat = 44
+
+    var hasAnyValue: Bool {
+        metrics.cpuPercent != nil
+            || metrics.gpuPercent != nil
+            || metrics.memoryPercent != nil
+            || metrics.thermalPercent != nil
+    }
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 10) {
+            LatsGauge(label: "CPU", percent: metrics.cpuPercent, barHeight: barHeight)
+            LatsGauge(label: "GPU", percent: metrics.gpuPercent, barHeight: barHeight)
+            LatsGauge(label: "MEM", percent: metrics.memoryPercent, barHeight: barHeight)
+            if metrics.thermalPercent != nil {
+                LatsGauge(label: "THM", percent: metrics.thermalPercent, barHeight: barHeight)
+            }
+        }
+        .fixedSize()
+    }
+}
+
+// MARK: - Vertical gauge primitive
+
+/// Vertical bar meter — value 0…100, color shifts green → amber → red as
+/// load climbs past 65 / 85.
+///
+/// `barHeight` controls how tall the fill area is; bar width and surrounding
+/// label/value sizes scale with it so the gauge stays readable from compact
+/// in-card usage up to a dedicated telemetry panel.
+struct LatsGauge: View {
+    let label: String
+    let percent: Double?
+    var barHeight: CGFloat = 44
+
+    private var barWidth: CGFloat  { barHeight >= 70 ? 16 : 14 }
+    private var valueSize: CGFloat { barHeight >= 70 ? 10 : 9 }
+    private var labelSize: CGFloat { barHeight >= 70 ? 8  : 7 }
+    private var spacing:   CGFloat { barHeight >= 70 ? 4  : 3 }
+
+    var body: some View {
+        VStack(spacing: spacing) {
+            valueText
+            barTrack
+            labelText
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityDescription)
+    }
+
+    private var valueText: some View {
+        Text(percent.map { "\(Int($0.rounded()))" } ?? "—")
+            .font(LatsFont.mono(valueSize, weight: .semibold))
+            .foregroundStyle(percent != nil ? LatsPalette.text : LatsPalette.textFaint)
+            .monospacedDigit()
+    }
+
+    private var barTrack: some View {
+        ZStack(alignment: .bottom) {
+            RoundedRectangle(cornerRadius: 3)
+                .fill(Color.white.opacity(0.04))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 3)
+                        .stroke(LatsPalette.hairline2, lineWidth: 1)
+                )
+
+            if let p = percent {
+                GeometryReader { geo in
+                    let h = geo.size.height * CGFloat(min(max(p, 0), 100) / 100)
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(loadTint(for: p))
+                        .frame(height: max(h, 1))
+                        .frame(maxHeight: .infinity, alignment: .bottom)
+                        .padding(2)
+                }
+            }
+        }
+        .frame(width: barWidth, height: barHeight)
+    }
+
+    private var labelText: some View {
+        Text(label)
+            .font(LatsFont.mono(labelSize, weight: .bold))
+            .tracking(0.6)
+            .foregroundStyle(LatsPalette.textFaint)
+    }
+
+    private func loadTint(for p: Double) -> Color {
+        if p >= 85 { return LatsPalette.red }
+        if p >= 65 { return LatsPalette.amber }
+        return LatsPalette.green
+    }
+
+    private var accessibilityDescription: String {
+        if let p = percent {
+            return "\(label) \(Int(p.rounded())) percent"
+        }
+        return "\(label) unavailable"
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Gauges · in-card column") {
+    LatsBackground {
+        HomeMachineGauges(
+            metrics: HomeMachineMetrics(
+                cpuPercent: 39,
+                gpuPercent: 12,
+                memoryPercent: 67,
+                thermalPercent: 28
+            ),
+            barHeight: 80
+        )
+        .padding(20)
+    }
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Gauges · standalone") {
+    LatsBackground {
+        HomeMachineGauges(
+            metrics: HomeMachineMetrics(
+                cpuPercent: 4,
+                gpuPercent: 1,
+                memoryPercent: 18,
+                thermalPercent: 12
+            )
+        )
+        .padding(20)
+    }
+    .preferredColorScheme(.dark)
+}

--- a/iOS/LatticesCompanion/Sources/Home/HomeMockData.swift
+++ b/iOS/LatticesCompanion/Sources/Home/HomeMockData.swift
@@ -68,6 +68,18 @@ struct HomeMachine: Identifiable, Equatable {
     let agentState: HomeAgentState
     let attentionCount: Int   // pending attention items
     let latencyMs: Int?       // ping latency in ms
+    /// Live load gauges. nil when the machine isn't reporting telemetry
+    /// (offline / standby / discovered-but-not-paired).
+    var metrics: HomeMachineMetrics? = nil
+}
+
+/// Per-machine load metrics surfaced as gauges. All fields are 0…100
+/// percentages and any may be nil if that signal isn't available.
+struct HomeMachineMetrics: Equatable {
+    let cpuPercent: Double?
+    let gpuPercent: Double?
+    let memoryPercent: Double?
+    let thermalPercent: Double?
 }
 
 // MARK: - Scenes (layout presets — instant, deterministic)
@@ -198,7 +210,13 @@ enum HomeMock {
             lastActionAgo: "2m",
             agentState: .running(task: "writing tile spec"),
             attentionCount: 3,
-            latencyMs: 14
+            latencyMs: 14,
+            metrics: HomeMachineMetrics(
+                cpuPercent: 39,
+                gpuPercent: 12,
+                memoryPercent: 67,
+                thermalPercent: 28
+            )
         ),
         HomeMachine(
             id: "arach-mini",

--- a/iOS/LatticesCompanion/Sources/Home/HomeTargetsRow.swift
+++ b/iOS/LatticesCompanion/Sources/Home/HomeTargetsRow.swift
@@ -90,58 +90,116 @@ private struct HomeTargetCard: View {
     var onEnterDeck: ((HomeMachine) -> Void)? = nil
     var onAttention: ((HomeMachine) -> Void)? = nil
 
+    /// Shared minimum card height. Picked so the gauge column has room to
+    /// breathe (status badge + tall gauges + latency) and offline cards
+    /// reserve the same space — keeps geometry identical regardless of state.
+    private var cardMinHeight: CGFloat { 156 }
+
     var body: some View {
         Button(action: { onEnterDeck?(machine) }) {
             LatsCard(padding: 12, radius: 8) {
-                VStack(alignment: .leading, spacing: 10) {
-                    headerRow
-                    identityBlock
-                    LatsHairlineDivider()
-                    bodyBlock
-                    LatsHairlineDivider()
-                    footerRow
+                HStack(alignment: .top, spacing: 14) {
+                    leftColumn
+                    rightColumn
                 }
+                .frame(minHeight: cardMinHeight)
             }
         }
         .buttonStyle(.plain)
         .opacity(emphasis == .deemphasized ? 0.78 : 1.0)
     }
 
-    // MARK: Header — icon, status, attention, chevron
+    private func hasGaugeContent(_ m: HomeMachineMetrics) -> Bool {
+        m.cpuPercent != nil
+            || m.gpuPercent != nil
+            || m.memoryPercent != nil
+            || m.thermalPercent != nil
+    }
 
-    private var headerRow: some View {
-        HStack(alignment: .top, spacing: 10) {
+    // MARK: Left column — name, identity, metadata, agent
+
+    private var leftColumn: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            nameRow
+            identityBlock
+            metadataBlock
+            Spacer(minLength: 0)
+            footerRow
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+    }
+
+    private var nameRow: some View {
+        HStack(spacing: 10) {
             iconTile
-            VStack(alignment: .leading, spacing: 3) {
-                Text(machine.name)
-                    .font(LatsFont.mono(13, weight: .semibold))
-                    .foregroundStyle(bodyText)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                Text(machine.host)
-                    .font(LatsFont.mono(10))
-                    .foregroundStyle(LatsPalette.textDim)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
+            Text(machine.name)
+                .font(LatsFont.mono(13, weight: .semibold))
+                .foregroundStyle(bodyText)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    // MARK: Right column — status badge above the gauge stack
+
+    private var rightColumn: some View {
+        VStack(alignment: .trailing, spacing: 10) {
+            statusStack
+
+            if let metrics = machine.metrics, hasGaugeContent(metrics) {
+                Spacer(minLength: 4)
+                HomeMachineGauges(metrics: metrics, barHeight: 80)
+                Spacer(minLength: 0)
+            } else {
+                Spacer(minLength: 0)
             }
-            Spacer(minLength: 4)
-            VStack(alignment: .trailing, spacing: 6) {
-                HStack(spacing: 6) {
-                    if machine.attentionCount > 0 {
-                        attentionDot
-                    }
-                    LatsBadge(
-                        text: machine.status.label,
-                        tint: machine.status.tint,
-                        dot: machine.status == .active
-                    )
+        }
+        .frame(width: 110, alignment: .trailing)
+    }
+
+    private var statusStack: some View {
+        VStack(alignment: .trailing, spacing: 4) {
+            HStack(spacing: 6) {
+                if machine.attentionCount > 0 {
+                    attentionDot
                 }
-                if let lat = machine.latencyMs, machine.status != .offline {
-                    Text("\(lat)ms")
-                        .font(LatsFont.mono(9))
-                        .tracking(0.4)
-                        .foregroundStyle(LatsPalette.textFaint)
-                }
+                LatsBadge(
+                    text: machine.status.label,
+                    tint: machine.status.tint,
+                    dot: machine.status == .active
+                )
+            }
+            if let lat = machine.latencyMs, machine.status != .offline {
+                Text("\(lat)ms")
+                    .font(LatsFont.mono(9))
+                    .tracking(0.4)
+                    .foregroundStyle(LatsPalette.textFaint)
+            }
+        }
+    }
+
+    // MARK: Metadata — focus/last for live targets, paired info for offline
+
+    @ViewBuilder
+    private var metadataBlock: some View {
+        switch machine.status {
+        case .offline:
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text("PAIRED")
+                    .font(LatsFont.mono(9, weight: .bold))
+                    .tracking(0.8)
+                    .foregroundStyle(LatsPalette.textFaint)
+                    .frame(width: 50, alignment: .leading)
+                Text(machine.lastActionAgo ?? "—")
+                    .font(LatsFont.mono(11))
+                    .foregroundStyle(bodyDim)
+                Spacer(minLength: 0)
+            }
+        default:
+            VStack(alignment: .leading, spacing: 6) {
+                focusedRow
+                lastActionRow
             }
         }
     }
@@ -206,14 +264,7 @@ private struct HomeTargetCard: View {
         }
     }
 
-    // MARK: Body — focused app + window, last action
-
-    private var bodyBlock: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            focusedRow
-            lastActionRow
-        }
-    }
+    // MARK: Focused app + last action rows (active/online machines)
 
     @ViewBuilder
     private var focusedRow: some View {

--- a/iOS/LatticesCompanion/Sources/Home/HomeView.swift
+++ b/iOS/LatticesCompanion/Sources/Home/HomeView.swift
@@ -6,11 +6,11 @@ import SwiftUI
 /// Composed of independent sections:
 ///   - HomeTopBar       (chrome — fleet pills, agent count, settings)
 ///   - HomeTargetsRow   (adaptive cards: 1, 2, 3-4 Macs)
-///   - HomeOverflowGrid (foreground machine "third monitor" tiles)
 ///   - HomeScenesGrid   (instant layout presets)
 ///   - HomeRoutinesList (agent recipes)
-///   - HomeRecentTape   (cross-fleet activity)
+///   - HomeActivityFeed (combined: attention + recent + agent narration)
 ///   - HomeSyncSection  (broadcast / fleet ops)
+///   - HomeVoicePanel   (inline voice — slides in above the cloud strip)
 ///   - HomeCloudStrip   (separate cloud aggregate)
 ///   - HomeBottomBar    (chrome — status, voice/cmd)
 ///
@@ -50,7 +50,7 @@ struct HomeView: View {
     var onVoiceCancel: (() -> Void)? = nil
     var onVoiceRemediate: ((DeckRemediationAction) -> Void)? = nil
 
-    @State private var showingVoiceOverlay: Bool = false
+    @State private var voicePanelOpen: Bool = false
 
     private var foregroundMachine: HomeMachine? {
         machines.first(where: { $0.isForeground })
@@ -72,40 +72,24 @@ struct HomeView: View {
                     connectedLayout
                 }
             }
-            voiceTrigger
-                .padding(.trailing, 18)
-                .padding(.bottom, 70) // sit above the HomeBottomBar
+            if !voicePanelOpen {
+                voiceTrigger
+                    .padding(.trailing, 18)
+                    .padding(.bottom, 70) // sit above the HomeBottomBar
+            }
         }
-        .fullScreenCover(isPresented: $showingVoiceOverlay) {
-            HomeVoiceOverlay(
-                voiceState: voiceState,
-                macLabel: voiceMacLabel,
-                isPerforming: isVoicePerforming,
-                onStart: { onVoiceStart?() },
-                onStop:  { onVoiceStop?() },
-                onCancel: {
-                    onVoiceCancel?()
-                    showingVoiceOverlay = false
-                },
-                onClose: { showingVoiceOverlay = false },
-                onRemediate: { onVoiceRemediate?($0) }
-            )
-        }
+        // Auto-open the panel when the Mac reports active voice work (a
+        // dictation kicked off elsewhere, or an error needs attention). We
+        // don't auto-open just for stale transcripts/responses — closing the
+        // panel must stay closed once the turn is done.
         .onChange(of: voiceState?.phase) { _, newPhase in
-            // Auto-close when the Mac finishes a successful turn (idle + result, no error).
-            guard showingVoiceOverlay,
-                  newPhase == .idle,
-                  voiceState?.error == nil,
-                  let summary = voiceState?.responseSummary,
-                  !summary.isEmpty,
-                  summary != "Transcribing...",
-                  summary != "thinking..."
-            else { return }
-            Task {
-                try? await Task.sleep(for: .milliseconds(1400))
-                if voiceState?.phase == .idle && voiceState?.error == nil {
-                    showingVoiceOverlay = false
-                }
+            if let newPhase, newPhase != .idle {
+                voicePanelOpen = true
+            }
+        }
+        .onChange(of: voiceState?.error?.code) { _, newCode in
+            if newCode != nil {
+                voicePanelOpen = true
             }
         }
     }
@@ -113,7 +97,7 @@ struct HomeView: View {
     private var voiceTrigger: some View {
         Button {
             onVoiceStart?()
-            showingVoiceOverlay = true
+            voicePanelOpen = true
         } label: {
             Image(systemName: "mic.fill")
                 .font(.system(size: 18, weight: .semibold))
@@ -158,7 +142,11 @@ struct HomeView: View {
 
                     HomeRoutinesList(routines: routines, onRun: onRoutine)
 
-                    HomeRecentTape(entries: recent)
+                    HomeActivityFeed(
+                        recent: recent,
+                        agentFeed: agentFeed,
+                        attention: attention
+                    )
 
                     HomeSyncSection(
                         actions: sync,
@@ -168,8 +156,24 @@ struct HomeView: View {
                 }
                 .padding(.horizontal, 24)
                 .padding(.vertical, 18)
-                .frame(maxWidth: 1100)
                 .frame(maxWidth: .infinity)
+            }
+
+            if voicePanelOpen {
+                HomeVoicePanel(
+                    voiceState: voiceState,
+                    macLabel: voiceMacLabel,
+                    isPerforming: isVoicePerforming,
+                    onStart: { onVoiceStart?() },
+                    onStop:  { onVoiceStop?() },
+                    onCancel: {
+                        onVoiceCancel?()
+                        voicePanelOpen = false
+                    },
+                    onClose: { voicePanelOpen = false },
+                    onRemediate: { onVoiceRemediate?($0) }
+                )
+                .transition(.move(edge: .bottom).combined(with: .opacity))
             }
 
             HomeCloudStrip(cloud: cloud)
@@ -178,6 +182,7 @@ struct HomeView: View {
                 telemetry: bottomTelemetry
             )
         }
+        .animation(.easeInOut(duration: 0.22), value: voicePanelOpen)
     }
 }
 

--- a/iOS/LatticesCompanion/Sources/Home/HomeVoiceOverlay.swift
+++ b/iOS/LatticesCompanion/Sources/Home/HomeVoiceOverlay.swift
@@ -7,9 +7,8 @@ import SwiftUI
 /// for the Mac that's actually listening.
 ///
 /// Presented as `.fullScreenCover` from `HomeView` when the user taps the
-/// voice button in `HomeBottomBar`. Auto-dismisses ~1.4s after the Mac
-/// returns to `idle` with a successful `responseSummary`; sticks around when
-/// there's an error so the user can read + retry.
+/// voice button. The overlay stays open until the user closes it so command
+/// results remain visible for review.
 struct HomeVoiceOverlay: View {
     let voiceState: DeckVoiceState?
     let macLabel: String
@@ -371,7 +370,7 @@ struct HomeVoiceOverlay: View {
 
 // MARK: - Voice orb
 
-private struct VoiceOrb: View {
+struct VoiceOrb: View {
     let phase: DeckVoicePhase
     let severity: DeckErrorSeverity?
 

--- a/iOS/LatticesCompanion/Sources/Home/HomeVoicePanel.swift
+++ b/iOS/LatticesCompanion/Sources/Home/HomeVoicePanel.swift
@@ -1,0 +1,427 @@
+import DeckKit
+import SwiftUI
+
+/// Inline voice panel — slots into the Home layout above the cloud strip
+/// instead of taking over the screen. The dashboard stays visible above so
+/// the user can see fleet state while dictating.
+///
+/// Renders nothing when there's nothing to say (idle, no transcript, no
+/// response, no error, panel not explicitly opened). Hosting view controls
+/// visibility via `isOpen` so an explicit FAB tap can pre-open the panel
+/// before any state arrives from the Mac.
+struct HomeVoicePanel: View {
+    let voiceState: DeckVoiceState?
+    let macLabel: String
+    let isPerforming: Bool
+
+    var onStart: () -> Void
+    var onStop: () -> Void
+    var onCancel: () -> Void
+    var onClose: () -> Void
+    var onRemediate: ((DeckRemediationAction) -> Void)? = nil
+
+    private var phase: DeckVoicePhase { voiceState?.phase ?? .idle }
+    private var error: DeckVoiceError? { voiceState?.error }
+
+    private var transcript: String? {
+        let raw = voiceState?.transcript?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (raw?.isEmpty == false) ? raw : nil
+    }
+
+    private var responseSummary: String? {
+        let raw = voiceState?.responseSummary?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let raw, !raw.isEmpty else { return nil }
+        if raw == "Transcribing..." || raw == "thinking..." { return nil }
+        return raw
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .top, spacing: 14) {
+                // Single round CTA — combines mic icon, phase indicator, and
+                // start/stop action into one tap target. Color + glyph reflect
+                // current phase; tapping advances the state.
+                VoiceCTA(
+                    phase: phase,
+                    severity: error?.severity,
+                    onTap: handlePrimaryTap
+                )
+                .frame(width: 64, height: 64)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    headerRow
+
+                    Text(caption)
+                        .font(LatsFont.mono(11))
+                        .tracking(0.4)
+                        .foregroundStyle(LatsPalette.textDim)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    if let transcript {
+                        transcriptInline(transcript)
+                    }
+                    if let responseSummary {
+                        responseInline(responseSummary)
+                    }
+                    if let error {
+                        errorInline(error)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+        }
+        .background(Color.black.opacity(0.32))
+        .overlay(alignment: .top) {
+            Rectangle().fill(LatsPalette.hairline2).frame(height: 1)
+        }
+    }
+
+    // MARK: - Header — target label + close
+
+    private var headerRow: some View {
+        HStack(spacing: 8) {
+            Text(macLabel.lowercased())
+                .font(LatsFont.mono(11))
+                .tracking(0.5)
+                .foregroundStyle(LatsPalette.textDim)
+                .lineLimit(1)
+
+            Spacer(minLength: 8)
+
+            Button(action: onClose) {
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(LatsPalette.textDim)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close voice")
+        }
+    }
+
+    // MARK: - Tap routing for the single CTA
+
+    /// One button, three jobs depending on phase. Idle starts; listening stops;
+    /// transcribing/reasoning/speaking cancels the in-flight turn. Errors with
+    /// remediations route through the remediation handler instead.
+    private func handlePrimaryTap() {
+        if let err = error, let remediation = err.remediation {
+            onRemediate?(remediation)
+            return
+        }
+        switch phase {
+        case .idle:
+            onStart()
+        case .listening:
+            onStop()
+        case .transcribing, .reasoning, .speaking:
+            onCancel()
+        }
+    }
+
+    // MARK: - Inline transcript / response / error
+
+    private func transcriptInline(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text("›")
+                .font(LatsFont.mono(12, weight: .semibold))
+                .foregroundStyle(LatsPalette.green.opacity(0.8))
+            Text(text)
+                .font(LatsFont.mono(12))
+                .foregroundStyle(LatsPalette.text)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .multilineTextAlignment(.leading)
+        }
+    }
+
+    private func responseInline(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "checkmark")
+                .font(.system(size: 10, weight: .bold))
+                .foregroundStyle(LatsPalette.green)
+                .frame(width: 12)
+            Text(text)
+                .font(LatsFont.ui(12))
+                .foregroundStyle(LatsPalette.text)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func errorInline(_ err: DeckVoiceError) -> some View {
+        let tint = severityTint(err.severity)
+        return VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Image(systemName: severityIcon(err.code))
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(tint)
+                Text(err.code.rawValue.uppercased())
+                    .font(LatsFont.mono(9, weight: .bold))
+                    .tracking(1.2)
+                    .foregroundStyle(tint)
+                Spacer()
+            }
+            Text(err.message)
+                .font(LatsFont.ui(12, weight: .medium))
+                .foregroundStyle(LatsPalette.text)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .multilineTextAlignment(.leading)
+            if let remediation = err.remediation {
+                LatsButton(
+                    title: remediationLabel(remediation),
+                    icon: remediationIcon(remediation),
+                    style: .primary(remediationTint(err.severity))
+                ) {
+                    onRemediate?(remediation)
+                }
+            }
+        }
+        .padding(10)
+        .background(RoundedRectangle(cornerRadius: 6).fill(tint.opacity(0.08)))
+        .overlay(RoundedRectangle(cornerRadius: 6).stroke(tint.opacity(0.4), lineWidth: 1))
+    }
+
+    // MARK: - Phase / severity helpers
+
+    private var caption: String {
+        if error != nil { return "voice paused — see status above" }
+        switch phase {
+        case .idle:         return "tap to dictate on \(macLabel)"
+        case .listening:    return "listening on \(macLabel) — tap to stop"
+        case .transcribing: return "transcribing…"
+        case .reasoning:    return "matching intent…"
+        case .speaking:     return "responding…"
+        }
+    }
+
+    private var phaseTint: Color {
+        if let err = error { return severityTint(err.severity) }
+        switch phase {
+        case .idle:         return LatsPalette.textDim
+        case .listening:    return LatsPalette.green
+        case .transcribing: return LatsPalette.teal
+        case .reasoning:    return LatsPalette.violet
+        case .speaking:     return LatsPalette.blue
+        }
+    }
+
+    private func severityTint(_ severity: DeckErrorSeverity) -> Color {
+        switch severity {
+        case .info:    return LatsPalette.blue
+        case .warning: return LatsPalette.amber
+        case .error,
+             .blocked: return LatsPalette.red
+        }
+    }
+
+    private func severityIcon(_ code: DeckVoiceErrorCode) -> String {
+        switch code {
+        case .micDenied:           return "mic.slash"
+        case .accessibilityDenied: return "lock.shield"
+        case .micBusy:             return "mic.badge.xmark"
+        case .voxNotRunning,
+             .voxLoading,
+             .voxUnreachable:      return "waveform.badge.exclamationmark"
+        case .daemonUnreachable,
+             .network,
+             .connectionLost:      return "wifi.exclamationmark"
+        case .noActiveTarget:      return "scope"
+        case .intentUnresolved:    return "questionmark.circle"
+        case .actionFailed:        return "bolt.trianglebadge.exclamationmark"
+        case .transcriptionFailed: return "waveform.slash"
+        case .emptyTranscript:     return "ear"
+        case .languageUnsupported: return "globe"
+        }
+    }
+
+    private func remediationLabel(_ remediation: DeckRemediationAction) -> String {
+        switch remediation {
+        case .openVox:            return "Open Vox"
+        case .openSystemSettings: return "Open settings"
+        case .retryVoice:         return "Retry"
+        case .openDiagnostics:    return "Open diagnostics"
+        case .chooseTarget:       return "Pick target"
+        }
+    }
+
+    private func remediationIcon(_ remediation: DeckRemediationAction) -> String {
+        switch remediation {
+        case .openVox:            return "waveform"
+        case .openSystemSettings: return "gearshape"
+        case .retryVoice:         return "arrow.clockwise"
+        case .openDiagnostics:    return "stethoscope"
+        case .chooseTarget:       return "scope"
+        }
+    }
+
+    private func remediationTint(_ severity: DeckErrorSeverity) -> LatsTint {
+        switch severity {
+        case .info:    return .blue
+        case .warning: return .amber
+        case .error,
+             .blocked: return .red
+        }
+    }
+}
+
+// MARK: - VoiceCTA — single round button that absorbs orb + phase pill + action
+
+/// A round mic button whose color, glyph, and pulse animation reflect the
+/// current voice phase. Replaces the old triple of orb + "READY" pill +
+/// Start/Stop button with one tappable surface — the host wires its tap to
+/// a phase-aware handler that starts, stops, or cancels as appropriate.
+struct VoiceCTA: View {
+    let phase: DeckVoicePhase
+    let severity: DeckErrorSeverity?
+    var onTap: () -> Void
+
+    @State private var pulse: Bool = false
+
+    var body: some View {
+        Button(action: onTap) {
+            ZStack {
+                // Outer pulse ring — only animates while listening so the
+                // CTA visually "hears."
+                Circle()
+                    .stroke(tint.opacity(0.45), lineWidth: 1.5)
+                    .scaleEffect(pulse ? 1.18 : 1.0)
+                    .opacity(pulse ? 0.0 : 0.85)
+                    .animation(
+                        isAnimating
+                            ? .easeOut(duration: 1.4).repeatForever(autoreverses: false)
+                            : .default,
+                        value: pulse
+                    )
+
+                Circle().fill(tint.opacity(0.18))
+                Circle().stroke(tint.opacity(0.55), lineWidth: 1)
+
+                if isThinking {
+                    ProgressView()
+                        .tint(tint)
+                        .scaleEffect(0.9)
+                } else {
+                    Image(systemName: glyph)
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundStyle(tint)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .contentShape(Circle())
+        .onAppear { if isAnimating { pulse = true } }
+        .onChange(of: phase) { _, _ in pulse = isAnimating }
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var isAnimating: Bool { severity == nil && phase == .listening }
+    private var isThinking: Bool {
+        severity == nil && (phase == .transcribing || phase == .reasoning || phase == .speaking)
+    }
+
+    private var tint: Color {
+        if let severity {
+            switch severity {
+            case .info:    return LatsPalette.blue
+            case .warning: return LatsPalette.amber
+            case .error,
+                 .blocked: return LatsPalette.red
+            }
+        }
+        switch phase {
+        case .idle:         return LatsPalette.violet
+        case .listening:    return LatsPalette.red
+        case .transcribing: return LatsPalette.teal
+        case .reasoning:    return LatsPalette.violet
+        case .speaking:     return LatsPalette.blue
+        }
+    }
+
+    private var glyph: String {
+        if severity != nil { return "exclamationmark.triangle.fill" }
+        switch phase {
+        case .idle:      return "mic.fill"
+        case .listening: return "stop.fill"
+        default:         return "mic.fill"
+        }
+    }
+
+    private var accessibilityLabel: String {
+        if severity != nil { return "Resolve voice issue" }
+        switch phase {
+        case .idle:      return "Start dictation"
+        case .listening: return "Stop dictation"
+        default:         return "Cancel voice turn"
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Panel · listening") {
+    LatsBackground {
+        VStack {
+            Spacer()
+            HomeVoicePanel(
+                voiceState: DeckVoiceState(
+                    phase: .listening,
+                    transcript: "tile chrome two-up right",
+                    provider: "vox"
+                ),
+                macLabel: "arach-laptop",
+                isPerforming: false,
+                onStart: {}, onStop: {}, onCancel: {}, onClose: {}
+            )
+        }
+    }
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Panel · result") {
+    LatsBackground {
+        VStack {
+            Spacer()
+            HomeVoicePanel(
+                voiceState: DeckVoiceState(
+                    phase: .idle,
+                    transcript: "tile chrome two-up right",
+                    responseSummary: "Tiled 3 windows in two columns on display 1",
+                    provider: "vox"
+                ),
+                macLabel: "arach-laptop",
+                isPerforming: false,
+                onStart: {}, onStop: {}, onCancel: {}, onClose: {}
+            )
+        }
+    }
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Panel · error") {
+    LatsBackground {
+        VStack {
+            Spacer()
+            HomeVoicePanel(
+                voiceState: DeckVoiceState(
+                    phase: .idle,
+                    provider: "vox",
+                    error: DeckVoiceError(
+                        code: .voxNotRunning,
+                        severity: .error,
+                        recoverable: true,
+                        retry: .afterLaunch,
+                        source: .mac,
+                        message: "Vox offline — start it to dictate",
+                        remediation: .openVox
+                    )
+                ),
+                macLabel: "arach-laptop",
+                isPerforming: false,
+                onStart: {}, onStop: {}, onCancel: {}, onClose: {}
+            )
+        }
+    }
+    .preferredColorScheme(.dark)
+}

--- a/install.sh
+++ b/install.sh
@@ -75,16 +75,33 @@ install_dep tmux
 install_dep bun "oven-sh/bun/bun" "oven-sh/bun"
 
 # ── Install CLI ───────────────────────────────────────────────────────
+# If run from inside the source repo, link the local checkout instead of
+# fetching from npm. Detected by package.json next to this script with
+# name "@lattices/cli".
 
-info "Installing @lattices/cli..."
-
-if command -v lattices &>/dev/null; then
-  CURRENT="$(lattices --version 2>/dev/null || echo "unknown")"
-  warn "lattices already installed ($CURRENT) — upgrading"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOCAL_MODE=0
+if [[ -f "$SCRIPT_DIR/package.json" ]] && \
+   grep -q '"@lattices/cli"' "$SCRIPT_DIR/package.json"; then
+  LOCAL_MODE=1
 fi
 
-bun install -g @lattices/cli
-ok "CLI installed → $(which lattices)"
+if [[ "$LOCAL_MODE" -eq 1 ]]; then
+  info "Linking @lattices/cli from $SCRIPT_DIR..."
+else
+  info "Installing @lattices/cli..."
+fi
+
+if command -v lattices &>/dev/null; then
+  warn "lattices already installed — replacing"
+fi
+
+if [[ "$LOCAL_MODE" -eq 1 ]]; then
+  (cd "$SCRIPT_DIR" && bun link && bun link @lattices/cli)
+else
+  bun install -g @lattices/cli
+fi
+ok "CLI installed → $(command -v lattices)"
 
 # ── Verify CLI ────────────────────────────────────────────────────────
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "app/Resources",
     "app/Sources",
     "app/Tests",
+    "swift/Package.swift",
+    "swift/Sources",
+    "swift/Tests",
     "assets/AppIcon.icns",
     "docs"
   ],


### PR DESCRIPTION
## Summary

Brings the iPad companion cockpit work to main, plus a self-healing macOS mouse gesture controller and CLI/install polish.

**Already on this branch (prior commits):**
- Local-network companion cockpit for iPad (Bonjour-discovered bridge)
- Secured the local companion bridge
- Deck bridge telemetry, spaces, cockpit modes
- Lats Deck cockpit prototype + bottom-control polish
- iPad Home dashboard with live data wiring

**New on this branch (today):**
- ✨ Mouse gesture controller with async dispatch + self-healing circuit breaker. Tap callback never blocks — actions dispatch async to the main queue. Breaker trips on OS tap timeouts or actions exceeding 500ms, with 30s → 2min → permanent backoff and auto-recovery.
- ✨ iPad Home: inline voice panel (replaces fullscreen overlay), activity feed, machine gauges, and adaptive polling (5s ambient → 1s when Deck/Settings open or voice is active).
- 🙈 Ignore Xcode xcuserdata and swift/.swiftpm.
- 🔧 install.sh detects local source repo and uses bun link; bin/lattices-dev gains link/unlink subcommands; lattices-app surfaces non-zero build exits; package.json includes swift/ in the published file set.

## Follow-up PRs (opening separately off main)

- **PR 2** wires the mouse gesture controller into the app — adds the AppDelegate \`.start()\` call, a Settings card, and docs/mouse-gestures.md. The controller code itself is in this PR; PR 2 activates the UI.
- **PR 3** refactors hands-off voice inference to use a shared resolver + .env loading.
- **PR 4** polishes Mac voice/audio (Vox auto-launch, human result summaries, deck voice routing).

## Test plan

- [ ] iPad app builds and launches; Home shows the new activity feed + machine gauges
- [ ] Voice panel slides in inline rather than fullscreen
- [ ] Polling speeds up when entering Deck/Settings, slows back down on return to Home
- [ ] Mac app builds; mouse gesture controller is present but not yet wired into AppDelegate (intentional — PR 2)
- [ ] \`install.sh\` from a local repo links instead of npm-fetching
- [ ] \`lattices-dev link\` symlinks the local CLI globally