### PR TITLE
Polish docs navigation, code copy, and highlighting

### DIFF
--- a/apps/site/bun.lock
+++ b/apps/site/bun.lock
@@ -12,6 +12,7 @@
         "rehype-raw": "^7.0.0",
         "rehype-slug": "^6.0.0",
         "remark-gfm": "^4.0.1",
+        "shiki": "^4.0.2",
       },
       "devDependencies": {
         "@arach/og": "^0.3.0",
@@ -347,6 +348,22 @@
     "@rspack/lite-tapable": ["@rspack/lite-tapable@1.1.0", "", {}, "sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw=="],
 
     "@rspack/plugin-react-refresh": ["@rspack/plugin-react-refresh@1.6.1", "", { "dependencies": { "error-stack-parser": "^2.1.4", "html-entities": "^2.6.0" }, "peerDependencies": { "react-refresh": ">=0.10.0 <1.0.0", "webpack-hot-middleware": "2.x" }, "optionalPeers": ["webpack-hot-middleware"] }, "sha512-eqqW5645VG3CzGzFgNg5HqNdHVXY+567PGjtDhhrM8t67caxmsSzRmT5qfoEIfBcGgFkH9vEg7kzXwmCYQdQDw=="],
+
+    "@shikijs/core": ["@shikijs/core@4.0.2", "", { "dependencies": { "@shikijs/primitive": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg=="],
+
+    "@shikijs/langs": ["@shikijs/langs@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2" } }, "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg=="],
+
+    "@shikijs/primitive": ["@shikijs/primitive@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw=="],
+
+    "@shikijs/themes": ["@shikijs/themes@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2" } }, "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA=="],
+
+    "@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
@@ -690,6 +707,8 @@
 
     "hast-util-raw": ["hast-util-raw@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "hast-util-from-parse5": "^8.0.0", "hast-util-to-parse5": "^8.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "parse5": "^7.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw=="],
 
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
 
     "hast-util-to-parse5": ["hast-util-to-parse5@8.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA=="],
@@ -926,6 +945,10 @@
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
+    "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
+
     "open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
@@ -998,6 +1021,12 @@
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
     "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
 
     "rehype-slug": ["rehype-slug@6.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "github-slugger": "^2.0.0", "hast-util-heading-rank": "^3.0.0", "hast-util-to-string": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A=="],
@@ -1035,6 +1064,8 @@
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -15,12 +15,13 @@
   },
   "dependencies": {
     "@arach/arc": "^0.3.1",
-    "rehype-raw": "^7.0.0",
-    "rehype-slug": "^6.0.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1"
+    "rehype-raw": "^7.0.0",
+    "rehype-slug": "^6.0.0",
+    "remark-gfm": "^4.0.1",
+    "shiki": "^4.0.2"
   },
   "devDependencies": {
     "@arach/og": "^0.3.0",

--- a/apps/site/scripts/export-static.mjs
+++ b/apps/site/scripts/export-static.mjs
@@ -1,12 +1,35 @@
 import { copyFile, mkdir, readdir, readFile, writeFile } from 'node:fs/promises'
 import { basename, dirname, join, resolve } from 'node:path'
 import { marked } from 'marked'
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
+import { createHighlighterCore } from 'shiki/core'
+import bash from 'shiki/langs/sh.mjs'
+import javascript from 'shiki/langs/js.mjs'
+import json from 'shiki/langs/json.mjs'
+import markdown from 'shiki/langs/md.mjs'
+import mermaid from 'shiki/langs/mermaid.mjs'
+import swift from 'shiki/langs/swift.mjs'
+import typescript from 'shiki/langs/ts.mjs'
 import { writeAgentArtifacts } from './agent-docs.mjs'
 
 const siteDir = resolve(import.meta.dirname, '..')
 const repoRoot = resolve(siteDir, '..', '..')
 const distDir = join(siteDir, 'dist')
 const template = await readFile(join(distDir, 'index.html'), 'utf8')
+const shikiTheme = JSON.parse(await readFile(join(siteDir, 'src', 'data', 'lattices-shiki-theme.json'), 'utf8'))
+const highlighter = await createHighlighterCore({
+  themes: [shikiTheme],
+  langs: [
+    ...bash,
+    ...json,
+    ...javascript,
+    ...typescript,
+    ...swift,
+    ...markdown,
+    ...mermaid,
+  ],
+  engine: createJavaScriptRegexEngine(),
+})
 
 marked.use({
   mangle: false,
@@ -222,14 +245,37 @@ function createRenderer() {
   const renderer = new marked.Renderer()
 
   renderer.code = (token) => {
-    const language = token.lang ? ` class="language-${escapeHtml(token.lang)}"` : ''
+    const language = normalizeLanguage(token.lang)
+    const highlighted = highlightStaticCode(token.text, language)
+
     return [
       '<div class="code-block">',
       '<button type="button" class="code-copy-button" data-pagefind-ignore>Copy</button>',
-      `<pre><code${language}>${escapeHtml(token.text)}</code></pre>`,
+      `<div class="shiki-code">${highlighted}</div>`,
       '</div>',
     ].join('')
   }
 
   return renderer
+}
+
+function highlightStaticCode(code, language) {
+  try {
+    return highlighter.codeToHtml(code, { lang: language, theme: 'lattices-green' })
+  } catch {
+    return highlighter.codeToHtml(code, { lang: 'text', theme: 'lattices-green' })
+  }
+}
+
+function normalizeLanguage(language) {
+  const lang = language?.toLowerCase().trim()
+
+  if (!lang) return 'text'
+  if (lang === 'sh' || lang === 'shell' || lang === 'zsh') return 'bash'
+  if (lang === 'js' || lang === 'jsx') return 'javascript'
+  if (lang === 'ts' || lang === 'tsx') return 'typescript'
+
+  return ['bash', 'json', 'javascript', 'typescript', 'swift', 'markdown', 'mermaid', 'text'].includes(lang)
+    ? lang
+    : 'text'
 }

--- a/apps/site/scripts/export-static.mjs
+++ b/apps/site/scripts/export-static.mjs
@@ -11,6 +11,7 @@ const template = await readFile(join(distDir, 'index.html'), 'utf8')
 marked.use({
   mangle: false,
   headerIds: true,
+  renderer: createRenderer(),
 })
 
 const mdxComponents = [
@@ -215,4 +216,20 @@ function escapeHtml(value) {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
+}
+
+function createRenderer() {
+  const renderer = new marked.Renderer()
+
+  renderer.code = (token) => {
+    const language = token.lang ? ` class="language-${escapeHtml(token.lang)}"` : ''
+    return [
+      '<div class="code-block">',
+      '<button type="button" class="code-copy-button" data-pagefind-ignore>Copy</button>',
+      `<pre><code${language}>${escapeHtml(token.text)}</code></pre>`,
+      '</div>',
+    ].join('')
+  }
+
+  return renderer
 }

--- a/apps/site/src/SiteApp.tsx
+++ b/apps/site/src/SiteApp.tsx
@@ -1,17 +1,48 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { BlogIndex, BlogPostPage } from './components/Blog'
 import { DocsPage } from './components/Docs'
 import LandingPage from './components/LandingPage'
 import { defaultDoc, getBlogPost, getDoc } from './lib/content'
 
 export default function SiteApp() {
-  const path = normalizePath(window.location.pathname)
+  const [path, setPath] = useState(() => normalizePath(window.location.pathname))
   const route = resolveRoute(path)
 
   useEffect(() => {
     document.title = route.title
     setMeta('description', route.description)
   }, [route.description, route.title])
+
+  useEffect(() => {
+    const syncPath = () => setPath(normalizePath(window.location.pathname))
+    window.addEventListener('popstate', syncPath)
+    return () => window.removeEventListener('popstate', syncPath)
+  }, [])
+
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      if (shouldIgnoreClick(event)) return
+
+      const target = event.target instanceof Element ? event.target : null
+      const anchor = target?.closest<HTMLAnchorElement>('a[href]')
+      if (!anchor || shouldIgnoreAnchor(anchor)) return
+
+      const url = new URL(anchor.href, window.location.href)
+      if (url.origin !== window.location.origin) return
+
+      const nextPath = normalizePath(url.pathname)
+      if (url.pathname === window.location.pathname && url.hash) return
+      if (resolveRoute(nextPath).kind === 'not-found') return
+
+      event.preventDefault()
+      window.history.pushState({}, '', `${url.pathname}${url.search}${url.hash}`)
+      setPath(nextPath)
+      scrollAfterNavigation(url.hash)
+    }
+
+    document.addEventListener('click', handleClick)
+    return () => document.removeEventListener('click', handleClick)
+  }, [])
 
   if (route.kind === 'home') return <LandingPage />
   if (route.kind === 'docs') return <DocsPage slug={route.slug} />
@@ -91,6 +122,40 @@ function resolveRoute(path: string): Route {
     title: 'Page not found — Lattices',
     description: 'Page not found',
   }
+}
+
+function shouldIgnoreClick(event: MouseEvent): boolean {
+  return (
+    event.defaultPrevented ||
+    event.button !== 0 ||
+    event.metaKey ||
+    event.altKey ||
+    event.ctrlKey ||
+    event.shiftKey
+  )
+}
+
+function shouldIgnoreAnchor(anchor: HTMLAnchorElement): boolean {
+  return (
+    Boolean(anchor.target && anchor.target !== '_self') ||
+    anchor.hasAttribute('download') ||
+    anchor.dataset.router === 'reload'
+  )
+}
+
+function scrollAfterNavigation(hash: string): void {
+  requestAnimationFrame(() => {
+    if (!hash) {
+      window.scrollTo({ top: 0, left: 0 })
+      return
+    }
+
+    try {
+      document.getElementById(decodeURIComponent(hash.slice(1)))?.scrollIntoView()
+    } catch {
+      document.getElementById(hash.slice(1))?.scrollIntoView()
+    }
+  })
 }
 
 function normalizePath(pathname: string): string {

--- a/apps/site/src/components/Docs.tsx
+++ b/apps/site/src/components/Docs.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { defaultDoc, getDoc, navGroups, type DocPage } from '../lib/content'
 import { MarkdownRenderer } from './MarkdownRenderer'
 import { SiteHeader } from './SiteChrome'
@@ -26,7 +27,7 @@ export function DocsPage({ slug }: DocsPageProps) {
       <SiteHeader />
       <main className="docs-shell" data-pagefind-body>
         <aside className="docs-sidebar" data-pagefind-ignore>
-          <Sidebar currentSlug={doc.slug} />
+          <Sidebar key={doc.slug} currentSlug={doc.slug} />
         </aside>
         <article className="docs-article">
           <header className="docs-article-header">
@@ -44,10 +45,41 @@ export function DocsPage({ slug }: DocsPageProps) {
 }
 
 function Sidebar({ currentSlug }: { currentSlug: string }) {
+  const [mobileOpen, setMobileOpen] = useState(false)
+  const currentItem = navGroups.flatMap((group) => group.items).find((item) => item.id === currentSlug)
+
   return (
     <nav className="sidebar-nav" aria-label="Documentation">
+      <div className="desktop-sidebar-nav">
+        <NavGroups currentSlug={currentSlug} />
+      </div>
+      <div className={mobileOpen ? 'mobile-docs-nav open' : 'mobile-docs-nav'}>
+        <button
+          type="button"
+          className="mobile-docs-trigger"
+          aria-expanded={mobileOpen}
+          aria-controls="mobile-docs-panel"
+          onClick={() => setMobileOpen((open) => !open)}
+        >
+          <span>
+            <span className="mobile-docs-label">Docs menu</span>
+            <span className="mobile-docs-current">{currentItem?.title || 'Documentation'}</span>
+          </span>
+          <span className="mobile-docs-chevron" aria-hidden="true">{mobileOpen ? '−' : '+'}</span>
+        </button>
+        <div id="mobile-docs-panel" className="mobile-docs-panel" hidden={!mobileOpen}>
+          <NavGroups currentSlug={currentSlug} compact />
+        </div>
+      </div>
+    </nav>
+  )
+}
+
+function NavGroups({ currentSlug, compact = false }: { currentSlug: string; compact?: boolean }) {
+  return (
+    <>
       {navGroups.map((group) => (
-        <details key={group.id} open>
+        <details key={group.id} open={!compact || group.items.some((item) => item.id === currentSlug)}>
           <summary>
             <span>{group.title}</span>
             <span>▾</span>
@@ -63,7 +95,7 @@ function Sidebar({ currentSlug }: { currentSlug: string }) {
           </ul>
         </details>
       ))}
-    </nav>
+    </>
   )
 }
 

--- a/apps/site/src/components/MarkdownRenderer.tsx
+++ b/apps/site/src/components/MarkdownRenderer.tsx
@@ -1,3 +1,4 @@
+import { isValidElement, useState, type ReactNode } from 'react'
 import ReactMarkdown, { type Components } from 'react-markdown'
 import rehypeRaw from 'rehype-raw'
 import rehypeSlug from 'rehype-slug'
@@ -45,6 +46,9 @@ const components: Components = {
   img(props) {
     return <img loading="lazy" {...props} />
   },
+  pre({ children, ...props }) {
+    return <CodeBlock {...props}>{children}</CodeBlock>
+  },
 }
 
 interface MarkdownRendererProps {
@@ -64,4 +68,59 @@ export function MarkdownRenderer({ content, className = 'markdown-body' }: Markd
       </ReactMarkdown>
     </div>
   )
+}
+
+function CodeBlock({ children, ...props }: { children?: ReactNode }) {
+  const [copied, setCopied] = useState(false)
+  const code = extractText(children).replace(/\n$/, '')
+
+  const copy = async () => {
+    if (!code) return
+    await copyText(code)
+    setCopied(true)
+    window.setTimeout(() => setCopied(false), 1400)
+  }
+
+  return (
+    <div className="code-block">
+      <button
+        type="button"
+        className="code-copy-button"
+        onClick={copy}
+        aria-label={copied ? 'Copied code' : 'Copy code'}
+        data-pagefind-ignore
+      >
+        {copied ? 'Copied' : 'Copy'}
+      </button>
+      <pre {...props}>{children}</pre>
+    </div>
+  )
+}
+
+function extractText(node: ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(extractText).join('')
+  if (isValidElement<{ children?: ReactNode }>(node)) return extractText(node.props.children)
+  return ''
+}
+
+async function copyText(value: string): Promise<void> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(value)
+      return
+    } catch {
+      // Fall through for browsers that expose Clipboard API but deny writes.
+    }
+  }
+
+  const textarea = document.createElement('textarea')
+  textarea.value = value
+  textarea.setAttribute('readonly', '')
+  textarea.style.position = 'fixed'
+  textarea.style.top = '-9999px'
+  document.body.appendChild(textarea)
+  textarea.select()
+  document.execCommand('copy')
+  textarea.remove()
 }

--- a/apps/site/src/components/MarkdownRenderer.tsx
+++ b/apps/site/src/components/MarkdownRenderer.tsx
@@ -1,4 +1,4 @@
-import { isValidElement, useState, type ReactNode } from 'react'
+import { isValidElement, useEffect, useState, type ReactNode } from 'react'
 import ReactMarkdown, { type Components } from 'react-markdown'
 import rehypeRaw from 'rehype-raw'
 import rehypeSlug from 'rehype-slug'
@@ -72,7 +72,28 @@ export function MarkdownRenderer({ content, className = 'markdown-body' }: Markd
 
 function CodeBlock({ children, ...props }: { children?: ReactNode }) {
   const [copied, setCopied] = useState(false)
+  const [highlighted, setHighlighted] = useState<{ key: string; html: string } | null>(null)
   const code = extractText(children).replace(/\n$/, '')
+  const language = extractLanguage(children)
+  const highlightKey = `${language || 'text'}:${code}`
+  const highlightedHtml = highlighted?.key === highlightKey ? highlighted.html : null
+
+  useEffect(() => {
+    let cancelled = false
+
+    import('../lib/highlight')
+      .then(({ highlightCode }) => highlightCode(code, language))
+      .then((html) => {
+        if (!cancelled) setHighlighted({ key: highlightKey, html })
+      })
+      .catch(() => {
+        if (!cancelled) setHighlighted(null)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [code, highlightKey, language])
 
   const copy = async () => {
     if (!code) return
@@ -92,7 +113,11 @@ function CodeBlock({ children, ...props }: { children?: ReactNode }) {
       >
         {copied ? 'Copied' : 'Copy'}
       </button>
-      <pre {...props}>{children}</pre>
+      {highlightedHtml ? (
+        <div className="shiki-code" dangerouslySetInnerHTML={{ __html: highlightedHtml }} />
+      ) : (
+        <pre {...props}>{children}</pre>
+      )}
     </div>
   )
 }
@@ -102,6 +127,18 @@ function extractText(node: ReactNode): string {
   if (Array.isArray(node)) return node.map(extractText).join('')
   if (isValidElement<{ children?: ReactNode }>(node)) return extractText(node.props.children)
   return ''
+}
+
+function extractLanguage(node: ReactNode): string | undefined {
+  if (Array.isArray(node)) {
+    return node.map(extractLanguage).find(Boolean)
+  }
+
+  if (!isValidElement<{ className?: string; children?: ReactNode }>(node)) return undefined
+
+  const className = node.props.className
+  const match = className?.match(/language-([A-Za-z0-9_-]+)/)
+  return match?.[1] || extractLanguage(node.props.children)
 }
 
 async function copyText(value: string): Promise<void> {

--- a/apps/site/src/data/lattices-shiki-theme.json
+++ b/apps/site/src/data/lattices-shiki-theme.json
@@ -1,0 +1,88 @@
+{
+  "name": "lattices-green",
+  "type": "dark",
+  "colors": {
+    "editor.background": "#111113",
+    "editor.foreground": "#E9F0EC",
+    "editorLineNumber.foreground": "#5A665F",
+    "editor.selectionBackground": "#1E3B2A"
+  },
+  "tokenColors": [
+    {
+      "scope": ["comment", "punctuation.definition.comment"],
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#68746E"
+      }
+    },
+    {
+      "scope": ["keyword", "storage", "storage.type", "support.type"],
+      "settings": {
+        "foreground": "#5FE08E"
+      }
+    },
+    {
+      "scope": ["string", "string.quoted", "string.template"],
+      "settings": {
+        "foreground": "#33C773"
+      }
+    },
+    {
+      "scope": ["constant", "constant.numeric", "constant.language", "support.constant"],
+      "settings": {
+        "foreground": "#A7E86F"
+      }
+    },
+    {
+      "scope": ["entity.name.function", "support.function", "meta.function-call"],
+      "settings": {
+        "foreground": "#B6F7C8"
+      }
+    },
+    {
+      "scope": ["entity.name.type", "entity.name.class", "support.class", "support.type.swift"],
+      "settings": {
+        "foreground": "#79D98D"
+      }
+    },
+    {
+      "scope": ["variable", "variable.other", "entity.name.variable", "support.variable"],
+      "settings": {
+        "foreground": "#D7E2DC"
+      }
+    },
+    {
+      "scope": ["punctuation", "meta.brace", "meta.delimiter"],
+      "settings": {
+        "foreground": "#74A984"
+      }
+    },
+    {
+      "scope": ["markup.heading", "markup.heading punctuation.definition.heading"],
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#B6F7C8"
+      }
+    },
+    {
+      "scope": ["markup.italic"],
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#D7E2DC"
+      }
+    },
+    {
+      "scope": ["markup.bold"],
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#E9F0EC"
+      }
+    },
+    {
+      "scope": ["invalid", "invalid.illegal"],
+      "settings": {
+        "foreground": "#FF7A7A"
+      }
+    }
+  ]
+}

--- a/apps/site/src/lib/highlight.ts
+++ b/apps/site/src/lib/highlight.ts
@@ -1,0 +1,62 @@
+import shikiTheme from '../data/lattices-shiki-theme.json'
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
+import { createHighlighterCore } from 'shiki/core'
+import bash from 'shiki/langs/sh.mjs'
+import javascript from 'shiki/langs/js.mjs'
+import json from 'shiki/langs/json.mjs'
+import markdown from 'shiki/langs/md.mjs'
+import mermaid from 'shiki/langs/mermaid.mjs'
+import swift from 'shiki/langs/swift.mjs'
+import typescript from 'shiki/langs/ts.mjs'
+import type { ThemeRegistrationRaw } from 'shiki/core'
+
+const themeName = 'lattices-green'
+const languages = ['bash', 'json', 'javascript', 'typescript', 'swift', 'markdown', 'mermaid', 'text'] as const
+const shikiLanguages = [
+  ...bash,
+  ...json,
+  ...javascript,
+  ...typescript,
+  ...swift,
+  ...markdown,
+  ...mermaid,
+]
+
+type Highlighter = {
+  codeToHtml: (code: string, options: { lang: string; theme: string }) => string
+}
+
+let highlighterPromise: Promise<Highlighter> | null = null
+
+export async function highlightCode(code: string, language?: string): Promise<string> {
+  const highlighter = await getHighlighter()
+  const normalized = normalizeLanguage(language)
+
+  try {
+    return highlighter.codeToHtml(code, { lang: normalized, theme: themeName })
+  } catch {
+    return highlighter.codeToHtml(code, { lang: 'text', theme: themeName })
+  }
+}
+
+export function normalizeLanguage(language?: string): string {
+  const lang = language?.toLowerCase().trim()
+
+  if (!lang) return 'text'
+  if (lang === 'sh' || lang === 'shell' || lang === 'zsh') return 'bash'
+  if (lang === 'js' || lang === 'jsx') return 'javascript'
+  if (lang === 'ts' || lang === 'tsx') return 'typescript'
+  if (languages.includes(lang as (typeof languages)[number])) return lang
+
+  return 'text'
+}
+
+async function getHighlighter(): Promise<Highlighter> {
+  highlighterPromise ??= createHighlighterCore({
+    themes: [shikiTheme as unknown as ThemeRegistrationRaw],
+    langs: shikiLanguages,
+    engine: createJavaScriptRegexEngine(),
+  }) as Promise<Highlighter>
+
+  return highlighterPromise
+}

--- a/apps/site/src/styles/docs.css
+++ b/apps/site/src/styles/docs.css
@@ -289,6 +289,13 @@
   font-size: 0.88em;
 }
 
+.code-block {
+  position: relative;
+  margin: 20px 0;
+}
+
+.markdown-body .code-block pre,
+.prose .code-block pre,
 .markdown-body pre,
 .prose pre {
   margin: 20px 0;
@@ -299,11 +306,39 @@
   background: #111;
 }
 
+.markdown-body .code-block pre,
+.prose .code-block pre {
+  margin: 0;
+  padding-right: 84px;
+}
+
 .markdown-body pre code,
 .prose pre code {
   border: 0;
   background: transparent;
   padding: 0;
+}
+
+.code-copy-button {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 1;
+  min-width: 54px;
+  height: 28px;
+  border: 1px solid var(--docs-border-lit);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--docs-bg) 82%, transparent);
+  color: var(--docs-muted);
+  font: inherit;
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.code-copy-button:hover {
+  color: var(--docs-text);
+  background: var(--docs-surface);
 }
 
 .markdown-body table,

--- a/apps/site/src/styles/docs.css
+++ b/apps/site/src/styles/docs.css
@@ -108,9 +108,13 @@
   align-self: start;
 }
 
-.sidebar-nav {
+.desktop-sidebar-nav {
   display: grid;
   gap: 16px;
+}
+
+.mobile-docs-nav {
+  display: none;
 }
 
 .sidebar-nav details {
@@ -154,6 +158,64 @@
 .sidebar-nav a.active {
   color: var(--docs-accent);
   background: color-mix(in srgb, var(--docs-accent) 10%, transparent);
+}
+
+.mobile-docs-trigger {
+  display: flex;
+  width: 100%;
+  min-height: 58px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px solid var(--docs-border-lit);
+  border-radius: 8px;
+  background: var(--docs-surface);
+  color: var(--docs-text);
+  padding: 10px 12px;
+  font: inherit;
+  text-align: left;
+}
+
+.mobile-docs-trigger > span:first-child {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.mobile-docs-label {
+  color: var(--docs-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.mobile-docs-current {
+  overflow: hidden;
+  font-size: 14px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mobile-docs-chevron {
+  display: inline-flex;
+  width: 20px;
+  height: 20px;
+  align-items: center;
+  justify-content: center;
+  color: var(--docs-muted);
+  font-size: 18px;
+  line-height: 1;
+}
+
+.mobile-docs-panel {
+  margin-top: 10px;
+  display: grid;
+  gap: 10px;
+}
+
+.mobile-docs-panel[hidden] {
+  display: none;
 }
 
 .docs-article {
@@ -294,6 +356,10 @@
   margin: 20px 0;
 }
 
+.shiki-code {
+  display: block;
+}
+
 .markdown-body .code-block pre,
 .prose .code-block pre,
 .markdown-body pre,
@@ -310,6 +376,17 @@
 .prose .code-block pre {
   margin: 0;
   padding-right: 84px;
+}
+
+.markdown-body .code-block .shiki,
+.prose .code-block .shiki {
+  background: #111113 !important;
+  box-shadow: inset 0 1px 0 rgba(95, 224, 142, 0.08);
+}
+
+.markdown-body .code-block .line,
+.prose .code-block .line {
+  min-height: 1.55em;
 }
 
 .markdown-body pre code,
@@ -546,8 +623,18 @@
   }
 
   .docs-sidebar {
-    position: static;
-    margin-bottom: 28px;
+    position: sticky;
+    top: 62px;
+    z-index: 10;
+    margin-bottom: 24px;
+  }
+
+  .desktop-sidebar-nav {
+    display: none;
+  }
+
+  .mobile-docs-nav {
+    display: block;
   }
 }
 


### PR DESCRIPTION
## Summary

- keep same-origin docs and blog links inside the React app so sidebar/section navigation no longer does a full document reload
- add copy buttons for fenced markdown code blocks in the React renderer and static exporter
- add Shiki syntax highlighting with a custom green Lattices theme
- lazy-load the client highlighter and pre-highlight static exported docs/blog HTML
- replace the mobile docs sidebar wall with a compact collapsible docs menu

## Verification

- `bunx tsc -b` in `apps/site`
- `bun run lint` in `apps/site`
- `bun run build` in `apps/site`
- preview + Puppeteer: clicked `/docs/overview` → `/docs/config` and confirmed the document marker survived
- preview + Puppeteer: verified code copy, Shiki green tokens, mobile collapsed menu, mobile expanded current-group menu, and menu collapse after navigation
- confirmed static `dist/docs/config/index.html` includes `code-copy-button` and `shiki lattices-green` markup
- confirmed Astro sweep remains clean

Note: Vite still emits the large chunk warning. The new Shiki highlighter is split into a lazy chunk; static HTML is already highlighted before client JS loads.