### PR TITLE
⚡️🛡️ Move input event taps off main + self-healing breaker + measurement

### DIFF
--- a/app/Sources/AppShell/SettingsView.swift
+++ b/app/Sources/AppShell/SettingsView.swift
@@ -68,6 +68,8 @@ struct SettingsContentView: View {
     @ObservedObject var mouseShortcutStore: MouseShortcutStore = .shared
     @ObservedObject var keyboardRemapStore: KeyboardRemapStore = .shared
     @ObservedObject var permChecker: PermissionChecker = .shared
+    @ObservedObject var mouseGestureController: MouseGestureController = .shared
+    @ObservedObject var keyboardRemapController: KeyboardRemapController = .shared
     var onBack: (() -> Void)? = nil
 
     @State private var selectedTab: SettingsSection = .general
@@ -768,6 +770,13 @@ struct SettingsContentView: View {
                             }
                         }
 
+                        breakerStatusRow(
+                            state: mouseGestureController.breakerState,
+                            label: "Mouse gestures"
+                        ) {
+                            mouseGestureController.reArmAfterBreakerTrip()
+                        }
+
                         HStack(spacing: 8) {
                             Button {
                                 mouseShortcutStore.openConfiguration()
@@ -863,6 +872,13 @@ struct SettingsContentView: View {
                                     .font(Typo.caption(9))
                                     .foregroundColor(Palette.textMuted.opacity(0.6))
                             }
+                        }
+
+                        breakerStatusRow(
+                            state: keyboardRemapController.breakerState,
+                            label: "Keyboard remaps"
+                        ) {
+                            keyboardRemapController.reArmAfterBreakerTrip()
                         }
 
                         HStack(spacing: 8) {
@@ -1938,6 +1954,53 @@ struct SettingsContentView: View {
                         .strokeBorder(status == "not set" ? Palette.detach.opacity(0.22) : Palette.borderLit.opacity(0.6), lineWidth: 0.5)
                 )
         )
+    }
+
+    @ViewBuilder
+    private func breakerStatusRow(
+        state: EventTapBreaker.State,
+        label: String,
+        onReArm: @escaping () -> Void
+    ) -> some View {
+        switch state {
+        case .armed:
+            EmptyView()
+        case .paused(let cooldownSec):
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(Color.orange)
+                    .frame(width: 6, height: 6)
+                Text("\(label) paused — \(cooldownSec)s cooldown")
+                    .font(Typo.caption(9))
+                    .foregroundColor(Palette.textMuted)
+                Spacer()
+            }
+        case .disabled:
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(Color.red)
+                    .frame(width: 6, height: 6)
+                Text("\(label) disabled — tap callback exceeded OS budget repeatedly")
+                    .font(Typo.caption(9))
+                    .foregroundColor(Palette.textMuted)
+                Spacer()
+                Button {
+                    onReArm()
+                } label: {
+                    Text("Re-enable")
+                        .font(Typo.monoBold(10))
+                        .foregroundColor(Palette.text)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 3)
+                        .background(
+                            RoundedRectangle(cornerRadius: 4)
+                                .fill(Palette.surfaceHov)
+                                .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.borderLit, lineWidth: 0.5))
+                        )
+                }
+                .buttonStyle(.plain)
+            }
+        }
     }
 
     // MARK: - Shortcuts

--- a/app/Sources/Core/Input/EventTapBreaker.swift
+++ b/app/Sources/Core/Input/EventTapBreaker.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Self-healing circuit breaker for session-wide `CGEventTap`s.
+///
+/// macOS disables a tap (`tapDisabledByTimeout`) when its callback exceeds
+/// the OS budget. The naive recovery — re-enable and continue — fights the
+/// OS in a loop when the underlying cause is still present, and the system
+/// input pipeline keeps stuttering.
+///
+/// This breaker counts trips inside a rolling window and backs off in
+/// escalating cooldowns: 30s → 2 min → permanent (until app restart).
+/// During cooldown the tap stays disabled — input flows through the OS
+/// without our interference. On cooldown expiry, `rearm` fires on the main
+/// queue to re-enable the tap.
+///
+/// Thread-safe; `recordTrip()` is safe to call from the event-tap thread.
+final class EventTapBreaker {
+    private let label: String
+    private let trippedWindow: TimeInterval = 600          // 10 min
+    private let cooldowns: [TimeInterval] = [30, 120]      // trip 1 → 30s, trip 2 → 2 min, trip 3+ → permanent
+
+    private let lock = NSLock()
+    private var tripsInWindow: [Date] = []
+    private var permanentlyDisabled = false
+    private var pendingRearm: DispatchWorkItem?
+
+    /// Called on the main queue when a cooldown elapses. Caller wires this
+    /// to `CGEvent.tapEnable(tap:, enable: true)`.
+    var rearm: (() -> Void)?
+
+    init(label: String) {
+        self.label = label
+    }
+
+    /// Record that the OS just delivered `.tapDisabledByTimeout`. Schedules
+    /// a re-enable after the appropriate cooldown, or marks the breaker
+    /// permanently open after too many trips.
+    ///
+    /// Returns `true` if the caller should re-enable the tap immediately
+    /// (always `false` once we're on a cooldown path — keeping it false
+    /// is what stops the re-enable loop).
+    @discardableResult
+    func recordTrip() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if permanentlyDisabled { return false }
+
+        let now = Date()
+        tripsInWindow.removeAll { now.timeIntervalSince($0) > trippedWindow }
+        tripsInWindow.append(now)
+
+        let count = tripsInWindow.count
+        if count > cooldowns.count {
+            permanentlyDisabled = true
+            pendingRearm?.cancel()
+            pendingRearm = nil
+            DiagnosticLog.shared.error("\(label): tap tripped \(count)× in \(Int(trippedWindow))s — disabled until app restart")
+            return false
+        }
+
+        let cooldown = cooldowns[count - 1]
+        DiagnosticLog.shared.warn("\(label): tap disabled by OS (trip #\(count)) — paused for \(Int(cooldown))s")
+
+        pendingRearm?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            DiagnosticLog.shared.info("\(self.label): tap auto-recovering")
+            self.rearm?()
+        }
+        pendingRearm = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + cooldown, execute: work)
+        return false
+    }
+
+    var isPermanentlyDisabled: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return permanentlyDisabled
+    }
+}

--- a/app/Sources/Core/Input/EventTapBreaker.swift
+++ b/app/Sources/Core/Input/EventTapBreaker.swift
@@ -8,43 +8,53 @@ import Foundation
 /// input pipeline keeps stuttering.
 ///
 /// This breaker counts trips inside a rolling window and backs off in
-/// escalating cooldowns: 30s → 2 min → permanent (until app restart).
-/// During cooldown the tap stays disabled — input flows through the OS
-/// without our interference. On cooldown expiry, `rearm` fires on the main
-/// queue to re-enable the tap.
+/// escalating cooldowns: 30s → 2 min → permanent (until app restart or
+/// manual re-arm). During cooldown the tap stays disabled — input flows
+/// through the OS without our interference. On cooldown expiry, `rearm`
+/// fires on the main queue to re-enable the tap.
 ///
 /// Thread-safe; `recordTrip()` is safe to call from the event-tap thread.
 final class EventTapBreaker {
+    enum State: Equatable {
+        case armed
+        case paused(cooldownSec: Int)
+        case disabled
+    }
+
     private let label: String
-    private let trippedWindow: TimeInterval = 600          // 10 min
+    private let trippedWindow: TimeInterval = 600          // 10 min rolling window
     private let cooldowns: [TimeInterval] = [30, 120]      // trip 1 → 30s, trip 2 → 2 min, trip 3+ → permanent
 
     private let lock = NSLock()
     private var tripsInWindow: [Date] = []
     private var permanentlyDisabled = false
     private var pendingRearm: DispatchWorkItem?
+    private var _state: State = .armed
 
     /// Called on the main queue when a cooldown elapses. Caller wires this
     /// to `CGEvent.tapEnable(tap:, enable: true)`.
     var rearm: (() -> Void)?
 
+    /// Called on the main queue whenever `state` transitions. UI uses this
+    /// to surface "paused" / "disabled" messages and re-enable affordances.
+    var onStateChanged: ((State) -> Void)?
+
     init(label: String) {
         self.label = label
+    }
+
+    var state: State {
+        lock.lock(); defer { lock.unlock() }
+        return _state
     }
 
     /// Record that the OS just delivered `.tapDisabledByTimeout`. Schedules
     /// a re-enable after the appropriate cooldown, or marks the breaker
     /// permanently open after too many trips.
-    ///
-    /// Returns `true` if the caller should re-enable the tap immediately
-    /// (always `false` once we're on a cooldown path — keeping it false
-    /// is what stops the re-enable loop).
     @discardableResult
     func recordTrip() -> Bool {
         lock.lock()
-        defer { lock.unlock() }
-
-        if permanentlyDisabled { return false }
+        if permanentlyDisabled { lock.unlock(); return false }
 
         let now = Date()
         tripsInWindow.removeAll { now.timeIntervalSince($0) > trippedWindow }
@@ -55,26 +65,60 @@ final class EventTapBreaker {
             permanentlyDisabled = true
             pendingRearm?.cancel()
             pendingRearm = nil
-            DiagnosticLog.shared.error("\(label): tap tripped \(count)× in \(Int(trippedWindow))s — disabled until app restart")
+            _state = .disabled
+            lock.unlock()
+            DiagnosticLog.shared.error("\(label): tap tripped \(count)× in \(Int(trippedWindow))s — disabled until app restart or manual re-arm")
+            notifyStateChanged(.disabled)
             return false
         }
 
         let cooldown = cooldowns[count - 1]
-        DiagnosticLog.shared.warn("\(label): tap disabled by OS (trip #\(count)) — paused for \(Int(cooldown))s")
+        _state = .paused(cooldownSec: Int(cooldown))
+        let nextState: State = .paused(cooldownSec: Int(cooldown))
 
         pendingRearm?.cancel()
         let work = DispatchWorkItem { [weak self] in
             guard let self else { return }
             DiagnosticLog.shared.info("\(self.label): tap auto-recovering")
+            self.lock.lock()
+            self._state = .armed
+            self.lock.unlock()
+            self.notifyStateChanged(.armed)
             self.rearm?()
         }
         pendingRearm = work
+        lock.unlock()
+
+        DiagnosticLog.shared.warn("\(label): tap disabled by OS (trip #\(count)) — paused for \(Int(cooldown))s")
+        notifyStateChanged(nextState)
         DispatchQueue.main.asyncAfter(deadline: .now() + cooldown, execute: work)
         return false
     }
 
-    var isPermanentlyDisabled: Bool {
-        lock.lock(); defer { lock.unlock() }
-        return permanentlyDisabled
+    /// Clears all trip history and any pending cooldown. Caller should
+    /// re-enable the tap after this to actually recover.
+    /// Use cases: tap (re)install, manual re-arm from Settings.
+    func reset() {
+        lock.lock()
+        let wasNotArmed = _state != .armed
+        pendingRearm?.cancel()
+        pendingRearm = nil
+        tripsInWindow.removeAll()
+        permanentlyDisabled = false
+        _state = .armed
+        lock.unlock()
+        if wasNotArmed {
+            DiagnosticLog.shared.info("\(label): tap state reset (armed)")
+            notifyStateChanged(.armed)
+        }
+    }
+
+    private func notifyStateChanged(_ newState: State) {
+        guard let callback = onStateChanged else { return }
+        if Thread.isMainThread {
+            callback(newState)
+        } else {
+            DispatchQueue.main.async { callback(newState) }
+        }
     }
 }

--- a/app/Sources/Core/Input/EventTapThread.swift
+++ b/app/Sources/Core/Input/EventTapThread.swift
@@ -1,0 +1,54 @@
+import Foundation
+import CoreFoundation
+
+/// Hosts a long-lived thread + CFRunLoop dedicated to CGEventTap callbacks,
+/// so taps installed at `.headInsertEventTap` don't add main-thread latency
+/// to every keyboard/mouse event in the user's session.
+///
+/// Callbacks fire on this thread — callers must hop AppKit/UI work back to
+/// main themselves (DispatchQueue.main.async).
+final class EventTapThread {
+    static let shared = EventTapThread()
+
+    private let lock = NSLock()
+    private var runLoop: CFRunLoop?
+
+    private init() {
+        let ready = DispatchSemaphore(value: 0)
+        let thread = Thread { [unowned self] in
+            let loop = CFRunLoopGetCurrent()
+            // Keep the run loop alive across add/remove cycles by anchoring a
+            // no-op port; otherwise CFRunLoopRun() returns when the last
+            // source is removed.
+            let keepalive = NSMachPort()
+            RunLoop.current.add(keepalive, forMode: .common)
+            self.lock.lock()
+            self.runLoop = loop
+            self.lock.unlock()
+            ready.signal()
+            CFRunLoopRun()
+        }
+        thread.qualityOfService = .userInteractive
+        thread.name = "com.arach.lattices.EventTapThread"
+        thread.start()
+        ready.wait()
+    }
+
+    func add(source: CFRunLoopSource) {
+        lock.lock()
+        let loop = runLoop
+        lock.unlock()
+        guard let loop else { return }
+        CFRunLoopAddSource(loop, source, .commonModes)
+        CFRunLoopWakeUp(loop)
+    }
+
+    func remove(source: CFRunLoopSource) {
+        lock.lock()
+        let loop = runLoop
+        lock.unlock()
+        guard let loop else { return }
+        CFRunLoopRemoveSource(loop, source, .commonModes)
+        CFRunLoopWakeUp(loop)
+    }
+}

--- a/app/Sources/Core/Input/KeyboardRemapController.swift
+++ b/app/Sources/Core/Input/KeyboardRemapController.swift
@@ -2,8 +2,12 @@ import AppKit
 import Combine
 import CoreGraphics
 
-final class KeyboardRemapController {
+final class KeyboardRemapController: ObservableObject {
     static let shared = KeyboardRemapController()
+
+    /// Live state of the event-tap circuit breaker. SettingsView observes
+    /// this to surface "paused" / "disabled" status and a re-arm button.
+    @Published private(set) var breakerState: EventTapBreaker.State = .armed
 
     private static let syntheticMarker: Int64 = 0x4C4B524D
 
@@ -14,8 +18,24 @@ final class KeyboardRemapController {
     private var capsLayerActive = false
     private var capsUsedAsModifier = false
     private let breaker = EventTapBreaker(label: "KeyboardRemap")
+    private let budgetMeter = TapBudgetMeter(label: "KeyboardRemap")
 
-    private init() {}
+    private init() {
+        breaker.onStateChanged = { [weak self] newState in
+            self?.breakerState = newState
+        }
+    }
+
+    /// Re-enable the tap after a breaker trip, clearing trip history.
+    /// Settings UI calls this when the user explicitly chooses to recover
+    /// from a `disabled` state.
+    func reArmAfterBreakerTrip() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        breaker.reset()
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: true)
+        }
+    }
 
     func start() {
         installObserversIfNeeded()
@@ -59,6 +79,10 @@ final class KeyboardRemapController {
     }
 
     private func installEventTap() {
+        // Fresh install is a clean slate — drop any stale trip history so
+        // the new tap's first failure is judged on its own merits.
+        breaker.reset()
+
         var mask = CGEventMask(0)
         mask |= CGEventMask(1) << CGEventType.keyDown.rawValue
         mask |= CGEventMask(1) << CGEventType.keyUp.rawValue
@@ -111,6 +135,12 @@ final class KeyboardRemapController {
     }
 
     private func handleEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        let started = CFAbsoluteTimeGetCurrent()
+        defer {
+            let elapsedMs = (CFAbsoluteTimeGetCurrent() - started) * 1000
+            budgetMeter.record(durationMs: elapsedMs)
+        }
+
         if type == .tapDisabledByTimeout {
             // OS killed the tap because a callback was too slow. Run through
             // the breaker — it backs off in escalating cooldowns rather than

--- a/app/Sources/Core/Input/KeyboardRemapController.swift
+++ b/app/Sources/Core/Input/KeyboardRemapController.swift
@@ -13,6 +13,7 @@ final class KeyboardRemapController {
     private var installedObservers = false
     private var capsLayerActive = false
     private var capsUsedAsModifier = false
+    private let breaker = EventTapBreaker(label: "KeyboardRemap")
 
     private init() {}
 
@@ -85,6 +86,10 @@ final class KeyboardRemapController {
             EventTapThread.shared.add(source: source)
         }
         CGEvent.tapEnable(tap: tap, enable: true)
+        breaker.rearm = { [weak self] in
+            guard let self, let tap = self.eventTap else { return }
+            CGEvent.tapEnable(tap: tap, enable: true)
+        }
         DiagnosticLog.shared.info("KeyboardRemap: keyboard event tap installed")
     }
 
@@ -106,7 +111,15 @@ final class KeyboardRemapController {
     }
 
     private func handleEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
-        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+        if type == .tapDisabledByTimeout {
+            // OS killed the tap because a callback was too slow. Run through
+            // the breaker — it backs off in escalating cooldowns rather than
+            // re-enabling immediately and getting killed again.
+            breaker.recordTrip()
+            return Unmanaged.passUnretained(event)
+        }
+        if type == .tapDisabledByUserInput {
+            // User-driven disable (rare). Re-enable directly, no cooldown.
             if let eventTap {
                 CGEvent.tapEnable(tap: eventTap, enable: true)
             }

--- a/app/Sources/Core/Input/KeyboardRemapController.swift
+++ b/app/Sources/Core/Input/KeyboardRemapController.swift
@@ -82,7 +82,7 @@ final class KeyboardRemapController {
         runLoopSource = source
 
         if let source {
-            CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+            EventTapThread.shared.add(source: source)
         }
         CGEvent.tapEnable(tap: tap, enable: true)
         DiagnosticLog.shared.info("KeyboardRemap: keyboard event tap installed")
@@ -90,7 +90,7 @@ final class KeyboardRemapController {
 
     private func removeEventTap() {
         if let source = runLoopSource {
-            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+            EventTapThread.shared.remove(source: source)
         }
         runLoopSource = nil
         if let tap = eventTap {

--- a/app/Sources/Core/Input/KeyboardRemapStore.swift
+++ b/app/Sources/Core/Input/KeyboardRemapStore.swift
@@ -8,7 +8,11 @@ final class KeyboardRemapStore: ObservableObject {
     @Published private(set) var config: KeyboardRemapConfig
 
     let configURL: URL
+    /// Lock-protected mirror of `config` for tap-thread reads. The keyboard
+    /// event tap runs on EventTapThread and must not read the @Published
+    /// SwiftUI-facing config directly while main may be mutating it.
     private let stateLock = NSLock()
+    private var snapshot: KeyboardRemapConfig
     private var lastLoadedModifiedDate: Date?
 
     private init() {
@@ -17,12 +21,14 @@ final class KeyboardRemapStore: ObservableObject {
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         self.configURL = dir.appendingPathComponent("keyboard-remaps.json")
         self.config = .defaults
+        self.snapshot = .defaults
         ensureConfigFile()
         reload()
     }
 
     var enabledRules: [KeyboardRemapRule] {
-        config.rules.filter(\.enabled)
+        stateLock.lock(); defer { stateLock.unlock() }
+        return snapshot.rules.filter(\.enabled)
     }
 
     var summaryLines: [String] {
@@ -45,19 +51,29 @@ final class KeyboardRemapStore: ObservableObject {
             return
         }
         let newDate = modifiedDate()
+        let newConfig: KeyboardRemapConfig
         guard let data = FileManager.default.contents(atPath: configURL.path) else {
-            config = .defaults
-            stateLock.lock(); lastLoadedModifiedDate = newDate; stateLock.unlock()
+            newConfig = .defaults
+            stateLock.lock()
+            snapshot = newConfig
+            lastLoadedModifiedDate = newDate
+            stateLock.unlock()
+            config = newConfig
             return
         }
 
         do {
-            config = try JSONDecoder().decode(KeyboardRemapConfig.self, from: data)
-            stateLock.lock(); lastLoadedModifiedDate = newDate; stateLock.unlock()
+            newConfig = try JSONDecoder().decode(KeyboardRemapConfig.self, from: data)
         } catch {
             DiagnosticLog.shared.error("KeyboardRemapStore: failed to decode keyboard-remaps.json - \(error.localizedDescription)")
-            config = .defaults
+            newConfig = .defaults
         }
+
+        stateLock.lock()
+        snapshot = newConfig
+        lastLoadedModifiedDate = newDate
+        stateLock.unlock()
+        config = newConfig
     }
 
     func reloadIfNeeded() {
@@ -94,7 +110,10 @@ final class KeyboardRemapStore: ObservableObject {
         guard let data = try? encoder.encode(config) else { return }
         try? data.write(to: configURL, options: .atomic)
         let newDate = modifiedDate()
-        stateLock.lock(); lastLoadedModifiedDate = newDate; stateLock.unlock()
+        stateLock.lock()
+        snapshot = config
+        lastLoadedModifiedDate = newDate
+        stateLock.unlock()
     }
 
     private func modifiedDate() -> Date? {

--- a/app/Sources/Core/Input/KeyboardRemapStore.swift
+++ b/app/Sources/Core/Input/KeyboardRemapStore.swift
@@ -8,6 +8,7 @@ final class KeyboardRemapStore: ObservableObject {
     @Published private(set) var config: KeyboardRemapConfig
 
     let configURL: URL
+    private let stateLock = NSLock()
     private var lastLoadedModifiedDate: Date?
 
     private init() {
@@ -38,14 +39,21 @@ final class KeyboardRemapStore: ObservableObject {
     }
 
     func reload() {
+        // @Published mutation must run on main; hop if called off-main.
+        if !Thread.isMainThread {
+            DispatchQueue.main.async { [weak self] in self?.reload() }
+            return
+        }
+        let newDate = modifiedDate()
         guard let data = FileManager.default.contents(atPath: configURL.path) else {
             config = .defaults
+            stateLock.lock(); lastLoadedModifiedDate = newDate; stateLock.unlock()
             return
         }
 
         do {
             config = try JSONDecoder().decode(KeyboardRemapConfig.self, from: data)
-            lastLoadedModifiedDate = modifiedDate()
+            stateLock.lock(); lastLoadedModifiedDate = newDate; stateLock.unlock()
         } catch {
             DiagnosticLog.shared.error("KeyboardRemapStore: failed to decode keyboard-remaps.json - \(error.localizedDescription)")
             config = .defaults
@@ -53,8 +61,19 @@ final class KeyboardRemapStore: ObservableObject {
     }
 
     func reloadIfNeeded() {
+        // Called from the keyboard event-tap thread on every key event. The
+        // `stat` is cheap and thread-safe; the @Published mutation is hopped
+        // to main inside reload(). We claim the new mtime up-front so
+        // concurrent calls don't queue duplicate reloads while one is in
+        // flight (if reload fails, we'll retry on the next mtime change).
         let currentModifiedDate = modifiedDate()
-        guard currentModifiedDate != lastLoadedModifiedDate else { return }
+        stateLock.lock()
+        let needsReload = currentModifiedDate != lastLoadedModifiedDate
+        if needsReload {
+            lastLoadedModifiedDate = currentModifiedDate
+        }
+        stateLock.unlock()
+        guard needsReload else { return }
         reload()
     }
 
@@ -74,7 +93,8 @@ final class KeyboardRemapStore: ObservableObject {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
         guard let data = try? encoder.encode(config) else { return }
         try? data.write(to: configURL, options: .atomic)
-        lastLoadedModifiedDate = modifiedDate()
+        let newDate = modifiedDate()
+        stateLock.lock(); lastLoadedModifiedDate = newDate; stateLock.unlock()
     }
 
     private func modifiedDate() -> Date? {

--- a/app/Sources/Core/Input/MouseGestureController.swift
+++ b/app/Sources/Core/Input/MouseGestureController.swift
@@ -45,8 +45,12 @@ private struct MouseGestureOverlayTheme {
     )
 }
 
-final class MouseGestureController {
+final class MouseGestureController: ObservableObject {
     static let shared = MouseGestureController()
+
+    /// Live state of the event-tap circuit breaker. SettingsView observes
+    /// this to surface "paused" / "disabled" status and a re-arm button.
+    @Published private(set) var breakerState: EventTapBreaker.State = .armed
 
     private struct GestureOutcome {
         let label: String
@@ -95,6 +99,7 @@ final class MouseGestureController {
     private var installedObservers = false
     private let shapeRecognizer = ShapeRecognizer()
     private let breaker = EventTapBreaker(label: "MouseGesture")
+    private let budgetMeter = TapBudgetMeter(label: "MouseGesture")
 
     // Tap-thread-side mirror of "which button (if any) is currently being
     // tracked as a gesture". The tap callback runs on EventTapThread; main
@@ -114,7 +119,11 @@ final class MouseGestureController {
         trackingLock.lock(); trackingButtonNumber = value; trackingLock.unlock()
     }
 
-    private init() {}
+    private init() {
+        breaker.onStateChanged = { [weak self] newState in
+            self?.breakerState = newState
+        }
+    }
 
     func start() {
         installObserversIfNeeded()
@@ -181,7 +190,22 @@ final class MouseGestureController {
         }
     }
 
+    /// Re-enable the tap after a breaker trip, clearing trip history.
+    /// Settings UI calls this when the user explicitly chooses to recover
+    /// from a `disabled` state.
+    func reArmAfterBreakerTrip() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        breaker.reset()
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: true)
+        }
+    }
+
     private func installEventTap() {
+        // Fresh install is a clean slate — drop any stale trip history so
+        // the new tap's first failure is judged on its own merits.
+        breaker.reset()
+
         var mask = CGEventMask(0)
         mask |= CGEventMask(1) << CGEventType.leftMouseDown.rawValue
         mask |= CGEventMask(1) << CGEventType.leftMouseUp.rawValue
@@ -239,6 +263,12 @@ final class MouseGestureController {
     }
 
     private func handleEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        let started = CFAbsoluteTimeGetCurrent()
+        defer {
+            let elapsedMs = (CFAbsoluteTimeGetCurrent() - started) * 1000
+            budgetMeter.record(durationMs: elapsedMs)
+        }
+
         if type == .tapDisabledByTimeout {
             // OS killed the tap because a callback was too slow. Run through
             // the breaker — it backs off in escalating cooldowns rather than

--- a/app/Sources/Core/Input/MouseGestureController.swift
+++ b/app/Sources/Core/Input/MouseGestureController.swift
@@ -19,6 +19,16 @@ private enum MouseGestureVisualPhase: String {
     case completed
 }
 
+/// Captured CGEvent fields safe to ferry across an async dispatch boundary.
+/// CGEvent itself is reference-counted; the tap callback only borrows the
+/// event for the duration of its return, so we copy what we need into a
+/// value type before hopping to main.
+private struct MouseEventSnapshot {
+    let location: CGPoint
+    let flags: CGEventFlags
+    let buttonNumber: Int64
+}
+
 private struct MouseGestureOverlayTheme {
     let graphite: NSColor
     let graphiteDark: NSColor
@@ -84,6 +94,24 @@ final class MouseGestureController {
     private var subscriptions: Set<AnyCancellable> = []
     private var installedObservers = false
     private let shapeRecognizer = ShapeRecognizer()
+
+    // Tap-thread-side mirror of "which button (if any) is currently being
+    // tracked as a gesture". The tap callback runs on EventTapThread; main
+    // owns the full GestureSession but the tap thread needs a fast,
+    // synchronous answer to "should I consume this drag/up event?". Lock
+    // protects cross-thread access (tap thread reads/writes; main writes
+    // via clearSession() or processMouseDownConsume's bail path).
+    private let trackingLock = NSLock()
+    private var trackingButtonNumber: Int64? = nil
+
+    private func currentTrackingButton() -> Int64? {
+        trackingLock.lock(); defer { trackingLock.unlock() }
+        return trackingButtonNumber
+    }
+
+    private func setTrackingButton(_ value: Int64?) {
+        trackingLock.lock(); trackingButtonNumber = value; trackingLock.unlock()
+    }
 
     private init() {}
 
@@ -182,7 +210,7 @@ final class MouseGestureController {
         runLoopSource = source
 
         if let source {
-            CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+            EventTapThread.shared.add(source: source)
         }
         CGEvent.tapEnable(tap: tap, enable: true)
         DiagnosticLog.shared.info("MouseGesture: mouse shortcut event tap installed")
@@ -190,7 +218,7 @@ final class MouseGestureController {
 
     private func removeEventTap() {
         if let source = runLoopSource {
-            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+            EventTapThread.shared.remove(source: source)
         }
         runLoopSource = nil
         if let tap = eventTap {
@@ -247,10 +275,28 @@ final class MouseGestureController {
         }
     }
 
+    // MARK: - Tap-thread dispatch
+    //
+    // handle* methods run on EventTapThread. They compute the consume/pass
+    // verdict from cheap, thread-safe reads, capture the event into a
+    // MouseEventSnapshot, and hand the heavy work to main async — so a slow
+    // main thread never adds latency to mouse events at the head-insert tap.
+
     private func handlePassiveMouseButtonEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
-        guard MouseInputEventViewer.shared.isCaptureActive else {
-            return Unmanaged.passUnretained(event)
+        let snapshot = MouseEventSnapshot(
+            location: event.location,
+            flags: event.flags,
+            buttonNumber: event.getIntegerValueField(.mouseEventButtonNumber)
+        )
+        DispatchQueue.main.async { [weak self] in
+            self?.processPassiveMouseButton(type: type, snapshot: snapshot)
         }
+        return Unmanaged.passUnretained(event)
+    }
+
+    private func processPassiveMouseButton(type: CGEventType, snapshot: MouseEventSnapshot) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard MouseInputEventViewer.shared.isCaptureActive else { return }
 
         let phase: String
         switch type {
@@ -259,62 +305,119 @@ final class MouseGestureController {
         case .leftMouseUp, .rightMouseUp:
             phase = "up"
         default:
-            return Unmanaged.passUnretained(event)
+            return
         }
 
-        let buttonNumber = Int(event.getIntegerValueField(.mouseEventButtonNumber))
-        let appInfo = currentAppInfo()
         recordObservedEvent(
             phase: phase,
-            button: MouseShortcutButton(rawButtonNumber: buttonNumber),
-            location: event.location,
+            button: MouseShortcutButton(rawButtonNumber: Int(snapshot.buttonNumber)),
+            location: snapshot.location,
             delta: .zero,
-            modifiers: event.flags,
+            modifiers: snapshot.flags,
             candidate: nil,
             match: nil,
             note: "pass-through primary button",
-            appInfo: appInfo
+            appInfo: currentAppInfo()
         )
-        return Unmanaged.passUnretained(event)
     }
 
     private func handleMouseDown(_ event: CGEvent, buttonNumber: Int64) -> Unmanaged<CGEvent>? {
-        MouseShortcutStore.shared.reloadIfNeeded()
-        let point = event.location
-        let button = MouseShortcutButton(rawButtonNumber: Int(buttonNumber))
-        let appInfo = currentAppInfo()
-        let canRecognize = Preferences.shared.mouseGesturesEnabled && MouseShortcutStore.shared.watchedButtonNumbers.contains(buttonNumber)
+        let snapshot = MouseEventSnapshot(
+            location: event.location,
+            flags: event.flags,
+            buttonNumber: buttonNumber
+        )
+        // NSScreen.screens reads are safe off-main; Preferences/Store snapshot
+        // reads are lock-protected (see MouseShortcutStore).
+        let canRecognize = Preferences.shared.mouseGesturesEnabled
+            && MouseShortcutStore.shared.watchedButtonNumbers.contains(buttonNumber)
+        let onScreen = (screen(containing: snapshot.location) != nil)
 
-        guard let screen = screen(containing: point) else {
-            DiagnosticLog.shared.info("MouseGesture: ignored click at \(format(point)) (off-screen)")
+        if !onScreen {
+            DispatchQueue.main.async { [weak self] in
+                self?.processMouseDownPassthrough(snapshot: snapshot, reason: .offScreen)
+            }
+            return Unmanaged.passUnretained(event)
+        }
+        if !canRecognize {
+            DispatchQueue.main.async { [weak self] in
+                self?.processMouseDownPassthrough(snapshot: snapshot, reason: .notMapped)
+            }
+            return Unmanaged.passUnretained(event)
+        }
+
+        // Mark this button as actively tracked before the OS sees a follow-up
+        // drag/up — the tap thread reads this on subsequent events to decide
+        // whether to consume them.
+        setTrackingButton(buttonNumber)
+        DispatchQueue.main.async { [weak self] in
+            self?.processMouseDownConsume(snapshot: snapshot)
+        }
+        return nil
+    }
+
+    private enum MouseDownPassthroughReason {
+        case offScreen
+        case notMapped
+    }
+
+    private func processMouseDownPassthrough(snapshot: MouseEventSnapshot, reason: MouseDownPassthroughReason) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        let button = MouseShortcutButton(rawButtonNumber: Int(snapshot.buttonNumber))
+        let appInfo = currentAppInfo()
+        switch reason {
+        case .offScreen:
+            DiagnosticLog.shared.info("MouseGesture: ignored click at \(format(snapshot.location)) (off-screen)")
             recordObservedEvent(
                 phase: "down",
                 button: button,
-                location: point,
+                location: snapshot.location,
                 delta: .zero,
-                modifiers: event.flags,
+                modifiers: snapshot.flags,
                 candidate: nil,
                 match: nil,
                 note: "off-screen",
                 appInfo: appInfo
             )
             clearSession()
-            return Unmanaged.passUnretained(event)
-        }
-
-        guard canRecognize else {
+        case .notMapped:
             recordObservedEvent(
                 phase: "down",
                 button: button,
-                location: point,
+                location: snapshot.location,
                 delta: .zero,
-                modifiers: event.flags,
+                modifiers: snapshot.flags,
                 candidate: nil,
                 match: nil,
                 note: "button not mapped",
                 appInfo: appInfo
             )
-            return Unmanaged.passUnretained(event)
+        }
+    }
+
+    private func processMouseDownConsume(snapshot: MouseEventSnapshot) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        MouseShortcutStore.shared.reloadIfNeeded()
+        let button = MouseShortcutButton(rawButtonNumber: Int(snapshot.buttonNumber))
+        let appInfo = currentAppInfo()
+
+        guard let screen = screen(containing: snapshot.location) else {
+            // Screens changed between tap-thread verdict and main; treat as
+            // off-screen and clear the tap-side tracking we eagerly set.
+            setTrackingButton(nil)
+            recordObservedEvent(
+                phase: "down",
+                button: button,
+                location: snapshot.location,
+                delta: .zero,
+                modifiers: snapshot.flags,
+                candidate: nil,
+                match: nil,
+                note: "off-screen (post-dispatch)",
+                appInfo: appInfo
+            )
+            clearSession()
+            return
         }
 
         clearSession()
@@ -323,39 +426,51 @@ final class MouseGestureController {
             guard let self, let overlay else { return }
             self.releaseOverlay(overlay)
         }
-        let newSession = GestureSession(buttonNumber: buttonNumber, startPoint: point, overlay: overlay)
+        let newSession = GestureSession(buttonNumber: snapshot.buttonNumber, startPoint: snapshot.location, overlay: overlay)
         newSession.visual = MouseShortcutStore.shared.visualHint(for: button)
         session = newSession
-        DiagnosticLog.shared.info("MouseGesture: began at \(format(point)) button=\(buttonNumber)")
+        DiagnosticLog.shared.info("MouseGesture: began at \(format(snapshot.location)) button=\(snapshot.buttonNumber)")
         recordObservedEvent(
             phase: "down",
             button: button,
-            location: point,
+            location: snapshot.location,
             delta: .zero,
-            modifiers: event.flags,
+            modifiers: snapshot.flags,
             candidate: nil,
             match: nil,
             note: "tracking",
             appInfo: appInfo
         )
-        return nil
     }
 
     private func handleMouseDragged(_ event: CGEvent, buttonNumber: Int64) -> Unmanaged<CGEvent>? {
-        guard let session else {
+        guard currentTrackingButton() == buttonNumber else {
             return Unmanaged.passUnretained(event)
         }
-        guard session.buttonNumber == buttonNumber else {
-            return Unmanaged.passUnretained(event)
+        let snapshot = MouseEventSnapshot(
+            location: event.location,
+            flags: event.flags,
+            buttonNumber: buttonNumber
+        )
+        DispatchQueue.main.async { [weak self] in
+            self?.processMouseDragged(snapshot: snapshot)
+        }
+        return nil
+    }
+
+    private func processMouseDragged(snapshot: MouseEventSnapshot) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard let session, session.buttonNumber == snapshot.buttonNumber else {
+            return
         }
         MouseShortcutStore.shared.reloadIfNeeded()
 
-        session.currentPoint = event.location
-        session.recordPoint(event.location)
-        let button = MouseShortcutButton(rawButtonNumber: Int(buttonNumber))
+        session.currentPoint = snapshot.location
+        session.recordPoint(snapshot.location)
+        let button = MouseShortcutButton(rawButtonNumber: Int(snapshot.buttonNumber))
         let delta = CGPoint(
-            x: event.location.x - session.startPoint.x,
-            y: event.location.y - session.startPoint.y
+            x: snapshot.location.x - session.startPoint.x,
+            y: snapshot.location.y - session.startPoint.y
         )
         let tuning = MouseShortcutStore.shared.tuning
         let direction = Self.resolveDirection(delta: delta, threshold: tuning.dragThreshold, axisBias: tuning.axisBias)
@@ -369,9 +484,9 @@ final class MouseGestureController {
                 recordObservedEvent(
                     phase: "drag",
                     button: button,
-                    location: event.location,
+                    location: snapshot.location,
                     delta: delta,
-                    modifiers: event.flags,
+                    modifiers: snapshot.flags,
                     candidate: triggerEvent.triggerName,
                     match: match,
                     note: match == nil ? "no rule" : "candidate",
@@ -403,7 +518,7 @@ final class MouseGestureController {
                 origin: session.startPoint,
                 direction: nil,
                 label: nil,
-                style: overlayStyle(for: MouseShortcutButton(rawButtonNumber: Int(buttonNumber))),
+                style: overlayStyle(for: button),
                 visual: session.visual,
                 visualPhase: .updated,
                 shape: nil,
@@ -412,38 +527,60 @@ final class MouseGestureController {
                 progress: 0
             )
         }
-
-        return nil
     }
 
     private func handleMouseUp(_ event: CGEvent, buttonNumber: Int64) -> Unmanaged<CGEvent>? {
+        let snapshot = MouseEventSnapshot(
+            location: event.location,
+            flags: event.flags,
+            buttonNumber: buttonNumber
+        )
+        guard currentTrackingButton() == buttonNumber else {
+            DispatchQueue.main.async { [weak self] in
+                self?.processMouseUpNoSession(snapshot: snapshot)
+            }
+            return Unmanaged.passUnretained(event)
+        }
+        // We consumed the matching mouseDown; clear tap-side tracking so a
+        // subsequent drag/up for this button falls through.
+        setTrackingButton(nil)
+        DispatchQueue.main.async { [weak self] in
+            self?.processMouseUp(snapshot: snapshot)
+        }
+        return nil
+    }
+
+    private func processMouseUpNoSession(snapshot: MouseEventSnapshot) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        recordObservedEvent(
+            phase: "up",
+            button: MouseShortcutButton(rawButtonNumber: Int(snapshot.buttonNumber)),
+            location: snapshot.location,
+            delta: .zero,
+            modifiers: snapshot.flags,
+            candidate: nil,
+            match: nil,
+            note: "no active session",
+            appInfo: currentAppInfo()
+        )
+    }
+
+    private func processMouseUp(snapshot: MouseEventSnapshot) {
+        dispatchPrecondition(condition: .onQueue(.main))
         MouseShortcutStore.shared.reloadIfNeeded()
-        let button = MouseShortcutButton(rawButtonNumber: Int(buttonNumber))
+        let button = MouseShortcutButton(rawButtonNumber: Int(snapshot.buttonNumber))
         let appInfo = currentAppInfo()
 
-        guard let session else {
-            recordObservedEvent(
-                phase: "up",
-                button: button,
-                location: event.location,
-                delta: .zero,
-                modifiers: event.flags,
-                candidate: nil,
-                match: nil,
-                note: "no active session",
-                appInfo: appInfo
-            )
-            return Unmanaged.passUnretained(event)
+        guard let session, session.buttonNumber == snapshot.buttonNumber else {
+            // Session was cleared between the tap-thread dispatch and now.
+            return
         }
-        guard session.buttonNumber == buttonNumber else {
-            return Unmanaged.passUnretained(event)
-        }
-        session.currentPoint = event.location
-        session.recordPoint(event.location)
+        session.currentPoint = snapshot.location
+        session.recordPoint(snapshot.location)
 
         let delta = CGPoint(
-            x: event.location.x - session.startPoint.x,
-            y: event.location.y - session.startPoint.y
+            x: snapshot.location.x - session.startPoint.x,
+            y: snapshot.location.y - session.startPoint.y
         )
         let tuning = MouseShortcutStore.shared.tuning
         let direction = Self.resolveDirection(delta: delta, threshold: tuning.dragThreshold, axisBias: tuning.axisBias)
@@ -470,9 +607,9 @@ final class MouseGestureController {
                     self.recordObservedEvent(
                         phase: "up",
                         button: button,
-                        location: event.location,
+                        location: snapshot.location,
                         delta: delta,
-                        modifiers: event.flags,
+                        modifiers: snapshot.flags,
                         candidate: shapeTrigger.triggerName,
                         match: shapeMatch,
                         note: "shape fired confidence=\(String(format: "%.2f", Double(shapeResult.confidence)))",
@@ -493,20 +630,20 @@ final class MouseGestureController {
                         )
                     }
                 }
-                return nil
+                return
             }
         }
 
         guard let direction else {
             let clickTrigger = MouseShortcutTriggerEvent(button: button, kind: .click, direction: nil, device: nil)
             let clickMatch = MouseShortcutStore.shared.match(for: clickTrigger)
-            DiagnosticLog.shared.info("MouseGesture: released without a gesture at \(format(event.location))")
+            DiagnosticLog.shared.info("MouseGesture: released without a gesture at \(format(snapshot.location))")
             recordObservedEvent(
                 phase: "up",
                 button: button,
-                location: event.location,
+                location: snapshot.location,
                 delta: delta,
-                modifiers: event.flags,
+                modifiers: snapshot.flags,
                 candidate: clickMatch != nil ? clickTrigger.triggerName : nil,
                 match: clickMatch,
                 note: clickMatch != nil ? "click action" : "replay click",
@@ -523,13 +660,13 @@ final class MouseGestureController {
                 DispatchQueue.main.async { [weak self] in
                     session.overlay.dismiss()
                     self?.replayMouseClick(
-                        buttonNumber: buttonNumber,
+                        buttonNumber: snapshot.buttonNumber,
                         at: session.startPoint,
-                        flags: event.flags
+                        flags: snapshot.flags
                     )
                 }
             }
-            return nil
+            return
         }
 
         let triggerEvent = MouseShortcutTriggerEvent(button: button, kind: .drag, direction: direction, device: nil)
@@ -549,9 +686,9 @@ final class MouseGestureController {
             self.recordObservedEvent(
                 phase: "up",
                 button: button,
-                location: event.location,
+                location: snapshot.location,
                 delta: delta,
-                modifiers: event.flags,
+                modifiers: snapshot.flags,
                 candidate: triggerEvent.triggerName,
                 match: match,
                 note: outcome.success ? "fired" : "blocked",
@@ -572,7 +709,6 @@ final class MouseGestureController {
                 )
             }
         }
-        return nil
     }
 
     private func performAction(match: MouseShortcutMatchResult?, startPoint: CGPoint) -> GestureOutcome {
@@ -650,6 +786,10 @@ final class MouseGestureController {
     private func clearSession() {
         session?.overlay.dismiss(immediately: true)
         session = nil
+        // Keep tap-side tracking in sync with main-side session lifetime so a
+        // subsequent drag/up isn't consumed for a session that no longer
+        // exists.
+        setTrackingButton(nil)
     }
 
     private func replayMouseClick(buttonNumber: Int64, at point: CGPoint, flags: CGEventFlags) {

--- a/app/Sources/Core/Input/MouseGestureController.swift
+++ b/app/Sources/Core/Input/MouseGestureController.swift
@@ -94,6 +94,7 @@ final class MouseGestureController {
     private var subscriptions: Set<AnyCancellable> = []
     private var installedObservers = false
     private let shapeRecognizer = ShapeRecognizer()
+    private let breaker = EventTapBreaker(label: "MouseGesture")
 
     // Tap-thread-side mirror of "which button (if any) is currently being
     // tracked as a gesture". The tap callback runs on EventTapThread; main
@@ -213,6 +214,10 @@ final class MouseGestureController {
             EventTapThread.shared.add(source: source)
         }
         CGEvent.tapEnable(tap: tap, enable: true)
+        breaker.rearm = { [weak self] in
+            guard let self, let tap = self.eventTap else { return }
+            CGEvent.tapEnable(tap: tap, enable: true)
+        }
         DiagnosticLog.shared.info("MouseGesture: mouse shortcut event tap installed")
     }
 
@@ -234,7 +239,15 @@ final class MouseGestureController {
     }
 
     private func handleEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
-        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+        if type == .tapDisabledByTimeout {
+            // OS killed the tap because a callback was too slow. Run through
+            // the breaker — it backs off in escalating cooldowns rather than
+            // re-enabling immediately and getting killed again.
+            breaker.recordTrip()
+            return Unmanaged.passUnretained(event)
+        }
+        if type == .tapDisabledByUserInput {
+            // User-driven disable (rare). Re-enable directly, no cooldown.
             if let eventTap {
                 CGEvent.tapEnable(tap: eventTap, enable: true)
             }

--- a/app/Sources/Core/Input/MouseShortcutStore.swift
+++ b/app/Sources/Core/Input/MouseShortcutStore.swift
@@ -5,9 +5,19 @@ import Foundation
 final class MouseShortcutStore: ObservableObject {
     static let shared = MouseShortcutStore()
 
+    /// Drives SwiftUI bindings; mutations always happen on main.
     @Published private(set) var config: MouseShortcutConfig
 
     let configURL: URL
+
+    /// Lock-protected mirror of `config` for tap-thread reads. The mouse event
+    /// tap fires on a non-main thread (EventTapThread) and reads
+    /// `watchedButtonNumbers` to compute the consume-vs-pass verdict; mutating
+    /// `config` (a struct) on main while reading from the tap thread is a
+    /// torn-read race. All tap-thread accessors read this snapshot under
+    /// `stateLock`.
+    private let stateLock = NSLock()
+    private var snapshot: MouseShortcutConfig
     private var lastLoadedModifiedDate: Date?
 
     private init() {
@@ -16,28 +26,34 @@ final class MouseShortcutStore: ObservableObject {
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         self.configURL = dir.appendingPathComponent("mouse-shortcuts.json")
         self.config = .defaults
+        self.snapshot = .defaults
         ensureConfigFile()
         reload()
     }
 
     var tuning: MouseShortcutTuning {
-        config.tuning
+        stateLock.lock(); defer { stateLock.unlock() }
+        return snapshot.tuning
     }
 
     var enabledRules: [MouseShortcutRule] {
-        config.rules.filter(\.enabled)
+        stateLock.lock(); defer { stateLock.unlock() }
+        return snapshot.rules.filter(\.enabled)
     }
 
     var watchedButtonNumbers: Set<Int64> {
-        Set(enabledRules.map { Int64($0.trigger.button.rawButtonNumber) })
+        stateLock.lock(); defer { stateLock.unlock() }
+        return Set(snapshot.rules.filter(\.enabled).map { Int64($0.trigger.button.rawButtonNumber) })
     }
 
     var summaryLines: [String] {
-        enabledRules.map { "\($0.trigger.triggerName) -> \($0.action.type.rawValue)" }
+        stateLock.lock(); defer { stateLock.unlock() }
+        return snapshot.rules.filter(\.enabled).map { "\($0.trigger.triggerName) -> \($0.action.type.rawValue)" }
     }
 
     func visualHint(for button: MouseShortcutButton) -> MouseShortcutVisualDefinition? {
-        enabledRules.first { $0.trigger.button == button && $0.visual != nil }?.visual
+        stateLock.lock(); defer { stateLock.unlock() }
+        return snapshot.rules.filter(\.enabled).first { $0.trigger.button == button && $0.visual != nil }?.visual
     }
 
     func ensureConfigFile() {
@@ -46,23 +62,46 @@ final class MouseShortcutStore: ObservableObject {
     }
 
     func reload() {
-        guard let data = FileManager.default.contents(atPath: configURL.path) else {
-            config = .defaults
-            return
+        let newDate = modifiedDate()
+        let newConfig: MouseShortcutConfig
+        if let data = FileManager.default.contents(atPath: configURL.path) {
+            do {
+                newConfig = try JSONDecoder().decode(MouseShortcutConfig.self, from: data)
+            } catch {
+                DiagnosticLog.shared.error("MouseShortcutStore: failed to decode mouse-shortcuts.json - \(error.localizedDescription)")
+                newConfig = .defaults
+            }
+        } else {
+            newConfig = .defaults
         }
-
-        do {
-            config = try JSONDecoder().decode(MouseShortcutConfig.self, from: data)
-            lastLoadedModifiedDate = modifiedDate()
-        } catch {
-            DiagnosticLog.shared.error("MouseShortcutStore: failed to decode mouse-shortcuts.json - \(error.localizedDescription)")
-            config = .defaults
+        stateLock.lock()
+        snapshot = newConfig
+        lastLoadedModifiedDate = newDate
+        stateLock.unlock()
+        // @Published mutation must happen on main.
+        if Thread.isMainThread {
+            config = newConfig
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.config = newConfig
+            }
         }
     }
 
     func reloadIfNeeded() {
+        // Called from the mouse event-tap thread (and from main paths). The
+        // stat is cheap and thread-safe; we claim the new mtime up-front so
+        // concurrent calls don't queue duplicate reloads while one is in
+        // flight (if reload fails to decode, we'll retry on the next mtime
+        // change).
         let currentModifiedDate = modifiedDate()
-        guard currentModifiedDate != lastLoadedModifiedDate else { return }
+        stateLock.lock()
+        let needsReload = currentModifiedDate != lastLoadedModifiedDate
+        if needsReload {
+            lastLoadedModifiedDate = currentModifiedDate
+        }
+        stateLock.unlock()
+        guard needsReload else { return }
         reload()
     }
 
@@ -78,7 +117,10 @@ final class MouseShortcutStore: ObservableObject {
     }
 
     func match(for event: MouseShortcutTriggerEvent) -> MouseShortcutMatchResult? {
-        for rule in enabledRules {
+        stateLock.lock()
+        let rules = snapshot.rules.filter(\.enabled)
+        stateLock.unlock()
+        for rule in rules {
             guard rule.trigger.kind == event.kind,
                   rule.trigger.button == event.button,
                   rule.device.matches(event.device) else {
@@ -108,7 +150,8 @@ final class MouseShortcutStore: ObservableObject {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
         guard let data = try? encoder.encode(config) else { return }
         try? data.write(to: configURL, options: .atomic)
-        lastLoadedModifiedDate = modifiedDate()
+        let newDate = modifiedDate()
+        stateLock.lock(); lastLoadedModifiedDate = newDate; stateLock.unlock()
     }
 
     private func modifiedDate() -> Date? {

--- a/app/Sources/Core/Input/TapBudgetMeter.swift
+++ b/app/Sources/Core/Input/TapBudgetMeter.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Measures CGEventTap callback duration and logs throttled warnings when
+/// callbacks exceed the budget. Thread-safe — designed to be invoked from
+/// the event-tap thread on every event.
+///
+/// Logging is throttled to at most one warning per second per meter, with
+/// the peak value observed in that window. This keeps the log readable
+/// when something is misbehaving without losing the signal.
+///
+/// Why this exists: the whole point of the EventTapThread off-main move is
+/// "tap callbacks are now fast." This is the measurement that confirms it
+/// stays true and surfaces regressions before they cause `tapDisabledByTimeout`.
+final class TapBudgetMeter {
+    private let label: String
+    private let warnThresholdMs: Double
+    private let throttleSec: TimeInterval
+
+    private let lock = NSLock()
+    private var maxMsInWindow: Double = 0
+    private var samplesInWindow: Int = 0
+    private var lastLog: Date = .distantPast
+
+    init(label: String, warnThresholdMs: Double = 5.0, throttleSec: TimeInterval = 1.0) {
+        self.label = label
+        self.warnThresholdMs = warnThresholdMs
+        self.throttleSec = throttleSec
+    }
+
+    /// Records one callback's wall-clock duration. No-op when below the
+    /// threshold. Logs at most once per `throttleSec` window.
+    func record(durationMs: Double) {
+        guard durationMs > warnThresholdMs else { return }
+
+        lock.lock()
+        if durationMs > maxMsInWindow { maxMsInWindow = durationMs }
+        samplesInWindow += 1
+
+        let now = Date()
+        guard now.timeIntervalSince(lastLog) > throttleSec else {
+            lock.unlock()
+            return
+        }
+
+        let peak = maxMsInWindow
+        let count = samplesInWindow
+        maxMsInWindow = 0
+        samplesInWindow = 0
+        lastLog = now
+        lock.unlock()
+
+        DiagnosticLog.shared.warn(
+            "\(label): tap callback peak \(Int(peak))ms (× \(count) over threshold \(Int(warnThresholdMs))ms in last \(Int(throttleSec))s)"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Two session-wide `CGEventTap`s (mouse gestures + keyboard remap) were running on `CFRunLoopGetMain()`, which means every keystroke and every mouse event in the user's session funneled through the main run loop behind SwiftUI rendering, AX scans, etc. `tapDisabledByTimeout` was being recovered naively — re-enable, return — which fights the OS in a loop when the underlying cause persists.

This PR migrates both taps off main and adds defense-in-depth.

## Stack (4 commits)

1. **`3574d60` ⚡️ Keyboard tap → EventTapThread**
   - New `Core/Input/EventTapThread.swift`: long-lived `userInteractive`-QoS thread + `CFRunLoop` for tap callbacks.
   - `KeyboardRemapStore.reload()` hops to main when called off-main; `NSLock` deduplicates concurrent reloads.

2. **`29dbeab` ⚡️ Mouse tap → EventTapThread + tap/main handler split**
   - `MouseGestureController` callbacks split into thin tap-thread verdict + `DispatchQueue.main.async` heavy work, with `dispatchPrecondition` guards.
   - `trackingButtonNumber` lock-protected so the tap thread can decide consume/pass without touching main-only `GestureSession`.
   - `MouseShortcutStore` snapshot pattern for tap-thread reads.

3. **`c506e5f` 🛡️ EventTapBreaker: self-healing cooldown**
   - Circuit breaker for `tapDisabledByTimeout`. Cooldown escalates **30s → 2min → permanent** inside a 10-min rolling window. `tapDisabledByUserInput` keeps immediate re-enable.

4. **`6c593e4` 🛡️ Measurement, user-visible state, manual recovery**
   - `TapBudgetMeter`: throttled (1/sec) warning when any tap callback exceeds 5ms. Confirms the off-main move stays effective and catches future regressions.
   - `EventTapBreaker.State { .armed | .paused(cooldownSec) | .disabled }` published on main.
   - Both controllers conform to `ObservableObject`; `SettingsView` shows a status row in the Mouse gestures and Keyboard remaps cards — amber dot during paused cooldown, red dot + Re-enable button when permanently disabled.
   - `breaker.reset()` on tap install so fresh installs start with a clean trip counter.
   - `reArmAfterBreakerTrip()` exposed for the SettingsView Re-enable button.

## Notes from spec-review (`@openscout-spec-review-claude`)

- Tap-thread / main-thread split: airtight. `trackingButtonNumber` + lock pattern correct.
- Two TSan-flaggable but practically benign reads from the tap thread: `Preferences.shared.mouseGesturesEnabled` (Bool, atomic on arm64) and `NSScreen.screens` via `screen(containing:)` (cached array). Neither blocks merge; can be hardened later if anyone runs TSan.
- `KeyboardRemapStore.reloadIfNeeded()` claims the new mtime up-front to dedupe concurrent reloads. Failure path (decode fails → mtime committed → won't retry until file changes again) is the right call vs a hot-loop on a corrupt file.
- No UI flicker: single `@Published` assignment per breaker transition, coalesces in one runloop turn.
- **Verdict: ship it.**

## Test plan

- [x] `swift build -c debug` clean
- [ ] Live smoke: `bun bin/lattices-app.ts restart` → exercise button-3 grid gestures → verify `~/.lattices/lattices.log` shows gestures committing without `tap callback peak` warnings under normal load
- [ ] Toggle Caps Lock — confirm hyper layer still works
- [ ] Open Settings → Shortcuts during normal operation: status rows render nothing (armed)
- [ ] (Manual): synthesize a slow callback to verify breaker trips, badge shows in Settings, Re-enable button works