### PR TITLE
✨ iPad Home: inline voice panel, activity feed, machine gauges

### DIFF
--- a/iOS/LatticesCompanion/Sources/ContentView.swift
+++ b/iOS/LatticesCompanion/Sources/ContentView.swift
@@ -103,6 +103,14 @@ struct ContentView: View {
                 LatsSettingsView(store: store)
                     .preferredColorScheme(.dark)
             }
+            // Adaptive polling: speed up while the user is in the cockpit
+            // (Deck or settings) — Home alone runs in ambient mode.
+            .onChange(of: showLatsDeck) { _, isOpen in
+                store.setUIPriority(isOpen ? .fast : .ambient)
+            }
+            .onChange(of: showSettings) { _, isOpen in
+                store.setUIPriority(isOpen ? .fast : .ambient)
+            }
         }
         .preferredColorScheme(.dark)
     }

--- a/iOS/LatticesCompanion/Sources/DeckStore.swift
+++ b/iOS/LatticesCompanion/Sources/DeckStore.swift
@@ -1,6 +1,15 @@
 import DeckKit
 import Foundation
 
+/// How aggressively the store should pull snapshots from the Mac. Two
+/// presets, mapped to interval values inside `DeckStore`:
+/// - `.fast`    → ~1s (active engagement: Deck open, voice in flight)
+/// - `.ambient` → ~5s (passive observation: Home idle)
+enum DeckPollPriority {
+    case fast
+    case ambient
+}
+
 @MainActor
 final class DeckStore: ObservableObject {
     @Published private(set) var discoveredBridges: [BridgeEndpoint] = []
@@ -21,6 +30,13 @@ final class DeckStore: ObservableObject {
     private let client = DeckBridgeClient()
     private let discovery = BridgeDiscovery()
     private var pollingTask: Task<Void, Never>?
+
+    /// UI hint for how aggressively to poll. Hosts flip this to `.fast` when
+    /// the user is actively engaged (Deck open, voice panel open, recording)
+    /// and back to `.ambient` when they're just looking at Home idle.
+    /// The store will *also* go fast on its own if the snapshot reports voice
+    /// activity or pending questions, so callers don't have to be exhaustive.
+    private var uiPriority: DeckPollPriority = .ambient
 
     var connectionLabel: String {
         // Prefer human-readable names (Bonjour service name / health-reported name)
@@ -114,6 +130,15 @@ final class DeckStore: ObservableObject {
         Task {
             await refreshSnapshot(endpoint: endpoint)
         }
+    }
+
+    /// Tell the store the user is actively engaged (or no longer engaged)
+    /// so it can speed up / slow down snapshot polling. Idempotent — call as
+    /// often as needed from `.onAppear` / `.onChange` hooks. The store will
+    /// independently go fast for in-snapshot signals (voice, attention) so
+    /// callers don't need to be perfect.
+    func setUIPriority(_ priority: DeckPollPriority) {
+        uiPriority = priority
     }
 
     func perform(
@@ -256,11 +281,26 @@ private extension DeckStore {
         pollingTask?.cancel()
         pollingTask = Task { [weak self] in
             while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(1))
+                let interval = self?.currentPollInterval ?? 5.0
+                try? await Task.sleep(for: .seconds(interval))
                 guard let self else { return }
                 await self.refreshSnapshot(endpoint: endpoint)
             }
         }
+    }
+
+    /// Decide the next poll interval based on UI hint + last snapshot.
+    /// Voice activity, pending attention, or an explicit `.fast` UI hint
+    /// pull us into 1s mode; otherwise we sip at 5s. Intervals are
+    /// re-evaluated each tick so the loop adapts as state changes.
+    private var currentPollInterval: TimeInterval {
+        if uiPriority == .fast { return 1.0 }
+        if let voice = snapshot?.voice {
+            if voice.phase != .idle { return 1.0 }
+            if voice.error != nil   { return 1.0 }
+        }
+        if !(snapshot?.questions.isEmpty ?? true) { return 1.0 }
+        return 5.0
     }
 
     func preferredEndpoint(fallback: BridgeEndpoint? = nil) -> BridgeEndpoint? {

--- a/iOS/LatticesCompanion/Sources/Home/HomeActivityFeed.swift
+++ b/iOS/LatticesCompanion/Sources/Home/HomeActivityFeed.swift
@@ -1,0 +1,251 @@
+import SwiftUI
+
+/// Combined activity log — folds three signal streams into a single card so
+/// the user gets one place to look instead of three half-empty sections:
+///   1. Attention (pending decisions)            → amber, pinned at top
+///   2. Recent    (history: command/voice/agent) → per-kind dot + ago
+///   3. Agent     (narration / tool log)         → violet glyph, dim text
+///
+/// Each block keeps its own visual prominence; they're stacked inside one
+/// LatsCard rather than fully homogenized so the kind of each row is still
+/// legible at a glance.
+struct HomeActivityFeed: View {
+    let recent: [HomeRecentEntry]
+    let agentFeed: [HomeAgentFeedEntry]
+    let attention: [HomeAttentionItem]
+    var onReplay: ((HomeRecentEntry) -> Void)? = nil
+
+    private var hasAny: Bool {
+        !recent.isEmpty || !agentFeed.isEmpty || !attention.isEmpty
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                LatsSectionLabel(text: "Activity")
+                Spacer()
+                Text(metaLine)
+                    .font(LatsFont.mono(9))
+                    .tracking(0.5)
+                    .foregroundStyle(LatsPalette.textFaint)
+            }
+
+            LatsCard(padding: 0) {
+                if !hasAny {
+                    Text("no activity yet")
+                        .font(LatsFont.mono(10))
+                        .foregroundStyle(LatsPalette.textFaint)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 14)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else {
+                    VStack(spacing: 0) {
+                        if !attention.isEmpty {
+                            block(of: attention) { item, isLast in
+                                ActivityAttentionRow(item: item)
+                                if !isLast { LatsHairlineDivider() }
+                            }
+                            if !recent.isEmpty || !agentFeed.isEmpty {
+                                LatsHairlineDivider()
+                            }
+                        }
+
+                        if !recent.isEmpty {
+                            block(of: recent) { entry, isLast in
+                                Button { onReplay?(entry) } label: {
+                                    ActivityRecentRow(entry: entry)
+                                }
+                                .buttonStyle(.plain)
+                                .disabled(onReplay == nil)
+                                if !isLast { LatsHairlineDivider() }
+                            }
+                            if !agentFeed.isEmpty {
+                                LatsHairlineDivider()
+                            }
+                        }
+
+                        if !agentFeed.isEmpty {
+                            block(of: agentFeed) { entry, isLast in
+                                ActivityAgentRow(entry: entry)
+                                if !isLast { LatsHairlineDivider() }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var metaLine: String {
+        var parts: [String] = []
+        if !attention.isEmpty { parts.append("\(attention.count) pending") }
+        if !recent.isEmpty    { parts.append("\(recent.count) recent") }
+        if !agentFeed.isEmpty { parts.append("\(agentFeed.count) agent") }
+        return parts.isEmpty ? "last 24h" : parts.joined(separator: " · ")
+    }
+
+    @ViewBuilder
+    private func block<Item: Identifiable, RowContent: View>(
+        of items: [Item],
+        @ViewBuilder row: @escaping (Item, Bool) -> RowContent
+    ) -> some View {
+        ForEach(Array(items.enumerated()), id: \.element.id) { idx, item in
+            row(item, idx == items.count - 1)
+        }
+    }
+}
+
+// MARK: - Attention row (pinned, amber prominence)
+
+private struct ActivityAttentionRow: View {
+    let item: HomeAttentionItem
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: item.icon)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(item.tint.color)
+                .frame(width: 14)
+
+            Text("ATTENTION")
+                .font(LatsFont.mono(9, weight: .bold))
+                .tracking(0.9)
+                .foregroundStyle(LatsPalette.amber.opacity(0.85))
+                .frame(width: 64, alignment: .leading)
+
+            Text(item.label)
+                .font(LatsFont.ui(12, weight: .semibold))
+                .foregroundStyle(LatsPalette.text)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .frame(minHeight: 38)
+        .background(LatsPalette.amber.opacity(0.05))
+        .contentShape(Rectangle())
+    }
+}
+
+// MARK: - Recent row (history, kind-colored dot + ago)
+
+private struct ActivityRecentRow: View {
+    let entry: HomeRecentEntry
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Circle()
+                .fill(entry.kind.dotColor)
+                .frame(width: 6, height: 6)
+                .frame(width: 14)
+
+            Text(entry.kind.label.uppercased())
+                .font(LatsFont.mono(9, weight: .semibold))
+                .tracking(0.9)
+                .foregroundStyle(LatsPalette.textFaint)
+                .frame(width: 64, alignment: .leading)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(entry.title)
+                    .font(LatsFont.ui(12, weight: .medium))
+                    .foregroundStyle(LatsPalette.text)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                if let subtitle = entry.subtitle {
+                    Text(subtitle)
+                        .font(LatsFont.mono(10))
+                        .foregroundStyle(LatsPalette.textDim)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            if let target = entry.target {
+                LatsBadge(text: target, tint: LatsPalette.textDim)
+            }
+
+            Text(entry.agoLabel)
+                .font(LatsFont.mono(10))
+                .foregroundStyle(LatsPalette.textFaint)
+                .frame(width: 56, alignment: .trailing)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .frame(minHeight: 38)
+        .contentShape(Rectangle())
+    }
+}
+
+// MARK: - Agent narration row (violet glyph, dim text)
+
+private struct ActivityAgentRow: View {
+    let entry: HomeAgentFeedEntry
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Text(entry.glyph)
+                .font(LatsFont.mono(11, weight: .semibold))
+                .foregroundStyle(entry.tint.color)
+                .frame(width: 14)
+
+            Text("AGENT")
+                .font(LatsFont.mono(9, weight: .semibold))
+                .tracking(0.9)
+                .foregroundStyle(LatsPalette.violet.opacity(0.7))
+                .frame(width: 64, alignment: .leading)
+
+            Text(entry.text)
+                .font(LatsFont.mono(11))
+                .foregroundStyle(LatsPalette.textDim)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .frame(minHeight: 38)
+        .contentShape(Rectangle())
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Activity · all sources") {
+    LatsBackground {
+        ScrollView {
+            HomeActivityFeed(
+                recent: HomeMock.recent,
+                agentFeed: HomeMock.agentFeed,
+                attention: HomeMock.attention
+            )
+            .padding(14)
+        }
+    }
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Activity · attention only") {
+    LatsBackground {
+        ScrollView {
+            HomeActivityFeed(
+                recent: [],
+                agentFeed: [],
+                attention: HomeMock.attention
+            )
+            .padding(14)
+        }
+    }
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Activity · empty") {
+    LatsBackground {
+        ScrollView {
+            HomeActivityFeed(recent: [], agentFeed: [], attention: [])
+                .padding(14)
+        }
+    }
+    .preferredColorScheme(.dark)
+}

--- a/iOS/LatticesCompanion/Sources/Home/HomeDataAdapter.swift
+++ b/iOS/LatticesCompanion/Sources/Home/HomeDataAdapter.swift
@@ -168,7 +168,20 @@ private extension HomeDataAdapter {
             lastActionAgo: firstHistory.map { agoLabel(from: $0.createdAt) },
             agentState: agentState(for: voice),
             attentionCount: snapshot?.questions.count ?? 0,
-            latencyMs: nil
+            latencyMs: nil,
+            metrics: metrics(from: snapshot?.telemetry)
+        )
+    }
+
+    /// Map `DeckSystemTelemetry` onto the gauge struct. Returns nil if no
+    /// telemetry sample exists, so the card hides its gauge cluster.
+    static func metrics(from tel: DeckSystemTelemetry?) -> HomeMachineMetrics? {
+        guard let tel else { return nil }
+        return HomeMachineMetrics(
+            cpuPercent: tel.cpuLoadPercent,
+            gpuPercent: tel.gpuLoadPercent,
+            memoryPercent: tel.memoryUsedPercent,
+            thermalPercent: tel.thermalPressurePercent
         )
     }
 

--- a/iOS/LatticesCompanion/Sources/Home/HomeMachineGauges.swift
+++ b/iOS/LatticesCompanion/Sources/Home/HomeMachineGauges.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+
+/// Per-machine load gauges. Renders 3-4 vertical bar meters showing the
+/// telemetry the daemon already publishes (CPU, GPU, memory, thermal).
+/// Lives inside the machine card so the live signal sits next to the
+/// thing it describes instead of in a detached status bar.
+///
+/// `compact` shrinks the bar dimensions so the cluster slots into the
+/// body row of a target card without growing the card height. The
+/// non-compact (full) form is for places with vertical room — e.g. a
+/// dedicated telemetry detail view.
+struct HomeMachineGauges: View {
+    let metrics: HomeMachineMetrics
+    /// Height of the bar fill area. Default is the standalone-view size;
+    /// in-card uses pass a value tuned to the right-column height.
+    var barHeight: CGFloat = 44
+
+    var hasAnyValue: Bool {
+        metrics.cpuPercent != nil
+            || metrics.gpuPercent != nil
+            || metrics.memoryPercent != nil
+            || metrics.thermalPercent != nil
+    }
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 10) {
+            LatsGauge(label: "CPU", percent: metrics.cpuPercent, barHeight: barHeight)
+            LatsGauge(label: "GPU", percent: metrics.gpuPercent, barHeight: barHeight)
+            LatsGauge(label: "MEM", percent: metrics.memoryPercent, barHeight: barHeight)
+            if metrics.thermalPercent != nil {
+                LatsGauge(label: "THM", percent: metrics.thermalPercent, barHeight: barHeight)
+            }
+        }
+        .fixedSize()
+    }
+}
+
+// MARK: - Vertical gauge primitive
+
+/// Vertical bar meter — value 0…100, color shifts green → amber → red as
+/// load climbs past 65 / 85.
+///
+/// `barHeight` controls how tall the fill area is; bar width and surrounding
+/// label/value sizes scale with it so the gauge stays readable from compact
+/// in-card usage up to a dedicated telemetry panel.
+struct LatsGauge: View {
+    let label: String
+    let percent: Double?
+    var barHeight: CGFloat = 44
+
+    private var barWidth: CGFloat  { barHeight >= 70 ? 16 : 14 }
+    private var valueSize: CGFloat { barHeight >= 70 ? 10 : 9 }
+    private var labelSize: CGFloat { barHeight >= 70 ? 8  : 7 }
+    private var spacing:   CGFloat { barHeight >= 70 ? 4  : 3 }
+
+    var body: some View {
+        VStack(spacing: spacing) {
+            valueText
+            barTrack
+            labelText
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityDescription)
+    }
+
+    private var valueText: some View {
+        Text(percent.map { "\(Int($0.rounded()))" } ?? "—")
+            .font(LatsFont.mono(valueSize, weight: .semibold))
+            .foregroundStyle(percent != nil ? LatsPalette.text : LatsPalette.textFaint)
+            .monospacedDigit()
+    }
+
+    private var barTrack: some View {
+        ZStack(alignment: .bottom) {
+            RoundedRectangle(cornerRadius: 3)
+                .fill(Color.white.opacity(0.04))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 3)
+                        .stroke(LatsPalette.hairline2, lineWidth: 1)
+                )
+
+            if let p = percent {
+                GeometryReader { geo in
+                    let h = geo.size.height * CGFloat(min(max(p, 0), 100) / 100)
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(loadTint(for: p))
+                        .frame(height: max(h, 1))
+                        .frame(maxHeight: .infinity, alignment: .bottom)
+                        .padding(2)
+                }
+            }
+        }
+        .frame(width: barWidth, height: barHeight)
+    }
+
+    private var labelText: some View {
+        Text(label)
+            .font(LatsFont.mono(labelSize, weight: .bold))
+            .tracking(0.6)
+            .foregroundStyle(LatsPalette.textFaint)
+    }
+
+    private func loadTint(for p: Double) -> Color {
+        if p >= 85 { return LatsPalette.red }
+        if p >= 65 { return LatsPalette.amber }
+        return LatsPalette.green
+    }
+
+    private var accessibilityDescription: String {
+        if let p = percent {
+            return "\(label) \(Int(p.rounded())) percent"
+        }
+        return "\(label) unavailable"
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Gauges · in-card column") {
+    LatsBackground {
+        HomeMachineGauges(
+            metrics: HomeMachineMetrics(
+                cpuPercent: 39,
+                gpuPercent: 12,
+                memoryPercent: 67,
+                thermalPercent: 28
+            ),
+            barHeight: 80
+        )
+        .padding(20)
+    }
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Gauges · standalone") {
+    LatsBackground {
+        HomeMachineGauges(
+            metrics: HomeMachineMetrics(
+                cpuPercent: 4,
+                gpuPercent: 1,
+                memoryPercent: 18,
+                thermalPercent: 12
+            )
+        )
+        .padding(20)
+    }
+    .preferredColorScheme(.dark)
+}

--- a/iOS/LatticesCompanion/Sources/Home/HomeMockData.swift
+++ b/iOS/LatticesCompanion/Sources/Home/HomeMockData.swift
@@ -68,6 +68,18 @@ struct HomeMachine: Identifiable, Equatable {
     let agentState: HomeAgentState
     let attentionCount: Int   // pending attention items
     let latencyMs: Int?       // ping latency in ms
+    /// Live load gauges. nil when the machine isn't reporting telemetry
+    /// (offline / standby / discovered-but-not-paired).
+    var metrics: HomeMachineMetrics? = nil
+}
+
+/// Per-machine load metrics surfaced as gauges. All fields are 0…100
+/// percentages and any may be nil if that signal isn't available.
+struct HomeMachineMetrics: Equatable {
+    let cpuPercent: Double?
+    let gpuPercent: Double?
+    let memoryPercent: Double?
+    let thermalPercent: Double?
 }
 
 // MARK: - Scenes (layout presets — instant, deterministic)
@@ -198,7 +210,13 @@ enum HomeMock {
             lastActionAgo: "2m",
             agentState: .running(task: "writing tile spec"),
             attentionCount: 3,
-            latencyMs: 14
+            latencyMs: 14,
+            metrics: HomeMachineMetrics(
+                cpuPercent: 39,
+                gpuPercent: 12,
+                memoryPercent: 67,
+                thermalPercent: 28
+            )
         ),
         HomeMachine(
             id: "arach-mini",

--- a/iOS/LatticesCompanion/Sources/Home/HomeTargetsRow.swift
+++ b/iOS/LatticesCompanion/Sources/Home/HomeTargetsRow.swift
@@ -90,58 +90,116 @@ private struct HomeTargetCard: View {
     var onEnterDeck: ((HomeMachine) -> Void)? = nil
     var onAttention: ((HomeMachine) -> Void)? = nil
 
+    /// Shared minimum card height. Picked so the gauge column has room to
+    /// breathe (status badge + tall gauges + latency) and offline cards
+    /// reserve the same space — keeps geometry identical regardless of state.
+    private var cardMinHeight: CGFloat { 156 }
+
     var body: some View {
         Button(action: { onEnterDeck?(machine) }) {
             LatsCard(padding: 12, radius: 8) {
-                VStack(alignment: .leading, spacing: 10) {
-                    headerRow
-                    identityBlock
-                    LatsHairlineDivider()
-                    bodyBlock
-                    LatsHairlineDivider()
-                    footerRow
+                HStack(alignment: .top, spacing: 14) {
+                    leftColumn
+                    rightColumn
                 }
+                .frame(minHeight: cardMinHeight)
             }
         }
         .buttonStyle(.plain)
         .opacity(emphasis == .deemphasized ? 0.78 : 1.0)
     }
 
-    // MARK: Header — icon, status, attention, chevron
+    private func hasGaugeContent(_ m: HomeMachineMetrics) -> Bool {
+        m.cpuPercent != nil
+            || m.gpuPercent != nil
+            || m.memoryPercent != nil
+            || m.thermalPercent != nil
+    }
 
-    private var headerRow: some View {
-        HStack(alignment: .top, spacing: 10) {
+    // MARK: Left column — name, identity, metadata, agent
+
+    private var leftColumn: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            nameRow
+            identityBlock
+            metadataBlock
+            Spacer(minLength: 0)
+            footerRow
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+    }
+
+    private var nameRow: some View {
+        HStack(spacing: 10) {
             iconTile
-            VStack(alignment: .leading, spacing: 3) {
-                Text(machine.name)
-                    .font(LatsFont.mono(13, weight: .semibold))
-                    .foregroundStyle(bodyText)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                Text(machine.host)
-                    .font(LatsFont.mono(10))
-                    .foregroundStyle(LatsPalette.textDim)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
+            Text(machine.name)
+                .font(LatsFont.mono(13, weight: .semibold))
+                .foregroundStyle(bodyText)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    // MARK: Right column — status badge above the gauge stack
+
+    private var rightColumn: some View {
+        VStack(alignment: .trailing, spacing: 10) {
+            statusStack
+
+            if let metrics = machine.metrics, hasGaugeContent(metrics) {
+                Spacer(minLength: 4)
+                HomeMachineGauges(metrics: metrics, barHeight: 80)
+                Spacer(minLength: 0)
+            } else {
+                Spacer(minLength: 0)
             }
-            Spacer(minLength: 4)
-            VStack(alignment: .trailing, spacing: 6) {
-                HStack(spacing: 6) {
-                    if machine.attentionCount > 0 {
-                        attentionDot
-                    }
-                    LatsBadge(
-                        text: machine.status.label,
-                        tint: machine.status.tint,
-                        dot: machine.status == .active
-                    )
+        }
+        .frame(width: 110, alignment: .trailing)
+    }
+
+    private var statusStack: some View {
+        VStack(alignment: .trailing, spacing: 4) {
+            HStack(spacing: 6) {
+                if machine.attentionCount > 0 {
+                    attentionDot
                 }
-                if let lat = machine.latencyMs, machine.status != .offline {
-                    Text("\(lat)ms")
-                        .font(LatsFont.mono(9))
-                        .tracking(0.4)
-                        .foregroundStyle(LatsPalette.textFaint)
-                }
+                LatsBadge(
+                    text: machine.status.label,
+                    tint: machine.status.tint,
+                    dot: machine.status == .active
+                )
+            }
+            if let lat = machine.latencyMs, machine.status != .offline {
+                Text("\(lat)ms")
+                    .font(LatsFont.mono(9))
+                    .tracking(0.4)
+                    .foregroundStyle(LatsPalette.textFaint)
+            }
+        }
+    }
+
+    // MARK: Metadata — focus/last for live targets, paired info for offline
+
+    @ViewBuilder
+    private var metadataBlock: some View {
+        switch machine.status {
+        case .offline:
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text("PAIRED")
+                    .font(LatsFont.mono(9, weight: .bold))
+                    .tracking(0.8)
+                    .foregroundStyle(LatsPalette.textFaint)
+                    .frame(width: 50, alignment: .leading)
+                Text(machine.lastActionAgo ?? "—")
+                    .font(LatsFont.mono(11))
+                    .foregroundStyle(bodyDim)
+                Spacer(minLength: 0)
+            }
+        default:
+            VStack(alignment: .leading, spacing: 6) {
+                focusedRow
+                lastActionRow
             }
         }
     }
@@ -206,14 +264,7 @@ private struct HomeTargetCard: View {
         }
     }
 
-    // MARK: Body — focused app + window, last action
-
-    private var bodyBlock: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            focusedRow
-            lastActionRow
-        }
-    }
+    // MARK: Focused app + last action rows (active/online machines)
 
     @ViewBuilder
     private var focusedRow: some View {

--- a/iOS/LatticesCompanion/Sources/Home/HomeView.swift
+++ b/iOS/LatticesCompanion/Sources/Home/HomeView.swift
@@ -6,11 +6,11 @@ import SwiftUI
 /// Composed of independent sections:
 ///   - HomeTopBar       (chrome — fleet pills, agent count, settings)
 ///   - HomeTargetsRow   (adaptive cards: 1, 2, 3-4 Macs)
-///   - HomeOverflowGrid (foreground machine "third monitor" tiles)
 ///   - HomeScenesGrid   (instant layout presets)
 ///   - HomeRoutinesList (agent recipes)
-///   - HomeRecentTape   (cross-fleet activity)
+///   - HomeActivityFeed (combined: attention + recent + agent narration)
 ///   - HomeSyncSection  (broadcast / fleet ops)
+///   - HomeVoicePanel   (inline voice — slides in above the cloud strip)
 ///   - HomeCloudStrip   (separate cloud aggregate)
 ///   - HomeBottomBar    (chrome — status, voice/cmd)
 ///
@@ -50,7 +50,7 @@ struct HomeView: View {
     var onVoiceCancel: (() -> Void)? = nil
     var onVoiceRemediate: ((DeckRemediationAction) -> Void)? = nil
 
-    @State private var showingVoiceOverlay: Bool = false
+    @State private var voicePanelOpen: Bool = false
 
     private var foregroundMachine: HomeMachine? {
         machines.first(where: { $0.isForeground })
@@ -72,40 +72,24 @@ struct HomeView: View {
                     connectedLayout
                 }
             }
-            voiceTrigger
-                .padding(.trailing, 18)
-                .padding(.bottom, 70) // sit above the HomeBottomBar
+            if !voicePanelOpen {
+                voiceTrigger
+                    .padding(.trailing, 18)
+                    .padding(.bottom, 70) // sit above the HomeBottomBar
+            }
         }
-        .fullScreenCover(isPresented: $showingVoiceOverlay) {
-            HomeVoiceOverlay(
-                voiceState: voiceState,
-                macLabel: voiceMacLabel,
-                isPerforming: isVoicePerforming,
-                onStart: { onVoiceStart?() },
-                onStop:  { onVoiceStop?() },
-                onCancel: {
-                    onVoiceCancel?()
-                    showingVoiceOverlay = false
-                },
-                onClose: { showingVoiceOverlay = false },
-                onRemediate: { onVoiceRemediate?($0) }
-            )
-        }
+        // Auto-open the panel when the Mac reports active voice work (a
+        // dictation kicked off elsewhere, or an error needs attention). We
+        // don't auto-open just for stale transcripts/responses — closing the
+        // panel must stay closed once the turn is done.
         .onChange(of: voiceState?.phase) { _, newPhase in
-            // Auto-close when the Mac finishes a successful turn (idle + result, no error).
-            guard showingVoiceOverlay,
-                  newPhase == .idle,
-                  voiceState?.error == nil,
-                  let summary = voiceState?.responseSummary,
-                  !summary.isEmpty,
-                  summary != "Transcribing...",
-                  summary != "thinking..."
-            else { return }
-            Task {
-                try? await Task.sleep(for: .milliseconds(1400))
-                if voiceState?.phase == .idle && voiceState?.error == nil {
-                    showingVoiceOverlay = false
-                }
+            if let newPhase, newPhase != .idle {
+                voicePanelOpen = true
+            }
+        }
+        .onChange(of: voiceState?.error?.code) { _, newCode in
+            if newCode != nil {
+                voicePanelOpen = true
             }
         }
     }
@@ -113,7 +97,7 @@ struct HomeView: View {
     private var voiceTrigger: some View {
         Button {
             onVoiceStart?()
-            showingVoiceOverlay = true
+            voicePanelOpen = true
         } label: {
             Image(systemName: "mic.fill")
                 .font(.system(size: 18, weight: .semibold))
@@ -158,7 +142,11 @@ struct HomeView: View {
 
                     HomeRoutinesList(routines: routines, onRun: onRoutine)
 
-                    HomeRecentTape(entries: recent)
+                    HomeActivityFeed(
+                        recent: recent,
+                        agentFeed: agentFeed,
+                        attention: attention
+                    )
 
                     HomeSyncSection(
                         actions: sync,
@@ -168,8 +156,24 @@ struct HomeView: View {
                 }
                 .padding(.horizontal, 24)
                 .padding(.vertical, 18)
-                .frame(maxWidth: 1100)
                 .frame(maxWidth: .infinity)
+            }
+
+            if voicePanelOpen {
+                HomeVoicePanel(
+                    voiceState: voiceState,
+                    macLabel: voiceMacLabel,
+                    isPerforming: isVoicePerforming,
+                    onStart: { onVoiceStart?() },
+                    onStop:  { onVoiceStop?() },
+                    onCancel: {
+                        onVoiceCancel?()
+                        voicePanelOpen = false
+                    },
+                    onClose: { voicePanelOpen = false },
+                    onRemediate: { onVoiceRemediate?($0) }
+                )
+                .transition(.move(edge: .bottom).combined(with: .opacity))
             }
 
             HomeCloudStrip(cloud: cloud)
@@ -178,6 +182,7 @@ struct HomeView: View {
                 telemetry: bottomTelemetry
             )
         }
+        .animation(.easeInOut(duration: 0.22), value: voicePanelOpen)
     }
 }
 

--- a/iOS/LatticesCompanion/Sources/Home/HomeVoiceOverlay.swift
+++ b/iOS/LatticesCompanion/Sources/Home/HomeVoiceOverlay.swift
@@ -7,9 +7,8 @@ import SwiftUI
 /// for the Mac that's actually listening.
 ///
 /// Presented as `.fullScreenCover` from `HomeView` when the user taps the
-/// voice button in `HomeBottomBar`. Auto-dismisses ~1.4s after the Mac
-/// returns to `idle` with a successful `responseSummary`; sticks around when
-/// there's an error so the user can read + retry.
+/// voice button. The overlay stays open until the user closes it so command
+/// results remain visible for review.
 struct HomeVoiceOverlay: View {
     let voiceState: DeckVoiceState?
     let macLabel: String
@@ -371,7 +370,7 @@ struct HomeVoiceOverlay: View {
 
 // MARK: - Voice orb
 
-private struct VoiceOrb: View {
+struct VoiceOrb: View {
     let phase: DeckVoicePhase
     let severity: DeckErrorSeverity?
 

--- a/iOS/LatticesCompanion/Sources/Home/HomeVoicePanel.swift
+++ b/iOS/LatticesCompanion/Sources/Home/HomeVoicePanel.swift
@@ -1,0 +1,427 @@
+import DeckKit
+import SwiftUI
+
+/// Inline voice panel — slots into the Home layout above the cloud strip
+/// instead of taking over the screen. The dashboard stays visible above so
+/// the user can see fleet state while dictating.
+///
+/// Renders nothing when there's nothing to say (idle, no transcript, no
+/// response, no error, panel not explicitly opened). Hosting view controls
+/// visibility via `isOpen` so an explicit FAB tap can pre-open the panel
+/// before any state arrives from the Mac.
+struct HomeVoicePanel: View {
+    let voiceState: DeckVoiceState?
+    let macLabel: String
+    let isPerforming: Bool
+
+    var onStart: () -> Void
+    var onStop: () -> Void
+    var onCancel: () -> Void
+    var onClose: () -> Void
+    var onRemediate: ((DeckRemediationAction) -> Void)? = nil
+
+    private var phase: DeckVoicePhase { voiceState?.phase ?? .idle }
+    private var error: DeckVoiceError? { voiceState?.error }
+
+    private var transcript: String? {
+        let raw = voiceState?.transcript?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (raw?.isEmpty == false) ? raw : nil
+    }
+
+    private var responseSummary: String? {
+        let raw = voiceState?.responseSummary?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let raw, !raw.isEmpty else { return nil }
+        if raw == "Transcribing..." || raw == "thinking..." { return nil }
+        return raw
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .top, spacing: 14) {
+                // Single round CTA — combines mic icon, phase indicator, and
+                // start/stop action into one tap target. Color + glyph reflect
+                // current phase; tapping advances the state.
+                VoiceCTA(
+                    phase: phase,
+                    severity: error?.severity,
+                    onTap: handlePrimaryTap
+                )
+                .frame(width: 64, height: 64)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    headerRow
+
+                    Text(caption)
+                        .font(LatsFont.mono(11))
+                        .tracking(0.4)
+                        .foregroundStyle(LatsPalette.textDim)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    if let transcript {
+                        transcriptInline(transcript)
+                    }
+                    if let responseSummary {
+                        responseInline(responseSummary)
+                    }
+                    if let error {
+                        errorInline(error)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+        }
+        .background(Color.black.opacity(0.32))
+        .overlay(alignment: .top) {
+            Rectangle().fill(LatsPalette.hairline2).frame(height: 1)
+        }
+    }
+
+    // MARK: - Header — target label + close
+
+    private var headerRow: some View {
+        HStack(spacing: 8) {
+            Text(macLabel.lowercased())
+                .font(LatsFont.mono(11))
+                .tracking(0.5)
+                .foregroundStyle(LatsPalette.textDim)
+                .lineLimit(1)
+
+            Spacer(minLength: 8)
+
+            Button(action: onClose) {
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(LatsPalette.textDim)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close voice")
+        }
+    }
+
+    // MARK: - Tap routing for the single CTA
+
+    /// One button, three jobs depending on phase. Idle starts; listening stops;
+    /// transcribing/reasoning/speaking cancels the in-flight turn. Errors with
+    /// remediations route through the remediation handler instead.
+    private func handlePrimaryTap() {
+        if let err = error, let remediation = err.remediation {
+            onRemediate?(remediation)
+            return
+        }
+        switch phase {
+        case .idle:
+            onStart()
+        case .listening:
+            onStop()
+        case .transcribing, .reasoning, .speaking:
+            onCancel()
+        }
+    }
+
+    // MARK: - Inline transcript / response / error
+
+    private func transcriptInline(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text("›")
+                .font(LatsFont.mono(12, weight: .semibold))
+                .foregroundStyle(LatsPalette.green.opacity(0.8))
+            Text(text)
+                .font(LatsFont.mono(12))
+                .foregroundStyle(LatsPalette.text)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .multilineTextAlignment(.leading)
+        }
+    }
+
+    private func responseInline(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "checkmark")
+                .font(.system(size: 10, weight: .bold))
+                .foregroundStyle(LatsPalette.green)
+                .frame(width: 12)
+            Text(text)
+                .font(LatsFont.ui(12))
+                .foregroundStyle(LatsPalette.text)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func errorInline(_ err: DeckVoiceError) -> some View {
+        let tint = severityTint(err.severity)
+        return VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Image(systemName: severityIcon(err.code))
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(tint)
+                Text(err.code.rawValue.uppercased())
+                    .font(LatsFont.mono(9, weight: .bold))
+                    .tracking(1.2)
+                    .foregroundStyle(tint)
+                Spacer()
+            }
+            Text(err.message)
+                .font(LatsFont.ui(12, weight: .medium))
+                .foregroundStyle(LatsPalette.text)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .multilineTextAlignment(.leading)
+            if let remediation = err.remediation {
+                LatsButton(
+                    title: remediationLabel(remediation),
+                    icon: remediationIcon(remediation),
+                    style: .primary(remediationTint(err.severity))
+                ) {
+                    onRemediate?(remediation)
+                }
+            }
+        }
+        .padding(10)
+        .background(RoundedRectangle(cornerRadius: 6).fill(tint.opacity(0.08)))
+        .overlay(RoundedRectangle(cornerRadius: 6).stroke(tint.opacity(0.4), lineWidth: 1))
+    }
+
+    // MARK: - Phase / severity helpers
+
+    private var caption: String {
+        if error != nil { return "voice paused — see status above" }
+        switch phase {
+        case .idle:         return "tap to dictate on \(macLabel)"
+        case .listening:    return "listening on \(macLabel) — tap to stop"
+        case .transcribing: return "transcribing…"
+        case .reasoning:    return "matching intent…"
+        case .speaking:     return "responding…"
+        }
+    }
+
+    private var phaseTint: Color {
+        if let err = error { return severityTint(err.severity) }
+        switch phase {
+        case .idle:         return LatsPalette.textDim
+        case .listening:    return LatsPalette.green
+        case .transcribing: return LatsPalette.teal
+        case .reasoning:    return LatsPalette.violet
+        case .speaking:     return LatsPalette.blue
+        }
+    }
+
+    private func severityTint(_ severity: DeckErrorSeverity) -> Color {
+        switch severity {
+        case .info:    return LatsPalette.blue
+        case .warning: return LatsPalette.amber
+        case .error,
+             .blocked: return LatsPalette.red
+        }
+    }
+
+    private func severityIcon(_ code: DeckVoiceErrorCode) -> String {
+        switch code {
+        case .micDenied:           return "mic.slash"
+        case .accessibilityDenied: return "lock.shield"
+        case .micBusy:             return "mic.badge.xmark"
+        case .voxNotRunning,
+             .voxLoading,
+             .voxUnreachable:      return "waveform.badge.exclamationmark"
+        case .daemonUnreachable,
+             .network,
+             .connectionLost:      return "wifi.exclamationmark"
+        case .noActiveTarget:      return "scope"
+        case .intentUnresolved:    return "questionmark.circle"
+        case .actionFailed:        return "bolt.trianglebadge.exclamationmark"
+        case .transcriptionFailed: return "waveform.slash"
+        case .emptyTranscript:     return "ear"
+        case .languageUnsupported: return "globe"
+        }
+    }
+
+    private func remediationLabel(_ remediation: DeckRemediationAction) -> String {
+        switch remediation {
+        case .openVox:            return "Open Vox"
+        case .openSystemSettings: return "Open settings"
+        case .retryVoice:         return "Retry"
+        case .openDiagnostics:    return "Open diagnostics"
+        case .chooseTarget:       return "Pick target"
+        }
+    }
+
+    private func remediationIcon(_ remediation: DeckRemediationAction) -> String {
+        switch remediation {
+        case .openVox:            return "waveform"
+        case .openSystemSettings: return "gearshape"
+        case .retryVoice:         return "arrow.clockwise"
+        case .openDiagnostics:    return "stethoscope"
+        case .chooseTarget:       return "scope"
+        }
+    }
+
+    private func remediationTint(_ severity: DeckErrorSeverity) -> LatsTint {
+        switch severity {
+        case .info:    return .blue
+        case .warning: return .amber
+        case .error,
+             .blocked: return .red
+        }
+    }
+}
+
+// MARK: - VoiceCTA — single round button that absorbs orb + phase pill + action
+
+/// A round mic button whose color, glyph, and pulse animation reflect the
+/// current voice phase. Replaces the old triple of orb + "READY" pill +
+/// Start/Stop button with one tappable surface — the host wires its tap to
+/// a phase-aware handler that starts, stops, or cancels as appropriate.
+struct VoiceCTA: View {
+    let phase: DeckVoicePhase
+    let severity: DeckErrorSeverity?
+    var onTap: () -> Void
+
+    @State private var pulse: Bool = false
+
+    var body: some View {
+        Button(action: onTap) {
+            ZStack {
+                // Outer pulse ring — only animates while listening so the
+                // CTA visually "hears."
+                Circle()
+                    .stroke(tint.opacity(0.45), lineWidth: 1.5)
+                    .scaleEffect(pulse ? 1.18 : 1.0)
+                    .opacity(pulse ? 0.0 : 0.85)
+                    .animation(
+                        isAnimating
+                            ? .easeOut(duration: 1.4).repeatForever(autoreverses: false)
+                            : .default,
+                        value: pulse
+                    )
+
+                Circle().fill(tint.opacity(0.18))
+                Circle().stroke(tint.opacity(0.55), lineWidth: 1)
+
+                if isThinking {
+                    ProgressView()
+                        .tint(tint)
+                        .scaleEffect(0.9)
+                } else {
+                    Image(systemName: glyph)
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundStyle(tint)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .contentShape(Circle())
+        .onAppear { if isAnimating { pulse = true } }
+        .onChange(of: phase) { _, _ in pulse = isAnimating }
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var isAnimating: Bool { severity == nil && phase == .listening }
+    private var isThinking: Bool {
+        severity == nil && (phase == .transcribing || phase == .reasoning || phase == .speaking)
+    }
+
+    private var tint: Color {
+        if let severity {
+            switch severity {
+            case .info:    return LatsPalette.blue
+            case .warning: return LatsPalette.amber
+            case .error,
+                 .blocked: return LatsPalette.red
+            }
+        }
+        switch phase {
+        case .idle:         return LatsPalette.violet
+        case .listening:    return LatsPalette.red
+        case .transcribing: return LatsPalette.teal
+        case .reasoning:    return LatsPalette.violet
+        case .speaking:     return LatsPalette.blue
+        }
+    }
+
+    private var glyph: String {
+        if severity != nil { return "exclamationmark.triangle.fill" }
+        switch phase {
+        case .idle:      return "mic.fill"
+        case .listening: return "stop.fill"
+        default:         return "mic.fill"
+        }
+    }
+
+    private var accessibilityLabel: String {
+        if severity != nil { return "Resolve voice issue" }
+        switch phase {
+        case .idle:      return "Start dictation"
+        case .listening: return "Stop dictation"
+        default:         return "Cancel voice turn"
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Panel · listening") {
+    LatsBackground {
+        VStack {
+            Spacer()
+            HomeVoicePanel(
+                voiceState: DeckVoiceState(
+                    phase: .listening,
+                    transcript: "tile chrome two-up right",
+                    provider: "vox"
+                ),
+                macLabel: "arach-laptop",
+                isPerforming: false,
+                onStart: {}, onStop: {}, onCancel: {}, onClose: {}
+            )
+        }
+    }
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Panel · result") {
+    LatsBackground {
+        VStack {
+            Spacer()
+            HomeVoicePanel(
+                voiceState: DeckVoiceState(
+                    phase: .idle,
+                    transcript: "tile chrome two-up right",
+                    responseSummary: "Tiled 3 windows in two columns on display 1",
+                    provider: "vox"
+                ),
+                macLabel: "arach-laptop",
+                isPerforming: false,
+                onStart: {}, onStop: {}, onCancel: {}, onClose: {}
+            )
+        }
+    }
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Panel · error") {
+    LatsBackground {
+        VStack {
+            Spacer()
+            HomeVoicePanel(
+                voiceState: DeckVoiceState(
+                    phase: .idle,
+                    provider: "vox",
+                    error: DeckVoiceError(
+                        code: .voxNotRunning,
+                        severity: .error,
+                        recoverable: true,
+                        retry: .afterLaunch,
+                        source: .mac,
+                        message: "Vox offline — start it to dictate",
+                        remediation: .openVox
+                    )
+                ),
+                macLabel: "arach-laptop",
+                isPerforming: false,
+                onStart: {}, onStop: {}, onCancel: {}, onClose: {}
+            )
+        }
+    }
+    .preferredColorScheme(.dark)
+}


### PR DESCRIPTION
## Summary

Cherry-picked iPad Home dashboard work from the parked cockpit branch onto fresh main.

- **HomeVoicePanel.swift** — inline voice panel that slides in above the cloud strip
- **HomeActivityFeed.swift** — combined feed: attention + recent + agent narration
- **HomeMachineGauges.swift** — adaptive machine gauges
- Adaptive polling in `DeckStore` / `HomeDataAdapter`
- Wires the new sections into `HomeView` and `ContentView`

## Cherry-pick notes

Original commit was based on pre-PR-#5 main. One conflict on `iOS/LatticesCompanion/LatticesCompanion.xcodeproj/project.pbxproj` — resolved by taking main's version since this project uses Xcode synchronized groups (no manual `.pbxproj` edits needed for new Swift files).

## Test plan

- [ ] Open in Xcode, build for iPad sim
- [ ] Voice panel slide-in works
- [ ] Activity feed renders combined entries
- [ ] Machine gauges show live data
- [ ] Adaptive polling kicks in on connect/disconnect