### PR TITLE
Implement LAT overlay and menu architecture

### DIFF
--- a/app/Lattices.app/Contents/Info.plist
+++ b/app/Lattices.app/Contents/Info.plist
@@ -29,6 +29,14 @@
     <string>0.4.10</string>
     <key>CFBundleShortVersionString</key>
     <string>0.4.10</string>
+    <key>LatticesBuildChannel</key>
+    <string>dev</string>
+    <key>LatticesBuildTrack</key>
+    <string>latest</string>
+    <key>LatticesBuildRevision</key>
+    <string>921e181</string>
+    <key>LatticesBuildTimestamp</key>
+    <string>2026-05-03T18:07:28Z</string>
     <key>LSMinimumSystemVersion</key>
     <string>13.0</string>
     <key>LSUIElement</key>

--- a/app/Sources/AppShell/AppActivationCoordinator.swift
+++ b/app/Sources/AppShell/AppActivationCoordinator.swift
@@ -1,0 +1,27 @@
+import AppKit
+
+final class AppActivationCoordinator {
+    static let shared = AppActivationCoordinator()
+
+    private var surfaceVisibilityProviders: [(id: String, isVisible: () -> Bool)] = []
+
+    private init() {}
+
+    func registerSurface(id: String, isVisible: @escaping () -> Bool) {
+        guard !surfaceVisibilityProviders.contains(where: { $0.id == id }) else { return }
+        surfaceVisibilityProviders.append((id: id, isVisible: isVisible))
+    }
+
+    func refresh() {
+        let hasVisibleWindow = surfaceVisibilityProviders.contains { provider in
+            provider.isVisible()
+        }
+        let desired: NSApplication.ActivationPolicy = hasVisibleWindow ? .regular : .accessory
+        if NSApp.activationPolicy() != desired {
+            NSApp.setActivationPolicy(desired)
+            if desired == .regular {
+                NSApp.activate(ignoringOtherApps: true)
+            }
+        }
+    }
+}

--- a/app/Sources/AppShell/AppDelegate.swift
+++ b/app/Sources/AppShell/AppDelegate.swift
@@ -1,199 +1,38 @@
 import AppKit
 import Carbon
-import SwiftUI
 
 extension Notification.Name {
     static let latticesPopoverWillShow = Notification.Name("latticesPopoverWillShow")
     static let latticesShowAssistantSettings = Notification.Name("latticesShowAssistantSettings")
 }
 
-/// Manages the NSStatusItem (menu bar icon), left-click popover, and right-click context menu.
-/// Replaces the previous SwiftUI MenuBarExtra approach for full click-event control.
-class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
-    private static weak var shared: AppDelegate?
-
-    private var statusItem: NSStatusItem!
-    private var popover: NSPopover?
-    private var contextMenu: NSMenu!
-
-    /// 3×3 grid icon for the menu bar — L-shape bright, rest dim (template for auto light/dark)
-    private static let menuBarIcon: NSImage = {
-        let size: CGFloat = 18
-        let img = NSImage(size: NSSize(width: size, height: size), flipped: true) { _ in
-            let pad: CGFloat = 2
-            let gap: CGFloat = 1.5
-            let cellSize = (size - 2 * pad - 2 * gap) / 3
-
-            let solidCells: Set<Int> = [0, 3, 6, 7, 8]
-
-            for row in 0..<3 {
-                for col in 0..<3 {
-                    let idx = row * 3 + col
-                    let x = pad + CGFloat(col) * (cellSize + gap)
-                    let y = pad + CGFloat(row) * (cellSize + gap)
-                    let rect = NSRect(x: x, y: y, width: cellSize, height: cellSize)
-
-                    if solidCells.contains(idx) {
-                        NSColor.black.setFill()
-                    } else {
-                        NSColor.black.withAlphaComponent(0.25).setFill()
-                    }
-                    let path = NSBezierPath(roundedRect: rect, xRadius: 0.8, yRadius: 0.8)
-                    path.fill()
-                }
-            }
-            return true
-        }
-        img.isTemplate = true
-        return img
-    }()
-
-    /// Toggle between .accessory (hidden from Dock/Cmd+Tab) and .regular (visible)
-    /// based on whether any managed windows are open.
+class AppDelegate: NSObject, NSApplicationDelegate {
     static func updateActivationPolicy() {
-        let hasVisibleWindow =
-            (Self.shared?.popover?.isShown == true) ||
-            CommandModeWindow.shared.isVisible ||
-            CommandPaletteWindow.shared.isVisible ||
-            MainWindow.shared.isVisible ||
-            ScreenMapWindowController.shared.isVisible ||
-            OmniSearchWindow.shared.isVisible
-        let desired: NSApplication.ActivationPolicy = hasVisibleWindow ? .regular : .accessory
-        if NSApp.activationPolicy() != desired {
-            NSApp.setActivationPolicy(desired)
-            if desired == .regular {
-                NSApp.activate(ignoringOtherApps: true)
-            }
-        }
+        AppActivationCoordinator.shared.refresh()
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        Self.shared = self
         NSApp.setActivationPolicy(.accessory)
         NSApp.appearance = NSAppearance(named: .darkAqua)
         registerDeepLinkHandler()
 
-        // --- Status item ---
-        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
-        if let button = statusItem.button {
-            button.image = Self.menuBarIcon
-            button.action = #selector(statusItemClicked(_:))
-            button.sendAction(on: [.leftMouseUp, .rightMouseUp])
-            button.target = self
-        }
+        MenuBarController.shared.start()
+        registerVisibleSurfaces()
+        HotkeyBootstrap.registerHotkeys()
 
-        // --- Context menu (right-click) ---
-        contextMenu = buildContextMenu()
-
-        // --- Hotkey registration ---
-        let scanner = ProjectScanner.shared
-        CommandPaletteWindow.shared.configure(scanner: scanner)
-
-        let store = HotkeyStore.shared
-        store.register(action: .palette) { CommandPaletteWindow.shared.toggle() }
-        store.register(action: .unifiedWindow) { ScreenMapWindowController.shared.toggle() }
-        store.register(action: .bezel) { Self.showWorkspaceInspector() }
-        store.register(action: .cheatSheet) { SettingsWindowController.shared.show() }
-        store.register(action: .desktopInventory) {
-            DiagnosticLog.shared.info("Hotkey: desktopInventory triggered")
-            ScreenMapWindowController.shared.showPage(.desktopInventory)
-        }
-        store.register(action: .voiceCommand) {
-            DiagnosticLog.shared.info("Hotkey: voiceCommand triggered")
-            VoiceCommandWindow.shared.toggle()
-        }
-        store.register(action: .handsOff) {
-            DiagnosticLog.shared.info("Hotkey: handsOff triggered")
-            HandsOffSession.shared.toggle()
-            // Show voice bar when starting, hide when stopping
-            if HandsOffSession.shared.state != .idle {
-                HUDController.shared.showVoiceBar()
-            } else {
-                HUDController.shared.hideVoiceBar()
-            }
-        }
-        store.register(action: .hud) { HUDController.shared.toggle() }
-        store.register(action: .mouseFinder) { MouseFinder.shared.find() }
-
-        // Pre-render HUD panels off-screen for instant first open
         DispatchQueue.main.async { HUDController.shared.warmUp() }
-        // Pre-build the menu bar popover so the first click doesn't pay the SwiftUI mount cost.
-        // Touching `.view` forces NSHostingController to materialize the SwiftUI view tree.
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-            let p = self.makePopover()
-            _ = p.contentViewController?.view
-        }
-        store.register(action: .omniSearch) { OmniSearchWindow.shared.toggle() }
+        DispatchQueue.main.async { MenuBarController.shared.warmUpPopover() }
+        DispatchQueue.main.async { ScreenOverlayCanvasController.shared.warmUp() }
+
         WindowDragSnapController.shared.start()
         MouseGestureController.shared.start()
         KeyboardRemapController.shared.start()
 
-        // Session layer cycling
-        store.register(action: .layerNext) { SessionLayerStore.shared.cycleNext() }
-        store.register(action: .layerPrev) { SessionLayerStore.shared.cyclePrev() }
-        store.register(action: .layerTag)  { SessionLayerStore.shared.tagFrontmostWindow() }
-
-        // Layer-switching hotkeys (1-9): session layers take priority
-        let workspace = WorkspaceManager.shared
-        let configLayerCount = (workspace.config?.layers ?? []).count
-        let maxLayers = max(configLayerCount, 9)
-        for (i, action) in HotkeyAction.layerActions.prefix(maxLayers).enumerated() {
-            let index = i
-            store.register(action: action) {
-                let session = SessionLayerStore.shared
-                if !session.layers.isEmpty && index < session.layers.count {
-                    session.switchTo(index: index)
-                } else {
-                    workspace.focusLayer(index: index)
-                }
-                EventBus.shared.post(.layerSwitched(index: index))
-            }
-        }
-
-        // Tiling hotkeys
-        let tileMap: [(HotkeyAction, TilePosition)] = [
-            (.tileLeft, .left), (.tileRight, .right),
-            (.tileMaximize, .maximize), (.tileCenter, .center),
-            (.tileTopLeft, .topLeft), (.tileTopRight, .topRight),
-            (.tileBottomLeft, .bottomLeft), (.tileBottomRight, .bottomRight),
-            (.tileTop, .top), (.tileBottom, .bottom),
-            (.tileLeftThird, .leftThird), (.tileCenterThird, .centerThird),
-            (.tileRightThird, .rightThird),
-        ]
-        for (action, position) in tileMap {
-            store.register(action: action) { WindowTiler.tileFrontmostViaAX(to: position) }
-        }
-        store.register(action: .tileDistribute) { WindowTiler.distributeVisible(reactivateLattices: false) }
-        store.register(action: .tileTypeGrid) { WindowTiler.distributeVisibleByFrontmostType(reactivateLattices: false) }
-        store.register(action: .tileOrganize) {
-            let appName = DesktopModel.shared.frontmostWindow()?.app
-                ?? NSWorkspace.shared.frontmostApplication?.localizedName
-            CommandModeWindow.shared.show(launchMode: .organize(appName: appName))
-        }
-
-        // Onboarding on first launch; otherwise just check permissions
         if !OnboardingWindowController.shared.showIfNeeded() {
             PermissionChecker.shared.check()
         }
 
-        // Start daemon services
-        let diag = DiagnosticLog.shared
-        let tBoot = diag.startTimed("Daemon services boot")
-        OcrStore.shared.open()
-        DesktopModel.shared.start()
-        OcrModel.shared.start()
-        TmuxModel.shared.start()
-        ProcessModel.shared.start()
-        LatticesApi.setup()
-        DaemonServer.shared.start()
-        if Preferences.shared.companionBridgeEnabled {
-            LatticesCompanionBridgeServer.shared.start()
-        } else {
-            diag.info("CompanionBridge: disabled by preference")
-        }
-        AgentPool.shared.start()
-        diag.finish(tBoot)
+        AppServicesBootstrap.start()
 
         Task {
             await AppUpdater.shared.checkIfNeeded()
@@ -216,135 +55,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     func applicationWillTerminate(_ notification: Notification) {
         KeyboardRemapController.shared.stop()
-        LatticesCompanionBridgeServer.shared.stop()
-        DaemonServer.shared.stop()
+        AppServicesBootstrap.stop()
     }
 
-    // MARK: - Status item click handler
-
-    @objc private func statusItemClicked(_ sender: Any?) {
-        guard let event = NSApp.currentEvent, let button = statusItem.button else { return }
-
-        if event.type == .rightMouseUp {
-            // Right-click → context menu
-            contextMenu.popUp(positioning: nil, at: NSPoint(x: 0, y: button.bounds.height + 4), in: button)
-        } else {
-            // Left-click → toggle the menu bar projects popover.
-            if let shown = popover, shown.isShown {
-                shown.performClose(sender)
-            } else {
-                showProjectsPopover()
-            }
-        }
+    private func registerVisibleSurfaces() {
+        let coordinator = AppActivationCoordinator.shared
+        coordinator.registerSurface(id: "menuBarPopover") { MenuBarController.shared.isPopoverShown }
+        coordinator.registerSurface(id: "commandMode") { CommandModeWindow.shared.isVisible }
+        coordinator.registerSurface(id: "commandPalette") { CommandPaletteWindow.shared.isVisible }
+        coordinator.registerSurface(id: "mainWindow") { MainWindow.shared.isVisible }
+        coordinator.registerSurface(id: "screenMap") { ScreenMapWindowController.shared.isVisible }
+        coordinator.registerSurface(id: "omniSearch") { OmniSearchWindow.shared.isVisible }
     }
-
-    /// Dismiss the popover programmatically (e.g. from the pop-out button).
-    func dismissPopover() {
-        popover?.performClose(nil)
-    }
-
-    /// Cached popover — built lazily on first click, reused on every subsequent open.
-    /// Keeping the SwiftUI view tree alive avoids rebuilding on each click (slow first paint).
-    /// Data refresh is driven from `popoverWillShow` + a notification MainView listens to.
-    private func makePopover() -> NSPopover {
-        if let p = popover { return p }
-        let t = DiagnosticLog.shared.startTimed("makePopover")
-        let p = NSPopover()
-        p.contentViewController = NSHostingController(rootView: MainView(scanner: ProjectScanner.shared))
-        p.behavior = .transient
-        p.contentSize = NSSize(width: 380, height: 300)
-        p.appearance = NSAppearance(named: .darkAqua)
-        p.delegate = self
-        popover = p
-        DiagnosticLog.shared.finish(t)
-        return p
-    }
-
-    private func showProjectsPopover() {
-        guard let button = statusItem.button else { return }
-        let p = makePopover()
-        p.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-        p.contentViewController?.view.window?.makeKey()
-    }
-
-    func popoverWillShow(_ notification: Notification) {
-        Self.updateActivationPolicy()
-        NotificationCenter.default.post(name: .latticesPopoverWillShow, object: nil)
-    }
-
-    func popoverDidClose(_ notification: Notification) {
-        Self.updateActivationPolicy()
-    }
-
-    // MARK: - Context menu
-
-    private func buildContextMenu() -> NSMenu {
-        let menu = NSMenu()
-
-        let actions: [(String, String, Selector)] = [
-            ("Home", "", #selector(menuWorkspace)),
-            ("Layout", "", #selector(menuLayout)),
-            ("Search", "", #selector(menuSearch)),
-            ("Command Palette", "⌘⇧M", #selector(menuCommandPalette)),
-        ]
-        for (title, shortcut, action) in actions {
-            let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
-            item.target = self
-            if !shortcut.isEmpty {
-                // Display-only; the actual hotkey is global
-            }
-            menu.addItem(item)
-        }
-
-        menu.addItem(.separator())
-
-        let cliActions: [(String, Selector)] = [
-            ("Projects…", #selector(menuProjects)),
-            ("Initialize Project in Terminal…", #selector(menuInitializeProject)),
-            ("Launch Project in Terminal…", #selector(menuLaunchProject)),
-        ]
-        for (title, action) in cliActions {
-            let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
-            item.target = self
-            menu.addItem(item)
-        }
-
-        menu.addItem(.separator())
-
-        let update = NSMenuItem(title: "Update Lattices…", action: #selector(menuUpdate), keyEquivalent: "")
-        update.target = self
-        menu.addItem(update)
-
-        menu.addItem(.separator())
-
-        let settings = NSMenuItem(title: "Help & Settings…", action: #selector(menuSettings), keyEquivalent: ",")
-        settings.target = self
-        menu.addItem(settings)
-
-        menu.addItem(.separator())
-
-        let quit = NSMenuItem(title: "Quit Lattices", action: #selector(menuQuit), keyEquivalent: "q")
-        quit.target = self
-        menu.addItem(quit)
-
-        return menu
-    }
-
-    @objc private func menuCommandPalette() { CommandPaletteWindow.shared.toggle() }
-    @objc private func menuWorkspace() { ScreenMapWindowController.shared.showPage(.home) }
-    @objc private func menuLayout() { ScreenMapWindowController.shared.showPage(.screenMap) }
-    @objc private func menuSearch() { ScreenMapWindowController.shared.showPage(.desktopInventory) }
-    @objc private func menuDocs() { SettingsWindowController.shared.show() }
-    @objc private func menuProjects() { DispatchQueue.main.async { self.showProjectsPopover() } }
-    @objc private func menuInitializeProject() { CliActionLauncher.initializeProjectInTerminal() }
-    @objc private func menuLaunchProject() { CliActionLauncher.launchProjectInTerminal() }
-    @objc private func menuHUD() { HUDController.shared.toggle() }
-    @objc private func menuWindowBezel() { Self.showWorkspaceInspector() }
-    @objc private func menuCheatSheet() { SettingsWindowController.shared.show() }
-    @objc private func menuOmniSearch() { OmniSearchWindow.shared.toggle() }
-    @MainActor @objc private func menuUpdate() { AppUpdater.shared.promptForUpdate() }
-    @objc private func menuSettings() { SettingsWindowController.shared.show() }
-    @objc private func menuQuit() { NSApp.terminate(nil) }
 
     // MARK: - Deep Links
 
@@ -397,13 +119,4 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
     }
 
-    private static func showWorkspaceInspector() {
-        guard let entry = DesktopModel.shared.frontmostWindow(),
-              entry.app != "Lattices" else {
-            ScreenMapWindowController.shared.showPage(.screenMap)
-            return
-        }
-
-        ScreenMapWindowController.shared.showWindow(wid: entry.wid)
-    }
 }

--- a/app/Sources/AppShell/AppServicesBootstrap.swift
+++ b/app/Sources/AppShell/AppServicesBootstrap.swift
@@ -1,0 +1,25 @@
+enum AppServicesBootstrap {
+    static func start() {
+        let diagnosticLog = DiagnosticLog.shared
+        let timedBoot = diagnosticLog.startTimed("Daemon services boot")
+        OcrStore.shared.open()
+        DesktopModel.shared.start()
+        OcrModel.shared.start()
+        TmuxModel.shared.start()
+        ProcessModel.shared.start()
+        LatticesApi.setup()
+        DaemonServer.shared.start()
+        if Preferences.shared.companionBridgeEnabled {
+            LatticesCompanionBridgeServer.shared.start()
+        } else {
+            diagnosticLog.info("CompanionBridge: disabled by preference")
+        }
+        AgentPool.shared.start()
+        diagnosticLog.finish(timedBoot)
+    }
+
+    static func stop() {
+        LatticesCompanionBridgeServer.shared.stop()
+        DaemonServer.shared.stop()
+    }
+}

--- a/app/Sources/AppShell/AppUpdater.swift
+++ b/app/Sources/AppShell/AppUpdater.swift
@@ -31,6 +31,7 @@ final class AppUpdater: ObservableObject {
     private init() {}
 
     var currentVersion: String { LatticesRuntime.appVersion }
+    var currentDisplayVersion: String { LatticesRuntime.appDisplayVersion }
 
     var canUpdate: Bool {
         LatticesRuntime.bunPath != nil && LatticesRuntime.appHelperScriptPath != nil
@@ -124,7 +125,7 @@ final class AppUpdater: ObservableObject {
                 } else {
                     presentAlert(
                         title: "Lattices Is Up to Date",
-                        message: "You’re running \(currentVersion), which is the latest published release."
+                        message: "You’re running \(currentDisplayVersion), which is the latest available build for this install."
                     )
                 }
             }
@@ -140,7 +141,7 @@ final class AppUpdater: ObservableObject {
         if let update = availableUpdate {
             alert.messageText = "Update Lattices?"
             alert.informativeText = """
-            Current version: \(currentVersion)
+            Current version: \(currentDisplayVersion)
             New version: \(update.version)
 
             Lattices will download the signed release, quit briefly, replace the app, and relaunch when the update is ready.
@@ -148,7 +149,7 @@ final class AppUpdater: ObservableObject {
         } else {
             alert.messageText = "Check and update Lattices?"
             alert.informativeText = """
-            Current version: \(currentVersion)
+            Current version: \(currentDisplayVersion)
             New version: latest published release
 
             Lattices will download the signed release, quit briefly, replace the app, and relaunch when the update is ready.

--- a/app/Sources/AppShell/HotkeyBootstrap.swift
+++ b/app/Sources/AppShell/HotkeyBootstrap.swift
@@ -1,0 +1,86 @@
+import AppKit
+
+enum HotkeyBootstrap {
+    static func registerHotkeys() {
+        let scanner = ProjectScanner.shared
+        CommandPaletteWindow.shared.configure(scanner: scanner)
+
+        let store = HotkeyStore.shared
+        store.register(action: .palette) { CommandPaletteWindow.shared.toggle() }
+        store.register(action: .unifiedWindow) { ScreenMapWindowController.shared.toggle() }
+        store.register(action: .bezel) { WorkspaceInspectorPresenter.show() }
+        store.register(action: .cheatSheet) { SettingsWindowController.shared.show() }
+        store.register(action: .desktopInventory) {
+            DiagnosticLog.shared.info("Hotkey: desktopInventory triggered")
+            ScreenMapWindowController.shared.showPage(.desktopInventory)
+        }
+        store.register(action: .voiceCommand) {
+            DiagnosticLog.shared.info("Hotkey: voiceCommand triggered")
+            VoiceCommandWindow.shared.toggle()
+        }
+        store.register(action: .handsOff) {
+            DiagnosticLog.shared.info("Hotkey: handsOff triggered")
+            HandsOffSession.shared.toggle()
+            if HandsOffSession.shared.state != .idle {
+                HUDController.shared.showVoiceBar()
+            } else {
+                HUDController.shared.hideVoiceBar()
+            }
+        }
+        store.register(action: .hud) { HUDController.shared.toggle() }
+        store.register(action: .mouseFinder) { MouseFinder.shared.find() }
+        store.register(action: .omniSearch) { OmniSearchWindow.shared.toggle() }
+
+        registerLayerHotkeys(store: store)
+        registerTilingHotkeys(store: store)
+    }
+
+    private static func registerLayerHotkeys(store: HotkeyStore) {
+        store.register(action: .layerNext) { SessionLayerStore.shared.cycleNext() }
+        store.register(action: .layerPrev) { SessionLayerStore.shared.cyclePrev() }
+        store.register(action: .layerTag) { SessionLayerStore.shared.tagFrontmostWindow() }
+
+        let workspace = WorkspaceManager.shared
+        let configLayerCount = (workspace.config?.layers ?? []).count
+        let maxLayers = max(configLayerCount, 9)
+        for (index, action) in HotkeyAction.layerActions.prefix(maxLayers).enumerated() {
+            store.register(action: action) {
+                let session = SessionLayerStore.shared
+                if !session.layers.isEmpty && index < session.layers.count {
+                    session.switchTo(index: index)
+                } else {
+                    workspace.focusLayer(index: index)
+                }
+                EventBus.shared.post(.layerSwitched(index: index))
+            }
+        }
+    }
+
+    private static func registerTilingHotkeys(store: HotkeyStore) {
+        let tileMap: [(HotkeyAction, TilePosition)] = [
+            (.tileLeft, .left), (.tileRight, .right),
+            (.tileMaximize, .maximize), (.tileCenter, .center),
+            (.tileTopLeft, .topLeft), (.tileTopRight, .topRight),
+            (.tileBottomLeft, .bottomLeft), (.tileBottomRight, .bottomRight),
+            (.tileTop, .top), (.tileBottom, .bottom),
+            (.tileLeftThird, .leftThird), (.tileCenterThird, .centerThird),
+            (.tileRightThird, .rightThird),
+        ]
+        for (action, position) in tileMap {
+            store.register(action: action) {
+                WindowTiler.tileFrontmostViaAX(to: position)
+            }
+        }
+        store.register(action: .tileDistribute) {
+            WindowTiler.distributeVisible(reactivateLattices: false)
+        }
+        store.register(action: .tileTypeGrid) {
+            WindowTiler.distributeVisibleByFrontmostType(reactivateLattices: false)
+        }
+        store.register(action: .tileOrganize) {
+            let appName = DesktopModel.shared.frontmostWindow()?.app
+                ?? NSWorkspace.shared.frontmostApplication?.localizedName
+            CommandModeWindow.shared.show(launchMode: .organize(appName: appName))
+        }
+    }
+}

--- a/app/Sources/AppShell/LatticesRuntime.swift
+++ b/app/Sources/AppShell/LatticesRuntime.swift
@@ -55,7 +55,46 @@ enum LatticesRuntime {
             ?? "unknown"
     }
 
+    static var appDisplayVersion: String {
+        let base = appVersion == "unknown" ? "unknown" : "v\(appVersion)"
+        guard isDevBuild else { return base }
+
+        let track = buildTrack ?? "latest"
+        return "\(base)-dev.\(track)"
+    }
+
+    static var buildChannel: String {
+        let raw = Bundle.main.infoDictionary?["LatticesBuildChannel"] as? String
+        return raw?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? "release"
+    }
+
+    static var buildTrack: String? {
+        normalizedInfoValue("LatticesBuildTrack")
+    }
+
+    static var buildRevision: String? {
+        normalizedInfoValue("LatticesBuildRevision")
+    }
+
+    static var buildTimestamp: String? {
+        normalizedInfoValue("LatticesBuildTimestamp")
+    }
+
+    static var isDevBuild: Bool {
+        buildChannel == "dev"
+    }
+
+    static var buildStatusLabel: String {
+        isDevBuild ? "Latest local dev build" : "Signed release build"
+    }
+
     private static func hasAppHelper(in root: String) -> Bool {
         FileManager.default.fileExists(atPath: root + "/bin/lattices-app.ts")
+    }
+
+    private static func normalizedInfoValue(_ key: String) -> String? {
+        guard let raw = Bundle.main.infoDictionary?[key] as? String else { return nil }
+        let value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty || value == "unknown" ? nil : value
     }
 }

--- a/app/Sources/AppShell/MainView.swift
+++ b/app/Sources/AppShell/MainView.swift
@@ -108,19 +108,19 @@ struct MainView: View {
                     Spacer()
 
                     headerButton(icon: "house") {
-                        (NSApp.delegate as? AppDelegate)?.dismissPopover()
+                        MenuBarController.shared.dismissPopover()
                         ScreenMapWindowController.shared.showPage(.home)
                     }
                     headerButton(icon: "rectangle.3.group") {
-                        (NSApp.delegate as? AppDelegate)?.dismissPopover()
+                        MenuBarController.shared.dismissPopover()
                         ScreenMapWindowController.shared.showPage(.screenMap)
                     }
                     headerButton(icon: "magnifyingglass") {
-                        (NSApp.delegate as? AppDelegate)?.dismissPopover()
+                        MenuBarController.shared.dismissPopover()
                         ScreenMapWindowController.shared.showPage(.desktopInventory)
                     }
                     headerButton(icon: "command") {
-                        (NSApp.delegate as? AppDelegate)?.dismissPopover()
+                        MenuBarController.shared.dismissPopover()
                         CommandPaletteWindow.shared.toggle()
                     }
                     headerButton(icon: "arrow.clockwise") { scanner.scan(); inventory.refresh() }

--- a/app/Sources/AppShell/MenuBarController.swift
+++ b/app/Sources/AppShell/MenuBarController.swift
@@ -1,0 +1,177 @@
+import AppKit
+import SwiftUI
+
+final class MenuBarController: NSObject, NSPopoverDelegate {
+    static let shared = MenuBarController()
+
+    private var statusItem: NSStatusItem?
+    private var popover: NSPopover?
+    private var contextMenu: NSMenu?
+
+    var isPopoverShown: Bool {
+        popover?.isShown == true
+    }
+
+    private override init() {
+        super.init()
+    }
+
+    func start() {
+        guard statusItem == nil else { return }
+
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+        if let button = statusItem?.button {
+            button.image = Self.menuBarIcon
+            button.action = #selector(statusItemClicked(_:))
+            button.sendAction(on: [.leftMouseUp, .rightMouseUp])
+            button.target = self
+        }
+
+        contextMenu = buildContextMenu()
+    }
+
+    func warmUpPopover() {
+        let popover = makePopover()
+        _ = popover.contentViewController?.view
+    }
+
+    func dismissPopover() {
+        popover?.performClose(nil)
+    }
+
+    private func showProjectsPopover() {
+        guard let button = statusItem?.button else { return }
+        let popover = makePopover()
+        popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        popover.contentViewController?.view.window?.makeKey()
+    }
+
+    @objc private func statusItemClicked(_ sender: Any?) {
+        guard let event = NSApp.currentEvent,
+              let button = statusItem?.button else { return }
+
+        if event.type == .rightMouseUp {
+            contextMenu?.popUp(positioning: nil, at: NSPoint(x: 0, y: button.bounds.height + 4), in: button)
+        } else if let shown = popover, shown.isShown {
+            shown.performClose(sender)
+        } else {
+            showProjectsPopover()
+        }
+    }
+
+    private func makePopover() -> NSPopover {
+        if let popover { return popover }
+        let timed = DiagnosticLog.shared.startTimed("makePopover")
+        let popover = NSPopover()
+        popover.contentViewController = NSHostingController(rootView: MainView(scanner: ProjectScanner.shared))
+        popover.behavior = .transient
+        popover.contentSize = NSSize(width: 380, height: 300)
+        popover.appearance = NSAppearance(named: .darkAqua)
+        popover.delegate = self
+        self.popover = popover
+        DiagnosticLog.shared.finish(timed)
+        return popover
+    }
+
+    func popoverWillShow(_ notification: Notification) {
+        AppActivationCoordinator.shared.refresh()
+        NotificationCenter.default.post(name: .latticesPopoverWillShow, object: nil)
+    }
+
+    func popoverDidClose(_ notification: Notification) {
+        AppActivationCoordinator.shared.refresh()
+    }
+
+    private func buildContextMenu() -> NSMenu {
+        let menu = NSMenu()
+
+        let actions: [(String, String, Selector)] = [
+            ("Home", "", #selector(menuWorkspace)),
+            ("Layout", "", #selector(menuLayout)),
+            ("Search", "", #selector(menuSearch)),
+            ("Command Palette", "⌘⇧M", #selector(menuCommandPalette)),
+        ]
+        for (title, shortcut, action) in actions {
+            let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+            item.target = self
+            if !shortcut.isEmpty {
+                // Display-only; the actual hotkey is global.
+            }
+            menu.addItem(item)
+        }
+
+        menu.addItem(.separator())
+
+        let cliActions: [(String, Selector)] = [
+            ("Projects…", #selector(menuProjects)),
+            ("Initialize Project in Terminal…", #selector(menuInitializeProject)),
+            ("Launch Project in Terminal…", #selector(menuLaunchProject)),
+        ]
+        for (title, action) in cliActions {
+            let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+            item.target = self
+            menu.addItem(item)
+        }
+
+        menu.addItem(.separator())
+
+        let update = NSMenuItem(title: "Update Lattices…", action: #selector(menuUpdate), keyEquivalent: "")
+        update.target = self
+        menu.addItem(update)
+
+        menu.addItem(.separator())
+
+        let settings = NSMenuItem(title: "Help & Settings…", action: #selector(menuSettings), keyEquivalent: ",")
+        settings.target = self
+        menu.addItem(settings)
+
+        menu.addItem(.separator())
+
+        let quit = NSMenuItem(title: "Quit Lattices", action: #selector(menuQuit), keyEquivalent: "q")
+        quit.target = self
+        menu.addItem(quit)
+
+        return menu
+    }
+
+    @objc private func menuCommandPalette() { CommandPaletteWindow.shared.toggle() }
+    @objc private func menuWorkspace() { ScreenMapWindowController.shared.showPage(.home) }
+    @objc private func menuLayout() { ScreenMapWindowController.shared.showPage(.screenMap) }
+    @objc private func menuSearch() { ScreenMapWindowController.shared.showPage(.desktopInventory) }
+    @objc private func menuProjects() { DispatchQueue.main.async { self.showProjectsPopover() } }
+    @objc private func menuInitializeProject() { CliActionLauncher.initializeProjectInTerminal() }
+    @objc private func menuLaunchProject() { CliActionLauncher.launchProjectInTerminal() }
+    @MainActor @objc private func menuUpdate() { AppUpdater.shared.promptForUpdate() }
+    @objc private func menuSettings() { SettingsWindowController.shared.show() }
+    @objc private func menuQuit() { NSApp.terminate(nil) }
+
+    private static let menuBarIcon: NSImage = {
+        let size: CGFloat = 18
+        let image = NSImage(size: NSSize(width: size, height: size), flipped: true) { _ in
+            let pad: CGFloat = 2
+            let gap: CGFloat = 1.5
+            let cellSize = (size - 2 * pad - 2 * gap) / 3
+            let solidCells: Set<Int> = [0, 3, 6, 7, 8]
+
+            for row in 0..<3 {
+                for column in 0..<3 {
+                    let index = row * 3 + column
+                    let x = pad + CGFloat(column) * (cellSize + gap)
+                    let y = pad + CGFloat(row) * (cellSize + gap)
+                    let rect = NSRect(x: x, y: y, width: cellSize, height: cellSize)
+
+                    if solidCells.contains(index) {
+                        NSColor.black.setFill()
+                    } else {
+                        NSColor.black.withAlphaComponent(0.25).setFill()
+                    }
+                    let path = NSBezierPath(roundedRect: rect, xRadius: 0.8, yRadius: 0.8)
+                    path.fill()
+                }
+            }
+            return true
+        }
+        image.isTemplate = true
+        return image
+    }()
+}

--- a/app/Sources/AppShell/SettingsView.swift
+++ b/app/Sources/AppShell/SettingsView.swift
@@ -304,7 +304,7 @@ struct SettingsContentView: View {
                                 .font(Typo.mono(12))
                                 .foregroundColor(Palette.text)
                             Spacer()
-                            Text("Current v\(appUpdater.currentVersion)")
+                            Text("Current \(appUpdater.currentDisplayVersion)")
                                 .font(Typo.caption(10))
                                 .foregroundColor(Palette.textMuted)
                         }
@@ -312,6 +312,21 @@ struct SettingsContentView: View {
                         Text("Lattices can check for new signed releases and prepare the update here. You’ll confirm before the app quits and relaunches.")
                             .font(Typo.caption(10))
                             .foregroundColor(Palette.textMuted)
+
+                        HStack(spacing: 6) {
+                            Image(systemName: LatticesRuntime.isDevBuild ? "hammer.fill" : "checkmark.seal.fill")
+                                .font(.system(size: 9, weight: .semibold))
+                                .foregroundColor(LatticesRuntime.isDevBuild ? Palette.running : Palette.textMuted)
+                            Text(LatticesRuntime.buildStatusLabel)
+                                .font(Typo.monoBold(9))
+                                .foregroundColor(LatticesRuntime.isDevBuild ? Palette.running.opacity(0.9) : Palette.textMuted.opacity(0.9))
+                            if let revision = LatticesRuntime.buildRevision {
+                                Text(revision)
+                                    .font(Typo.caption(9))
+                                    .foregroundColor(Palette.textMuted.opacity(0.75))
+                            }
+                            Spacer()
+                        }
 
                         if let update = appUpdater.availableUpdate {
                             VStack(alignment: .leading, spacing: 6) {

--- a/app/Sources/AppShell/WorkspaceInspectorPresenter.swift
+++ b/app/Sources/AppShell/WorkspaceInspectorPresenter.swift
@@ -1,0 +1,13 @@
+import AppKit
+
+enum WorkspaceInspectorPresenter {
+    static func show() {
+        guard let entry = DesktopModel.shared.frontmostWindow(),
+              entry.app != "Lattices" else {
+            ScreenMapWindowController.shared.showPage(.screenMap)
+            return
+        }
+
+        ScreenMapWindowController.shared.showWindow(wid: entry.wid)
+    }
+}

--- a/app/Sources/Core/Desktop/WindowDragSnapController.swift
+++ b/app/Sources/Core/Desktop/WindowDragSnapController.swift
@@ -36,7 +36,6 @@ final class WindowDragSnapController {
 
     private var dragCandidate: DragWindowCandidate?
     private var activeSession: DragSession?
-    private var overlayPanels: [String: WindowSnapOverlayPanel] = [:]
     private var modifierModeEnabled = false
     private var windowHasMoved = false
 
@@ -203,9 +202,7 @@ final class WindowDragSnapController {
     }
 
     private func hideOverlays() {
-        for panel in overlayPanels.values {
-            panel.orderOut(nil)
-        }
+        ScreenOverlayCanvasController.shared.removeLayers(owner: .dragSnap)
     }
 
     private func captureFocusedWindow(at mouseLocation: NSPoint) -> DragWindowCandidate? {
@@ -271,7 +268,7 @@ final class WindowDragSnapController {
 
         var resolved: [ResolvedSnapZone] = []
         for screen in NSScreen.screens {
-            let screenID = Self.screenID(for: screen)
+            let screenID = ScreenOverlayCanvasController.screenID(for: screen)
             for (zone, placement, triggerFractions, priority) in baseZones {
                 let triggerRect = Self.screenRect(for: triggerFractions, on: screen)
                 let previewRect = Self.screenRect(fromAX: WindowTiler.tileFrame(for: placement, on: screen))
@@ -312,17 +309,14 @@ final class WindowDragSnapController {
     private func render(zones: [ResolvedSnapZone], hoveredZone: ResolvedSnapZone?) {
         let config = WorkspaceManager.shared.snapZonesConfig
         let grouped = Dictionary(grouping: zones, by: \.screenID)
-        let activeScreenIDs = Set(grouped.keys)
+        var layers: [ScreenOverlayLayerSnapshot] = []
 
         for screen in NSScreen.screens {
-            let screenID = Self.screenID(for: screen)
+            let screenID = ScreenOverlayCanvasController.screenID(for: screen)
             guard let screenZones = grouped[screenID], !screenZones.isEmpty else { continue }
 
-            let panel = overlayPanels[screenID] ?? makeOverlayPanel(for: screen)
-            panel.setFrame(screen.frame, display: false)
-
             let localZones = screenZones.map {
-                WindowSnapOverlayView.Zone(
+                ScreenOverlaySnapZone(
                     id: $0.id,
                     label: $0.label,
                     rect: $0.visibleRect.offsetBy(dx: -screen.frame.minX, dy: -screen.frame.minY),
@@ -334,7 +328,7 @@ final class WindowDragSnapController {
                 ? hoveredZone?.previewRect.offsetBy(dx: -screen.frame.minX, dy: -screen.frame.minY)
                 : nil
 
-            panel.overlayView.model = WindowSnapOverlayView.Model(
+            let payload = ScreenOverlaySnapZonesPayload(
                 zones: localZones,
                 previewRect: previewRect,
                 previewLabel: nil,
@@ -344,26 +338,20 @@ final class WindowDragSnapController {
                 cornerRadius: config.cornerRadius ?? SnapZonesConfig.defaults.cornerRadius ?? 18
             )
 
-            panel.orderFrontRegardless()
+            layers.append(
+                ScreenOverlayLayerSnapshot(
+                    id: ScreenOverlayLayerID("dragSnap.\(screenID)"),
+                    owner: .dragSnap,
+                    screen: .screen(id: screenID),
+                    zIndex: 100,
+                    opacity: 1,
+                    payload: .snapZones(payload),
+                    expiresAt: nil
+                )
+            )
         }
 
-        for (screenID, panel) in overlayPanels where !activeScreenIDs.contains(screenID) {
-            panel.orderOut(nil)
-        }
-    }
-
-    private func makeOverlayPanel(for screen: NSScreen) -> WindowSnapOverlayPanel {
-        let panel = WindowSnapOverlayPanel(frame: screen.frame)
-        overlayPanels[Self.screenID(for: screen)] = panel
-        return panel
-    }
-
-    private static func screenID(for screen: NSScreen) -> String {
-        let key = NSDeviceDescriptionKey("NSScreenNumber")
-        if let number = screen.deviceDescription[key] as? NSNumber {
-            return number.stringValue
-        }
-        return screen.localizedName
+        ScreenOverlayCanvasController.shared.replaceLayers(owner: .dragSnap, with: layers)
     }
 
     private static func screenRect(for fractions: (CGFloat, CGFloat, CGFloat, CGFloat), on screen: NSScreen) -> CGRect {
@@ -437,192 +425,5 @@ final class WindowDragSnapController {
 
     private static func clamp(_ value: CGFloat, min lower: CGFloat, max upper: CGFloat) -> CGFloat {
         Swift.max(lower, Swift.min(upper, value))
-    }
-}
-
-private final class WindowSnapOverlayPanel: NSPanel {
-    let overlayView = WindowSnapOverlayView(frame: .zero)
-
-    init(frame: CGRect) {
-        super.init(
-            contentRect: frame,
-            styleMask: [.borderless, .nonactivatingPanel],
-            backing: .buffered,
-            defer: false
-        )
-
-        isOpaque = false
-        backgroundColor = .clear
-        hasShadow = false
-        ignoresMouseEvents = true
-        level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.maximumWindow)))
-        collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
-        isMovable = false
-        hidesOnDeactivate = false
-        animationBehavior = .none
-        overlayView.frame = NSRect(origin: .zero, size: frame.size)
-        overlayView.autoresizingMask = [.width, .height]
-        contentView = overlayView
-    }
-
-    override var canBecomeKey: Bool { false }
-    override var canBecomeMain: Bool { false }
-}
-
-private final class WindowSnapOverlayView: NSView {
-    struct Zone {
-        let id: String
-        let label: String
-        let rect: CGRect
-        let isHovered: Bool
-    }
-
-    struct Model {
-        let zones: [Zone]
-        let previewRect: CGRect?
-        let previewLabel: String?
-        let zoneOpacity: CGFloat
-        let highlightOpacity: CGFloat
-        let previewOpacity: CGFloat
-        let cornerRadius: CGFloat
-
-        static let empty = Model(
-            zones: [],
-            previewRect: nil,
-            previewLabel: nil,
-            zoneOpacity: 0.10,
-            highlightOpacity: 0.22,
-            previewOpacity: 0.18,
-            cornerRadius: 18
-        )
-    }
-
-    var model: Model = .empty {
-        didSet { needsDisplay = true }
-    }
-
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-        wantsLayer = true
-        layer?.backgroundColor = NSColor.clear.cgColor
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func draw(_ dirtyRect: NSRect) {
-        NSColor.clear.setFill()
-        bounds.fill()
-
-        for zone in model.zones {
-            drawZone(zone)
-        }
-
-        if let previewRect = model.previewRect {
-            drawPreview(previewRect, label: model.previewLabel)
-        }
-    }
-
-    private func drawZone(_ zone: Zone) {
-        let rect = zone.rect.insetBy(dx: 1.5, dy: 1.5)
-        let radius = min(model.cornerRadius, min(rect.width, rect.height) * 0.34)
-        let path = NSBezierPath(roundedRect: rect, xRadius: radius, yRadius: radius)
-        let idleStrength = max(0.35, min(model.zoneOpacity / 0.10, 1.4))
-        let hoverStrength = max(0.35, min(model.highlightOpacity / 0.22, 1.4))
-
-        let shadow = NSShadow()
-        shadow.shadowBlurRadius = zone.isHovered ? 18 : 10
-        shadow.shadowOffset = NSSize(width: 0, height: -2)
-        shadow.shadowColor = NSColor.black.withAlphaComponent(zone.isHovered ? 0.20 : 0.10)
-
-        NSGraphicsContext.saveGraphicsState()
-        shadow.set()
-        let baseTop = NSColor(
-            calibratedWhite: 0.13,
-            alpha: zone.isHovered ? 0.42 * hoverStrength : 0.22 * idleStrength
-        )
-        let baseBottom = NSColor(
-            calibratedWhite: 0.07,
-            alpha: zone.isHovered ? 0.34 * hoverStrength : 0.15 * idleStrength
-        )
-        NSGradient(starting: baseTop, ending: baseBottom)?.draw(in: path, angle: -90)
-        NSGraphicsContext.restoreGraphicsState()
-
-        if zone.isHovered {
-            let glowPath = path.copy() as! NSBezierPath
-            glowPath.lineWidth = 6
-            NSColor(calibratedRed: 0.25, green: 0.84, blue: 0.58, alpha: model.highlightOpacity * 0.28).setStroke()
-            glowPath.stroke()
-        }
-
-        path.lineWidth = zone.isHovered ? 1.6 : 1.0
-        NSColor(
-            calibratedRed: 0.52,
-            green: 0.94,
-            blue: 0.72,
-            alpha: zone.isHovered ? 0.54 * hoverStrength : 0.10 * idleStrength
-        ).setStroke()
-        path.stroke()
-
-        let lipRect = CGRect(x: rect.minX + 1.5, y: rect.maxY - 2.5, width: rect.width - 3, height: 2)
-        if lipRect.width > 0 {
-            let lipPath = NSBezierPath(roundedRect: lipRect, xRadius: 1, yRadius: 1)
-            NSColor.white.withAlphaComponent(zone.isHovered ? 0.18 : 0.08).setFill()
-            lipPath.fill()
-        }
-
-        drawLabel(zone.label, in: rect, emphasized: zone.isHovered)
-    }
-
-    private func drawPreview(_ rect: CGRect, label: String?) {
-        let previewRect = rect.insetBy(dx: 10, dy: 10)
-        let radius = min(model.cornerRadius, min(previewRect.width, previewRect.height) * 0.14)
-        let path = NSBezierPath(roundedRect: previewRect, xRadius: radius, yRadius: radius)
-
-        NSColor(calibratedWhite: 1.0, alpha: model.previewOpacity * 0.22).setFill()
-        path.fill()
-
-        path.lineWidth = 1.6
-        path.setLineDash([10, 8], count: 2, phase: 0)
-        NSColor(
-            calibratedRed: 0.44,
-            green: 0.90,
-            blue: 0.68,
-            alpha: max(0.34, model.previewOpacity * 3.2)
-        ).setStroke()
-        path.stroke()
-        path.setLineDash([], count: 0, phase: 0)
-
-        let innerPath = NSBezierPath(roundedRect: previewRect.insetBy(dx: 7, dy: 7), xRadius: max(radius - 4, 8), yRadius: max(radius - 4, 8))
-        innerPath.lineWidth = 1
-        NSColor.white.withAlphaComponent(max(0.08, model.previewOpacity * 1.2)).setStroke()
-        innerPath.stroke()
-
-        if let label {
-            let tagRect = CGRect(x: previewRect.minX + 14, y: previewRect.maxY - 34, width: 110, height: 24)
-            let tagPath = NSBezierPath(roundedRect: tagRect, xRadius: 12, yRadius: 12)
-            NSColor(calibratedWhite: 0.08, alpha: 0.62).setFill()
-            tagPath.fill()
-            NSColor.white.withAlphaComponent(0.10).setStroke()
-            tagPath.lineWidth = 1
-            tagPath.stroke()
-            drawLabel(label, in: tagRect, emphasized: true)
-        }
-    }
-
-    private func drawLabel(_ label: String, in rect: CGRect, emphasized: Bool) {
-        let font = NSFont.monospacedSystemFont(ofSize: emphasized ? 11 : 10, weight: emphasized ? .semibold : .medium)
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: font,
-            .foregroundColor: NSColor.white.withAlphaComponent(emphasized ? 0.92 : 0.72),
-        ]
-        let attr = NSAttributedString(string: label.uppercased(), attributes: attributes)
-        let size = attr.size()
-        let drawPoint = CGPoint(
-            x: rect.midX - size.width / 2,
-            y: rect.midY - size.height / 2
-        )
-        attr.draw(at: drawPoint)
     }
 }

--- a/app/Sources/Core/Input/MouseGestureConfig.swift
+++ b/app/Sources/Core/Input/MouseGestureConfig.swift
@@ -323,19 +323,25 @@ struct MouseShortcutActionDefinition: Codable, Equatable {
 
 struct MouseShortcutVisualDefinition: Codable, Equatable {
     var renderer: String
+    var theme: String?
     var asset: String?
     var character: String?
+    var markers: [String: String]?
     var events: [String: String]?
 
     init(
         renderer: String = "native",
+        theme: String? = nil,
         asset: String? = nil,
         character: String? = nil,
+        markers: [String: String]? = nil,
         events: [String: String]? = nil
     ) {
         self.renderer = renderer
+        self.theme = theme
         self.asset = asset
         self.character = character
+        self.markers = markers
         self.events = events
     }
 
@@ -351,6 +357,9 @@ struct MouseShortcutVisualDefinition: Codable, Equatable {
         ].compactMap { $0 }
 
         for key in keys {
+            if let marker = markers?[key] {
+                return marker
+            }
             if let marker = events?[key] {
                 return marker
             }

--- a/app/Sources/Core/Overlays/ScreenOverlayCanvasController.swift
+++ b/app/Sources/Core/Overlays/ScreenOverlayCanvasController.swift
@@ -1,0 +1,354 @@
+import AppKit
+
+struct ScreenOverlayLayerID: Hashable {
+    let rawValue: String
+
+    init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+enum ScreenOverlayOwner: String {
+    case dragSnap
+    case mouseGesture
+    case hotkeyHints
+    case focusHighlight
+}
+
+enum ScreenOverlayScreenTarget: Equatable {
+    case screen(id: String)
+    case all
+}
+
+struct ScreenOverlayLayerSnapshot {
+    let id: ScreenOverlayLayerID
+    let owner: ScreenOverlayOwner
+    let screen: ScreenOverlayScreenTarget
+    let zIndex: Int
+    let opacity: CGFloat
+    let payload: ScreenOverlayPayload
+    let expiresAt: Date?
+}
+
+enum ScreenOverlayPayload {
+    case snapZones(ScreenOverlaySnapZonesPayload)
+}
+
+struct ScreenOverlaySnapZone {
+    let id: String
+    let label: String
+    let rect: CGRect
+    let isHovered: Bool
+}
+
+struct ScreenOverlaySnapZonesPayload {
+    let zones: [ScreenOverlaySnapZone]
+    let previewRect: CGRect?
+    let previewLabel: String?
+    let zoneOpacity: CGFloat
+    let highlightOpacity: CGFloat
+    let previewOpacity: CGFloat
+    let cornerRadius: CGFloat
+}
+
+final class ScreenOverlayCanvasController {
+    static let shared = ScreenOverlayCanvasController()
+
+    private var windowsByScreenID: [String: ScreenOverlayWindow] = [:]
+    private var layersByID: [ScreenOverlayLayerID: ScreenOverlayLayerSnapshot] = [:]
+
+    private init() {}
+
+    func warmUp() {
+        reconcileScreens()
+        for window in windowsByScreenID.values {
+            window.orderFrontRegardless()
+            window.alphaValue = 0
+        }
+    }
+
+    func reconcileScreens() {
+        let currentScreenIDs = Set(NSScreen.screens.map(Self.screenID(for:)))
+        for staleID in windowsByScreenID.keys where !currentScreenIDs.contains(staleID) {
+            windowsByScreenID[staleID]?.orderOut(nil)
+            windowsByScreenID.removeValue(forKey: staleID)
+        }
+
+        for screen in NSScreen.screens {
+            let screenID = Self.screenID(for: screen)
+            let window = windowsByScreenID[screenID] ?? makeWindow(for: screen)
+            window.setFrame(screen.frame, display: false)
+            window.overlayView.frame = NSRect(origin: .zero, size: screen.frame.size)
+            windowsByScreenID[screenID] = window
+        }
+    }
+
+    func publishLayer(_ layer: ScreenOverlayLayerSnapshot) {
+        layersByID[layer.id] = layer
+        render()
+    }
+
+    func replaceLayers(owner: ScreenOverlayOwner, with layers: [ScreenOverlayLayerSnapshot]) {
+        layersByID = layersByID.filter { _, layer in layer.owner != owner }
+        for layer in layers {
+            layersByID[layer.id] = layer
+        }
+        render()
+    }
+
+    func removeLayer(id: ScreenOverlayLayerID) {
+        layersByID.removeValue(forKey: id)
+        render()
+    }
+
+    func removeLayers(owner: ScreenOverlayOwner) {
+        layersByID = layersByID.filter { _, layer in layer.owner != owner }
+        render()
+    }
+
+    static func screenID(for screen: NSScreen) -> String {
+        let key = NSDeviceDescriptionKey("NSScreenNumber")
+        if let number = screen.deviceDescription[key] as? NSNumber {
+            return number.stringValue
+        }
+        return screen.localizedName
+    }
+
+    private func makeWindow(for screen: NSScreen) -> ScreenOverlayWindow {
+        let window = ScreenOverlayWindow(frame: screen.frame)
+        windowsByScreenID[Self.screenID(for: screen)] = window
+        return window
+    }
+
+    private func render() {
+        reconcileScreens()
+        dropExpiredLayers()
+
+        for screen in NSScreen.screens {
+            let screenID = Self.screenID(for: screen)
+            guard let window = windowsByScreenID[screenID] else { continue }
+            let visibleLayers = layersByID.values
+                .filter { layer in
+                    switch layer.screen {
+                    case .all:
+                        return true
+                    case .screen(let targetID):
+                        return targetID == screenID
+                    }
+                }
+                .sorted { left, right in
+                    if left.zIndex != right.zIndex {
+                        return left.zIndex < right.zIndex
+                    }
+                    return left.id.rawValue < right.id.rawValue
+                }
+
+            window.overlayView.layers = visibleLayers
+            if visibleLayers.isEmpty {
+                window.alphaValue = 0
+            } else {
+                window.alphaValue = 1
+                window.orderFrontRegardless()
+            }
+        }
+    }
+
+    private func dropExpiredLayers() {
+        let now = Date()
+        layersByID = layersByID.filter { _, layer in
+            guard let expiresAt = layer.expiresAt else { return true }
+            return expiresAt > now
+        }
+    }
+}
+
+private final class ScreenOverlayWindow: NSPanel {
+    let overlayView = ScreenOverlayCanvasView(frame: .zero)
+
+    init(frame: CGRect) {
+        super.init(
+            contentRect: frame,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = false
+        ignoresMouseEvents = true
+        level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.maximumWindow)))
+        collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
+        isMovable = false
+        hidesOnDeactivate = false
+        animationBehavior = .none
+        alphaValue = 0
+        overlayView.frame = NSRect(origin: .zero, size: frame.size)
+        overlayView.autoresizingMask = [.width, .height]
+        contentView = overlayView
+    }
+
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+}
+
+private final class ScreenOverlayCanvasView: NSView {
+    var layers: [ScreenOverlayLayerSnapshot] = [] {
+        didSet { needsDisplay = true }
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.clear.cgColor
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        NSColor.clear.setFill()
+        bounds.fill()
+
+        for layer in layers {
+            NSGraphicsContext.saveGraphicsState()
+            NSColor.black.withAlphaComponent(0).set()
+            switch layer.payload {
+            case .snapZones(let payload):
+                drawSnapZones(payload, opacity: layer.opacity)
+            }
+            NSGraphicsContext.restoreGraphicsState()
+        }
+    }
+
+    private func drawSnapZones(_ payload: ScreenOverlaySnapZonesPayload, opacity: CGFloat) {
+        for zone in payload.zones {
+            drawSnapZone(zone, payload: payload, opacity: opacity)
+        }
+
+        if let previewRect = payload.previewRect {
+            drawSnapPreview(previewRect, label: payload.previewLabel, payload: payload, opacity: opacity)
+        }
+    }
+
+    private func drawSnapZone(
+        _ zone: ScreenOverlaySnapZone,
+        payload: ScreenOverlaySnapZonesPayload,
+        opacity: CGFloat
+    ) {
+        let rect = zone.rect.insetBy(dx: 1.5, dy: 1.5)
+        let radius = min(payload.cornerRadius, min(rect.width, rect.height) * 0.34)
+        let path = NSBezierPath(roundedRect: rect, xRadius: radius, yRadius: radius)
+        let idleStrength = max(0.35, min(payload.zoneOpacity / 0.10, 1.4))
+        let hoverStrength = max(0.35, min(payload.highlightOpacity / 0.22, 1.4))
+
+        let shadow = NSShadow()
+        shadow.shadowBlurRadius = zone.isHovered ? 18 : 10
+        shadow.shadowOffset = NSSize(width: 0, height: -2)
+        shadow.shadowColor = NSColor.black.withAlphaComponent((zone.isHovered ? 0.20 : 0.10) * opacity)
+
+        NSGraphicsContext.saveGraphicsState()
+        shadow.set()
+        let baseTop = NSColor(
+            calibratedWhite: 0.13,
+            alpha: (zone.isHovered ? 0.42 * hoverStrength : 0.22 * idleStrength) * opacity
+        )
+        let baseBottom = NSColor(
+            calibratedWhite: 0.07,
+            alpha: (zone.isHovered ? 0.34 * hoverStrength : 0.15 * idleStrength) * opacity
+        )
+        NSGradient(starting: baseTop, ending: baseBottom)?.draw(in: path, angle: -90)
+        NSGraphicsContext.restoreGraphicsState()
+
+        if zone.isHovered {
+            let glowPath = path.copy() as! NSBezierPath
+            glowPath.lineWidth = 6
+            NSColor(
+                calibratedRed: 0.25,
+                green: 0.84,
+                blue: 0.58,
+                alpha: payload.highlightOpacity * 0.28 * opacity
+            ).setStroke()
+            glowPath.stroke()
+        }
+
+        path.lineWidth = zone.isHovered ? 1.6 : 1.0
+        NSColor(
+            calibratedRed: 0.52,
+            green: 0.94,
+            blue: 0.72,
+            alpha: (zone.isHovered ? 0.54 * hoverStrength : 0.10 * idleStrength) * opacity
+        ).setStroke()
+        path.stroke()
+
+        let lipRect = CGRect(x: rect.minX + 1.5, y: rect.maxY - 2.5, width: rect.width - 3, height: 2)
+        if lipRect.width > 0 {
+            let lipPath = NSBezierPath(roundedRect: lipRect, xRadius: 1, yRadius: 1)
+            NSColor.white.withAlphaComponent((zone.isHovered ? 0.18 : 0.08) * opacity).setFill()
+            lipPath.fill()
+        }
+
+        drawLabel(zone.label, in: rect, emphasized: zone.isHovered, opacity: opacity)
+    }
+
+    private func drawSnapPreview(
+        _ rect: CGRect,
+        label: String?,
+        payload: ScreenOverlaySnapZonesPayload,
+        opacity: CGFloat
+    ) {
+        let previewRect = rect.insetBy(dx: 10, dy: 10)
+        let radius = min(payload.cornerRadius, min(previewRect.width, previewRect.height) * 0.14)
+        let path = NSBezierPath(roundedRect: previewRect, xRadius: radius, yRadius: radius)
+
+        NSColor(calibratedWhite: 1.0, alpha: payload.previewOpacity * 0.22 * opacity).setFill()
+        path.fill()
+
+        path.lineWidth = 1.6
+        path.setLineDash([10, 8], count: 2, phase: 0)
+        NSColor(
+            calibratedRed: 0.44,
+            green: 0.90,
+            blue: 0.68,
+            alpha: max(0.34, payload.previewOpacity * 3.2) * opacity
+        ).setStroke()
+        path.stroke()
+        path.setLineDash([], count: 0, phase: 0)
+
+        let innerPath = NSBezierPath(
+            roundedRect: previewRect.insetBy(dx: 7, dy: 7),
+            xRadius: max(radius - 4, 8),
+            yRadius: max(radius - 4, 8)
+        )
+        innerPath.lineWidth = 1
+        NSColor.white.withAlphaComponent(max(0.08, payload.previewOpacity * 1.2) * opacity).setStroke()
+        innerPath.stroke()
+
+        if let label {
+            let tagRect = CGRect(x: previewRect.minX + 14, y: previewRect.maxY - 34, width: 110, height: 24)
+            let tagPath = NSBezierPath(roundedRect: tagRect, xRadius: 12, yRadius: 12)
+            NSColor(calibratedWhite: 0.08, alpha: 0.62 * opacity).setFill()
+            tagPath.fill()
+            NSColor.white.withAlphaComponent(0.10 * opacity).setStroke()
+            tagPath.lineWidth = 1
+            tagPath.stroke()
+            drawLabel(label, in: tagRect, emphasized: true, opacity: opacity)
+        }
+    }
+
+    private func drawLabel(_ label: String, in rect: CGRect, emphasized: Bool, opacity: CGFloat) {
+        let font = NSFont.monospacedSystemFont(ofSize: emphasized ? 11 : 10, weight: emphasized ? .semibold : .medium)
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor.white.withAlphaComponent((emphasized ? 0.92 : 0.72) * opacity),
+        ]
+        let attributed = NSAttributedString(string: label.uppercased(), attributes: attributes)
+        let size = attributed.size()
+        let drawPoint = CGPoint(
+            x: rect.midX - size.width / 2,
+            y: rect.midY - size.height / 2
+        )
+        attributed.draw(at: drawPoint)
+    }
+}

--- a/bin/lattices-app.ts
+++ b/bin/lattices-app.ts
@@ -68,6 +68,27 @@ function packageVersion(): string {
   }
 }
 
+function gitRevision(): string {
+  try {
+    return execSync("git rev-parse --short HEAD", {
+      cwd: cliRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+function xmlEscape(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
 function launch(extraArgs: string[] = []): void {
   if (isRunning()) {
     console.log("lattices app is already running.");
@@ -133,9 +154,35 @@ function signBundle(): void {
   } catch {}
 }
 
-function writeInfoPlist(): void {
+type BundleBuildMetadata = {
+  channel?: "dev" | "release";
+  track?: string;
+  revision?: string;
+  timestamp?: string;
+};
+
+function buildMetadataPlist(metadata: BundleBuildMetadata): string {
+  if (metadata.channel !== "dev") return "";
+
+  const track = metadata.track ?? "latest";
+  const revision = metadata.revision ?? gitRevision();
+  const timestamp = metadata.timestamp ?? new Date().toISOString();
+
+  return `    <key>LatticesBuildChannel</key>
+    <string>dev</string>
+    <key>LatticesBuildTrack</key>
+    <string>${xmlEscape(track)}</string>
+    <key>LatticesBuildRevision</key>
+    <string>${xmlEscape(revision)}</string>
+    <key>LatticesBuildTimestamp</key>
+    <string>${xmlEscape(timestamp)}</string>
+`;
+}
+
+function writeInfoPlist(metadata: BundleBuildMetadata = {}): void {
   mkdirSync(resolve(bundlePath, "Contents"), { recursive: true });
   const version = packageVersion();
+  const buildMetadata = buildMetadataPlist(metadata);
   const plist = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -167,7 +214,7 @@ function writeInfoPlist(): void {
     <string>${version}</string>
     <key>CFBundleShortVersionString</key>
     <string>${version}</string>
-    <key>LSMinimumSystemVersion</key>
+${buildMetadata}    <key>LSMinimumSystemVersion</key>
     <string>13.0</string>
     <key>LSUIElement</key>
     <true/>
@@ -209,7 +256,7 @@ function buildFromSource(): boolean {
 
   mkdirSync(binaryDir, { recursive: true });
   execSync(`cp '${builtPath}' '${binaryPath}'`);
-  writeInfoPlist();
+  writeInfoPlist({ channel: "dev", track: "latest" });
   syncBundleResources();
 
   // Re-sign the bundle so macOS TCC recognizes a stable identity across rebuilds.

--- a/bin/lattices-dev
+++ b/bin/lattices-dev
@@ -15,6 +15,8 @@ ENTITLEMENTS="$APP_DIR/Lattices.entitlements"
 ICON="$ROOT/assets/AppIcon.icns"
 TAP_SOUND="$APP_DIR/Resources/tap.wav"
 VERSION="$(node -p "require('$ROOT/package.json').version" 2>/dev/null || echo '0.1.0')"
+GIT_REVISION="$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo 'unknown')"
+BUILD_TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
 red()   { printf "\033[31m%s\033[0m\n" "$*"; }
 green() { printf "\033[32m%s\033[0m\n" "$*"; }
@@ -93,6 +95,14 @@ write_info_plist() {
     <string>$VERSION</string>
     <key>CFBundleShortVersionString</key>
     <string>$VERSION</string>
+    <key>LatticesBuildChannel</key>
+    <string>dev</string>
+    <key>LatticesBuildTrack</key>
+    <string>latest</string>
+    <key>LatticesBuildRevision</key>
+    <string>$GIT_REVISION</string>
+    <key>LatticesBuildTimestamp</key>
+    <string>$BUILD_TIMESTAMP</string>
     <key>LSMinimumSystemVersion</key>
     <string>13.0</string>
     <key>LSUIElement</key>

--- a/docs/proposals/LAT-001-gesture-visual-customization.md
+++ b/docs/proposals/LAT-001-gesture-visual-customization.md
@@ -1,0 +1,522 @@
+# LAT-001: Gesture Visual Customization and Renderer Hooks
+
+## Status
+
+Partially implemented.
+
+The current implementation supports shape triggers, optional `visual` rule metadata, legacy `events` marker mappings, and `markers` mappings. Native gesture rendering remains inside `MouseGestureController`; moving gesture visuals onto the shared overlay canvas is still pending.
+
+This is the first Lattices engineering proposal in the `LAT-00n` series, following the same proposal-numbering spirit as the `SCO-00n` documents used for Scout/OpenScout planning.
+
+This document covers how to productize the recent mouse gesture and visual customization prototypes without letting decoration leak into the recognition or action-dispatch fast path.
+
+## Summary
+
+Lattices now has the bones of a gesture system that feels unusually alive for a macOS workspace tool: low-level mouse capture, shape recognition, shortcut matching, immediate native action dispatch, and a fallback overlay that can draw paths, markers, and result labels.
+
+The next question is whether customization should become a supported product surface. The answer proposed here is yes, but with a hard boundary:
+
+- gesture recognition and action dispatch remain native, synchronous, and fast
+- custom rendering is declarative, best-effort, and optional
+- user assets and external renderers never block or decide actions
+- normal customization should not require recompiling the app
+
+The first supported model should be a declarative `visual` block on mouse shortcut rules, backed by native theme presets and marker-to-animation mappings. Real Lottie playback can follow once the configuration model is stable. A plugin or XPC renderer can come later, after the native path has proven the contract.
+
+## Current Gesture Pipeline
+
+The gesture pipeline lives mainly in:
+
+- `app/Sources/Core/Input/MouseGestureController.swift`
+- `app/Sources/Core/Input/MouseGestureConfig.swift`
+- `app/Sources/Core/Input/MouseShortcutStore.swift`
+- `app/Sources/Core/Input/ShapeRecognizer.swift`
+
+The current/prototyped flow is:
+
+1. A CG event tap captures mouse button and movement events.
+2. `MouseGestureController` starts and updates gesture sessions, tracking button state, phase, and path points.
+3. Movement points are fed to `ShapeRecognizer`, which compresses raw motion into direction runs.
+4. Recognized shapes such as `l-shape-down-right` become trigger facts.
+5. `MouseShortcutStore` matches a `MouseShortcutTriggerEvent` against enabled `MouseShortcutRule` entries.
+6. The matched rule dispatches its native action immediately.
+7. `MouseGestureOverlay` and `MouseGestureOverlayView`, currently nested in `MouseGestureController.swift`, render the fallback/native gesture feedback.
+
+The important split is already visible: input capture, recognition, rule matching, and action dispatch form the control path. Overlay drawing is feedback.
+
+## What Was Prototyped
+
+Recent prototype work explored both input semantics and visual expression.
+
+Input and matching:
+
+- shape triggers
+- right, back, forward, and middle button handling
+- MX back/forward aliases
+- a back-button L shape that activates iTerm
+- native action dispatch that stays immediate
+
+Visual feedback:
+
+- path drawing instead of a single direction arrow
+- Bezier/graffiti trail rendering
+- guide dots inspired by Android pattern lock
+- satisfying result labels such as `iTerm FOCUSED`
+- a `visual` block on shortcut rules
+- a native stand-in for a custom animated character
+
+The visual customization proof of concept added optional rule metadata:
+
+```json
+{
+  "visual": {
+    "renderer": "lottie",
+    "asset": "~/.lattices/gesture-assets/cat.json",
+    "character": "cat",
+    "events": {
+      "updated": "follow",
+      "recognized:l-shape-down-right": "pounce",
+      "completed.success": "celebrate",
+      "completed.failure": "confused"
+    }
+  }
+}
+```
+
+Today, `renderer: "lottie"` is a shim/POC name, not a real Lottie dependency. The native renderer draws a small reactive cat/avatar as a stand-in for an eventual Lottie asset.
+
+That is a good prototype shape because it tests the user-facing contract without prematurely committing to a rendering engine.
+
+## Architecture Principle
+
+Recognition and action dispatch are the fast path. They must never wait on:
+
+- custom rendering
+- scripts
+- Lottie playback
+- XPC processes
+- user-provided assets
+- filesystem reads after gesture start
+- network access
+
+Visual customization is decorative. It can make gestures more legible, delightful, and personal, but it cannot become part of whether a gesture succeeds.
+
+In practical terms:
+
+- if a renderer fails, the action still runs
+- if an asset is missing, the native fallback overlay appears
+- if an external renderer is slow, it drops frames or misses the gesture
+- if config is invalid, the rule can still match using native trigger/action fields
+- action success/failure is reported from the action layer, not inferred from animation state
+
+This boundary should be visible in the code. The gesture controller can emit visual events, but renderers should consume snapshots or markers asynchronously. They should not own recognition state.
+
+## Proposed Customization Model
+
+### 1. Declarative `visual` block first
+
+Mouse shortcut rules should support a stable optional `visual` block:
+
+```json
+{
+  "id": "back-l-iterm",
+  "enabled": true,
+  "device": "any",
+  "trigger": {
+    "button": "back",
+    "kind": "shape",
+    "shape": "l-shape-down-right"
+  },
+  "action": {
+    "type": "app.activate",
+    "app": "iTerm"
+  },
+  "visual": {
+    "renderer": "native",
+    "theme": "graffiti",
+    "markers": {
+      "updated": "follow",
+      "recognized:l-shape-down-right": "commit",
+      "completed.success": "success",
+      "completed.failure": "error"
+    }
+  }
+}
+```
+
+The `visual` block should be optional and ignored by older versions where possible. Its first stable fields should be:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `renderer` | string | Selects renderer family: `native`, later `lottie`, later `external` |
+| `theme` | string? | Native preset name such as `minimal`, `graffiti`, `pattern`, `avatar` |
+| `asset` | string? | Local asset reference for renderer families that need it |
+| `character` | string? | Optional named character/avatar inside a renderer or asset pack |
+| `markers` or `events` | object | Maps gesture markers to renderer actions |
+
+The POC uses `events`; the product model should choose one name. `markers` is slightly clearer because the keys are not all raw system events. They are renderer-facing semantic markers derived from gesture state.
+
+### 2. Theme presets
+
+Before exposing arbitrary assets as the main path, ship native presets:
+
+- `minimal`: simple path and endpoint feedback
+- `graffiti`: Bezier trail with energetic completion burst
+- `pattern`: guide dots and shape lock-in feedback
+- `avatar`: native character-style feedback, similar to the POC cat
+- `quiet`: subtle feedback for users who want confirmation without flourish
+
+Presets give users customization without loading code or assets. They also give maintainers a reference for the renderer contract.
+
+### 3. Marker mapping
+
+Renderer-facing markers should be small, named, and phase-based:
+
+| Marker | Meaning |
+|---|---|
+| `started` | Gesture session began |
+| `updated` | Path changed |
+| `recognized:<shape>` | Recognizer has a likely shape |
+| `matched:<rule-id>` | Rule matched |
+| `completed.success` | Action completed successfully |
+| `completed.failure` | Action failed or no rule matched |
+| `cancelled` | Gesture was cancelled |
+
+Renderers can map these to animation names, effects, or state transitions:
+
+```json
+{
+  "markers": {
+    "started": "wake",
+    "updated": "follow",
+    "recognized:l-shape-down-right": "pounce",
+    "completed.success": "celebrate",
+    "completed.failure": "confused",
+    "cancelled": "hide"
+  }
+}
+```
+
+The control path emits facts. The renderer interprets those facts.
+
+### 4. Asset references
+
+Asset references should be local file paths or app-bundled names:
+
+```json
+{
+  "visual": {
+    "renderer": "lottie",
+    "asset": "~/.lattices/gesture-assets/cat.json",
+    "markers": {
+      "updated": "follow",
+      "completed.success": "celebrate"
+    }
+  }
+}
+```
+
+Rules:
+
+- expand `~` explicitly
+- resolve relative paths relative to `~/.lattices/`, not the current project
+- do not fetch remote URLs
+- validate extension and size before loading
+- cache parsed assets outside the gesture hot path
+- fall back to `native` if loading fails
+
+### 5. Real Lottie player later
+
+The current native shim should not pretend to be production Lottie. The roadmap should be:
+
+1. stabilize the rule schema and marker model
+2. ship native presets
+3. add a real Lottie player behind the same renderer protocol
+4. keep Lottie playback isolated from recognition and action dispatch
+
+This avoids coupling the configuration surface to the first graphics library chosen.
+
+### 6. Optional external renderer or XPC later
+
+External renderers are powerful, but they are also where latency, crash, and security complexity enters. They should be a later feature, probably via XPC rather than arbitrary process execution.
+
+The contract should look like a one-way visual event stream:
+
+- Lattices sends gesture snapshots and markers.
+- The renderer returns nothing that affects recognition or actions.
+- The renderer may request drawing surfaces only through a narrow API.
+- Timeouts and crashes are expected and non-fatal.
+
+The open source nature of Lattices means users can always recompile experiments. Product customization should be easier and safer than that.
+
+## Config Examples
+
+### Back Button L to iTerm with Native Visual Markers
+
+```json
+{
+  "id": "back-l-iterm",
+  "enabled": true,
+  "device": "any",
+  "trigger": {
+    "button": "back",
+    "kind": "shape",
+    "shape": "l-shape-down-right"
+  },
+  "action": {
+    "type": "app.activate",
+    "app": "iTerm"
+  },
+  "visual": {
+    "renderer": "native",
+    "theme": "pattern",
+    "markers": {
+      "started": "show-guides",
+      "updated": "draw-path",
+      "recognized:l-shape-down-right": "lock-shape",
+      "completed.success": "success-label",
+      "completed.failure": "miss-label"
+    }
+  }
+}
+```
+
+### Back Button L to iTerm with Future Lottie Asset
+
+```json
+{
+  "id": "back-l-iterm",
+  "enabled": true,
+  "device": "any",
+  "trigger": {
+    "button": "back",
+    "kind": "shape",
+    "shape": "l-shape-down-right"
+  },
+  "action": {
+    "type": "app.activate",
+    "app": "iTerm"
+  },
+  "visual": {
+    "renderer": "lottie",
+    "asset": "~/.lattices/gesture-assets/cat.json",
+    "character": "cat",
+    "markers": {
+      "started": "wake",
+      "updated": "follow",
+      "recognized:l-shape-down-right": "pounce",
+      "completed.success": "celebrate",
+      "completed.failure": "confused",
+      "cancelled": "hide"
+    }
+  }
+}
+```
+
+### Quiet Native Preset
+
+```json
+{
+  "id": "middle-l-palette",
+  "enabled": true,
+  "trigger": {
+    "button": "middle",
+    "kind": "shape",
+    "shape": "l-shape-down-right"
+  },
+  "action": {
+    "type": "palette.open"
+  },
+  "visual": {
+    "renderer": "native",
+    "theme": "quiet"
+  }
+}
+```
+
+## Latency Considerations
+
+Gesture UX is latency-sensitive in two places:
+
+- recognition should keep up with pointer movement
+- action dispatch should happen as soon as the gesture commits
+
+Renderer latency is allowed to be worse than action latency. The user should never feel that an animation is in charge of the system.
+
+Implementation guidelines:
+
+- use immutable gesture snapshots for renderer updates
+- throttle rendering updates independently from event capture
+- pre-load and validate assets when config changes, not when the gesture begins
+- cap path point history passed to renderers
+- drop visual frames under pressure
+- keep completion labels tied to action receipts, not animation callbacks
+
+Target behavior:
+
+- action dispatch remains effectively immediate after match
+- native visual feedback tracks the pointer smoothly
+- custom renderer failure is invisible except for fallback visuals or debug logs
+
+## Stability Considerations
+
+The gesture system sits near global input, so failure modes must be boring.
+
+Renderer failures should not:
+
+- disable the event tap
+- wedge gesture state
+- prevent shortcut matching
+- crash the app
+- leave persistent overlay windows stuck on screen
+
+Recommended boundaries:
+
+- a `GestureVisualRenderer` protocol with small methods such as `start`, `update`, `mark`, `complete`, `cancel`
+- a native fallback renderer that is always available
+- renderer selection that can fail closed to `native`
+- defensive validation of unknown marker names
+- debug logging for invalid visuals, but no noisy user-facing alerts during gestures
+
+## Security Considerations
+
+Even though Lattices is open source, normal customization should not require recompilation. That means configuration and assets become part of the product surface and need constraints.
+
+For MVP:
+
+- no remote asset URLs
+- no shell commands in `visual`
+- no arbitrary scripts
+- no executable plugins
+- local assets only
+- size limits for loaded assets
+- clear fallback when assets are missing or invalid
+
+For a future external renderer:
+
+- prefer XPC over raw process execution
+- use a narrow, documented message protocol
+- treat renderer output as pixels or visual state only
+- never accept action decisions from the renderer
+- add a user-visible trust/install flow if third-party renderer bundles are supported
+
+## Proposed Internal Shape
+
+The implementation should keep the current architecture but name the boundary more explicitly.
+
+Possible types:
+
+```swift
+struct GestureVisualConfig {
+    let renderer: GestureVisualRendererID
+    let theme: String?
+    let asset: String?
+    let character: String?
+    let markers: [String: String]
+}
+
+struct GestureVisualSnapshot {
+    let sessionID: UUID
+    let phase: GesturePhase
+    let button: MouseShortcutButton
+    let points: [CGPoint]
+    let recognizedShape: String?
+    let matchedRuleID: String?
+}
+
+protocol GestureVisualRenderer {
+    func start(_ snapshot: GestureVisualSnapshot, config: GestureVisualConfig)
+    func update(_ snapshot: GestureVisualSnapshot)
+    func mark(_ marker: String, snapshot: GestureVisualSnapshot)
+    func complete(_ marker: String, snapshot: GestureVisualSnapshot)
+    func cancel(_ snapshot: GestureVisualSnapshot)
+}
+```
+
+The exact Swift names can differ. The important part is that renderers consume snapshots and markers; they do not mutate recognition state or decide actions.
+
+## Phased Roadmap
+
+### Phase 0: POC Cleanup
+
+Goal: make the prototype understandable and safe to keep iterating.
+
+- keep native avatar/Lottie shim clearly labeled as POC
+- document current supported marker keys
+- ensure missing or invalid visual config falls back to native overlay
+- verify back/forward button aliases and shape matching remain independent from visuals
+
+### Phase 1: MVP Native Customization
+
+Goal: support real user customization without external dependencies.
+
+- stabilize the `visual` schema
+- support `renderer: "native"`
+- ship a small set of native themes
+- support marker mapping for native themes
+- load visual config from normal shortcut config
+- add diagnostics for invalid visuals
+- keep existing native overlay as fallback
+
+### Phase 2: Real Lottie Integration
+
+Goal: make `renderer: "lottie"` honest.
+
+- add a real Lottie player dependency or embedded playback implementation
+- validate and cache Lottie assets outside the gesture hot path
+- map markers to animation segments or named states
+- enforce size and complexity limits
+- provide at least one bundled example asset
+
+### Phase 3: Renderer Hooks and XPC
+
+Goal: enable deeper experiments without compromising the app.
+
+- define a one-way renderer event protocol
+- run external renderers out of process
+- add crash and timeout handling
+- add user trust/install UX for third-party renderers
+- keep all action decisions inside Lattices
+
+## Open Questions
+
+- Should the field be named `events` to match the prototype, or `markers` to better describe the stable concept?
+- Should visual config live only on individual rules, or should users be able to define reusable named visual profiles?
+- How much of `MouseGestureOverlay` should become a renderer implementation versus remaining a fallback shell?
+- Should marker names be fully free-form, or should unknown keys be rejected during config validation?
+- Do we want app-level theme defaults, per-device defaults, or only per-rule visuals for MVP?
+- Should `completed.failure` mean "no rule matched", "action failed", or both with more specific submarkers?
+- Where should user assets live: `~/.lattices/gesture-assets/`, app support, or both?
+
+## Acceptance Criteria
+
+For the MVP:
+
+- A shortcut rule can include a `visual` block without changing trigger or action behavior.
+- A back-button `l-shape-down-right` rule can activate iTerm and show native marker-based feedback.
+- Invalid visual config falls back to the native overlay and does not prevent the action.
+- Missing assets do not crash the app or delay gesture completion.
+- Recognition and action dispatch do not wait on renderer work.
+- Native themes can render started, updated, recognized, success, failure, and cancelled states.
+- The config format is documented with at least one complete example.
+- Debug diagnostics make renderer fallback understandable to maintainers.
+
+For later Lottie support:
+
+- `renderer: "lottie"` uses a real Lottie player, not the native shim.
+- Lottie assets are validated and cached before gesture start.
+- Marker mappings can target named animations or segments.
+- Lottie renderer failure falls back to native rendering without affecting actions.
+
+## Recommendation
+
+Productize visual customization, but productize it as a renderer contract rather than as a graphics feature.
+
+The useful product surface is not "play a cat animation." It is:
+
+- gestures have stable semantic markers
+- users can bind visual feedback to those markers
+- Lattices keeps input and action dispatch fast
+- renderers are replaceable decoration
+
+That gives maintainers room to ship the fun parts without letting them become load-bearing.

--- a/docs/proposals/LAT-002-shared-overlay-canvas.md
+++ b/docs/proposals/LAT-002-shared-overlay-canvas.md
@@ -1,0 +1,353 @@
+# LAT-002: Shared Per-Screen Overlay Canvas
+
+## Status
+
+Partially implemented.
+
+The shared canvas primitive exists in `ScreenOverlayCanvasController`, and drag-snap zones now publish `snapZones` layers into it. Mouse gesture visuals, passive hotkey hints, and broader overlay consolidation are still pending.
+
+This document proposes a shared, click-through, per-screen overlay canvas for Lattices. The canvas would provide one persistent visual layer per display that features can draw into without each feature creating its own overlay window stack.
+
+## Summary
+
+Lattices already has several overlay-like systems:
+
+- `HUDController` prebuilds HUD panels, keeps them ordered, and toggles visibility with alpha.
+- `WindowDragSnapController` creates full-screen snap-zone panels per screen as needed.
+- `MouseGestureController` creates transient gesture overlay panels for gesture trails and results.
+- `MouseFinder`, `WindowTiler`, and Screen Map have their own small overlay and highlight mechanisms.
+
+These are useful, but they are still separate surfaces. Each one owns its own window lifecycle, z-order behavior, coordinate mapping, visibility rules, and cleanup. That makes every new ambient visual feature slightly more expensive than it should be.
+
+The proposed primitive is a `ScreenOverlayCanvas`: one transparent, click-through, always-on-top window per screen, owned by a central controller. Features publish lightweight visual layers into that canvas. The canvas stays passive by default and never becomes the place where input semantics or actions are decided.
+
+## Why Now
+
+Recent exploration of Clicky's macOS overlay approach highlighted a simpler mental model: create one full-screen transparent window per display, make it click-through, and draw small dynamic UI elements inside it. The visible object can be tiny and contextual, but the rendering surface is stable and screen-sized.
+
+That model maps well to several Lattices ideas:
+
+- snap drag target areas
+- passive hotkey information
+- layer and workspace hints
+- mouse gesture trails
+- focus and target highlights
+- command-mode affordances
+- window-map annotations
+
+Lattices already has the hard parts in pieces. The value is in unifying the canvas primitive so features stop reinventing overlay windows.
+
+## Current State
+
+### HUD
+
+`app/Sources/Core/Overlays/HUD/HUDController.swift` already uses a warm, persistent model:
+
+1. Panels are prebuilt.
+2. Panels stay ordered in the window server.
+3. Hidden state is mostly `alphaValue = 0`.
+4. Showing the HUD is an immediate alpha flip plus focus handling.
+5. Data refresh happens after first paint.
+
+This makes the HUD feel fast. But the HUD is a set of segmented panels: top, bottom, left, right, preview, and minimap panels. It is interactive and cockpit-like, not a general screen canvas.
+
+### Drag Snap
+
+`app/Sources/Core/Desktop/WindowDragSnapController.swift` creates `WindowSnapOverlayPanel` instances keyed by screen. Each panel covers a whole screen, ignores mouse events, joins all Spaces, and draws snap zones into an `NSView`.
+
+This is very close to the proposed canvas, but it is owned by drag snap and only exists for that feature's model.
+
+### Mouse Gestures
+
+`app/Sources/Core/Input/MouseGestureController.swift` creates a `MouseGestureOverlay` for a gesture session. It draws path feedback, recognition feedback, and completion labels. It is intentionally close to the input/action fast path, but its rendering should remain decorative.
+
+### Overlay Shells
+
+`app/Sources/Core/Overlays/OverlayPanelShell.swift` helps normal panel-based surfaces, but it is optimized for discrete overlay panels, not full-screen passive visual layers.
+
+## Proposal
+
+Create a shared `ScreenOverlayCanvasController` responsible for one click-through overlay window per `NSScreen`.
+
+The controller should provide:
+
+- stable full-screen transparent windows, one per display
+- local coordinate mapping for each screen
+- feature-scoped visual layer registration
+- cheap show/hide/update calls
+- deterministic z-order within the canvas
+- automatic screen-change reconciliation
+- explicit cleanup when features end
+
+The overlay windows should be:
+
+- borderless
+- transparent
+- non-activating
+- click-through
+- not key or main windows
+- able to join all Spaces
+- available in fullscreen auxiliary contexts where practical
+- high enough level for passive visual feedback, but configurable if a surface needs a lower level
+
+Conceptually:
+
+```swift
+@MainActor
+final class ScreenOverlayCanvasController {
+    static let shared = ScreenOverlayCanvasController()
+
+    func warmUp()
+    func reconcileScreens()
+    func publishLayer(_ layer: ScreenOverlayLayerSnapshot)
+    func removeLayer(id: ScreenOverlayLayerID)
+    func removeLayers(owner: ScreenOverlayOwner)
+}
+```
+
+The first implementation can be AppKit-first: an `NSPanel` or `NSWindow` per screen hosting a custom `NSView` that draws layer snapshots. SwiftUI hosting can come later for feature surfaces that benefit from it, but the lowest-level canvas should stay simple.
+
+## Non-Goals
+
+This proposal does not make the shared canvas interactive.
+
+Clickable UI should remain in separate panels or app windows. The shared canvas is for passive visual information and transient affordances. This keeps it safe: it should never steal clicks, focus, keyboard input, or app activation.
+
+This proposal also does not move action dispatch into the canvas. Features decide behavior elsewhere and publish visual state into the canvas.
+
+## Layer Model
+
+Layers should be declarative snapshots, not live feature-owned views by default.
+
+Good examples:
+
+- `snapZones`: trigger rects, hovered zone, preview rect
+- `gestureTrail`: path points, recognized shape, result label
+- `focusHighlight`: screen rect, color, pulse style, timeout
+- `hotkeyHints`: compact labels and positions
+- `layerStatus`: current layer, running sessions, stale sessions
+
+Each snapshot should include:
+
+- stable layer id
+- owner
+- target screen id, or all screens
+- z-index within the canvas
+- visibility/opacity
+- payload enum
+- optional expiry
+
+Example shape:
+
+```swift
+struct ScreenOverlayLayerSnapshot: Equatable {
+    let id: ScreenOverlayLayerID
+    let owner: ScreenOverlayOwner
+    let screen: ScreenOverlayScreenTarget
+    let zIndex: Int
+    let opacity: CGFloat
+    let payload: ScreenOverlayPayload
+    let expiresAt: Date?
+}
+
+enum ScreenOverlayPayload: Equatable {
+    case snapZones(SnapZoneOverlayPayload)
+    case gestureTrail(GestureTrailOverlayPayload)
+    case highlight(HighlightOverlayPayload)
+    case hotkeyHints(HotkeyHintOverlayPayload)
+}
+```
+
+This is intentionally plain. The canvas can render it synchronously without asking feature controllers for more state.
+
+## Coordinate Rules
+
+The canvas should make coordinate handling boring:
+
+- external feature APIs accept global AppKit screen coordinates unless explicitly documented otherwise
+- each screen view receives local coordinates derived from its `NSScreen.frame`
+- Y-axis conversion is centralized
+- screen identity uses `NSScreenNumber` when available
+- all features use the same screen id helper
+
+This matters because Lattices currently touches AppKit, CoreGraphics, AX, and ScreenCaptureKit coordinate systems. A shared canvas should reduce the number of local conversions.
+
+## Snap Drag Migration
+
+Snap drag is the best first adopter.
+
+Today, `WindowDragSnapController` already computes:
+
+- trigger rects
+- visible label rects
+- preview rects
+- hovered zone
+- screen grouping
+
+Instead of owning `WindowSnapOverlayPanel`, it can publish a `snapZones` layer:
+
+1. Drag begins and modifier mode is active.
+2. Controller resolves zones as it does today.
+3. Controller publishes `snapZones` snapshots grouped by screen.
+4. Mouse movement updates the hovered zone and preview rect.
+5. Mouse up removes the layer and dispatches tiling as today.
+
+The drag-snap action path should not change.
+
+## HUD Relationship
+
+The HUD should not be moved wholesale onto the shared canvas.
+
+The HUD is interactive: search, selection, keyboard focus, previews, sidebars. It should remain panel-based. But the shared canvas can support HUD-adjacent passive information:
+
+- pre-HUD hotkey hints
+- layer status while a modifier is held
+- ambient screen map outlines
+- tile target previews before full HUD activation
+- “what will happen if I drop here” hints
+
+Think of the canvas as the quiet always-ready visual substrate. The HUD remains the cockpit.
+
+## Mouse Gesture Relationship
+
+Mouse gesture recognition and event suppression must remain outside the canvas.
+
+The gesture controller can publish trail snapshots and completion markers to the canvas, but:
+
+- event tap callbacks still decide pass-through vs swallow
+- shape recognition stays in the gesture pipeline
+- action dispatch stays native and immediate
+- visual renderer failure cannot affect action behavior
+
+This dovetails with `LAT-001`: gesture visuals become consumers of semantic snapshots, not owners of recognition state.
+
+## Hotkey Overlay Mode
+
+A high-value use case is a passive hotkey layer.
+
+When the user holds a configured modifier chord, Lattices could fade in lightweight context:
+
+- current layer
+- active project/session names
+- snap zones
+- mouse gesture affordances
+- focused window identity
+- available drop targets
+- voice or command-mode status
+
+This would feel different from opening the HUD. It is not a modal command surface. It is a heads-up layer that answers, “what can I do right now?”
+
+If the user releases the chord, the layer fades away. If the user continues into an action, the relevant feature can take over and update its layer.
+
+## Window Level
+
+The canvas should probably start at a high but conservative level.
+
+Existing snap overlays use `CGWindowLevelForKey(.maximumWindow)`. Clicky uses `.screenSaver`. Both work, but they should not become an accidental default for every future surface.
+
+The canvas controller should centralize this decision and document it. A first version can use the level already proven by snap overlays, then adjust after testing with:
+
+- Terminal.app
+- iTerm2
+- browser fullscreen
+- Stage Manager
+- fullscreen Spaces
+- mission control edge cases
+
+## Performance Rules
+
+The canvas should be safe to keep warm:
+
+- no polling when no layers are visible
+- no timers inside the canvas unless a visible layer requires animation
+- no filesystem reads during drawing
+- no network access
+- no feature callbacks during draw
+- coalesce rapid updates per run loop
+- keep payloads small and value-like
+
+Animations should be bounded and cancelable. Expiring layers should clean themselves up even if a feature forgets to remove them.
+
+## Failure Model
+
+Overlay failure should be boring.
+
+If the canvas cannot create a window, the feature should still run without visuals.
+
+If one screen fails, other screens should continue.
+
+If a payload cannot be rendered, the canvas should skip that layer and log a diagnostic.
+
+If screen topology changes, the controller should reconcile windows and drop or remap stale screen-targeted layers.
+
+The shared canvas must not:
+
+- block input
+- steal focus
+- leave opaque windows stuck on screen
+- make actions depend on rendering
+- crash if a feature publishes malformed or stale visual state
+
+## Implementation Plan
+
+### Phase 1: Canvas Primitive
+
+- Add `ScreenOverlayCanvasController`.
+- Add a simple `ScreenOverlayWindow` or `ScreenOverlayPanel`.
+- Add screen identity and coordinate helpers.
+- Add a minimal `ScreenOverlayView` that can render `highlight` and `snapZones` payloads.
+- Warm up windows at app launch, hidden and click-through.
+
+### Phase 2: Drag Snap Adoption
+
+- Replace `WindowSnapOverlayPanel` ownership with canvas snapshots.
+- Keep existing snap-zone geometry and tiling behavior.
+- Verify multi-monitor drag, fullscreen Spaces, and modifier toggling.
+- Remove old snap overlay panel code after parity.
+
+### Phase 3: Gesture Visual Adoption
+
+- Publish gesture path snapshots from `MouseGestureController`.
+- Move native gesture trail drawing into the canvas renderer.
+- Keep recognition/action dispatch untouched.
+- Align with `LAT-001` renderer hooks.
+
+### Phase 4: Passive Hotkey Layer
+
+- Add a read-only modifier watcher for a passive “show context” chord.
+- Publish layer/session/window hints into the canvas.
+- Fade in/out quickly without activating Lattices.
+- Keep interactive HUD activation separate.
+
+### Phase 5: Consolidation
+
+- Identify duplicate overlay/highlight windows that can become canvas payloads.
+- Keep interactive panels on `OverlayPanelShell`.
+- Document which surfaces should use the canvas and which should remain separate.
+
+## Acceptance Criteria
+
+- One shared controller owns screen-sized click-through overlay windows.
+- Snap zones render through the shared canvas with no behavior regression.
+- Canvas rendering survives multiple monitors and screen changes.
+- Visual layers can be added/removed by owner id.
+- Hidden canvas windows do not intercept clicks or focus.
+- Drag snap still tiles correctly when visual rendering is disabled.
+- Mouse gestures can publish visual feedback without action dispatch depending on it.
+- Diagnostics make canvas creation, screen reconciliation, and render failures understandable.
+
+## Open Questions
+
+- Should the base window level match current snap overlays or use a lower default?
+- Should the canvas use one `NSView` renderer first, or host SwiftUI layers from the start?
+- How should expiry be modeled: controller-owned timers, per-layer deadlines, or both?
+- Should passive hotkey overlays live in the app config or user workspace config?
+- How much of `MouseFinder` and window highlight feedback should migrate to the canvas?
+
+## References
+
+- `app/Sources/Core/Overlays/HUD/HUDController.swift`
+- `app/Sources/Core/Desktop/WindowDragSnapController.swift`
+- `app/Sources/Core/Input/MouseGestureController.swift`
+- `app/Sources/Core/Overlays/OverlayPanelShell.swift`
+- `docs/proposals/LAT-001-gesture-visual-customization.md`

--- a/docs/proposals/LAT-003-menu-bar-controller-architecture.md
+++ b/docs/proposals/LAT-003-menu-bar-controller-architecture.md
@@ -1,0 +1,291 @@
+# LAT-003: Menu Bar Controller Architecture
+
+## Status
+
+Mostly implemented.
+
+The menu bar, hotkey registration, daemon/service startup, workspace-inspector presentation, and activation-policy ownership have been extracted from `AppDelegate`. The optional `MenuBarPanelShell` remains deferred until a concrete menu-bar-adjacent panel needs it.
+
+This document records a narrow architecture proposal for the Lattices menu bar surface. The product direction is deliberately conservative: keep the existing menu bar UX, which is already strong, and extract the architectural lessons that make future menu-adjacent surfaces easier to build.
+
+## Summary
+
+Lattices currently uses `NSStatusItem` directly from `AppDelegate`, with a cached `NSPopover`, a right-click context menu, prewarmed SwiftUI content, global hotkey setup, service startup, daemon boot, and onboarding checks all coordinated from the same launch object.
+
+That works, and the visible menu bar experience should remain intact.
+
+The improvement proposed here is structural:
+
+- split menu bar ownership out of `AppDelegate`
+- keep the current `NSPopover` for the main projects surface
+- use custom `NSPanel` only for menu-bar-adjacent surfaces that need exact focus, positioning, or dismissal behavior
+- keep activation policy updates centralized
+- make app startup easier to reason about by moving hotkeys and services into small bootstrap components
+
+The result should be less launch-time sprawl, not a new visual design.
+
+## Why Now
+
+Recent review of Clicky's menu bar implementation highlighted a useful pattern:
+
+- `NSStatusItem` owns the menu bar icon
+- a custom borderless `NSPanel` owns the transient control panel
+- click-outside dismissal is explicit
+- panel focus behavior is explicitly defined
+- the app avoids standard popover chrome when it needs full control
+
+Lattices does not need to copy that wholesale. Our `NSPopover` is a good fit for the main menu bar projects view, and it already gives us useful system behavior.
+
+The lesson is more about ownership. Clicky's menu bar controller has one job. Lattices' `AppDelegate` currently has many.
+
+## Current State
+
+The relevant code is in `app/Sources/AppShell/AppDelegate.swift`.
+
+Today, `AppDelegate` owns:
+
+- app activation policy decisions
+- status item creation
+- menu bar icon drawing
+- left-click popover toggling
+- right-click context menu construction
+- popover prewarming
+- global hotkey registration
+- command palette configuration
+- drag snap, mouse gesture, keyboard remap startup
+- layer hotkey registration
+- tiling hotkey registration
+- onboarding and permission checks
+- daemon/model service startup
+- updater checks
+- debug launch flags
+
+This is not a correctness problem by itself, but it makes the app entry point harder to change. Any new launch-time surface adds one more responsibility to a file that already coordinates too much.
+
+## Non-Goals
+
+This proposal does not redesign the menu bar UI.
+
+This proposal does not replace the main menu bar `NSPopover` with a custom `NSPanel` by default.
+
+This proposal does not change command palette, HUD, Screen Map, or daemon behavior.
+
+This proposal does not alter the app's existing visual identity.
+
+## Proposed Components
+
+### 1. `MenuBarController`
+
+Owns only menu bar behavior:
+
+- create and retain `NSStatusItem`
+- draw or load the status item icon
+- route left-click and right-click behavior
+- own the cached projects popover
+- own the context menu
+- expose `dismissPopover()`
+- publish menu bar visibility state needed for activation policy
+
+The existing popover behavior should move here almost unchanged:
+
+- lazy `NSPopover` creation
+- SwiftUI content prewarm
+- `.transient` behavior
+- dark appearance
+- `latticesPopoverWillShow` notification
+
+This keeps the UX stable while making ownership clearer.
+
+### 2. `AppActivationCoordinator`
+
+Owns activation policy decisions.
+
+Today `AppDelegate.updateActivationPolicy()` checks a list of surfaces directly. That should become an explicit coordinator that asks registered surfaces whether they are visible.
+
+Conceptually:
+
+```swift
+protocol AppVisibleSurface {
+    var isVisibleForActivationPolicy: Bool { get }
+}
+
+final class AppActivationCoordinator {
+    static let shared = AppActivationCoordinator()
+
+    func register(_ surface: AppVisibleSurface)
+    func refresh()
+}
+```
+
+This avoids long hard-coded conditionals in `AppDelegate` as new windows are added.
+
+### 3. `HotkeyBootstrap`
+
+Owns global hotkey registration.
+
+This includes:
+
+- command palette
+- unified window or Screen Map
+- HUD
+- voice command
+- Hands Off
+- mouse finder
+- session layers
+- tiling commands
+- organize mode
+- OmniSearch
+
+The point is not to abstract the hotkeys away. The point is to isolate the big registration block into a component whose only job is binding actions to the existing controllers.
+
+### 4. `AppServicesBootstrap`
+
+Owns daemon and model startup:
+
+- `OcrStore`
+- `DesktopModel`
+- `OcrModel`
+- `TmuxModel`
+- `ProcessModel`
+- `LatticesApi`
+- `DaemonServer`
+- companion bridge
+- agent pool
+
+This keeps service startup grouped and timed without mixing it into menu bar construction.
+
+### 5. Optional `MenuBarPanelShell`
+
+Keep `NSPopover` for the current project list.
+
+Add a small helper only if we introduce menu-bar-adjacent panels that need custom behavior:
+
+- borderless `NSPanel`
+- explicit click-outside dismissal
+- non-activating or keyable variants
+- manual positioning below the status item
+- exact sizing around SwiftUI content
+
+This helper should not replace `OverlayPanelShell`. It is specific to status-item anchored panels.
+
+## Popover vs Panel Rule
+
+Use the cached `NSPopover` when the surface is:
+
+- anchored to the menu bar icon
+- mostly standard transient menu behavior
+- comfortable with popover sizing and dismissal semantics
+- part of the existing projects/menu surface
+
+Use a custom `NSPanel` when the surface needs:
+
+- non-standard chrome
+- unusual animation
+- explicit click-outside rules
+- custom focus behavior
+- independent window level
+- tighter control over multi-Space behavior
+
+This is the main lesson from Clicky: use `NSPanel` where control matters. Do not replace a good `NSPopover` just to be clever.
+
+## Suggested File Shape
+
+```text
+app/Sources/AppShell/
+  AppDelegate.swift
+  MenuBarController.swift
+  AppActivationCoordinator.swift
+  HotkeyBootstrap.swift
+  AppServicesBootstrap.swift
+  MenuBarPanelShell.swift      # optional, only when needed
+```
+
+`AppDelegate` should become a launch conductor:
+
+1. set activation policy and appearance
+2. create `MenuBarController`
+3. register hotkeys
+4. start input controllers
+5. run onboarding or permission checks
+6. start daemon services
+7. process debug flags
+
+It should not own the details of each of those systems.
+
+## Migration Plan
+
+### Phase 1: Extract `MenuBarController`
+
+- Move status item creation.
+- Move menu icon creation.
+- Move context menu construction.
+- Move cached popover creation.
+- Keep existing public behavior and notifications.
+- Route `MainView` dismissal through `MenuBarController` instead of reaching into `AppDelegate` if practical.
+
+### Phase 2: Extract Hotkey Registration
+
+- Move the global hotkey registration block into `HotkeyBootstrap`.
+- Keep action closures identical.
+- Keep controller singletons unchanged.
+- Add small helper methods only where they improve readability.
+
+### Phase 3: Extract Service Startup
+
+- Move daemon/model startup into `AppServicesBootstrap`.
+- Preserve existing startup order.
+- Preserve diagnostic timing.
+- Keep companion bridge preference behavior unchanged.
+
+### Phase 4: Activation Policy Cleanup
+
+- Introduce `AppActivationCoordinator`.
+- Register visible surfaces.
+- Remove the long hard-coded visibility conditional from `AppDelegate`.
+- Keep the current `.accessory` to `.regular` behavior.
+
+### Phase 5: Add `MenuBarPanelShell` Only If Needed
+
+- Do not add this during initial extraction unless a concrete menu-bar panel needs it.
+- If added, keep it separate from the main popover.
+- Document why that surface needs panel behavior.
+
+## Acceptance Criteria
+
+- Main menu bar popover looks and behaves the same.
+- Right-click menu behaves the same.
+- First popover open remains prewarmed and fast.
+- App activation policy behavior is unchanged.
+- Hotkeys continue to register and fire as before.
+- Daemon and model startup order is unchanged.
+- `AppDelegate` is materially smaller and easier to scan.
+- No new custom panel replaces the existing popover without a concrete need.
+
+## Risks
+
+The main risk is accidental behavior drift around activation policy and popover focus. The migration should be done in small steps and tested manually after each extraction.
+
+The second risk is over-abstraction. These components should be plain controllers, not a framework. The goal is named ownership, not ceremony.
+
+## Testing Notes
+
+Manual testing should cover:
+
+- left-click menu bar toggle
+- right-click context menu
+- popover dismiss by outside click
+- popover dismiss from project actions
+- command palette hotkey
+- HUD hotkey
+- Screen Map hotkey
+- voice command hotkey
+- app activation policy returning to accessory mode when surfaces close
+- launch with `--diagnostics`
+- launch with `--screen-map`
+
+## References
+
+- `app/Sources/AppShell/AppDelegate.swift`
+- `app/Sources/AppShell/MainView.swift`
+- `app/Sources/Core/Overlays/OverlayPanelShell.swift`
+- `/Users/art/dev/ext/clicky/leanring-buddy/MenuBarPanelManager.swift`

--- a/docs/reference/dewey.config.ts
+++ b/docs/reference/dewey.config.ts
@@ -4,22 +4,22 @@ export default {
     name: 'lattices',
     tagline: 'macOS developer workspace manager — tmux sessions with a native menu bar app for tiling, navigation, and project management',
     type: 'cli-tool',
-    version: '0.1.0',
+    version: '0.4.10',
   },
 
   agent: {
     criticalContext: [
-      'lattices has TWO interfaces: a Node.js CLI (`bin/lattices.js`) and a native Swift menu bar app (`app/Sources/`)',
+      'lattices has TWO primary interfaces: a TypeScript CLI (`bin/lattices.ts`) and a native Swift menu bar app (`app/Sources/`)',
       'Session names are `<basename>-<sha256-6chars>` — both CLI and app must produce identical hashes',
       'The app finds terminal windows via a `[lattices:session-name]` tag embedded in the tmux window title',
       'Window navigation falls through CG → AX → AppleScript depending on macOS permissions',
       'Space switching uses private SkyLight framework APIs loaded via dlopen at runtime',
-      'The daemon runs on ws://127.0.0.1:9399 with 20 RPC methods and 3 real-time events',
+      'The daemon runs on ws://127.0.0.1:9399 with 35+ RPC methods and real-time events',
     ],
 
     entryPoints: {
-      'cli': 'bin/lattices.js',
-      'app-helper': 'bin/lattices-app.js',
+      'cli': 'bin/lattices.ts',
+      'app-helper': 'bin/lattices-app.ts',
       'menu-bar-app': 'app/Sources/',
       'docs': 'docs/',
       'docs-site': 'docs-site/',
@@ -27,14 +27,14 @@ export default {
     },
 
     rules: [
-      { pattern: 'cli', instruction: 'Check bin/lattices.js for CLI commands and session logic' },
+      { pattern: 'cli', instruction: 'Check bin/lattices.ts for CLI commands and session logic' },
       { pattern: 'app', instruction: 'Check app/Sources/ for Swift menu bar app code' },
       { pattern: 'config', instruction: 'Check docs/config.md for .lattices.json format and CLI reference' },
-      { pattern: 'tiling', instruction: 'Check app/Sources/WindowTiler.swift and bin/lattices.js tilePresets' },
-      { pattern: 'palette', instruction: 'Check app/Sources/PaletteCommand.swift for command palette actions' },
-      { pattern: 'terminal', instruction: 'Check app/Sources/Terminal.swift for supported terminals and launch logic' },
-      { pattern: 'daemon', instruction: 'Check app/Sources/DaemonServer.swift and app/Sources/LatticesApi.swift for WebSocket API' },
-      { pattern: 'api', instruction: 'Check docs/api.md for the full 20-method RPC reference' },
+      { pattern: 'tiling', instruction: 'Check app/Sources/Core/Desktop/WindowTiler.swift and app/Sources/Core/Desktop/PlacementSpec.swift' },
+      { pattern: 'palette', instruction: 'Check app/Sources/Core/Actions/PaletteCommand.swift for command palette actions' },
+      { pattern: 'terminal', instruction: 'Check app/Sources/Core/Workspace/Terminal/Terminal.swift for supported terminals and launch logic' },
+      { pattern: 'daemon', instruction: 'Check app/Sources/Core/Daemon/DaemonServer.swift and app/Sources/Core/Daemon/LatticesApi.swift for WebSocket API' },
+      { pattern: 'api', instruction: 'Check docs/api.md for the daemon RPC reference' },
       { pattern: 'twin', instruction: 'Check docs/twins.md and bin/project-twin.ts for the Pi-backed project twin runtime' },
     ],
 
@@ -56,10 +56,10 @@ export default {
     },
 
     prerequisites: [
-      'macOS 13.0+',
+      'macOS 26.0+',
       'tmux (brew install tmux)',
       'Node.js >= 18',
-      'Swift 5.9+ (only if building the menu bar app from source)',
+      'Swift 6.2 / Xcode 26+ (only if building the menu bar app from source)',
     ],
 
     steps: [


### PR DESCRIPTION
## Summary
- add LAT proposal docs for gesture visuals, shared overlay canvas, and menu bar architecture
- split AppDelegate responsibilities into menu, hotkey, activation, services, and inspector helpers
- route snap drag zones through a shared screen overlay canvas
- show dev/latest build metadata in General Settings and stamp dev bundle metadata

## Verification
- bunx tsc --noEmit
- env CLANG_MODULE_CACHE_PATH=/tmp/lattices-clang-cache SWIFTPM_TESTS_MODULECACHE=/tmp/lattices-swiftpm-cache swift build --package-path app