### PR TITLE
Clarify repository structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,28 @@ lattices app
 # Cmd+Shift+M
 ```
 
+## Repository layout
+
+Lattices has a few product surfaces in one repo: the macOS app, the CLI, the
+Swift package code, and the web/docs sites. The current root is transitional,
+so this map is the shortest way to get oriented:
+
+| Path | What lives there |
+| --- | --- |
+| `app/` | Native macOS menu bar app. |
+| `bin/` | Published CLI entry points and TypeScript runtime modules. |
+| `swift/` | Shared Swift package code. |
+| `iOS/` | Companion app work. |
+| `docs/` | Product docs, API docs, and engineering notes. |
+| `docs-site/` | Documentation website. |
+| `site/` | Marketing website. |
+| `content/` | Shared site/blog content. |
+| `scripts/` | Release and packaging scripts. |
+| `test/` | Integration and evaluation tests. |
+
+See [Repository Structure](docs/repo-structure.md) for the cleanup plan and the
+target `apps/` / `packages/` shape.
+
 ## Persistent terminal sessions
 
 Declare your dev environment in a `.lattices.json`: which panes, which

--- a/docs/repo-structure.md
+++ b/docs/repo-structure.md
@@ -1,10 +1,23 @@
 # Repository Structure
 
-Lattices is a small project with several real product surfaces. The root should
-make those surfaces obvious.
+Lattices is one project with several real product surfaces. The root should make
+those surfaces obvious before a maintainer has to infer history from directory
+names.
 
 This document is the current maintainer-facing map and the proposed direction
 for keeping file structure as architecture.
+
+## First Impression Goal
+
+A visitor should be able to answer three questions from the root:
+
+1. What are the product surfaces?
+2. What code is reusable package/runtime code?
+3. What is support material: docs, release tooling, tests, generated output, or
+   agent tooling?
+
+The current root partially answers those questions, but it exposes too many
+eras of the repo at the same level.
 
 ## Current Top-Level Areas
 
@@ -28,14 +41,24 @@ for keeping file structure as architecture.
 
 The root currently mixes categories:
 
-- shipped product surfaces: `app/`, `bin/`, `swift/`
+- shipped product surfaces: `app/`, `bin/`, `swift/`, `iOS/`
 - websites: `site/`, `docs-site/`, `content/`
-- companion experiments: `iOS/`
 - generated or release output: `dist/`
 - maintainer and agent affordances: `docs/`, `skills/`, `scripts/`, `test/`
 
 That makes the project feel larger than it is. It also makes it harder to see
 which directories are architecture and which are support material.
+
+The most confusing root-level pairs are:
+
+- `site/` and `docs-site/`: both are Astro apps, but their ownership and public
+  output are not obvious from the root.
+- `bin/` and `lib/`: public CLI entry points sit beside internal TypeScript
+  runtime modules.
+- `app/`, `swift/`, and `iOS/`: these are related Apple-platform code, but the
+  relationship is only implicit.
+- `docs/`, `docs.json`, `llms.txt`, `AGENTS.md`, `CLAUDE.md`, and `skills/`:
+  human docs, generated docs, and agent affordances compete for attention.
 
 ## Target Shape
 
@@ -67,6 +90,20 @@ This is intentionally similar to the `apps/` and `packages/` split used by
 small monorepos such as Flue, but adapted for Lattices' macOS app plus CLI
 shape.
 
+## Root Contract
+
+Long term, the root should contain only:
+
+- product/app directories: `apps/`
+- package/runtime directories: `packages/`
+- docs and content: `docs/`, `content/`
+- support tooling: `tools/`, `tests/`
+- package metadata and project policy files
+
+Generated output such as `dist/`, `.build/`, bundled apps, screenshots, and
+release artifacts should stay ignored or live under clearly named build output
+locations.
+
 ## Migration Rules
 
 - Move one category at a time.
@@ -80,13 +117,29 @@ shape.
 
 Good first moves:
 
-1. Treat `dist/` as generated output only.
-2. Move blog content closer to the site that owns it, or explicitly document it
+1. Decide whether `site/` and `docs-site/` are both active. If both stay, name
+   their roles clearly in README and package scripts.
+2. Treat `dist/`, `.build/`, and generated app bundles as generated output only.
+3. Make plist ownership canonical: one template/source of truth, generated
+   bundle files ignored or intentionally tracked.
+4. Regenerate or remove stale docs artifacts such as `docs.json`.
+5. Move blog content closer to the site that owns it, or explicitly document it
    as shared content.
-3. Move `iOS/` under `apps/ios/` once companion work becomes active again.
-4. Split `docs/proposals/` for numbered engineering docs such as `LAT-001`.
-5. Decide whether `bin/` remains the package root for the CLI or becomes
+6. Split internal plans/proposals from user-facing docs.
+7. Decide whether `bin/` remains the package root for the CLI or becomes
    `packages/cli/src/` before adding more exported modules.
+8. Move `iOS/` under `apps/ios/` once companion work becomes active again.
+
+## Suggested PR Sequence
+
+Keep the cleanup boring and reviewable:
+
+1. **Root clarity:** README map, this document, stale generated-doc cleanup.
+2. **Generated artifacts:** plist ownership, ignored bundle output, release
+   output cleanup.
+3. **Docs split:** public docs versus engineering notes and agent references.
+4. **Web ownership:** decide and document `site/` versus `docs-site/`.
+5. **Directory moves:** `apps/` and `packages/`, one category at a time.
 
 ## What Stays Boring
 


### PR DESCRIPTION
## Summary
- add a README repository layout section for first-time orientation
- sharpen docs/repo-structure.md around root first impression, confusing top-level pairs, and the target apps/packages shape
- outline a reviewable cleanup sequence before moving directories

## Validation
- git diff --check