### PR TITLE
🐛 Fix Swift 6.2.3 IRGen crash in ShapeRecognizer + add Swift CI

### DIFF
--- a/.github/workflows/swift-build.yml
+++ b/.github/workflows/swift-build.yml
@@ -1,0 +1,26 @@
+name: Swift Build
+
+on:
+  pull_request:
+    paths:
+      - 'app/**'
+      - '.github/workflows/swift-build.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'app/**'
+      - '.github/workflows/swift-build.yml'
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show toolchain
+        run: swift --version
+
+      - name: Build (debug)
+        working-directory: app
+        run: swift build -c debug

--- a/app/Sources/Core/Input/ShapeRecognizer.swift
+++ b/app/Sources/Core/Input/ShapeRecognizer.swift
@@ -365,6 +365,21 @@ final class ShapeRecognizer {
 
     // MARK: - Segment Building
 
+    private func makeDirectionSegment(
+        direction: MouseGestureDirection?,
+        start: Int,
+        end: Int,
+        length: CGFloat
+    ) -> DirectionSegment? {
+        guard let direction, length > 0 else { return nil }
+        return DirectionSegment(
+            direction: direction,
+            startIndex: start,
+            endIndex: end,
+            length: length
+        )
+    }
+
     private func buildDirectionRunSegments(points: [GesturePathPoint]) -> [DirectionSegment] {
         guard points.count >= 2 else { return [] }
 
@@ -373,18 +388,6 @@ final class ShapeRecognizer {
         var currentStart = 0
         var currentEnd = 0
         var currentLength: CGFloat = 0
-
-        func flushCurrent() {
-            guard let currentDirection, currentLength > 0 else { return }
-            rawSegments.append(
-                DirectionSegment(
-                    direction: currentDirection,
-                    startIndex: currentStart,
-                    endIndex: currentEnd,
-                    length: currentLength
-                )
-            )
-        }
 
         for index in 1..<points.count {
             let previous = points[index - 1]
@@ -405,14 +408,28 @@ final class ShapeRecognizer {
                 currentEnd = index
                 currentLength += length
             } else {
-                flushCurrent()
+                if let segment = makeDirectionSegment(
+                    direction: currentDirection,
+                    start: currentStart,
+                    end: currentEnd,
+                    length: currentLength
+                ) {
+                    rawSegments.append(segment)
+                }
                 currentDirection = direction
                 currentStart = index - 1
                 currentEnd = index
                 currentLength = length
             }
         }
-        flushCurrent()
+        if let segment = makeDirectionSegment(
+            direction: currentDirection,
+            start: currentStart,
+            end: currentEnd,
+            length: currentLength
+        ) {
+            rawSegments.append(segment)
+        }
 
         let merged = mergeShortDirectionRuns(rawSegments)
         let filtered = merged.filter { $0.length >= minSegmentLength }


### PR DESCRIPTION
## Summary

- **Fix**: refactor the nested `flushCurrent()` in `buildDirectionRunSegments(...)` to a regular private method `makeDirectionSegment(...)`. The nested form captured five mutable enclosing-scope variables and triggers a `swift-frontend` IRGen failure on Swift 6.2.3 — `swift build` fails on a clean checkout of `main` for anyone on that toolchain.
- **CI**: add `.github/workflows/swift-build.yml` running `swift build -c debug` on PRs that touch `app/`. Existing CI only deploys the docs site, so Swift compile breaks were sliding through unnoticed.

## Why

Swift's IRGen has a known sharp edge with nested functions that capture multiple mutable variables from enclosing scope. The hoisted method takes the values as parameters and returns an optional `DirectionSegment`, removing all captures while keeping behavior identical.

## Test plan

- [x] `swift build -c debug` passes locally (Swift 6.2.3) — previously crashed
- [ ] CI swift-build job runs green on this PR
- [ ] No behavior change in gesture recognition (pure refactor of segment flushing)