### PR TITLE
CLI / install QoL: bun link mode, local install, swift package files

### DIFF
--- a/bin/lattices-app.ts
+++ b/bin/lattices-app.ts
@@ -381,7 +381,10 @@ if (cmd === "build") {
     console.error("Swift is required. Install with: xcode-select --install");
     process.exit(1);
   }
-  buildFromSource();
+  if (!buildFromSource()) {
+    console.error("Build failed.");
+    process.exit(1);
+  }
 } else if (cmd === "quit") {
   if (quit()) {
     console.log("lattices app stopped.");

--- a/bin/lattices-dev
+++ b/bin/lattices-dev
@@ -177,6 +177,31 @@ cmd_clear_logs() {
     fi
 }
 
+cmd_link() {
+    if ! command -v bun >/dev/null 2>&1; then
+        red "bun not found. Install: curl -fsSL https://bun.sh/install | bash"
+        exit 1
+    fi
+    cd "$ROOT"
+    bun link
+    bun link @lattices/cli
+    if command -v lattices >/dev/null 2>&1; then
+        green "Linked. \`lattices\` -> $(command -v lattices)"
+    else
+        red "Linked, but \`lattices\` is not on PATH. Add bun's global bin to PATH:"
+        dim "  export PATH=\"\$HOME/.bun/bin:\$PATH\""
+    fi
+}
+
+cmd_unlink() {
+    if ! command -v bun >/dev/null 2>&1; then
+        red "bun not found."
+        exit 1
+    fi
+    bun remove -g @lattices/cli >/dev/null 2>&1 || true
+    green "Unlinked."
+}
+
 cmd_status() {
     if pgrep -x Lattices >/dev/null 2>&1; then
         local pid=$(pgrep -x Lattices)
@@ -198,6 +223,8 @@ cmd_status() {
 cmd_help() {
     echo "lattices-dev — Lattices development commands"
     echo ""
+    echo "  link         Symlink \`lattices\` to this checkout (bun link)"
+    echo "  unlink       Remove the bun link"
     echo "  restart      Quit + rebuild + relaunch"
     echo "  build        Build release binary"
     echo "  quit         Stop the running app"
@@ -210,6 +237,8 @@ cmd_help() {
 }
 
 case "${1:-help}" in
+    link)       cmd_link ;;
+    unlink)     cmd_unlink ;;
     restart)    cmd_restart ;;
     build)      cmd_build ;;
     quit|stop)  cmd_quit ;;

--- a/install.sh
+++ b/install.sh
@@ -75,16 +75,33 @@ install_dep tmux
 install_dep bun "oven-sh/bun/bun" "oven-sh/bun"
 
 # ── Install CLI ───────────────────────────────────────────────────────
+# If run from inside the source repo, link the local checkout instead of
+# fetching from npm. Detected by package.json next to this script with
+# name "@lattices/cli".
 
-info "Installing @lattices/cli..."
-
-if command -v lattices &>/dev/null; then
-  CURRENT="$(lattices --version 2>/dev/null || echo "unknown")"
-  warn "lattices already installed ($CURRENT) — upgrading"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOCAL_MODE=0
+if [[ -f "$SCRIPT_DIR/package.json" ]] && \
+   grep -q '"@lattices/cli"' "$SCRIPT_DIR/package.json"; then
+  LOCAL_MODE=1
 fi
 
-bun install -g @lattices/cli
-ok "CLI installed → $(which lattices)"
+if [[ "$LOCAL_MODE" -eq 1 ]]; then
+  info "Linking @lattices/cli from $SCRIPT_DIR..."
+else
+  info "Installing @lattices/cli..."
+fi
+
+if command -v lattices &>/dev/null; then
+  warn "lattices already installed — replacing"
+fi
+
+if [[ "$LOCAL_MODE" -eq 1 ]]; then
+  (cd "$SCRIPT_DIR" && bun link && bun link @lattices/cli)
+else
+  bun install -g @lattices/cli
+fi
+ok "CLI installed → $(command -v lattices)"
 
 # ── Verify CLI ────────────────────────────────────────────────────────
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "app/Resources",
     "app/Sources",
     "app/Tests",
+    "swift/Package.swift",
+    "swift/Sources",
+    "swift/Tests",
     "assets/AppIcon.icns",
     "docs"
   ],


### PR DESCRIPTION
## Summary

Four small QoL improvements to local dev + install:

- **`install.sh`**: detects when run from a local source repo (by finding a `package.json` with `"@lattices/cli"` next to itself) and uses `bun link` instead of fetching from npm. Useful for contributors who clone the repo and want to point their global `lattices` at their working tree.
- **`bin/lattices-dev`**: gains `link` / `unlink` subcommands that wrap `bun link` / `bun remove -g @lattices/cli`. Prints helpful PATH guidance if bun's global bin isn't on PATH.
- **`bin/lattices-app.ts`**: the `build` subcommand now exits non-zero when `buildFromSource()` fails. The `restart` subcommand already had this; this brings `build` in line.
- **`package.json`**: includes `swift/Package.swift`, `swift/Sources`, `swift/Tests` in the published file set so consumers of `@lattices/cli` get the swift package.

## Test plan

- [ ] `./install.sh` from a fresh clone uses bun link mode (info banner says "Linking @lattices/cli from ...")
- [ ] `lattices-dev link` then `which lattices` points at the local checkout
- [ ] `lattices-dev unlink` removes the global symlink cleanly
- [ ] `lattices-app build` with a known-failing build exits non-zero
- [ ] `npm pack` (or `bun pack`) on this repo includes the `swift/` files