### PR TITLE
Harden input release handling

### DIFF
--- a/apps/mac/Sources/Core/Input/KeyboardRemapController.swift
+++ b/apps/mac/Sources/Core/Input/KeyboardRemapController.swift
@@ -21,11 +21,12 @@ final class KeyboardRemapController: ObservableObject {
     private var capsLayerLastEventAt: CFAbsoluteTime?
     private var bypassUntil: CFAbsoluteTime = 0
     private var lastCapsLayerStaleLogAt: CFAbsoluteTime = 0
-    private var pressedKeyCodes = Set<Int64>()
+    private var pressedKeyCodes: [Int64: CFAbsoluteTime] = [:]
     private let breaker = EventTapBreaker(label: "KeyboardRemap")
     private let budgetMeter = TapBudgetMeter(label: "KeyboardRemap")
     private let maxCapsLayerIdleDuration: TimeInterval = 2.0
     private let maxCapsLayerHeldDuration: TimeInterval = 20.0
+    private let maxTrackedKeyDownDuration: TimeInterval = 120.0
     private let emergencyBypassDuration: TimeInterval = 3.0
 
     private init() {
@@ -182,7 +183,8 @@ final class KeyboardRemapController: ObservableObject {
             return Unmanaged.passUnretained(event)
         }
 
-        updatePressedKeys(type: type, keyCode: event.getIntegerValueField(.keyboardEventKeycode))
+        expireStalePressedKeys(now: started)
+        updatePressedKeys(type: type, keyCode: event.getIntegerValueField(.keyboardEventKeycode), now: started)
         if shouldTriggerEmergencyReset(type: type, event: event) {
             emergencyClear(now: started)
             InputCaptureResetCenter.reset(reason: "keyboard emergency chord")
@@ -295,15 +297,24 @@ final class KeyboardRemapController: ObservableObject {
         DiagnosticLog.shared.warn("KeyboardRemap: emergency bypass via Escape")
     }
 
-    private func updatePressedKeys(type: CGEventType, keyCode: Int64) {
+    private func updatePressedKeys(type: CGEventType, keyCode: Int64, now: CFAbsoluteTime) {
         switch type {
         case .keyDown:
-            pressedKeyCodes.insert(keyCode)
+            pressedKeyCodes[keyCode] = now
         case .keyUp:
-            pressedKeyCodes.remove(keyCode)
+            pressedKeyCodes.removeValue(forKey: keyCode)
         default:
             break
         }
+    }
+
+    private func expireStalePressedKeys(now: CFAbsoluteTime) {
+        let staleKeys = pressedKeyCodes.filter { now - $0.value > maxTrackedKeyDownDuration }.map(\.key)
+        guard !staleKeys.isEmpty else { return }
+        for keyCode in staleKeys {
+            pressedKeyCodes.removeValue(forKey: keyCode)
+        }
+        DiagnosticLog.shared.warn("KeyboardRemap: cleared stale key-down state for \(staleKeys.count) key(s)")
     }
 
     private func shouldTriggerEmergencyReset(type: CGEventType, event: CGEvent) -> Bool {
@@ -311,7 +322,7 @@ final class KeyboardRemapController: ObservableObject {
         let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
         let flags = event.flags
         return keyCode == 40
-            && pressedKeyCodes.contains(53)
+            && pressedKeyCodes[53] != nil
             && flags.contains(.maskShift)
     }
 

--- a/apps/mac/Sources/Core/Overlays/ScreenOverlayCanvasController.swift
+++ b/apps/mac/Sources/Core/Overlays/ScreenOverlayCanvasController.swift
@@ -371,30 +371,19 @@ final class ScreenOverlayCanvasController {
         let hasAgentLayer = layersByID.values.contains { $0.owner == .agentApi }
         if hasAgentLayer, globalDismissMonitor == nil {
             let mask: NSEvent.EventTypeMask = [
-                .mouseMoved,
                 .leftMouseDown,
-                .leftMouseUp,
                 .rightMouseDown,
                 .otherMouseDown,
-                .leftMouseDragged,
-                .rightMouseDragged,
-                .otherMouseDragged,
             ]
             globalDismissMonitor = NSEvent.addGlobalMonitorForEvents(matching: mask) { [weak self] event in
                 DispatchQueue.main.async {
                     _ = self?.handlePointerEvent(event)
                 }
             }
-            localDismissMonitor = NSEvent.addLocalMonitorForEvents(matching: mask.union(.keyDown)) { [weak self] event in
-                if event.type == .keyDown {
-                    if event.keyCode == 53 {
-                        self?.dismissAgentOverlays()
-                        return nil
-                    }
-                } else {
-                    if self?.handlePointerEvent(event) == true {
-                        return nil
-                    }
+            localDismissMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                if event.keyCode == 53 {
+                    self?.dismissAgentOverlays()
+                    return nil
                 }
                 return event
             }
@@ -416,35 +405,7 @@ final class ScreenOverlayCanvasController {
     @discardableResult
     private func handlePointerEvent(_ event: NSEvent) -> Bool {
         switch event.type {
-        case .mouseMoved:
-            updatePointerCapture(at: NSEvent.mouseLocation)
-            return false
-        case .leftMouseDown:
-            updatePointerCapture(at: NSEvent.mouseLocation)
-            if beginActorDrag(at: NSEvent.mouseLocation) {
-                return true
-            }
-            dismissAgentOverlays()
-            return false
-        case .leftMouseDragged:
-            if dragActor(to: NSEvent.mouseLocation) {
-                return true
-            }
-            dismissAgentOverlays()
-            return false
-        case .leftMouseUp:
-            let wasDragging = dragState != nil
-            endActorDrag()
-            updatePointerCapture(at: NSEvent.mouseLocation)
-            return wasDragging
-        case .rightMouseDown:
-            updatePointerCapture(at: NSEvent.mouseLocation)
-            if closeActor(at: NSEvent.mouseLocation) {
-                return true
-            }
-            dismissAgentOverlays()
-            return false
-        case .otherMouseDown, .rightMouseDragged, .otherMouseDragged:
+        case .leftMouseDown, .rightMouseDown, .otherMouseDown:
             dismissAgentOverlays()
             return false
         default:
@@ -453,16 +414,7 @@ final class ScreenOverlayCanvasController {
     }
 
     private func updatePointerCapture(at globalPoint: CGPoint) {
-        clearStaleActorDragIfNeeded()
-        let captureWindow: ScreenOverlayWindow?
-        if let dragState {
-            captureWindow = windowsByScreenID[dragState.screenID]
-        } else {
-            captureWindow = hitActor(at: globalPoint)?.window
-        }
-        for window in windowsByScreenID.values {
-            window.ignoresMouseEvents = window !== captureWindow
-        }
+        resetPointerCapture()
     }
 
     private func beginActorDrag(at globalPoint: CGPoint) -> Bool {
@@ -512,6 +464,7 @@ final class ScreenOverlayCanvasController {
               let layer = layersByID[dragState.id],
               case .pet(let payload) = layer.payload else {
             self.dragState = nil
+            cancelActorDragTimeout()
             resetPointerCapture()
             return
         }
@@ -520,7 +473,7 @@ final class ScreenOverlayCanvasController {
         cancelActorDragTimeout()
         render()
         updateLifecycleMonitors()
-        updatePointerCapture(at: NSEvent.mouseLocation)
+        resetPointerCapture()
     }
 
     private func clearStaleActorDragIfNeeded() {
@@ -562,7 +515,7 @@ final class ScreenOverlayCanvasController {
         }
         render()
         updateLifecycleMonitors()
-        updatePointerCapture(at: globalPoint)
+        resetPointerCapture()
         return true
     }
 


### PR DESCRIPTION
## Summary
- keep keyboard pressed-key tracking timestamped and clear stale key-down state after 120 seconds
- make agent overlay mouse monitoring dismiss-only so primary clicks never activate overlay capture
- reset overlay pointer capture after actor drag/close cleanup paths

## Tests
- bun run check