### PR TITLE
Hands-off voice: shared inference resolver + .env loading + abort timeouts

### DIFF
--- a/bin/handsoff-infer.ts
+++ b/bin/handsoff-infer.ts
@@ -4,7 +4,7 @@
  *
  * Usage: echo '{"transcript":"tile chrome left","snapshot":{...}}' | bun run bin/handsoff-infer.ts
  *
- * Reads JSON from stdin, calls Groq via lib/infer.ts, prints JSON result to stdout.
+ * Reads JSON from stdin, calls the configured voice inference provider, prints JSON result to stdout.
  * All logging goes to stderr so it doesn't pollute the JSON output.
  */
 
@@ -14,7 +14,9 @@ import {
   normalizeAssistantPlan,
   tryLocalAssistantPlan,
 } from "./assistant-intelligence.ts";
-import { inferJSON } from "../lib/infer.ts";
+import { inferJSON, resolveVoiceInferenceOptions } from "../lib/infer.ts";
+
+const INFER_TIMEOUT_MS = 15_000;
 
 // ── Read input from stdin ──────────────────────────────────────────
 
@@ -36,6 +38,7 @@ const req = JSON.parse(input) as {
 const transcript = req.transcript ?? "";
 const systemPrompt = buildAssistantSystemPrompt();
 const userMessage = buildAssistantContextMessage(transcript, req.snapshot ?? {});
+const voiceInference = resolveVoiceInferenceOptions();
 
 const localPlan = tryLocalAssistantPlan(transcript, req.snapshot ?? {});
 if (localPlan) {
@@ -50,14 +53,18 @@ const messages = (req.history ?? []).map((h) => ({
   content: h.content,
 }));
 
+const controller = new AbortController();
+const timer = setTimeout(() => controller.abort(), INFER_TIMEOUT_MS);
+
 try {
   const { data, raw } = await inferJSON(userMessage, {
-    provider: "groq",
-    model: "llama-3.3-70b-versatile",
+    provider: voiceInference.provider,
+    model: voiceInference.model,
     system: systemPrompt,
     messages,
     temperature: 0.2,
     maxTokens: 512,
+    abortSignal: controller.signal,
     tag: "hands-off",
   });
 
@@ -83,5 +90,7 @@ try {
       _meta: { error: err.message },
     })
   );
-  process.exit(1);
+  process.exitCode = 1;
+} finally {
+  clearTimeout(timer);
 }

--- a/bin/handsoff-worker.ts
+++ b/bin/handsoff-worker.ts
@@ -3,7 +3,7 @@
  * Hands-off worker — long-running process that handles both inference and TTS.
  *
  * Reads newline-delimited JSON commands from stdin, writes JSON responses to stdout.
- * Keeps SpeakEasy and inference warm — no cold starts.
+ * Keeps TTS and inference warm — no cold starts.
  *
  * Commands:
  *   {"cmd":"infer","transcript":"...","snapshot":{...},"history":[...]}
@@ -23,9 +23,10 @@ import {
   normalizeAssistantPlan,
   tryLocalAssistantPlan,
 } from "./assistant-intelligence.ts";
-import { infer } from "../lib/infer.ts";
+import { infer, resolveVoiceInferenceOptions } from "../lib/infer.ts";
 
 const INFER_TIMEOUT_MS = 15_000;
+const voiceInference = resolveVoiceInferenceOptions();
 
 /** Call infer and parse JSON if possible, otherwise treat as spoken-only response */
 async function inferSmart(prompt: string, options: any): Promise<{ data: any; raw: any }> {
@@ -291,12 +292,15 @@ log("worker started, streaming TTS ready");
 
 const systemPrompt = buildAssistantSystemPrompt();
 log("system prompt loaded");
+log(`voice inference: ${voiceInference.provider}/${voiceInference.model}`);
 
 // ── Auto-restart on file changes ───────────────────────────────────
 
 const watchFiles = [
   assistantPromptPath,
   join(import.meta.dir, "assistant-intelligence.ts"),
+  join(import.meta.dir, "..", ".env"),
+  join(import.meta.dir, "..", ".env.local"),
   import.meta.path, // this script itself
 ];
 
@@ -376,8 +380,8 @@ async function processLine(line: string) {
         }));
 
         const { data, raw } = await inferSmart(userMessage, {
-          provider: "xai",
-          model: "grok-4.20-beta-0309-non-reasoning",
+          provider: voiceInference.provider,
+          model: voiceInference.model,
           system: systemPrompt,
           messages,
           temperature: 0.2,
@@ -416,7 +420,7 @@ async function processLine(line: string) {
       //
       // Timeline:
       //   t=0  ──┬── ack TTS (fire & forget)
-      //          └── Groq inference
+      //          └── model inference
       //   t=~600ms ─┬── narrate TTS (what we're doing)
       //             └── execute actions (in parallel with narrate)
       //   t=done ── respond with results
@@ -445,8 +449,8 @@ async function processLine(line: string) {
         const userMessage = buildAssistantContextMessage(transcript, snap);
         try {
           const { data, raw } = await inferSmart(userMessage, {
-            provider: "xai",
-            model: "grok-4.20-beta-0309-non-reasoning",
+            provider: voiceInference.provider,
+            model: voiceInference.model,
             system: systemPrompt,
             messages,
             temperature: 0.2,

--- a/content/blog/hands-off-mode.mdx
+++ b/content/blog/hands-off-mode.mdx
@@ -13,47 +13,45 @@ import ArchDiagram from '../../site/src/components/blog/ArchDiagram'
 import ContextExplorer from '../../site/src/components/blog/ContextExplorer'
 import TestResults from '../../site/src/components/blog/TestResults'
 
-I've been building Lattices, a macOS workspace manager, for a while now. It tiles windows, manages tmux sessions, does OCR search across your desktop.
+I've been building Lattices for a while — it tiles windows, manages tmux sessions, does OCR search across the desktop. Standard workspace manager stuff.
 
-But I kept wanting to do things without reaching for a hotkey. Deep in code, thinking "I need Chrome next to this terminal" — I just wanted to *say* it.
-
-So I built hands-off mode.
+But I kept wanting to do things without reaching for a hotkey. Deep in code, thinking "I need Chrome next to this terminal" — I just wanted to *say* it. So I built hands-off mode.
 
 <StatsRow client:load />
 
-## The idea
+## What it does
 
-One hotkey. You speak. Things happen. No panel, no UI, no visual chrome.
+Press **Ctrl+Cmd+M**, say "tile Chrome left and iTerm right", press again. You hear a quick "Got it" followed by "Chrome left, iTerm right" and your windows slide into place. About 2 seconds total. No panel, no UI, no visual chrome.
 
-Press **Ctrl+Cmd+M**, say "tile Chrome left and iTerm right", press again. You hear a quick "Got it" followed by "Chrome left, iTerm right" and your windows slide into place. About 2 seconds total.
+The harder case: "I have too many terminals, organize them." The system looks at your desktop, sees 8 iTerm windows scattered across two monitors, and distributes them in a grid. Or "set up for a code review" puts the GitHub PR on the left and your terminal on the right.
 
-The harder case: "I have too many terminals, organize them" — the system looks at your desktop, sees 8 iTerm windows scattered across two monitors, and distributes them in a grid. Or "set up for a code review" puts the GitHub PR on the left and your terminal on the right.
+## It was slow for a long time
 
-## Six iterations to get here
-
-The early versions were slow. Even after moving past the initial prototypes, we were still at 6-7 seconds end-to-end. The user would speak, wait, and then their windows would silently rearrange. Not terrible, but not the instant-feeling interaction we wanted.
-
-Several iterations later, it feels natural — about 1 second to first response, 2 seconds end-to-end.
+The early versions were brutal. 6-7 seconds end-to-end. You'd speak, wait, and then your windows would silently rearrange. It worked, but it felt like talking to someone through a wall.
 
 <LatencyJourney client:load />
 
-The biggest single win was switching to direct API calls instead of shelling out to a CLI. After that, it was death by a thousand optimizations: persistent processes, streaming audio, cached phrases, and a narrate-before-act UX pattern that makes the whole thing feel intentional rather than magic.
+The biggest single win was switching to direct API calls instead of shelling out to a CLI. After that it was death by a thousand cuts: persistent processes, streaming audio, cached phrases, and a narrate-before-act pattern that makes the whole thing feel deliberate instead of magical.
 
-## How a turn works
+We're at about 1 second to first response now, 2 seconds end-to-end.
 
-Every voice command follows the same pipeline. The key insight: **the user should hear feedback before anything moves**.
+## The turn pipeline
+
+Every voice command follows the same flow. The part I'm most happy with: the user hears feedback before anything moves.
 
 <TurnPipeline client:load />
 
-The cached ack sound is important. It plays in under 50ms — before inference even starts — so the user knows the system heard them. Then the AI narrates what it's *about* to do, and only *then* do windows move. The user is never surprised.
+A cached ack sound plays in under 50ms — before inference even starts — so you know the system heard you. Then the AI narrates what it's *about* to do, and only *then* do windows move. You're never surprised by something happening silently.
 
-## The architecture
+That narrate-before-act pattern was one of those things that sounds obvious in retrospect but took us a few iterations to land on. The silent version felt broken even when it was doing the right thing.
 
-The system spans three layers: a native Swift app that owns the desktop, a persistent bun worker for inference and TTS, and cloud APIs for the heavy lifting.
+## Three layers
+
+Swift app owns the desktop. A persistent bun worker handles inference and TTS. Cloud APIs do the heavy lifting.
 
 <ArchDiagram client:load />
 
-Swift and the worker communicate over **stdin/stdout JSON lines**. The worker stays alive between turns — no cold starts. System prompts are loaded from `.md` files on disk and hot-reload on save, so prompt iteration doesn't require rebuilding.
+Swift and the worker communicate over stdin/stdout JSON lines. The worker stays alive between turns — no cold starts. System prompts live in `.md` files on disk and hot-reload on save, so I can iterate on prompts without rebuilding anything.
 
 The inference layer wraps the Vercel AI SDK and supports five providers. Swapping models is one line:
 
@@ -66,7 +64,7 @@ const { text } = await infer("tile chrome left", {
 });
 ```
 
-For TTS, we stream OpenAI's response directly into `ffplay` via stdin pipe — PCM format, no decoding overhead. Playback begins on the first audio chunk:
+For TTS, we stream OpenAI's response directly into `ffplay` via stdin pipe — PCM, no decoding overhead. Playback starts on the first audio chunk:
 
 ```typescript
 const player = spawn("ffplay", [
@@ -82,35 +80,33 @@ while (true) {
 }
 ```
 
-## The context problem
+## Context makes or breaks it
 
-A voice assistant is only as good as the information it has. Our first snapshot sent window titles and positions. That's it. Two iTerm windows both named "Claude Code" looked identical to the AI.
-
-The fix: send *everything*.
+Our first snapshot sent window titles and positions. That's it. Two iTerm windows both named "Claude Code" looked identical to the AI. Useless.
 
 <ContextExplorer client:load />
 
-A typical snapshot is about 2,000 tokens — nothing for a modern LLM. But the intelligence difference is dramatic. Every window gets its frame, Z-order, and on-screen status. Every terminal tab gets its working directory, running processes, tmux session name, and whether Claude Code is active. All screens with their resolutions. The active layer.
+The fix was sending everything. Every window gets its frame, Z-order, and on-screen status. Every terminal tab gets its working directory, running processes, tmux session name, and whether Claude Code is active. All screens with their resolutions. The active layer.
 
-"Focus on the lattices Claude Code" goes from "I see several Claude Code windows" to correctly identifying the one in `~/dev/lattices` and focusing it.
+A typical snapshot is about 2,000 tokens — nothing for a modern LLM. But the intelligence difference is dramatic. "Focus on the lattices Claude Code" goes from "I see several Claude Code windows" to correctly identifying the one in `~/dev/lattices` and focusing it.
 
-## Testing at scale
+## 100 scenarios, 202 assertions
 
-We built an automated test suite: 100 scenarios, 8 categories, 202 individual assertions. Each scenario feeds a transcript and desktop snapshot through the inference pipeline and checks the response against specific conditions.
+We built a test suite that feeds transcripts and desktop snapshots through the inference pipeline and checks responses against specific conditions. 100 scenarios across 8 categories.
 
 <TestResults client:load />
 
-The weakest area — error handling at 67% — is a known issue. The model *says* Photoshop isn't running (correct) but still sends a focus action (wrong). Function calling with typed parameters would fix this: the model calls `tile_window()` with a validated window reference, and we reject impossible actions before execution.
+The weakest area is error handling at 67%. The model *says* Photoshop isn't running (correct) but still sends a focus action (wrong). Function calling with typed parameters would fix this — the model calls `tile_window()` with a validated window reference, and we reject impossible actions before execution. Haven't shipped that yet.
 
-## What matters most
+## What actually matters
 
-The dual-model pattern is tempting: fire a fast model (Groq, 500ms) for a spoken ack while a smarter model (Grok, 1.2s) generates the actual actions. By the time the ack finishes playing, the smart response is ready.
+There's a dual-model pattern I keep thinking about: fire a fast model (Groq, 500ms) for a spoken ack while a smarter model (Grok, 1.2s) generates the actual actions. By the time the ack finishes playing, the smart response is ready.
 
-And Stage Manager awareness. We figured out how to detect stages, classify windows, and programmatically create new stages by simulating drag events. No other window manager does this. "Put Chrome and iTerm in a new stage" would just work.
+And we figured out Stage Manager awareness — how to detect stages, classify windows, and programmatically create new stages by simulating drag events. No other window manager does this. "Put Chrome and iTerm in a new stage" would just work.
 
-But honestly, the thing that matters most is the **prompt**. Every improvement to the system prompt has a bigger impact than any architectural change. When we added the rule "if spoken says you'll do something, actions must include it," empty-actions bugs nearly vanished. When we added concrete JSON examples for each scenario type, accuracy jumped across the board.
+But honestly, the thing that matters most is the prompt. Every improvement to the system prompt has had more impact than any architectural change. When we added the rule "if spoken says you'll do something, actions must include it," empty-action bugs nearly vanished. When we added concrete JSON examples for each scenario type, accuracy jumped across the board.
 
-The code is fast enough. The architecture is right. Now it's about making the AI genuinely helpful.
+The code is fast enough. The architecture is right. Now it's about making the AI genuinely helpful — and that's all prompt work.
 
 ---
 

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -134,6 +134,24 @@ reaches 75% of the model's limit, the session auto-resets.
 
 Context usage and session cost are shown in the AI corner header.
 
+## Hands-off inference
+
+Hands-off voice uses the shared inference wrapper in `lib/infer.ts`.
+By default it chooses the lowest-latency configured provider and, when
+Groq credentials are present, uses `groq/llama-3.1-8b-instant`.
+
+Credentials are read from process env, `.env.local`, `.env`,
+`~/.lattices/inference.json`, then `~/.config/speakeasy/settings.json`.
+For Groq, either `GROQ_API_KEY` or the common typo `GROK_API_KEY` works
+when the key has Groq's `gsk_` prefix.
+
+Override the voice engine if needed:
+
+```bash
+LATTICES_VOICE_PROVIDER=groq
+LATTICES_VOICE_MODEL=llama-3.1-8b-instant
+```
+
 ## Configuration
 
 Open **Settings > AI** to configure:

--- a/lib/infer.ts
+++ b/lib/infer.ts
@@ -3,7 +3,7 @@
  *
  * Features:
  *  - Multi-provider: groq, openai, anthropic, google, xai
- *  - Credential loading: env vars → ~/.lattices/inference.json → ~/.config/speakeasy/settings.json
+ *  - Credential loading: env vars → .env.local/.env → ~/.lattices/inference.json → ~/.config/speakeasy/settings.json
  *  - Instrumented: every call logged with timing, model, token usage
  *  - Simple API: `await infer("do something", { provider: "groq" })`
  */
@@ -48,13 +48,21 @@ export interface InferResult {
 
 // ── Default models per provider ────────────────────────────────────
 
+const PROVIDER_NAMES: ProviderName[] = ["groq", "openai", "anthropic", "google", "xai", "minimax"];
+const VOICE_PROVIDER_PRIORITY: ProviderName[] = ["groq", "xai", "openai", "google", "anthropic", "minimax"];
+
 const DEFAULT_MODELS: Record<ProviderName, string> = {
   groq: "llama-3.3-70b-versatile",
   openai: "gpt-4o-mini",
   anthropic: "claude-sonnet-4-6",
   google: "gemini-2.0-flash",
-  xai: "grok-4-1-fast",
+  xai: "grok-4-1-fast-non-reasoning",
   minimax: "MiniMax-M2.5-highspeed",
+};
+
+const VOICE_DEFAULT_MODELS: Record<ProviderName, string> = {
+  ...DEFAULT_MODELS,
+  groq: "llama-3.1-8b-instant",
 };
 
 // ── Credential loading ─────────────────────────────────────────────
@@ -69,6 +77,81 @@ interface CredentialStore {
 }
 
 let _cachedCreds: CredentialStore | null = null;
+let _cachedLocalEnv: Record<string, string> | null = null;
+
+function parseDotEnv(content: string): Record<string, string> {
+  const env: Record<string, string> = {};
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+
+    const match = line.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
+    if (!match) continue;
+
+    const [, key, rawValue] = match;
+    let value = rawValue.trim();
+    const quote = value[0];
+    if ((quote === `"` || quote === `'`) && value.endsWith(quote)) {
+      value = value.slice(1, -1);
+    } else {
+      value = value.replace(/\s+#.*$/, "").trim();
+    }
+
+    env[key] = value;
+  }
+
+  return env;
+}
+
+function loadLocalEnv(): Record<string, string> {
+  if (_cachedLocalEnv) return _cachedLocalEnv;
+
+  const repoRoot = join(import.meta.dir, "..");
+  const candidates = [
+    join(repoRoot, ".env"),
+    join(repoRoot, ".env.local"),
+    join(process.cwd(), ".env"),
+    join(process.cwd(), ".env.local"),
+  ];
+
+  const env: Record<string, string> = {};
+  for (const file of Array.from(new Set(candidates))) {
+    if (!existsSync(file)) continue;
+    try {
+      Object.assign(env, parseDotEnv(readFileSync(file, "utf-8")));
+    } catch {}
+  }
+
+  _cachedLocalEnv = env;
+  return env;
+}
+
+export function getInferenceEnv(name: string): string | undefined {
+  return process.env[name] || loadLocalEnv()[name];
+}
+
+function firstInferenceEnv(names: string[]): string | undefined {
+  for (const name of names) {
+    const value = getInferenceEnv(name);
+    if (value) return value;
+  }
+}
+
+function normalizeProvider(value: string | undefined): ProviderName | undefined {
+  const provider = value?.trim().toLowerCase();
+  return PROVIDER_NAMES.includes(provider as ProviderName) ? (provider as ProviderName) : undefined;
+}
+
+function assignGrokAlias(creds: CredentialStore) {
+  const key = getInferenceEnv("GROK_API_KEY");
+  if (!key) return;
+
+  // People often say/type "Grok" when they mean Groq. Use the key shape to
+  // route the alias without making xAI and Groq credentials interchangeable.
+  if (!creds.groq && key.startsWith("gsk_")) creds.groq = key;
+  if (!creds.xai && key.startsWith("xai-")) creds.xai = key;
+}
 
 function loadCredentials(): CredentialStore {
   if (_cachedCreds) return _cachedCreds;
@@ -76,12 +159,19 @@ function loadCredentials(): CredentialStore {
   const creds: CredentialStore = {};
 
   // Layer 1: env vars (highest priority)
-  if (process.env.GROQ_API_KEY) creds.groq = process.env.GROQ_API_KEY;
-  if (process.env.OPENAI_API_KEY) creds.openai = process.env.OPENAI_API_KEY;
-  if (process.env.ANTHROPIC_API_KEY) creds.anthropic = process.env.ANTHROPIC_API_KEY;
-  if (process.env.GOOGLE_GENERATIVE_AI_API_KEY) creds.google = process.env.GOOGLE_GENERATIVE_AI_API_KEY;
-  if (process.env.XAI_API_KEY) creds.xai = process.env.XAI_API_KEY;
-  if (process.env.MINIMAX_API_KEY) creds.minimax = process.env.MINIMAX_API_KEY;
+  const groqKey = getInferenceEnv("GROQ_API_KEY");
+  const openaiKey = getInferenceEnv("OPENAI_API_KEY");
+  const anthropicKey = getInferenceEnv("ANTHROPIC_API_KEY");
+  const googleKey = getInferenceEnv("GOOGLE_GENERATIVE_AI_API_KEY");
+  const xaiKey = getInferenceEnv("XAI_API_KEY");
+  const minimaxKey = getInferenceEnv("MINIMAX_API_KEY");
+  if (groqKey) creds.groq = groqKey;
+  if (openaiKey) creds.openai = openaiKey;
+  if (anthropicKey) creds.anthropic = anthropicKey;
+  if (googleKey) creds.google = googleKey;
+  if (xaiKey) creds.xai = xaiKey;
+  if (minimaxKey) creds.minimax = minimaxKey;
+  assignGrokAlias(creds);
 
   // Layer 2: ~/.lattices/inference.json
   const latticesConfig = join(homedir(), ".lattices", "inference.json");
@@ -109,6 +199,8 @@ function loadCredentials(): CredentialStore {
       if (!creds.openai && p.openai?.apiKey) creds.openai = p.openai.apiKey;
       if (!creds.anthropic && p.anthropic?.apiKey) creds.anthropic = p.anthropic.apiKey;
       if (!creds.google && p.gemini?.apiKey) creds.google = p.gemini.apiKey;
+      if (!creds.xai && p.xai?.apiKey) creds.xai = p.xai.apiKey;
+      if (!creds.minimax && p.minimax?.apiKey) creds.minimax = p.minimax.apiKey;
     } catch {}
   }
 
@@ -119,12 +211,35 @@ function loadCredentials(): CredentialStore {
 /** Clear cached credentials (call if config changes at runtime) */
 export function clearCredentialCache() {
   _cachedCreds = null;
+  _cachedLocalEnv = null;
 }
 
 /** List which providers have credentials available */
 export function availableProviders(): ProviderName[] {
   const creds = loadCredentials();
   return (Object.keys(creds) as ProviderName[]).filter((k) => !!creds[k]);
+}
+
+/** Voice/hands-off defaults favor the lowest-latency configured provider. */
+export function resolveVoiceInferenceOptions(): { provider: ProviderName; model: string } {
+  const configuredProvider = normalizeProvider(firstInferenceEnv([
+    "LATTICES_VOICE_PROVIDER",
+    "LATTICES_HANDSOFF_PROVIDER",
+    "LATTICES_INFER_PROVIDER",
+  ]));
+
+  const creds = loadCredentials();
+  const provider = configuredProvider
+    ?? VOICE_PROVIDER_PRIORITY.find((name) => !!creds[name])
+    ?? "groq";
+
+  const model = firstInferenceEnv([
+    "LATTICES_VOICE_MODEL",
+    "LATTICES_HANDSOFF_MODEL",
+    "LATTICES_INFER_MODEL",
+  ]) ?? VOICE_DEFAULT_MODELS[provider];
+
+  return { provider, model };
 }
 
 // ── Provider factory ───────────────────────────────────────────────
@@ -211,7 +326,7 @@ export async function infer(
   const creds = loadCredentials();
   if (!creds[provider]) {
     throw new Error(
-      `No API key for provider "${provider}". Set it in env, ~/.lattices/inference.json, or ~/.config/speakeasy/settings.json`
+      `No API key for provider "${provider}". Set it in env, .env.local, ~/.lattices/inference.json, or ~/.config/speakeasy/settings.json`
     );
   }
 

--- a/test/handsoff-tests.ts
+++ b/test/handsoff-tests.ts
@@ -6,7 +6,7 @@
  * Usage: bun run test/handsoff-tests.ts
  */
 
-import { infer } from "../lib/infer.ts";
+import { infer, resolveVoiceInferenceOptions } from "../lib/infer.ts";
 import { readFileSync } from "fs";
 import { join, dirname } from "path";
 
@@ -48,6 +48,8 @@ create_layer: Save current arrangement as a named layer
 `;
 
 systemPrompt = systemPrompt.replace("{{intent_catalog}}", intentCatalog);
+const voiceInference = resolveVoiceInferenceOptions();
+const INFER_TIMEOUT_MS = 15_000;
 
 // ── Realistic snapshot ─────────────────────────────────────────────
 
@@ -699,15 +701,18 @@ async function runTest(test: Test): Promise<{ pass: number; fail: number; errors
   }));
 
   const userMessage = `USER: "${test.say}"\n\n--- DESKTOP SNAPSHOT ---\n${snapshot}\n--- END SNAPSHOT ---\n`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), INFER_TIMEOUT_MS);
 
   try {
     const raw = await infer(userMessage, {
-      provider: "xai",
-      model: "grok-4.20-beta-0309-non-reasoning",
+      provider: voiceInference.provider,
+      model: voiceInference.model,
       system: systemPrompt,
       messages,
       temperature: 0.2,
       maxTokens: 512,
+      abortSignal: controller.signal,
       tag: `test-${test.id}`,
     });
 
@@ -743,12 +748,14 @@ async function runTest(test: Test): Promise<{ pass: number; fail: number; errors
     return { pass, fail, errors };
   } catch (err: any) {
     return { pass: 0, fail: test.checks.length, errors: [`API error: ${err.message}`] };
+  } finally {
+    clearTimeout(timer);
   }
 }
 
 // ── Main ───────────────────────────────────────────────────────────
 
-console.log(`Running ${tests.length} tests against xai/grok-4.20-beta-0309-non-reasoning...\n`);
+console.log(`Running ${tests.length} tests against ${voiceInference.provider}/${voiceInference.model}...\n`);
 
 let totalPass = 0;
 let totalFail = 0;


### PR DESCRIPTION
## Summary

Refactors the hands-off voice pipeline to stop hardcoding provider/model in three places, adds `.env` loading, and wraps every inference call in an `AbortController` with a 15s timeout.

## Changes

**`lib/infer.ts`**
- `resolveVoiceInferenceOptions()` picks the lowest-latency configured provider in priority order: `groq → xai → openai → google → anthropic → minimax`. `VOICE_DEFAULT_MODELS` favors `llama-3.1-8b-instant` on groq for voice latency.
- New `.env` / `.env.local` loader (repo root) sits between env vars and `~/.lattices/inference.json` / `~/.config/speakeasy/settings.json`.
- `assignGrokAlias()` handles the common `GROK_API_KEY` typo by routing to groq or xai based on the key prefix (`gsk_` vs `xai-`).
- Adds xai / minimax fall-through from speakeasy settings.

**`bin/handsoff-infer.ts`, `bin/handsoff-worker.ts`, `test/handsoff-tests.ts`**
- Use the shared resolver instead of hardcoded provider/model strings.
- Wrap inference calls in `AbortController` with a 15s timeout (was: hung indefinitely).
- `handsoff-worker` now watches `.env` / `.env.local` and restarts on change.

**Docs**
- `docs/voice.md` documents `LATTICES_VOICE_PROVIDER` / `LATTICES_VOICE_MODEL` env vars and the credential precedence order.
- `content/blog/hands-off-mode.mdx`: humanization pass on the existing post.

## Test plan

- [ ] `bun install && bun test/handsoff-tests.ts` runs against the configured provider
- [ ] `LATTICES_VOICE_PROVIDER=xai bun test/...` overrides via env
- [ ] `.env.local` with `GROQ_API_KEY=gsk_...` is picked up without exporting
- [ ] `GROK_API_KEY=gsk_...` (typo) routes to groq
- [ ] `handsoff-worker.ts` restarts when `.env.local` changes
- [ ] An inference that runs >15s aborts cleanly instead of hanging