### PR TITLE
Wire up mouse gestures: AppDelegate start, Settings card, docs

### DIFF
--- a/app/Sources/AppDelegate.swift
+++ b/app/Sources/AppDelegate.swift
@@ -177,6 +177,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         AgentPool.shared.start()
         diag.finish(tBoot)
 
+        // Mouse gesture controller
+        MouseGestureController.shared.start()
+
         // --diagnostics flag: auto-open diagnostics panel on launch
         if CommandLine.arguments.contains("--diagnostics") {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {

--- a/app/Sources/SettingsView.swift
+++ b/app/Sources/SettingsView.swift
@@ -1074,6 +1074,8 @@ struct SettingsContentView: View {
                             }
 
                             shortcutsTmuxCard
+
+                            mouseGesturesCard
                         }
                         .padding(.horizontal, 20)
                         .padding(.vertical, 16)
@@ -1444,6 +1446,86 @@ struct SettingsContentView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
+    }
+
+    // MARK: - Mouse Gestures
+
+    private var mouseGesturesCard: some View {
+        let config = MouseShortcutConfig.load()
+
+        return shortcutSectionCard(
+            title: "Mouse Gestures",
+            eyebrow: "MX Master",
+            summary: "Hold a side button and drag in a direction. Edit ~/.lattices/mouse-shortcuts.json to remap."
+        ) {
+            VStack(alignment: .leading, spacing: 14) {
+                Text("Button 3 — Grid / Layout")
+                    .font(Typo.monoBold(11))
+                    .foregroundColor(Palette.text)
+
+                HStack(spacing: 0) {
+                    ForEach([("↑", "up"), ("←", "left"), ("→", "right"), ("↓", "down")], id: \.0) { arrow, dir in
+                        mouseGestureRow(button: "button3", direction: dir, arrow: arrow, config: config)
+                        if arrow != "↓" { Divider().frame(width: 1).background(Palette.border) }
+                    }
+                }
+                .padding(12)
+                .background(shortcutsInsetPanel)
+
+                HStack(spacing: 6) {
+                    Image(systemName: "doc.text")
+                        .font(.system(size: 9))
+                        .foregroundColor(Palette.textMuted)
+                    Text("~/.lattices/mouse-shortcuts.json")
+                        .font(Typo.mono(10))
+                        .foregroundColor(Palette.textMuted)
+                }
+            }
+        }
+    }
+
+    private func mouseGestureRow(button: String, direction: String, arrow: String, config: MouseShortcutConfig?) -> some View {
+        let actionLabel = resolveAction(for: button, direction: direction, config: config)
+
+        return HStack(spacing: 6) {
+            Text(arrow)
+                .font(.system(size: 16, weight: .bold))
+                .foregroundColor(Palette.text)
+                .frame(width: 24)
+
+            Text(actionLabel)
+                .font(Typo.mono(10.5))
+                .foregroundColor(Palette.textMuted)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func resolveAction(for button: String, direction: String, config: MouseShortcutConfig?) -> String {
+        guard let config else {
+            switch (button, direction) {
+            case ("button3", "up"):    return "Maximize"
+            case ("button3", "left"):  return "2×2 Grid"
+            case ("button3", "right"): return "3×3 Grid"
+            case ("button3", "down"):  return "4×4 Grid"
+            default: return "—"
+            }
+        }
+
+        for rule in config.rules {
+            if rule.trigger.button == button && rule.trigger.direction == direction {
+                return formatActionType(rule.action.type)
+            }
+        }
+        return "—"
+    }
+
+    private func formatActionType(_ type: String) -> String {
+        type.replacingOccurrences(of: ".", with: " ")
+            .replacingOccurrences(of: "tile ", with: "")
+            .replacingOccurrences(of: "grid ", with: "")
+            .capitalized
     }
 
     // MARK: - Shortcut section UI

--- a/docs/mouse-gestures.md
+++ b/docs/mouse-gestures.md
@@ -1,0 +1,79 @@
+# Mouse Gestures
+
+## Concept
+
+Hold a mouse button → drag in a direction → release to execute an action.
+The MX Master 3S back-side button (button 3) triggers grid layouts.
+
+## Button Mapping
+
+Defaults — remap by editing `~/.lattices/mouse-shortcuts.json`:
+
+- **Button 3 (Back)** — grid layouts (Maximize / 2×2 / 3×3 / 4×4)
+
+## Gesture Detection
+
+1. Button held → start tracking mouse movement
+2. After 30px of movement, commit to a direction (↑ ← → ↓)
+3. Show HUD feedback badge: current direction + predicted action
+4. Release → execute the action
+
+If released before 30px threshold → no action (treated as a normal click).
+
+## Actions
+
+### Button 3 — Grid / Tile
+
+| Direction | Action | Result |
+|-----------|--------|--------|
+| ↑ Up | Maximize | Frontmost window fills the screen |
+| ← Left | 2×2 grid | Distribute frontmost 4 windows |
+| → Right | 3×3 grid | Distribute frontmost 9 windows |
+| ↓ Down | 4×4 grid | Distribute frontmost 16 windows |
+
+Grid distributes the visible non-Lattices windows to fill the grid cells on
+the screen the cursor is on.
+
+## HUD Feedback
+
+While dragging:
+- Small floating badge near the cursor: direction arrow + action name
+- Floats above all windows, fades out on release
+
+## Safety: self-healing event tap
+
+The controller installs a session-wide CGEvent tap. To avoid blocking the
+system input pipeline:
+
+- The tap callback never blocks — actions dispatch async to the main queue.
+- A circuit breaker trips on (a) OS `tapDisabledByTimeout` events, or
+  (b) any single action that exceeds 500ms.
+- Cooldowns escalate inside a 10-minute rolling window: **30s → 2min →
+  permanent** (until config reload or app restart).
+- A center-screen badge surfaces "Mouse gestures paused — resuming in Ns"
+  on trip and "Mouse gestures resumed" on auto-recover. All trips log to
+  `~/.lattices/lattices.log`.
+
+## Implementation
+
+- `app/Sources/MouseGestureController.swift` — CGEvent tap, gesture
+  state machine, breaker.
+- Tile actions go through `WindowTiler.tileFrontmostViaAX(...)`.
+- Grid actions enumerate visible windows via `DesktopModel.shared.allWindows()`
+  and batch-move them with `WindowTiler.batchMoveAndRaiseWindows(...)`.
+
+## Settings UI
+
+**Settings → Shortcuts → Mouse Gestures**:
+
+- Button 3 grid card showing the active mapping
+- Hint to edit `~/.lattices/mouse-shortcuts.json` for remapping
+
+## Edge Cases
+
+- Multiple monitors: gesture executes on the screen the cursor starts on
+- Button held + cursor leaves the screen: still tracks; action applies
+  to the starting screen
+- Short press (< 30px movement): ignored, treated as a normal click
+- Slow action / OS tap timeout: breaker trips, gestures pause briefly,
+  then auto-recover


### PR DESCRIPTION
## Summary

Activates the mouse gesture controller landed in #12 by wiring it into the app and giving it a UI + docs.

- `AppDelegate` boots `MouseGestureController.shared.start()` on launch
- `Settings → Shortcuts → Mouse Gestures` shows the active Button-3 grid mapping (Maximize / 2×2 / 3×3 / 4×4) with a hint to edit `~/.lattices/mouse-shortcuts.json` for remapping
- `docs/mouse-gestures.md` explains the gesture model, default mapping, HUD feedback, and the self-healing event-tap design (30s → 2min → permanent backoff)

## Stacked on

Base: `codex/companion-cockpit-trackpad` (#12). Will re-target to `main` once #12 merges.

## Test plan

- [ ] Mac app builds; on launch, gesture tap installs (check `~/.lattices/lattices.log` for `MouseGestureController: event tap installed`)
- [ ] Hold MX Master back-button + drag up → frontmost window maximizes
- [ ] Hold + drag in any direction → HUD badge shows the predicted action
- [ ] Settings → Shortcuts → Mouse Gestures renders the Button-3 card
- [ ] `docs/mouse-gestures.md` reads correctly (Button-4 / tmux-resize references should be gone)