### PR TITLE
Add opt-in permissions assistant

### DIFF
--- a/app/Lattices.app/Contents/Info.plist
+++ b/app/Lattices.app/Contents/Info.plist
@@ -34,9 +34,9 @@
     <key>LatticesBuildTrack</key>
     <string>latest</string>
     <key>LatticesBuildRevision</key>
-    <string>921e181</string>
+    <string>f802f0d</string>
     <key>LatticesBuildTimestamp</key>
-    <string>2026-05-03T18:07:28Z</string>
+    <string>2026-05-03T18:54:42Z</string>
     <key>LSMinimumSystemVersion</key>
     <string>13.0</string>
     <key>LSUIElement</key>

--- a/app/Sources/AppShell/AppDelegate.swift
+++ b/app/Sources/AppShell/AppDelegate.swift
@@ -51,6 +51,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 ScreenMapWindowController.shared.showPage(.screenMap)
             }
         }
+
+        // Explicit preview entry point for development/demo flows. This still
+        // requires a launch argument; the assistant never opens automatically.
+        if CommandLine.arguments.contains("--permissions-assistant") {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                PermissionsAssistantWindowController.shared.show()
+            }
+        }
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/app/Sources/AppShell/AppShellView.swift
+++ b/app/Sources/AppShell/AppShellView.swift
@@ -63,6 +63,21 @@ struct AppShellView: View {
         }
         .onChange(of: windowController.activePage) { page in
             syncPageState(page)
+            clearRelevantDismissals(for: page)
+        }
+    }
+
+    /// Entering a feature page clears its capability snooze — the user is
+    /// telling us they want this to work, so the banner can resurface.
+    private func clearRelevantDismissals(for page: AppPage) {
+        let prefs = Preferences.shared
+        switch page {
+        case .screenMap:
+            prefs.clearDismissal(Capability.windowControl.rawValue)
+        case .desktopInventory:
+            prefs.clearDismissal(Capability.screenSearch.rawValue)
+        default:
+            break
         }
     }
 

--- a/app/Sources/AppShell/LatticesRuntime.swift
+++ b/app/Sources/AppShell/LatticesRuntime.swift
@@ -88,6 +88,10 @@ enum LatticesRuntime {
         isDevBuild ? "Latest local dev build" : "Signed release build"
     }
 
+    static var buildChannelLabel: String {
+        isDevBuild ? "DEV" : "RELEASE"
+    }
+
     private static func hasAppHelper(in root: String) -> Bool {
         FileManager.default.fileExists(atPath: root + "/bin/lattices-app.ts")
     }

--- a/app/Sources/AppShell/MainView.swift
+++ b/app/Sources/AppShell/MainView.swift
@@ -14,7 +14,6 @@ struct MainView: View {
     @StateObject private var inventory = InventoryManager.shared
     @State private var searchText = ""
     @State private var hasCheckedSetup = false
-    @State private var bannerDismissed = false
     @State private var tmuxBannerDismissed = false
     @ObservedObject private var tmuxModel = TmuxModel.shared
     @State private var orphanSectionCollapsed = true
@@ -93,8 +92,11 @@ struct MainView: View {
         permChecker.check()
         DiagnosticLog.shared.finish(tPerm)
 
-        bannerDismissed = false
         DiagnosticLog.shared.finish(tTotal)
+    }
+
+    private var visiblyMissingCapabilities: [Capability] {
+        Capability.allCases.filter { !$0.isGranted && !prefs.isCapabilityDismissed($0.rawValue) }
     }
 
     private var mainContent: some View {
@@ -104,6 +106,7 @@ struct MainView: View {
                     Text("Lattices")
                         .font(Typo.mono(14))
                         .foregroundColor(Palette.text)
+                    buildChannelBadge
 
                     Spacer()
 
@@ -157,8 +160,8 @@ struct MainView: View {
                 .padding(.bottom, 10)
             }
 
-            // Permission banner
-            if !permChecker.allGranted && !bannerDismissed {
+            // Permission banner — only when something is missing AND not snoozed
+            if !visiblyMissingCapabilities.isEmpty {
                 permissionBanner
             }
 
@@ -401,12 +404,20 @@ struct MainView: View {
                 SettingsWindowController.shared.show()
             }
 
-            HStack(spacing: 4) {
-                if !permChecker.allGranted {
-                    Circle()
-                        .fill(Palette.detach)
-                        .frame(width: 5, height: 5)
+            if !permChecker.allGranted {
+                Button {
+                    PermissionsAssistantWindowController.shared.show()
+                } label: {
+                    HStack(spacing: 4) {
+                        Circle()
+                            .fill(Palette.detach)
+                            .frame(width: 5, height: 5)
+                        Text("Permissions")
+                            .font(Typo.mono(9))
+                            .foregroundColor(Palette.textMuted)
+                    }
                 }
+                .buttonStyle(.plain)
             }
 
             Spacer()
@@ -502,33 +513,61 @@ struct MainView: View {
     // MARK: - Permission banner
 
     private var permissionBanner: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        let missing = visiblyMissingCapabilities
+
+        return VStack(alignment: .leading, spacing: 8) {
             HStack {
-                Image(systemName: "exclamationmark.triangle.fill")
+                Image(systemName: "sparkles")
                     .font(.system(size: 10))
                     .foregroundColor(Palette.detach)
-                Text("PERMISSIONS NEEDED")
+                Text("OPTIONAL CAPABILITIES")
                     .font(Typo.monoBold(10))
                     .foregroundColor(Palette.detach)
                 Spacer()
-                Button { bannerDismissed = true } label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 8, weight: .bold))
+                Button {
+                    for cap in missing { prefs.dismissCapability(cap.rawValue) }
+                } label: {
+                    Text("Maybe later")
+                        .font(Typo.mono(9))
                         .foregroundColor(Palette.textMuted)
                 }
                 .buttonStyle(.plain)
             }
 
-            permissionRow("Accessibility", granted: permChecker.accessibility) {
-                permChecker.requestAccessibility()
-            }
-            permissionRow("Screen Capture", granted: permChecker.screenRecording) {
-                permChecker.requestScreenRecording()
+            Text(bannerSummary(missing))
+                .font(Typo.mono(10))
+                .foregroundColor(Palette.text)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 8) {
+                ForEach(missing) { cap in
+                    capabilityChip(cap)
+                }
+                Spacer(minLength: 0)
             }
 
-            Text("Click a row to continue the permission flow in macOS.")
-                .font(Typo.mono(9))
-                .foregroundColor(Palette.textMuted)
+            Button {
+                PermissionsAssistantWindowController.shared.show(focus: missing.first)
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "slider.horizontal.3")
+                        .font(.system(size: 10, weight: .semibold))
+                    Text("Open Permissions Assistant")
+                        .font(Typo.monoBold(10))
+                }
+                .foregroundColor(.white)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Palette.detach.opacity(0.18))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 4)
+                                .strokeBorder(Palette.detach.opacity(0.45), lineWidth: 0.5)
+                        )
+                )
+            }
+            .buttonStyle(.plain)
         }
         .padding(12)
         .background(
@@ -541,6 +580,56 @@ struct MainView: View {
         )
         .padding(.horizontal, 14)
         .padding(.bottom, 10)
+    }
+
+    private func bannerSummary(_ missing: [Capability]) -> String {
+        switch missing.count {
+        case 0: return ""
+        case 1: return "\(missing[0].title) is off. Lattices works without it."
+        default: return "\(missing.count) capabilities are off. Turn on whichever you want; the rest of the app works without them."
+        }
+    }
+
+    private func capabilityChip(_ cap: Capability) -> some View {
+        Button {
+            PermissionsAssistantWindowController.shared.show(focus: cap)
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: cap.iconName)
+                    .font(.system(size: 9, weight: .semibold))
+                Text(cap.title)
+                    .font(Typo.mono(9))
+            }
+            .foregroundColor(Palette.textDim)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(
+                Capsule()
+                    .fill(Palette.surface)
+                    .overlay(
+                        Capsule().strokeBorder(Palette.border, lineWidth: 0.5)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var buildChannelBadge: some View {
+        let tint = LatticesRuntime.isDevBuild ? Palette.detach : Palette.running
+
+        return Text(LatticesRuntime.buildChannelLabel)
+            .font(Typo.monoBold(9))
+            .foregroundColor(tint)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .background(
+                Capsule()
+                    .fill(tint.opacity(0.12))
+                    .overlay(
+                        Capsule()
+                            .strokeBorder(tint.opacity(0.28), lineWidth: 0.5)
+                    )
+            )
     }
 
     // MARK: - tmux banner
@@ -605,42 +694,6 @@ struct MainView: View {
         )
         .padding(.horizontal, 14)
         .padding(.bottom, 10)
-    }
-
-    private func permissionRow(_ name: String, granted: Bool, open: @escaping () -> Void) -> some View {
-        Button(action: { if !granted { open() } }) {
-            HStack(spacing: 6) {
-                Image(systemName: granted ? "checkmark.circle.fill" : "circle")
-                    .font(.system(size: 10))
-                    .foregroundColor(granted ? Palette.running : Palette.detach)
-                Text(name)
-                    .font(Typo.mono(10))
-                    .foregroundColor(Palette.text)
-                Spacer()
-                if granted {
-                    Text("granted")
-                        .font(Typo.mono(9))
-                        .foregroundColor(Palette.running)
-                } else {
-                    HStack(spacing: 4) {
-                        Text("not set")
-                            .font(Typo.mono(9))
-                            .foregroundColor(Palette.detach)
-                        Image(systemName: "arrow.up.forward.square")
-                            .font(.system(size: 9))
-                            .foregroundColor(Palette.detach)
-                    }
-                }
-            }
-            .padding(.vertical, 4)
-            .padding(.horizontal, 8)
-            .background(
-                RoundedRectangle(cornerRadius: 4)
-                    .fill(granted ? Color.clear : Palette.detach.opacity(0.06))
-            )
-        }
-        .buttonStyle(.plain)
-        .disabled(granted)
     }
 
     // MARK: - Helpers

--- a/app/Sources/AppShell/OnboardingView.swift
+++ b/app/Sources/AppShell/OnboardingView.swift
@@ -4,8 +4,8 @@ import AppKit
 // MARK: - Onboarding Flow
 
 /// A step-by-step welcome screen shown on first launch.
-/// Walks the user through granting Accessibility, Screen Recording,
-/// choosing a project root, and optionally installing tmux.
+/// Keeps setup quiet: permissions are introduced as optional capabilities
+/// and requested later from the feature that needs them.
 struct OnboardingView: View {
     @ObservedObject private var permChecker = PermissionChecker.shared
     @ObservedObject private var prefs = Preferences.shared
@@ -15,8 +15,7 @@ struct OnboardingView: View {
 
     enum Step: Int, CaseIterable {
         case welcome
-        case accessibility
-        case screenRecording
+        case capabilities
         case projectRoot
         case tmux
         case done
@@ -39,8 +38,7 @@ struct OnboardingView: View {
             Group {
                 switch step {
                 case .welcome:      welcomeStep
-                case .accessibility: accessibilityStep
-                case .screenRecording: screenRecordingStep
+                case .capabilities:  capabilitiesStep
                 case .projectRoot:  projectRootStep
                 case .tmux:         tmuxStep
                 case .done:         doneStep
@@ -98,24 +96,37 @@ struct OnboardingView: View {
         }
     }
 
-    private var accessibilityStep: some View {
-        permissionStep(
-            icon: "hand.raised.fill",
-            title: "Accessibility",
-            description: "Lattices needs Accessibility access to read window titles, move and resize windows, and tile your workspace.",
-            granted: permChecker.accessibility,
-            action: { permChecker.requestAccessibility() }
-        )
-    }
+    private var capabilitiesStep: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "slider.horizontal.3")
+                .font(.system(size: 28))
+                .foregroundColor(.white.opacity(0.7))
 
-    private var screenRecordingStep: some View {
-        permissionStep(
-            icon: "rectangle.dashed.badge.record",
-            title: "Screen Capture",
-            description: "Allows Lattices to index on-screen text with OCR so you can search across all your windows. On newer macOS versions this finishes in System Settings under Screen & System Audio Recording.",
-            granted: permChecker.screenRecording,
-            action: { permChecker.requestScreenRecording() }
-        )
+            Text("Enable more when you need it")
+                .font(Typo.title(16))
+                .foregroundColor(Palette.text)
+
+            Text("Lattices launches projects without any extra permissions. Click a capability to set it up now in the Permissions Assistant — or skip and turn it on later.")
+                .font(Typo.body(12))
+                .foregroundColor(Palette.textDim)
+                .multilineTextAlignment(.center)
+                .lineSpacing(3)
+
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(Capability.allCases) { cap in
+                    capabilityRow(cap)
+                }
+            }
+            .padding(10)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Palette.surface)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(Palette.border, lineWidth: 0.5)
+                    )
+            )
+        }
     }
 
     private var projectRootStep: some View {
@@ -251,8 +262,7 @@ struct OnboardingView: View {
                 .foregroundColor(Palette.text)
 
             VStack(alignment: .leading, spacing: 8) {
-                statusRow("Accessibility", granted: permChecker.accessibility)
-                statusRow("Screen Recording", granted: permChecker.screenRecording)
+                statusRow("Permission prompts", granted: true, detail: "shown when needed")
                 statusRow("Project root", granted: !prefs.scanRoot.isEmpty,
                           detail: prefs.scanRoot.isEmpty ? "not set" : abbreviatePath(prefs.scanRoot))
                 statusRow("tmux", granted: tmux.isAvailable,
@@ -293,43 +303,47 @@ struct OnboardingView: View {
 
     // MARK: - Shared helpers
 
-    private func permissionStep(icon: String, title: String, description: String, granted: Bool, action: @escaping () -> Void) -> some View {
-        VStack(spacing: 16) {
-            Image(systemName: icon)
-                .font(.system(size: 28))
-                .foregroundColor(.white.opacity(0.7))
-
-            Text(title)
-                .font(Typo.title(16))
-                .foregroundColor(Palette.text)
-
-            Text(description)
-                .font(Typo.body(12))
-                .foregroundColor(Palette.textDim)
-                .multilineTextAlignment(.center)
-                .lineSpacing(3)
-
-            if granted {
-                HStack(spacing: 6) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(Palette.running)
-                    Text("Granted")
+    private func capabilityRow(_ cap: Capability) -> some View {
+        let granted = cap.isGranted
+        return Button {
+            PermissionsAssistantWindowController.shared.show(focus: cap)
+        } label: {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: cap.iconName)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(granted ? Palette.running : Palette.text.opacity(0.85))
+                    .frame(width: 18)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(cap.title)
                         .font(Typo.monoBold(11))
-                        .foregroundColor(Palette.running)
+                        .foregroundColor(Palette.text)
+                    Text(cap.requirementLabel)
+                        .font(Typo.mono(10))
+                        .foregroundColor(Palette.textMuted)
                 }
-            } else {
-                Button(action: action) {
-                    Text("Grant \(title)")
-                        .angularButton(.white, filled: false)
-                }
-                .buttonStyle(.plain)
-
-                Text("macOS may send you to System Settings to finish this step.")
-                    .font(Typo.mono(10))
-                    .foregroundColor(Palette.textMuted)
-                    .multilineTextAlignment(.center)
+                Spacer(minLength: 0)
+                Text(granted ? "ON" : "Set up")
+                    .font(Typo.monoBold(9))
+                    .foregroundColor(granted ? Palette.running : Palette.textDim)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 3)
+                    .background(
+                        Capsule().fill((granted ? Palette.running : Palette.borderLit).opacity(0.12))
+                    )
             }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .contentShape(Rectangle())
+            .background(
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(Color.clear)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 5)
+                            .strokeBorder(Palette.border.opacity(0.6), lineWidth: 0.5)
+                    )
+            )
         }
+        .buttonStyle(.plain)
     }
 
     private func statusRow(_ label: String, granted: Bool, detail: String? = nil) -> some View {
@@ -382,8 +396,6 @@ struct OnboardingView: View {
 
     private var nextLabel: String {
         switch step {
-        case .accessibility where !permChecker.accessibility: return "Continue anyway"
-        case .screenRecording where !permChecker.screenRecording: return "Continue anyway"
         case .projectRoot where prefs.scanRoot.isEmpty: return "Skip for now"
         case .tmux where !tmux.isAvailable: return "Skip"
         default: return "Continue"

--- a/app/Sources/AppShell/PermissionsAssistantView.swift
+++ b/app/Sources/AppShell/PermissionsAssistantView.swift
@@ -1,0 +1,366 @@
+import AppKit
+import SwiftUI
+
+/// Calm, opt-in setup surface for capabilities that require an OS permission.
+/// Never opens automatically — only from explicit entry points
+/// (banner button, onboarding row, Settings, feature gate).
+struct PermissionsAssistantView: View {
+    @ObservedObject private var permChecker = PermissionChecker.shared
+    @ObservedObject private var prefs = Preferences.shared
+    @Binding var selected: Capability
+    var onClose: () -> Void
+
+    var body: some View {
+        HStack(spacing: 0) {
+            sidebar
+                .frame(width: 240, alignment: .top)
+
+            Rectangle()
+                .fill(Palette.border)
+                .frame(width: 0.5)
+                .frame(maxHeight: .infinity)
+
+            detail
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        }
+        .background(PanelBackground())
+        .preferredColorScheme(.dark)
+    }
+
+    // MARK: - Sidebar
+
+    private var sidebar: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("CAPABILITIES")
+                    .font(Typo.pixel(14))
+                    .foregroundColor(Palette.textDim)
+                    .tracking(1)
+                Text("Lattices works with whichever of these you turn on. Nothing here runs unless you press the button.")
+                    .font(Typo.caption(11))
+                    .foregroundColor(Palette.textMuted)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            VStack(spacing: 6) {
+                ForEach(Capability.allCases) { cap in
+                    sidebarRow(cap)
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(16)
+    }
+
+    private func sidebarRow(_ cap: Capability) -> some View {
+        let active = selected == cap
+        let granted = cap.isGranted
+
+        return Button {
+            selected = cap
+        } label: {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: cap.iconName)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(active ? Palette.text : Palette.textMuted)
+                    .frame(width: 16, alignment: .center)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(cap.title)
+                        .font(Typo.mono(11))
+                        .foregroundColor(active ? Palette.text : Palette.textMuted)
+
+                    Text(cap.requirementLabel)
+                        .font(Typo.caption(9.5))
+                        .foregroundColor(Palette.textMuted.opacity(active ? 0.9 : 0.7))
+                        .lineLimit(2)
+                }
+
+                Spacer(minLength: 0)
+
+                statusDot(granted: granted)
+                    .padding(.top, 2)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(active ? Palette.surfaceHov : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func statusDot(granted: Bool) -> some View {
+        Circle()
+            .fill(granted ? Palette.running : Palette.detach)
+            .frame(width: 6, height: 6)
+    }
+
+    // MARK: - Detail
+
+    private var detail: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            hero(selected)
+                .padding(.horizontal, 24)
+                .padding(.top, 22)
+                .padding(.bottom, 16)
+
+            Rectangle().fill(Palette.border).frame(height: 0.5)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    valueCard(selected)
+                    statusCard(selected)
+                    actionsCard(selected)
+
+                    if prefs.isCapabilityDismissed(selected.rawValue) {
+                        Text("You snoozed this earlier. We will not nag — opening this from a feature will surface it again.")
+                            .font(Typo.caption(10))
+                            .foregroundColor(Palette.textMuted)
+                            .padding(.horizontal, 4)
+                    }
+                }
+                .padding(.horizontal, 24)
+                .padding(.vertical, 18)
+            }
+        }
+    }
+
+    private func hero(_ cap: Capability) -> some View {
+        HStack(alignment: .center, spacing: 14) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Palette.surface)
+                    .frame(width: 40, height: 40)
+                Image(systemName: cap.iconName)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(.white.opacity(0.85))
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(cap.title)
+                    .font(Typo.heading(14))
+                    .foregroundColor(Palette.text)
+                Text(cap.requirementLabel)
+                    .font(Typo.mono(10))
+                    .foregroundColor(Palette.textMuted)
+            }
+
+            Spacer()
+
+            buildChannelBadge
+            statusBadge(cap)
+
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundColor(Palette.textMuted)
+                    .frame(width: 22, height: 22)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private func statusBadge(_ cap: Capability) -> some View {
+        let granted = cap.isGranted
+        let label = granted ? "ON" : (prefs.isCapabilityDismissed(cap.rawValue) ? "SNOOZED" : "OFF")
+        let color: Color = granted ? Palette.running : Palette.detach
+
+        return Text(label)
+            .font(Typo.monoBold(9))
+            .foregroundColor(color)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .background(
+                Capsule().fill(color.opacity(0.12))
+            )
+    }
+
+    private var buildChannelBadge: some View {
+        let tint = LatticesRuntime.isDevBuild ? Palette.detach : Palette.running
+
+        return Text(LatticesRuntime.buildChannelLabel)
+            .font(Typo.monoBold(9))
+            .foregroundColor(tint)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .background(
+                Capsule()
+                    .fill(tint.opacity(0.12))
+                    .overlay(
+                        Capsule()
+                            .strokeBorder(tint.opacity(0.28), lineWidth: 0.5)
+                    )
+            )
+    }
+
+    private func valueCard(_ cap: Capability) -> some View {
+        sectionCard(title: "WHAT YOU GET") {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(cap.pitch)
+                    .font(Typo.body(12))
+                    .foregroundColor(Palette.text)
+                    .lineSpacing(3)
+                Text(cap.why)
+                    .font(Typo.caption(10))
+                    .foregroundColor(Palette.textMuted)
+                    .lineSpacing(2)
+            }
+        }
+    }
+
+    private func statusCard(_ cap: Capability) -> some View {
+        sectionCard(title: "STATUS") {
+            HStack(spacing: 8) {
+                Image(systemName: cap.isGranted ? "checkmark.circle.fill" : "exclamationmark.circle")
+                    .font(.system(size: 12))
+                    .foregroundColor(cap.isGranted ? Palette.running : Palette.detach)
+                Text(cap.isGranted ? cap.whenGrantedDetail : "Not enabled. Lattices works without it; the rest of the app stays usable.")
+                    .font(Typo.mono(11))
+                    .foregroundColor(Palette.text)
+                Spacer(minLength: 0)
+            }
+        }
+    }
+
+    private func actionsCard(_ cap: Capability) -> some View {
+        sectionCard(title: "ACTIONS") {
+            VStack(alignment: .leading, spacing: 10) {
+                primaryAction(cap)
+
+                HStack(spacing: 10) {
+                    if !cap.isGranted {
+                        Button {
+                            prefs.dismissCapability(cap.rawValue)
+                        } label: {
+                            Text(prefs.isCapabilityDismissed(cap.rawValue) ? "Snoozed" : "Maybe later")
+                                .font(Typo.monoBold(10))
+                                .foregroundColor(Palette.textMuted)
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 6)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 4)
+                                        .fill(Palette.surface)
+                                        .overlay(
+                                            RoundedRectangle(cornerRadius: 4)
+                                                .strokeBorder(Palette.border, lineWidth: 0.5)
+                                        )
+                                )
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(prefs.isCapabilityDismissed(cap.rawValue))
+                    }
+
+                    Button {
+                        openSystemSettings(cap)
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "arrow.up.forward.app")
+                                .font(.system(size: 9))
+                            Text("Open System Settings")
+                                .font(Typo.monoBold(10))
+                        }
+                        .foregroundColor(Palette.textMuted)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(
+                            RoundedRectangle(cornerRadius: 4)
+                                .fill(Palette.surface)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 4)
+                                        .strokeBorder(Palette.border, lineWidth: 0.5)
+                                )
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                Text(actionFootnote(cap))
+                    .font(Typo.caption(9.5))
+                    .foregroundColor(Palette.textMuted)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func primaryAction(_ cap: Capability) -> some View {
+        if cap.isGranted {
+            HStack(spacing: 6) {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundColor(Palette.running)
+                Text("Enabled")
+                    .font(Typo.monoBold(11))
+                    .foregroundColor(Palette.running)
+            }
+            .padding(.vertical, 4)
+        } else {
+            Button {
+                triggerPrimary(cap)
+            } label: {
+                Text(primaryLabel(cap))
+                    .angularButton(.white, filled: false)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private func primaryLabel(_ cap: Capability) -> String {
+        switch cap {
+        case .windowControl: return "Request Accessibility"
+        case .screenSearch:  return "Enable OCR"
+        }
+    }
+
+    private func actionFootnote(_ cap: Capability) -> String {
+        switch cap {
+        case .windowControl:
+            return "macOS will add Lattices to its Accessibility list. You finish the toggle in System Settings."
+        case .screenSearch:
+            return "Enabling this turns on OCR and asks macOS for Screen Recording on this Mac."
+        }
+    }
+
+    private func triggerPrimary(_ cap: Capability) {
+        // The primary action is the explicit user gesture — clear any prior snooze.
+        prefs.clearDismissal(cap.rawValue)
+
+        switch cap {
+        case .windowControl:
+            permChecker.requestAccessibility()
+        case .screenSearch:
+            // Turning on OCR is the moment we ask for Screen Recording.
+            OcrModel.shared.setEnabled(true)
+        }
+    }
+
+    private func openSystemSettings(_ cap: Capability) {
+        switch cap {
+        case .windowControl: permChecker.openAccessibilitySettings()
+        case .screenSearch:  permChecker.openScreenRecordingSettings()
+        }
+    }
+
+    // MARK: - Section card
+
+    private func sectionCard<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(Typo.pixel(11))
+                .foregroundColor(Palette.textDim)
+                .tracking(1)
+            content()
+                .padding(12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(Palette.surface)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .strokeBorder(Palette.border, lineWidth: 0.5)
+                        )
+                )
+        }
+    }
+}

--- a/app/Sources/AppShell/PermissionsAssistantWindow.swift
+++ b/app/Sources/AppShell/PermissionsAssistantWindow.swift
@@ -1,0 +1,70 @@
+import AppKit
+import SwiftUI
+
+/// Dedicated window that hosts the Permissions Assistant. Singleton, opened
+/// only on explicit user intent (banner button, onboarding row, Settings,
+/// feature gate). Never shown automatically on app launch.
+final class PermissionsAssistantWindowController: ObservableObject {
+    static let shared = PermissionsAssistantWindowController()
+
+    private var window: NSWindow?
+    @Published private(set) var focusedCapability: Capability = .windowControl
+
+    var isVisible: Bool { window?.isVisible ?? false }
+
+    /// Open the assistant focused on the given capability. If `cap` is nil,
+    /// the first missing capability is selected, falling back to `windowControl`.
+    func show(focus cap: Capability? = nil) {
+        let target = cap ?? Capability.missing.first ?? .windowControl
+        focusedCapability = target
+
+        if let existing = window {
+            existing.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        let host = HostView(controller: self)
+
+        let w = AppWindowShell.makeWindow(
+            config: .init(
+                title: "Lattices Permissions",
+                titleVisible: false,
+                initialSize: NSSize(width: 720, height: 520),
+                minSize: NSSize(width: 640, height: 460),
+                maxSize: NSSize(width: 1100, height: 800)
+            ),
+            rootView: host
+        )
+        AppWindowShell.positionCentered(w)
+        AppWindowShell.present(w)
+        self.window = w
+    }
+
+    func close() {
+        window?.orderOut(nil)
+        window = nil
+        AppDelegate.updateActivationPolicy()
+    }
+
+    fileprivate func selectionBinding() -> Binding<Capability> {
+        Binding(
+            get: { self.focusedCapability },
+            set: { self.focusedCapability = $0 }
+        )
+    }
+}
+
+// SwiftUI host that observes the controller so the assistant updates when
+// `focusedCapability` is reassigned by an external caller (e.g. clicking a
+// different feature gate while the window is already open).
+private struct HostView: View {
+    @ObservedObject var controller: PermissionsAssistantWindowController
+
+    var body: some View {
+        PermissionsAssistantView(
+            selected: controller.selectionBinding(),
+            onClose: { controller.close() }
+        )
+    }
+}

--- a/app/Sources/AppShell/Preferences.swift
+++ b/app/Sources/AppShell/Preferences.swift
@@ -15,6 +15,8 @@ class Preferences: ObservableObject {
         static let cockpitLayout = "companion.cockpit.layout"
     }
 
+    private static let dismissedCapabilitiesKey = "permissions.dismissed"
+
     @Published var terminal: Terminal {
         didSet { UserDefaults.standard.set(terminal.rawValue, forKey: "terminal") }
     }
@@ -140,6 +142,30 @@ class Preferences: ObservableObject {
         didSet { UserDefaults.standard.set(ocrAccuracy, forKey: "ocr.accuracy") }
     }
 
+    // MARK: - Permissions Assistant
+
+    /// Capabilities the user has explicitly snoozed. Cleared per-capability when
+    /// the user re-enters the relevant feature. Persisted as raw values.
+    @Published var dismissedCapabilities: Set<String> {
+        didSet {
+            UserDefaults.standard.set(Array(dismissedCapabilities), forKey: Self.dismissedCapabilitiesKey)
+        }
+    }
+
+    func dismissCapability(_ rawValue: String) {
+        dismissedCapabilities.insert(rawValue)
+    }
+
+    func clearDismissal(_ rawValue: String) {
+        if dismissedCapabilities.contains(rawValue) {
+            dismissedCapabilities.remove(rawValue)
+        }
+    }
+
+    func isCapabilityDismissed(_ rawValue: String) -> Bool {
+        dismissedCapabilities.contains(rawValue)
+    }
+
     init() {
         if let saved = UserDefaults.standard.string(forKey: "terminal"),
            let t = Terminal(rawValue: saved), t.isInstalled {
@@ -201,8 +227,14 @@ class Preferences: ObservableObject {
         let savedBudgetUSD = UserDefaults.standard.double(forKey: "claude.advisorBudget")
         self.advisorBudgetUSD = savedBudgetUSD > 0 ? savedBudgetUSD : 0.50
 
-        // Search & OCR
-        self.ocrEnabled = !UserDefaults.standard.bool(forKey: "ocr.disabled")
+        // Search & OCR. Default off until the user explicitly enables it from
+        // the Permissions Assistant or Search settings. Honors any explicit
+        // ocr.disabled value already saved (true=off, false=on).
+        if UserDefaults.standard.object(forKey: "ocr.disabled") != nil {
+            self.ocrEnabled = !UserDefaults.standard.bool(forKey: "ocr.disabled")
+        } else {
+            self.ocrEnabled = false
+        }
 
         let savedInterval = UserDefaults.standard.double(forKey: "ocr.interval")
         self.ocrQuickInterval = savedInterval > 0 ? savedInterval : 60
@@ -221,6 +253,9 @@ class Preferences: ObservableObject {
 
         let savedAcc = UserDefaults.standard.string(forKey: "ocr.accuracy") ?? "accurate"
         self.ocrAccuracy = savedAcc
+
+        let dismissed = UserDefaults.standard.stringArray(forKey: Self.dismissedCapabilitiesKey) ?? []
+        self.dismissedCapabilities = Set(dismissed)
     }
 
     func updateCompanionCockpitSlot(

--- a/app/Sources/AppShell/SettingsView.swift
+++ b/app/Sources/AppShell/SettingsView.swift
@@ -291,9 +291,70 @@ struct SettingsContentView: View {
 
     // MARK: - General
 
+    private var permissionsAssistantCard: some View {
+        let missing = Capability.allCases.filter { !$0.isGranted }
+        return settingsCard {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .center, spacing: 8) {
+                    Image(systemName: "slider.horizontal.3")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(missing.isEmpty ? Palette.running : Palette.detach)
+                    Text("Permissions")
+                        .font(Typo.mono(12))
+                        .foregroundColor(Palette.text)
+                    Spacer()
+                    Text(missing.isEmpty ? "All on" : "\(missing.count) off")
+                        .font(Typo.caption(10))
+                        .foregroundColor(missing.isEmpty ? Palette.running : Palette.detach)
+                }
+
+                Text("The Permissions Assistant introduces each capability before any macOS prompt. Open it any time to review status or enable something new.")
+                    .font(Typo.caption(10))
+                    .foregroundColor(Palette.textMuted)
+
+                HStack(spacing: 8) {
+                    ForEach(Capability.allCases) { cap in
+                        HStack(spacing: 4) {
+                            Circle()
+                                .fill(cap.isGranted ? Palette.running : Palette.detach)
+                                .frame(width: 5, height: 5)
+                            Text(cap.title)
+                                .font(Typo.mono(9))
+                                .foregroundColor(Palette.textMuted)
+                        }
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(
+                            Capsule().fill(Palette.surface)
+                        )
+                    }
+                    Spacer(minLength: 0)
+                }
+
+                Button {
+                    PermissionsAssistantWindowController.shared.show(focus: missing.first)
+                } label: {
+                    Text(missing.isEmpty ? "Open Permissions Assistant" : "Set up permissions")
+                        .font(Typo.monoBold(10))
+                        .foregroundColor(Palette.text)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 5)
+                        .background(
+                            RoundedRectangle(cornerRadius: 4)
+                                .fill(Palette.surfaceHov)
+                                .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.borderLit, lineWidth: 0.5))
+                        )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
     private var generalContent: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
+                permissionsAssistantCard
+
                 settingsCard {
                     VStack(alignment: .leading, spacing: 10) {
                         HStack(alignment: .center, spacing: 8) {
@@ -303,6 +364,7 @@ struct SettingsContentView: View {
                             Text("Lattices app")
                                 .font(Typo.mono(12))
                                 .foregroundColor(Palette.text)
+                            buildChannelBadge
                             Spacer()
                             Text("Current \(appUpdater.currentDisplayVersion)")
                                 .font(Typo.caption(10))
@@ -1307,6 +1369,20 @@ struct SettingsContentView: View {
             }
             .padding(16)
         }
+    }
+
+    private var buildChannelBadge: some View {
+        let tint = LatticesRuntime.isDevBuild ? Palette.detach : Palette.running
+
+        return Text(LatticesRuntime.buildChannelLabel)
+            .font(Typo.monoBold(9))
+            .foregroundColor(tint)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .background(
+                Capsule()
+                    .fill(tint.opacity(0.12))
+            )
     }
 
     // MARK: - Search & OCR

--- a/app/Sources/Core/Desktop/OcrModel.swift
+++ b/app/Sources/Core/Desktop/OcrModel.swift
@@ -86,9 +86,15 @@ final class OcrModel: ObservableObject {
     func setEnabled(_ on: Bool) {
         enabled = on
         prefs.ocrEnabled = on
-        if on && timer == nil {
-            start()
-        } else if !on {
+        if on {
+            // User intentionally turning on OCR clears any prior snooze and is
+            // the moment we ask macOS for Screen Recording.
+            prefs.clearDismissal(Capability.screenSearch.rawValue)
+            if timer == nil {
+                PermissionChecker.shared.requestScreenRecording()
+                start()
+            }
+        } else {
             stop()
         }
     }

--- a/app/Sources/Core/Pi/PiChatSession.swift
+++ b/app/Sources/Core/Pi/PiChatSession.swift
@@ -370,7 +370,6 @@ final class PiChatSession: ObservableObject {
             isAuthPanelVisible = true
             statusText = "connecting..."
         } else if needsProviderSetup {
-            isAuthPanelVisible = true
             statusText = "setup ai"
         } else if hasPiBinary && (statusText == "setup ai" || statusText == "missing pi") {
             statusText = "idle"
@@ -437,6 +436,8 @@ final class PiChatSession: ObservableObject {
 
         guard !needsProviderSetup else {
             prepareForDisplay()
+            isAuthPanelVisible = true
+            dockHeight = max(dockHeight, 300)
             return
         }
 

--- a/app/Sources/Core/Pi/PiProviderSetupCallout.swift
+++ b/app/Sources/Core/Pi/PiProviderSetupCallout.swift
@@ -18,7 +18,7 @@ struct PiProviderSetupCallout: View {
 
             Text(session.isAuthenticating
                 ? "Finish the setup above. As soon as that one step is done, the chat box unlocks."
-                : "Next step: connect \(session.currentProvider.name). You only have to do this once.")
+                : "Chat is optional. Connect \(session.currentProvider.name) when you want the in-app assistant.")
                 .font(Typo.mono(compact ? 10 : 11))
                 .foregroundColor(Palette.textDim)
                 .fixedSize(horizontal: false, vertical: true)
@@ -32,18 +32,18 @@ struct PiProviderSetupCallout: View {
                 PiAuthNextStepCard(session: session, compact: compact)
             } else {
                 Text(session.currentProvider.authMode == .oauth
-                    ? "The setup panel above is already open, so you can connect right now."
-                    : "Paste your key in the setup panel above, save it once, and you are done.")
+                    ? "This opens the provider flow in your browser."
+                    : "Open setup when you are ready to paste and save a key.")
                     .font(Typo.mono(compact ? 9 : 10))
                     .foregroundColor(Palette.textMuted)
             }
 
             if session.currentProvider.authMode == .oauth && !session.isAuthenticating {
                 primaryActionButton(
-                    "CONNECT \(session.currentProvider.name.uppercased())",
+                    "SET UP \(session.currentProvider.name.uppercased())",
                     tint: Palette.running
                 ) {
-                    session.startSelectedAuthFlow()
+                    session.toggleAuthPanel()
                 }
             }
         }

--- a/app/Sources/Core/System/Capability.swift
+++ b/app/Sources/Core/System/Capability.swift
@@ -1,0 +1,79 @@
+import AppKit
+import Foundation
+
+/// An OS permission Lattices can ask for. The Permissions Assistant introduces
+/// these and only requests the underlying grant when the user explicitly opts
+/// in. Product configuration like Pi/provider auth is intentionally excluded —
+/// that lives in the Chat/Pi surface, not here.
+enum Capability: String, CaseIterable, Identifiable {
+    case windowControl   // macOS Accessibility — tiling, focus, snap
+    case screenSearch    // macOS Screen Recording — OCR / on-screen text search
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .windowControl: return "Tiling & focus"
+        case .screenSearch:  return "Screen text search"
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .windowControl: return "rectangle.3.group"
+        case .screenSearch:  return "text.viewfinder"
+        }
+    }
+
+    var requirementLabel: String {
+        switch self {
+        case .windowControl: return "Accessibility"
+        case .screenSearch:  return "Screen & System Audio Recording"
+        }
+    }
+
+    var pitch: String {
+        switch self {
+        case .windowControl:
+            return "Move, resize, snap, and arrange windows from the menu bar, command palette, and gestures."
+        case .screenSearch:
+            return "Index on-screen text with OCR so the omni search can jump to any window by what it shows."
+        }
+    }
+
+    var why: String {
+        switch self {
+        case .windowControl:
+            return "macOS Accessibility lets Lattices read window titles and move or resize windows. No keystrokes are recorded."
+        case .screenSearch:
+            return "Screen Recording lets Lattices read pixels to OCR what is on-screen. Captures stay on this Mac."
+        }
+    }
+
+    /// Optional one-liner shown when the capability is on, summarising current behavior.
+    var whenGrantedDetail: String {
+        switch self {
+        case .windowControl: return "Lattices can move and tile windows."
+        case .screenSearch:  return "OCR can index visible windows for omni search."
+        }
+    }
+
+    /// Live status — read directly from the system, never cached.
+    var isGranted: Bool {
+        switch self {
+        case .windowControl: return PermissionChecker.shared.accessibility
+        case .screenSearch:  return PermissionChecker.shared.screenRecording
+        }
+    }
+
+    /// All capabilities that are not yet granted.
+    static var missing: [Capability] {
+        Capability.allCases.filter { !$0.isGranted }
+    }
+
+    /// Capabilities that are missing AND have not been dismissed-for-now.
+    static var visiblyMissing: [Capability] {
+        let dismissed = Preferences.shared.dismissedCapabilities
+        return missing.filter { !dismissed.contains($0.rawValue) }
+    }
+}

--- a/app/Sources/Core/System/PermissionChecker.swift
+++ b/app/Sources/Core/System/PermissionChecker.swift
@@ -14,12 +14,20 @@ final class PermissionChecker: ObservableObject {
 
     var allGranted: Bool { accessibility && screenRecording }
 
+    var isSimulatingMissingPermissions: Bool {
+        CommandLine.arguments.contains("--simulate-missing-permissions")
+            || UserDefaults.standard.bool(forKey: "permissions.simulateMissing")
+    }
+
     /// Check current permission state without prompting.
-    func check() {
+    func check(pollIfMissing: Bool = false) {
         let diag = DiagnosticLog.shared
 
-        let ax = AXIsProcessTrusted()
-        let sr = CGPreflightScreenCaptureAccess()
+        let realAX = AXIsProcessTrusted()
+        let realSR = CGPreflightScreenCaptureAccess()
+        let simulating = isSimulatingMissingPermissions
+        let ax = simulating ? false : realAX
+        let sr = simulating ? false : realSR
 
         // First check: log identity info only
         if !hasLoggedInitial {
@@ -29,8 +37,11 @@ final class PermissionChecker: ObservableObject {
             let pid = ProcessInfo.processInfo.processIdentifier
             diag.info("PermissionChecker: bundleId=\(bundleId) pid=\(pid)")
             diag.info("PermissionChecker: exec=\(execPath)")
-            diag.info("AXIsProcessTrusted() → \(ax)")
-            diag.info("CGPreflightScreenCaptureAccess() → \(sr)")
+            diag.info("AXIsProcessTrusted() → \(realAX)")
+            diag.info("CGPreflightScreenCaptureAccess() → \(realSR)")
+            if simulating {
+                diag.warn("PermissionChecker: simulating missing permissions for UX preview")
+            }
         }
 
         // Log on state changes
@@ -41,11 +52,11 @@ final class PermissionChecker: ObservableObject {
         accessibility = ax
         screenRecording = sr
 
-        // If not all granted, start polling so we detect changes while user is in Settings.
-        // Once all granted, stop polling.
+        // Only poll after an intentional permission request. A passive launch-time
+        // check should not keep nudging macOS privacy state in the background.
         if allGranted {
             stopPolling()
-        } else {
+        } else if pollIfMissing {
             startPolling()
         }
     }
@@ -54,6 +65,11 @@ final class PermissionChecker: ObservableObject {
     /// which adds lattices to the Accessibility list and asks the user to toggle it on.
     func requestAccessibility() {
         let diag = DiagnosticLog.shared
+        if isSimulatingMissingPermissions {
+            diag.warn("requestAccessibility: skipped because missing-permission simulation is enabled")
+            accessibility = false
+            return
+        }
         let beforeCheck = AXIsProcessTrusted()
         diag.info("requestAccessibility: before=\(beforeCheck), prompting…")
         let opts = [kAXTrustedCheckOptionPrompt.takeUnretainedValue(): true] as CFDictionary
@@ -71,6 +87,11 @@ final class PermissionChecker: ObservableObject {
     /// which adds lattices to the Screen Recording list. The user toggles it on in Settings.
     func requestScreenRecording() {
         let diag = DiagnosticLog.shared
+        if isSimulatingMissingPermissions {
+            diag.warn("requestScreenRecording: skipped because missing-permission simulation is enabled")
+            screenRecording = false
+            return
+        }
         let beforeCheck = CGPreflightScreenCaptureAccess()
         diag.info("requestScreenRecording: before=\(beforeCheck), probing…")
 


### PR DESCRIPTION
## Summary
This PR replaces passive launch-time permission nudges with an explicit, feature-based Permissions Assistant. Lattices now explains each optional OS capability before asking macOS for access, and the app remains useful when a user chooses not to enable a capability.

## What changed
- Added a `Capability` model for OS-level permissions Lattices can request today: window control via Accessibility, and screen text search via Screen Recording.
- Added a dedicated Permissions Assistant window with focused capability details, status, primary setup actions, System Settings shortcuts, and per-capability snoozing.
- Reworked onboarding so first launch introduces optional capabilities without automatically requesting permissions.
- Added entry points from the main panel banner, onboarding rows, Settings, feature pages, and a `--permissions-assistant` launch flag.
- Made OCR opt-in by default; enabling Screen Text Recognition is now the explicit moment that requests Screen Recording.
- Updated permission checking so passive checks do not prompt, polling only starts after an intentional request, and macOS 15+ screen capture probing uses ScreenCaptureKit before falling back to System Settings.
- Added missing-permission simulation for dev/demo flows plus build-channel badges so dev/prod permission surfaces are easier to identify.
- Updated the dev app bundle metadata/signing flow so rebuilt local app bundles keep a stable TCC identity.

## Product behavior
- Lattices can launch projects and show the core workspace UI without Accessibility or Screen Recording.
- Users can snooze missing capabilities; returning to a relevant feature clears that snooze so the setup path can resurface at the right time.
- Permission requests happen only after an explicit user action such as “Request Accessibility” or enabling OCR.
- Product setup such as Pi/provider configuration stays outside the OS permissions assistant.

## Verification
- `swift build`
- `swift test`
- GitHub Actions: Swift Build passed
- Rebuilt and relaunched the app in simulated missing-permissions preview mode
