### PR TITLE
Reset input capture across sleep wake

### DIFF
--- a/apps/mac/Sources/AppShell/AppDelegate.swift
+++ b/apps/mac/Sources/AppShell/AppDelegate.swift
@@ -8,6 +8,8 @@ extension Notification.Name {
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate {
+    private var notificationObservers: [NSObjectProtocol] = []
+
     static func updateActivationPolicy() {
         AppActivationCoordinator.shared.refresh()
     }
@@ -16,6 +18,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.setActivationPolicy(.accessory)
         NSApp.appearance = NSAppearance(named: .darkAqua)
         registerDeepLinkHandler()
+        installSystemInputBoundaryObservers()
 
         MenuBarController.shared.start()
         registerVisibleSurfaces()
@@ -63,8 +66,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        removeSystemInputBoundaryObservers()
         KeyboardRemapController.shared.stop()
         AppServicesBootstrap.stop()
+    }
+
+    func applicationDidBecomeActive(_ notification: Notification) {
+        resetInputCapture(reason: "app became active")
+    }
+
+    func applicationWillResignActive(_ notification: Notification) {
+        resetInputCapture(reason: "app resigned active")
     }
 
     private func registerVisibleSurfaces() {
@@ -75,6 +87,53 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         coordinator.registerSurface(id: "mainWindow") { MainWindow.shared.isVisible }
         coordinator.registerSurface(id: "screenMap") { ScreenMapWindowController.shared.isVisible }
         coordinator.registerSurface(id: "omniSearch") { OmniSearchWindow.shared.isVisible }
+    }
+
+    private func installSystemInputBoundaryObservers() {
+        let center = NSWorkspace.shared.notificationCenter
+        notificationObservers.append(center.addObserver(
+            forName: NSWorkspace.willSleepNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.resetInputCapture(reason: "system will sleep")
+        })
+        notificationObservers.append(center.addObserver(
+            forName: NSWorkspace.didWakeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.resetInputCapture(reason: "system did wake")
+        })
+        notificationObservers.append(center.addObserver(
+            forName: NSWorkspace.screensDidWakeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.resetInputCapture(reason: "screens did wake")
+        })
+        notificationObservers.append(center.addObserver(
+            forName: NSWorkspace.screensDidSleepNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.resetInputCapture(reason: "screens did sleep")
+        })
+    }
+
+    private func removeSystemInputBoundaryObservers() {
+        let center = NSWorkspace.shared.notificationCenter
+        for observer in notificationObservers {
+            center.removeObserver(observer)
+        }
+        notificationObservers.removeAll()
+    }
+
+    private func resetInputCapture(reason: String) {
+        DiagnosticLog.shared.warn("InputCapture: reset for \(reason)")
+        ScreenOverlayCanvasController.shared.resetInputCapture(reason: reason)
+        MouseGestureController.shared.resetForSystemInputBoundary(reason: reason)
+        KeyboardRemapController.shared.resetForSystemInputBoundary(reason: reason)
     }
 
     // MARK: - Deep Links

--- a/apps/mac/Sources/AppShell/AppDelegate.swift
+++ b/apps/mac/Sources/AppShell/AppDelegate.swift
@@ -130,10 +130,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func resetInputCapture(reason: String) {
-        DiagnosticLog.shared.warn("InputCapture: reset for \(reason)")
-        ScreenOverlayCanvasController.shared.resetInputCapture(reason: reason)
-        MouseGestureController.shared.resetForSystemInputBoundary(reason: reason)
-        KeyboardRemapController.shared.resetForSystemInputBoundary(reason: reason)
+        InputCaptureResetCenter.reset(reason: reason)
     }
 
     // MARK: - Deep Links

--- a/apps/mac/Sources/AppShell/AppDelegate.swift
+++ b/apps/mac/Sources/AppShell/AppDelegate.swift
@@ -31,6 +31,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         WindowDragSnapController.shared.start()
         MouseGestureController.shared.start()
         KeyboardRemapController.shared.start()
+        SecureEventInputMonitor.shared.start()
 
         if !OnboardingWindowController.shared.showIfNeeded() {
             PermissionChecker.shared.check()
@@ -67,6 +68,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillTerminate(_ notification: Notification) {
         removeSystemInputBoundaryObservers()
+        SecureEventInputMonitor.shared.stop()
         KeyboardRemapController.shared.stop()
         AppServicesBootstrap.stop()
     }

--- a/apps/mac/Sources/Core/Input/InputCaptureResetCenter.swift
+++ b/apps/mac/Sources/Core/Input/InputCaptureResetCenter.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+enum InputCaptureResetCenter {
+    static func reset(reason: String) {
+        if Thread.isMainThread {
+            performReset(reason: reason)
+        } else {
+            DispatchQueue.main.async {
+                performReset(reason: reason)
+            }
+        }
+    }
+
+    private static func performReset(reason: String) {
+        DiagnosticLog.shared.warn("InputCapture: reset for \(reason)")
+        ScreenOverlayCanvasController.shared.resetInputCapture(reason: reason)
+        MouseGestureController.shared.resetForSystemInputBoundary(reason: reason)
+        KeyboardRemapController.shared.resetForSystemInputBoundary(reason: reason)
+    }
+}

--- a/apps/mac/Sources/Core/Input/KeyboardRemapController.swift
+++ b/apps/mac/Sources/Core/Input/KeyboardRemapController.swift
@@ -18,10 +18,15 @@ final class KeyboardRemapController: ObservableObject {
     private var capsLayerActive = false
     private var capsUsedAsModifier = false
     private var capsLayerActivatedAt: CFAbsoluteTime?
+    private var capsLayerLastEventAt: CFAbsoluteTime?
+    private var bypassUntil: CFAbsoluteTime = 0
     private var lastCapsLayerStaleLogAt: CFAbsoluteTime = 0
+    private var pressedKeyCodes = Set<Int64>()
     private let breaker = EventTapBreaker(label: "KeyboardRemap")
     private let budgetMeter = TapBudgetMeter(label: "KeyboardRemap")
-    private let maxCapsLayerDuration: TimeInterval = 2.0
+    private let maxCapsLayerIdleDuration: TimeInterval = 2.0
+    private let maxCapsLayerHeldDuration: TimeInterval = 20.0
+    private let emergencyBypassDuration: TimeInterval = 3.0
 
     private init() {
         breaker.onStateChanged = { [weak self] newState in
@@ -53,6 +58,7 @@ final class KeyboardRemapController: ObservableObject {
     func resetForSystemInputBoundary(reason: String) {
         dispatchPrecondition(condition: .onQueue(.main))
         clearCapsLayer()
+        pressedKeyCodes.removeAll()
         breaker.reset()
         if let eventTap {
             CGEvent.tapEnable(tap: eventTap, enable: true)
@@ -159,11 +165,13 @@ final class KeyboardRemapController: ObservableObject {
             // OS killed the tap because a callback was too slow. Run through
             // the breaker — it backs off in escalating cooldowns rather than
             // re-enabling immediately and getting killed again.
+            clearCapsLayer()
             breaker.recordTrip()
             return Unmanaged.passUnretained(event)
         }
         if type == .tapDisabledByUserInput {
             // User-driven disable (rare). Re-enable directly, no cooldown.
+            clearCapsLayer()
             if let eventTap {
                 CGEvent.tapEnable(tap: eventTap, enable: true)
             }
@@ -171,6 +179,17 @@ final class KeyboardRemapController: ObservableObject {
         }
 
         if event.getIntegerValueField(.eventSourceUserData) == Self.syntheticMarker {
+            return Unmanaged.passUnretained(event)
+        }
+
+        updatePressedKeys(type: type, keyCode: event.getIntegerValueField(.keyboardEventKeycode))
+        if shouldTriggerEmergencyReset(type: type, event: event) {
+            emergencyClear(now: started)
+            InputCaptureResetCenter.reset(reason: "keyboard emergency chord")
+            return Unmanaged.passUnretained(event)
+        }
+
+        if started < bypassUntil {
             return Unmanaged.passUnretained(event)
         }
 
@@ -185,17 +204,23 @@ final class KeyboardRemapController: ObservableObject {
             return handleCapsLockFlagsChanged(event, rule: rule)
         }
 
-        clearStaleCapsLayerIfNeeded(now: started)
+        reconcileCapsLayer(event: event, type: type, now: started)
         guard capsLayerActive else {
             return Unmanaged.passUnretained(event)
         }
 
         switch type {
         case .keyDown:
+            if keyCode == 53 {
+                emergencyClear(now: started)
+                return Unmanaged.passUnretained(event)
+            }
             capsUsedAsModifier = true
+            capsLayerLastEventAt = started
             event.flags = normalizedFlags(event.flags).union(.latticesHyper)
             return Unmanaged.passUnretained(event)
         case .keyUp:
+            capsLayerLastEventAt = started
             event.flags = normalizedFlags(event.flags).union(.latticesHyper)
             return Unmanaged.passUnretained(event)
         default:
@@ -208,7 +233,9 @@ final class KeyboardRemapController: ObservableObject {
         if isDown {
             capsLayerActive = true
             capsUsedAsModifier = false
-            capsLayerActivatedAt = CFAbsoluteTimeGetCurrent()
+            let now = CFAbsoluteTimeGetCurrent()
+            capsLayerActivatedAt = now
+            capsLayerLastEventAt = now
             DiagnosticLog.shared.info("KeyboardRemap: Caps Lock layer active")
         } else {
             let shouldTap = capsLayerActive && !capsUsedAsModifier && rule.toIfAlone == .escape
@@ -226,18 +253,66 @@ final class KeyboardRemapController: ObservableObject {
         capsLayerActive = false
         capsUsedAsModifier = false
         capsLayerActivatedAt = nil
+        capsLayerLastEventAt = nil
     }
 
-    private func clearStaleCapsLayerIfNeeded(now: CFAbsoluteTime) {
-        guard capsLayerActive,
-              let activatedAt = capsLayerActivatedAt,
-              now - activatedAt > maxCapsLayerDuration else { return }
+    private func reconcileCapsLayer(event: CGEvent, type: CGEventType, now: CFAbsoluteTime) {
+        guard capsLayerActive else { return }
 
+        // If a release event was dropped, later key events often arrive
+        // without the physical Caps flag. Treat that as an input boundary and
+        // fail open before rewriting the user's key.
+        if type == .keyDown || type == .keyUp,
+           !event.flags.contains(.maskAlphaShift) {
+            clearCapsLayer(reason: "physical Caps flag cleared", now: now)
+            return
+        }
+
+        if let lastEventAt = capsLayerLastEventAt,
+           now - lastEventAt > maxCapsLayerIdleDuration {
+            clearCapsLayer(reason: "idle", now: now)
+            return
+        }
+
+        if let activatedAt = capsLayerActivatedAt,
+           now - activatedAt > maxCapsLayerHeldDuration {
+            clearCapsLayer(reason: "held too long", now: now)
+        }
+    }
+
+    private func clearCapsLayer(reason: String, now: CFAbsoluteTime) {
         clearCapsLayer()
         if now - lastCapsLayerStaleLogAt > 1 {
             lastCapsLayerStaleLogAt = now
-            DiagnosticLog.shared.warn("KeyboardRemap: stale Caps Lock layer cleared after \(String(format: "%.1f", maxCapsLayerDuration))s")
+            DiagnosticLog.shared.warn("KeyboardRemap: Caps Lock layer cleared (\(reason))")
         }
+    }
+
+    private func emergencyClear(now: CFAbsoluteTime) {
+        clearCapsLayer()
+        pressedKeyCodes.removeAll()
+        bypassUntil = now + emergencyBypassDuration
+        DiagnosticLog.shared.warn("KeyboardRemap: emergency bypass via Escape")
+    }
+
+    private func updatePressedKeys(type: CGEventType, keyCode: Int64) {
+        switch type {
+        case .keyDown:
+            pressedKeyCodes.insert(keyCode)
+        case .keyUp:
+            pressedKeyCodes.remove(keyCode)
+        default:
+            break
+        }
+    }
+
+    private func shouldTriggerEmergencyReset(type: CGEventType, event: CGEvent) -> Bool {
+        guard type == .keyDown else { return false }
+        let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+        let flags = event.flags
+        return keyCode == 40
+            && pressedKeyCodes.contains(53)
+            && flags.contains(.maskShift)
     }
 
     private func normalizedFlags(_ flags: CGEventFlags) -> CGEventFlags {

--- a/apps/mac/Sources/Core/Input/KeyboardRemapController.swift
+++ b/apps/mac/Sources/Core/Input/KeyboardRemapController.swift
@@ -50,6 +50,18 @@ final class KeyboardRemapController: ObservableObject {
         clearCapsLayer()
     }
 
+    func resetForSystemInputBoundary(reason: String) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        clearCapsLayer()
+        breaker.reset()
+        if let eventTap {
+            CGEvent.tapEnable(tap: eventTap, enable: true)
+        } else {
+            refresh()
+        }
+        DiagnosticLog.shared.warn("KeyboardRemap: reset for \(reason)")
+    }
+
     private func installObserversIfNeeded() {
         guard !installedObservers else { return }
         installedObservers = true

--- a/apps/mac/Sources/Core/Input/KeyboardRemapController.swift
+++ b/apps/mac/Sources/Core/Input/KeyboardRemapController.swift
@@ -174,7 +174,7 @@ final class KeyboardRemapController: ObservableObject {
             return Unmanaged.passUnretained(event)
         }
 
-        KeyboardRemapStore.shared.reloadIfNeeded()
+        KeyboardRemapStore.shared.scheduleReloadCheckIfNeeded()
         guard let rule = KeyboardRemapStore.shared.capsLockRule,
               rule.toIfHeld == .hyper else {
             return Unmanaged.passUnretained(event)

--- a/apps/mac/Sources/Core/Input/KeyboardRemapStore.swift
+++ b/apps/mac/Sources/Core/Input/KeyboardRemapStore.swift
@@ -14,6 +14,9 @@ final class KeyboardRemapStore: ObservableObject {
     private let stateLock = NSLock()
     private var snapshot: KeyboardRemapConfig
     private var lastLoadedModifiedDate: Date?
+    private var lastReloadCheckAt: Date = .distantPast
+    private var reloadCheckInFlight = false
+    private let reloadCheckInterval: TimeInterval = 1.0
 
     private init() {
         let dir = FileManager.default.homeDirectoryForCurrentUser
@@ -76,18 +79,33 @@ final class KeyboardRemapStore: ObservableObject {
         config = newConfig
     }
 
-    func reloadIfNeeded() {
-        // Called from the keyboard event-tap thread on every key event. The
-        // `stat` is cheap and thread-safe; the @Published mutation is hopped
-        // to main inside reload(). We claim the new mtime up-front so
-        // concurrent calls don't queue duplicate reloads while one is in
-        // flight (if reload fails, we'll retry on the next mtime change).
+    func scheduleReloadCheckIfNeeded() {
+        // Called from the keyboard event-tap thread. Keep this path to memory
+        // bookkeeping only; filesystem work runs off the tap callback.
+        let now = Date()
+        stateLock.lock()
+        guard !reloadCheckInFlight,
+              now.timeIntervalSince(lastReloadCheckAt) >= reloadCheckInterval else {
+            stateLock.unlock()
+            return
+        }
+        reloadCheckInFlight = true
+        lastReloadCheckAt = now
+        stateLock.unlock()
+
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            self?.reloadIfNeeded()
+        }
+    }
+
+    private func reloadIfNeeded() {
         let currentModifiedDate = modifiedDate()
         stateLock.lock()
         let needsReload = currentModifiedDate != lastLoadedModifiedDate
         if needsReload {
             lastLoadedModifiedDate = currentModifiedDate
         }
+        reloadCheckInFlight = false
         stateLock.unlock()
         guard needsReload else { return }
         reload()

--- a/apps/mac/Sources/Core/Input/MouseGestureController.swift
+++ b/apps/mac/Sources/Core/Input/MouseGestureController.swift
@@ -157,6 +157,18 @@ final class MouseGestureController: ObservableObject {
         removeEventTap()
     }
 
+    func resetForSystemInputBoundary(reason: String) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        clearSession()
+        breaker.reset()
+        if let eventTap {
+            CGEvent.tapEnable(tap: eventTap, enable: true)
+        } else {
+            refresh()
+        }
+        DiagnosticLog.shared.warn("MouseGesture: reset for \(reason)")
+    }
+
     static func resolveDirection(
         delta: CGPoint,
         threshold: CGFloat = 68,

--- a/apps/mac/Sources/Core/Input/MouseGestureController.swift
+++ b/apps/mac/Sources/Core/Input/MouseGestureController.swift
@@ -322,6 +322,15 @@ final class MouseGestureController: ObservableObject {
             return Unmanaged.passUnretained(event)
         }
 
+        if isEmergencyMouseReset(type: type, event: event) {
+            setTrackingButton(nil)
+            DispatchQueue.main.async { [weak self] in
+                self?.clearSession()
+                InputCaptureResetCenter.reset(reason: "Hyper mouse click")
+            }
+            return Unmanaged.passUnretained(event)
+        }
+
         switch type {
         case .leftMouseDown, .leftMouseUp:
             return handlePassiveMouseButtonEvent(type: type, event: event)
@@ -369,6 +378,15 @@ final class MouseGestureController: ObservableObject {
             self?.processPassiveMouseButton(type: type, snapshot: snapshot)
         }
         return Unmanaged.passUnretained(event)
+    }
+
+    private func isEmergencyMouseReset(type: CGEventType, event: CGEvent) -> Bool {
+        switch type {
+        case .leftMouseDown, .rightMouseDown, .otherMouseDown:
+            return event.flags.intersection(.latticesHyper) == .latticesHyper
+        default:
+            return false
+        }
     }
 
     private func processPassiveMouseButton(type: CGEventType, snapshot: MouseEventSnapshot) {

--- a/apps/mac/Sources/Core/Input/MouseGestureController.swift
+++ b/apps/mac/Sources/Core/Input/MouseGestureController.swift
@@ -102,6 +102,13 @@ final class MouseGestureController: ObservableObject {
     private let breaker = EventTapBreaker(label: "MouseGesture")
     private let budgetMeter = TapBudgetMeter(label: "MouseGesture")
 
+    private struct TapTrackingState {
+        let buttonNumber: Int64
+        let startPoint: CGPoint
+        let nativeClickPassthrough: Bool
+        let startedAt: CFAbsoluteTime
+    }
+
     // Tap-thread-side mirror of "which button (if any) is currently being
     // tracked as a gesture". The tap callback runs on EventTapThread; main
     // owns the full GestureSession but the tap thread needs a fast,
@@ -109,35 +116,49 @@ final class MouseGestureController: ObservableObject {
     // protects cross-thread access (tap thread reads/writes; main writes
     // via clearSession(clearTracking:) or processMouseDownConsume's bail path).
     private let trackingLock = NSLock()
-    private var trackingButtonNumber: Int64? = nil
-    private var trackingStartedAt: CFAbsoluteTime?
+    private var tapTrackingState: TapTrackingState?
     private var lastTrackingStaleLogAt: CFAbsoluteTime = 0
     private let maxTapThreadTrackingDuration: TimeInterval = 3.0
 
-    private func currentTrackingButton() -> Int64? {
+    private func currentTrackingState() -> TapTrackingState? {
         trackingLock.lock()
         defer { trackingLock.unlock() }
         let now = CFAbsoluteTimeGetCurrent()
-        if let startedAt = trackingStartedAt,
-           now - startedAt > maxTapThreadTrackingDuration {
-            let staleButton = trackingButtonNumber
-            trackingButtonNumber = nil
-            trackingStartedAt = nil
+        if let state = tapTrackingState,
+           now - state.startedAt > maxTapThreadTrackingDuration {
+            let staleButton = state.buttonNumber
+            tapTrackingState = nil
             if now - lastTrackingStaleLogAt > 1 {
                 lastTrackingStaleLogAt = now
                 DispatchQueue.main.async {
-                    DiagnosticLog.shared.warn("MouseGesture: stale tap-side tracking cleared for button=\(staleButton.map(String.init) ?? "unknown")")
+                    DiagnosticLog.shared.warn("MouseGesture: stale tap-side tracking cleared for button=\(staleButton)")
                 }
             }
             return nil
         }
-        return trackingButtonNumber
+        return tapTrackingState
     }
 
-    private func setTrackingButton(_ value: Int64?) {
+    private func currentTrackingButton() -> Int64? {
+        currentTrackingState()?.buttonNumber
+    }
+
+    private func setTrackingButton(
+        _ value: Int64?,
+        startPoint: CGPoint = .zero,
+        nativeClickPassthrough: Bool = false
+    ) {
         trackingLock.lock()
-        trackingButtonNumber = value
-        trackingStartedAt = value == nil ? nil : CFAbsoluteTimeGetCurrent()
+        if let value {
+            tapTrackingState = TapTrackingState(
+                buttonNumber: value,
+                startPoint: startPoint,
+                nativeClickPassthrough: nativeClickPassthrough,
+                startedAt: CFAbsoluteTimeGetCurrent()
+            )
+        } else {
+            tapTrackingState = nil
+        }
         trackingLock.unlock()
     }
 
@@ -424,6 +445,10 @@ final class MouseGestureController: ObservableObject {
         )
         // NSScreen.screens reads are safe off-main; Preferences/Store snapshot
         // reads are lock-protected (see MouseShortcutStore).
+        let button = MouseShortcutButton(rawButtonNumber: Int(buttonNumber))
+        let needsNativeClickCapture = MouseShortcutStore.shared.hasEnabledRule(button: button, kind: .click)
+            || MouseShortcutStore.shared.hasEnabledRule(button: button, kind: .shape)
+        let nativeClickPassthrough = buttonNumber >= 2 && !needsNativeClickCapture
         let canRecognize = Preferences.shared.mouseGesturesEnabled
             && MouseShortcutStore.shared.watchedButtonNumbers.contains(buttonNumber)
         let onScreen = (screen(containing: snapshot.location) != nil)
@@ -444,11 +469,18 @@ final class MouseGestureController: ObservableObject {
         // Mark this button as actively tracked before the OS sees a follow-up
         // drag/up — the tap thread reads this on subsequent events to decide
         // whether to consume them.
-        setTrackingButton(buttonNumber)
+        setTrackingButton(
+            buttonNumber,
+            startPoint: snapshot.location,
+            nativeClickPassthrough: nativeClickPassthrough
+        )
         DispatchQueue.main.async { [weak self] in
-            self?.processMouseDownConsume(snapshot: snapshot)
+            self?.processMouseDownConsume(
+                snapshot: snapshot,
+                nativeClickPassthrough: nativeClickPassthrough
+            )
         }
-        return nil
+        return nativeClickPassthrough ? Unmanaged.passUnretained(event) : nil
     }
 
     private enum MouseDownPassthroughReason {
@@ -490,7 +522,7 @@ final class MouseGestureController: ObservableObject {
         }
     }
 
-    private func processMouseDownConsume(snapshot: MouseEventSnapshot) {
+    private func processMouseDownConsume(snapshot: MouseEventSnapshot, nativeClickPassthrough: Bool) {
         dispatchPrecondition(condition: .onQueue(.main))
         MouseShortcutStore.shared.reloadIfNeeded()
         let button = MouseShortcutButton(rawButtonNumber: Int(snapshot.buttonNumber))
@@ -534,7 +566,7 @@ final class MouseGestureController: ObservableObject {
             modifiers: snapshot.flags,
             candidate: nil,
             match: nil,
-            note: "tracking",
+            note: nativeClickPassthrough ? "tracking; native click passes through" : "tracking",
             appInfo: appInfo
         )
     }
@@ -632,14 +664,32 @@ final class MouseGestureController: ObservableObject {
             flags: event.flags,
             buttonNumber: buttonNumber
         )
-        guard currentTrackingButton() == buttonNumber else {
+        guard let trackingState = currentTrackingState(),
+              trackingState.buttonNumber == buttonNumber else {
             DispatchQueue.main.async { [weak self] in
                 self?.processMouseUpNoSession(snapshot: snapshot)
             }
             return Unmanaged.passUnretained(event)
         }
-        // We consumed the matching mouseDown; clear tap-side tracking so a
-        // subsequent drag/up for this button falls through.
+
+        if trackingState.nativeClickPassthrough {
+            let delta = CGPoint(
+                x: snapshot.location.x - trackingState.startPoint.x,
+                y: snapshot.location.y - trackingState.startPoint.y
+            )
+            let tuning = MouseShortcutStore.shared.tuning
+            let direction = Self.resolveDirection(delta: delta, threshold: tuning.dragThreshold, axisBias: tuning.axisBias)
+            if direction == nil {
+                setTrackingButton(nil)
+                DispatchQueue.main.async { [weak self] in
+                    self?.processMouseUpNativeClickPassthrough(snapshot: snapshot)
+                }
+                return Unmanaged.passUnretained(event)
+            }
+        }
+
+        // Clear tap-side tracking so a subsequent drag/up for this button
+        // falls through.
         setTrackingButton(nil)
         DispatchQueue.main.async { [weak self] in
             self?.processMouseUp(snapshot: snapshot)
@@ -660,6 +710,42 @@ final class MouseGestureController: ObservableObject {
             note: "no active session",
             appInfo: currentAppInfo()
         )
+    }
+
+    private func processMouseUpNativeClickPassthrough(snapshot: MouseEventSnapshot) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard let activeSession = session,
+              activeSession.buttonNumber == snapshot.buttonNumber else {
+            recordObservedEvent(
+                phase: "up",
+                button: MouseShortcutButton(rawButtonNumber: Int(snapshot.buttonNumber)),
+                location: snapshot.location,
+                delta: .zero,
+                modifiers: snapshot.flags,
+                candidate: nil,
+                match: nil,
+                note: "native click passthrough",
+                appInfo: currentAppInfo()
+            )
+            return
+        }
+
+        let delta = CGPoint(
+            x: snapshot.location.x - activeSession.startPoint.x,
+            y: snapshot.location.y - activeSession.startPoint.y
+        )
+        recordObservedEvent(
+            phase: "up",
+            button: MouseShortcutButton(rawButtonNumber: Int(snapshot.buttonNumber)),
+            location: snapshot.location,
+            delta: delta,
+            modifiers: snapshot.flags,
+            candidate: nil,
+            match: nil,
+            note: "native click passthrough",
+            appInfo: currentAppInfo()
+        )
+        clearSession()
     }
 
     private func processMouseUp(snapshot: MouseEventSnapshot) {

--- a/apps/mac/Sources/Core/Input/MouseShortcutStore.swift
+++ b/apps/mac/Sources/Core/Input/MouseShortcutStore.swift
@@ -46,6 +46,15 @@ final class MouseShortcutStore: ObservableObject {
         return Set(snapshot.rules.filter(\.enabled).map { Int64($0.trigger.button.rawButtonNumber) })
     }
 
+    func hasEnabledRule(button: MouseShortcutButton, kind: MouseShortcutTriggerKind) -> Bool {
+        stateLock.lock(); defer { stateLock.unlock() }
+        return snapshot.rules.contains { rule in
+            rule.enabled
+                && rule.trigger.button == button
+                && rule.trigger.kind == kind
+        }
+    }
+
     var summaryLines: [String] {
         stateLock.lock(); defer { stateLock.unlock() }
         return snapshot.rules.filter(\.enabled).map { "\($0.trigger.triggerName) -> \($0.action.type.rawValue)" }

--- a/apps/mac/Sources/Core/Input/SecureEventInputMonitor.swift
+++ b/apps/mac/Sources/Core/Input/SecureEventInputMonitor.swift
@@ -1,0 +1,39 @@
+import Carbon
+import Foundation
+
+final class SecureEventInputMonitor {
+    static let shared = SecureEventInputMonitor()
+
+    private var timer: Timer?
+    private var lastEnabled = IsSecureEventInputEnabled()
+
+    private init() {}
+
+    func start() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard timer == nil else { return }
+
+        lastEnabled = IsSecureEventInputEnabled()
+        let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
+            self?.poll()
+        }
+        self.timer = timer
+        RunLoop.main.add(timer, forMode: .common)
+    }
+
+    func stop() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func poll() {
+        let enabled = IsSecureEventInputEnabled()
+        guard enabled != lastEnabled else { return }
+
+        lastEnabled = enabled
+        let reason = enabled ? "Secure Event Input enabled" : "Secure Event Input disabled"
+        DiagnosticLog.shared.warn("InputCapture: \(reason)")
+        InputCaptureResetCenter.reset(reason: reason)
+    }
+}

--- a/apps/mac/Sources/Core/Overlays/ScreenOverlayCanvasController.swift
+++ b/apps/mac/Sources/Core/Overlays/ScreenOverlayCanvasController.swift
@@ -204,6 +204,12 @@ final class ScreenOverlayCanvasController {
         updateLifecycleMonitors()
     }
 
+    func resetInputCapture(reason: String) {
+        dragState = nil
+        resetPointerCapture()
+        DiagnosticLog.shared.warn("ScreenOverlay: input capture reset for \(reason)")
+    }
+
     @discardableResult
     func moveLayer(id: ScreenOverlayLayerID, to target: CGPoint, durationMs: Int, easing: String?) -> Bool {
         guard let layer = layersByID[id],


### PR DESCRIPTION
## Summary
- reset keyboard remap, mouse gesture, and overlay input capture state at sleep/wake boundaries
- re-arm input taps after system input boundaries so OS tap disables do not require a full app restart
- log input-boundary resets for future diagnosis

## Verification
- bun run check:app
- bunx tsc --noEmit