### PR TITLE
Add static HUD actors

### DIFF
--- a/apps/mac/Lattices.app/Contents/Info.plist
+++ b/apps/mac/Lattices.app/Contents/Info.plist
@@ -34,9 +34,9 @@
     <key>LatticesBuildTrack</key>
     <string>latest</string>
     <key>LatticesBuildRevision</key>
-    <string>3c7b053</string>
+    <string>4fc5b8a</string>
     <key>LatticesBuildTimestamp</key>
-    <string>2026-05-23T21:56:36.076Z</string>
+    <string>2026-05-29T01:19:38.705Z</string>
     <key>LSMinimumSystemVersion</key>
     <string>13.0</string>
     <key>LSUIElement</key>

--- a/apps/mac/Sources/Core/Actions/HotkeyStore.swift
+++ b/apps/mac/Sources/Core/Actions/HotkeyStore.swift
@@ -257,7 +257,7 @@ class HotkeyStore: ObservableObject {
         bind(.omniSearch, 23, hyper)       // Hyper+5
         bind(.cheatSheet, 22, hyper)       // Hyper+6
         bind(.mouseFinder, 26, hyper)      // Hyper+7
-        bind(.overlayActors, 28, hyper)    // Hyper+8
+        bind(.overlayActors, 11, hyper)    // Hyper+B
 
         // Layers: Cmd+Option+1-9
         let layerKeyCodes: [UInt32] = [18, 19, 20, 21, 23, 22, 26, 28, 25]

--- a/apps/mac/Sources/Core/Daemon/LatticesApi.swift
+++ b/apps/mac/Sources/Core/Daemon/LatticesApi.swift
@@ -836,6 +836,17 @@ final class LatticesApi {
                 Param(name: "petId", type: "string", required: false, description: "Bundled pet id from Resources/Pets"),
                 Param(name: "state", type: "string", required: false, description: "Pet animation state"),
                 Param(name: "name", type: "string", required: false, description: "Pet name"),
+                Param(name: "targetApp", type: "string", required: false, description: "App name to activate when this pet is clicked"),
+                Param(name: "targetBundleId", type: "string", required: false, description: "Bundle identifier to activate when this pet is clicked"),
+                Param(name: "targetAppPath", type: "string", required: false, description: "Application bundle path to open when this pet is clicked"),
+                Param(name: "scale", type: "double", required: false, description: "Actor scale multiplier"),
+                Param(name: "labelHidden", type: "bool", required: false, description: "Hide the actor label/message"),
+                Param(name: "closeOnActivate", type: "bool", required: false, description: "Remove the actor after activating its target app"),
+                Param(name: "hudUrl", type: "string", required: false, description: "URL to render in a hover HUD web view"),
+                Param(name: "hudHTML", type: "string", required: false, description: "Inline HTML to render in a hover HUD web view"),
+                Param(name: "hudWidth", type: "double", required: false, description: "Hover HUD width"),
+                Param(name: "hudHeight", type: "double", required: false, description: "Hover HUD height"),
+                Param(name: "hudReadAccess", type: "string", required: false, description: "Local folder the file-backed HUD may read"),
                 Param(name: "x", type: "double", required: false, description: "Screen-local x coordinate"),
                 Param(name: "y", type: "double", required: false, description: "Screen-local y coordinate"),
                 Param(name: "w", type: "double", required: false, description: "Highlight width"),
@@ -879,6 +890,17 @@ final class LatticesApi {
                 Param(name: "state", type: "string", required: false, description: "Actor state or animation name"),
                 Param(name: "name", type: "string", required: false, description: "Actor display name"),
                 Param(name: "message", type: "string", required: false, description: "Attached message text"),
+                Param(name: "targetApp", type: "string", required: false, description: "App name to activate when this actor is clicked"),
+                Param(name: "targetBundleId", type: "string", required: false, description: "Bundle identifier to activate when this actor is clicked"),
+                Param(name: "targetAppPath", type: "string", required: false, description: "Application bundle path to open when this actor is clicked"),
+                Param(name: "scale", type: "double", required: false, description: "Actor scale multiplier"),
+                Param(name: "labelHidden", type: "bool", required: false, description: "Hide the actor label/message"),
+                Param(name: "closeOnActivate", type: "bool", required: false, description: "Remove the actor after activating its target app"),
+                Param(name: "hudUrl", type: "string", required: false, description: "URL to render in a hover HUD web view"),
+                Param(name: "hudHTML", type: "string", required: false, description: "Inline HTML to render in a hover HUD web view"),
+                Param(name: "hudWidth", type: "double", required: false, description: "Hover HUD width"),
+                Param(name: "hudHeight", type: "double", required: false, description: "Hover HUD height"),
+                Param(name: "hudReadAccess", type: "string", required: false, description: "Local folder the file-backed HUD may read"),
                 Param(name: "x", type: "double", required: false, description: "Screen-local x coordinate"),
                 Param(name: "y", type: "double", required: false, description: "Screen-local y coordinate"),
                 Param(name: "placement", type: "string", required: false, description: "top, bottom, center, cursor, or point"),
@@ -909,6 +931,42 @@ final class LatticesApi {
             returns: .ok,
             handler: { params in
                 try Self.moveOverlayActor(params)
+            }
+        ))
+
+        api.register(Endpoint(
+            method: "overlay.actor.hud",
+            description: "Attach, update, or clear a hover web HUD for an overlay actor",
+            access: .mutate,
+            params: [
+                Param(name: "id", type: "string", required: true, description: "Actor id"),
+                Param(name: "hudUrl", type: "string", required: false, description: "URL to render in the hover HUD web view"),
+                Param(name: "hudHTML", type: "string", required: false, description: "Inline HTML to render in the hover HUD web view"),
+                Param(name: "hudTitle", type: "string", required: false, description: "HUD title metadata"),
+                Param(name: "hudWidth", type: "double", required: false, description: "HUD width"),
+                Param(name: "hudHeight", type: "double", required: false, description: "HUD height"),
+                Param(name: "hudReadAccess", type: "string", required: false, description: "Local folder the file-backed HUD may read"),
+                Param(name: "clear", type: "bool", required: false, description: "Clear the actor HUD"),
+            ],
+            returns: .ok,
+            handler: { params in
+                try Self.setOverlayActorHUD(params)
+            }
+        ))
+
+        api.register(Endpoint(
+            method: "overlay.actor.visibility",
+            description: "Show, hide, toggle, or inspect the persistent overlay actor layer",
+            access: .mutate,
+            params: [
+                Param(name: "action", type: "string", required: false, description: "show, hide, toggle, or status"),
+                Param(name: "visible", type: "bool", required: false, description: "Set actor layer visibility"),
+                Param(name: "hidden", type: "bool", required: false, description: "Set actor layer hidden state"),
+                Param(name: "feedback", type: "bool", required: false, description: "Show a short desktop feedback toast"),
+            ],
+            returns: .custom("Object with ok, visible, hidden, and actorCount"),
+            handler: { params in
+                try Self.setOverlayActorVisibility(params)
             }
         ))
 
@@ -2071,6 +2129,13 @@ private extension LatticesApi {
                 state: params["state"]?.stringValue,
                 name: params["name"]?.stringValue,
                 message: params["message"]?.stringValue ?? params["text"]?.stringValue,
+                targetApp: params["targetApp"]?.stringValue ?? params["app"]?.stringValue,
+                targetBundleIdentifier: params["targetBundleId"]?.stringValue ?? params["bundleIdentifier"]?.stringValue,
+                targetAppPath: params["targetAppPath"]?.stringValue,
+                scale: CGFloat(max(0.55, min(params["scale"]?.numericDouble ?? 1.0, 1.35))),
+                labelHidden: params["labelHidden"]?.boolValue ?? false,
+                closeOnActivate: params["closeOnActivate"]?.boolValue ?? false,
+                hud: try parseActorHUD(params),
                 point: point,
                 placement: placement,
                 style: style,
@@ -2153,6 +2218,13 @@ private extension LatticesApi {
                 state: params["state"]?.stringValue ?? "idle",
                 name: params["name"]?.stringValue,
                 message: message,
+                targetApp: params["targetApp"]?.stringValue ?? params["app"]?.stringValue,
+                targetBundleIdentifier: params["targetBundleId"]?.stringValue ?? params["bundleIdentifier"]?.stringValue,
+                targetAppPath: params["targetAppPath"]?.stringValue,
+                scale: CGFloat(max(0.55, min(params["scale"]?.numericDouble ?? 1.0, 1.35))),
+                labelHidden: params["labelHidden"]?.boolValue ?? false,
+                closeOnActivate: params["closeOnActivate"]?.boolValue ?? false,
+                hud: try parseActorHUD(params),
                 point: point,
                 placement: placement,
                 style: style,
@@ -2209,6 +2281,95 @@ private extension LatticesApi {
             "x": .double(x),
             "y": .double(y),
         ])
+    }
+
+    static func setOverlayActorHUD(_ params: JSON?) throws -> JSON {
+        guard let params else {
+            throw RouterError.missingParam("id")
+        }
+        let id = try requiredString(params, "id")
+        let hud = params["clear"]?.boolValue == true ? nil : try parseActorHUD(params, requireContent: true)
+        var updated = false
+
+        runOnMain {
+            updated = ScreenOverlayCanvasController.shared.setActorHUD(id: ScreenOverlayLayerID(id), hud: hud)
+        }
+        guard updated else {
+            throw RouterError.custom("Overlay actor not found or not HUD-capable: \(id)")
+        }
+        return .object(["ok": .bool(true), "id": .string(id), "hasHUD": .bool(hud?.hasContent == true)])
+    }
+
+    static func setOverlayActorVisibility(_ params: JSON?) throws -> JSON {
+        let action = params?["action"]?.stringValue?.lowercased()
+        let feedback = params?["feedback"]?.boolValue ?? true
+        var snapshot = ScreenOverlayActorVisibilitySnapshot(hidden: false, actorCount: 0)
+
+        runOnMain {
+            let controller = ScreenOverlayCanvasController.shared
+            if let visible = params?["visible"]?.boolValue {
+                snapshot = controller.setAgentActorsHidden(!visible, showFeedback: feedback)
+                return
+            }
+            if let hidden = params?["hidden"]?.boolValue {
+                snapshot = controller.setAgentActorsHidden(hidden, showFeedback: feedback)
+                return
+            }
+
+            switch action {
+            case nil, "toggle":
+                let current = controller.agentActorsVisibility()
+                snapshot = controller.setAgentActorsHidden(!current.hidden, showFeedback: feedback)
+            case "show", "on":
+                snapshot = controller.setAgentActorsHidden(false, showFeedback: feedback)
+            case "hide", "off":
+                snapshot = controller.setAgentActorsHidden(true, showFeedback: feedback)
+            case "status":
+                snapshot = controller.agentActorsVisibility()
+            default:
+                snapshot = controller.agentActorsVisibility()
+            }
+        }
+
+        if let action,
+           !["toggle", "show", "on", "hide", "off", "status"].contains(action),
+           params?["visible"]?.boolValue == nil,
+           params?["hidden"]?.boolValue == nil {
+            throw RouterError.custom("Unsupported actor visibility action: \(action)")
+        }
+
+        return .object([
+            "ok": .bool(true),
+            "visible": .bool(snapshot.visible),
+            "hidden": .bool(snapshot.hidden),
+            "actorCount": .int(snapshot.actorCount),
+        ])
+    }
+
+    static func parseActorHUD(_ params: JSON, requireContent: Bool = false) throws -> ScreenOverlayActorHUD? {
+        let url = params["hudUrl"]?.stringValue
+            ?? params["hudURL"]?.stringValue
+            ?? params["hud"]?.stringValue
+        let html = params["hudHTML"]?.stringValue
+            ?? params["hudHtml"]?.stringValue
+        guard url?.isEmpty == false || html?.isEmpty == false else {
+            if requireContent {
+                throw RouterError.missingParam("hudUrl")
+            }
+            return nil
+        }
+
+        let width = CGFloat(max(220, min(params["hudWidth"]?.numericDouble ?? params["width"]?.numericDouble ?? 360, 720)))
+        let height = CGFloat(max(140, min(params["hudHeight"]?.numericDouble ?? params["height"]?.numericDouble ?? 240, 560)))
+        return ScreenOverlayActorHUD(
+            url: url,
+            html: html,
+            title: params["hudTitle"]?.stringValue ?? params["title"]?.stringValue,
+            width: width,
+            height: height,
+            readAccessPath: params["hudReadAccess"]?.stringValue
+                ?? params["readAccess"]?.stringValue
+        )
     }
 
     static func runOnMain(_ work: @escaping () -> Void) {

--- a/apps/mac/Sources/Core/Input/KeyboardRemapController.swift
+++ b/apps/mac/Sources/Core/Input/KeyboardRemapController.swift
@@ -396,14 +396,23 @@ final class KeyboardRemapController: ObservableObject {
     }
 
     private func releaseCapsLockLatchIfNeeded() {
-        guard eventTapLocation != .cghidEventTap ||
-              CGEventSource.flagsState(.combinedSessionState).contains(.maskAlphaShift) else {
-            return
+        clearCapsLockLatch(reason: "event")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.04) { [weak self] in
+            self?.clearCapsLockLatch(reason: "settle")
         }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.14) { [weak self] in
+            self?.clearCapsLockLatch(reason: "deferred")
+        }
+    }
+
+    @discardableResult
+    private func clearCapsLockLatch(reason: String) -> Bool {
         let result = IOHIDSetModifierLockState(kIOMainPortDefault, Int32(kIOHIDCapsLockState), false)
         if result != kIOReturnSuccess {
-            DiagnosticLog.shared.warn("KeyboardRemap: failed to clear Caps Lock latch (\(result))")
+            DiagnosticLog.shared.warn("KeyboardRemap: failed to clear Caps Lock latch (\(reason), \(result))")
+            return false
         }
+        return true
     }
 
     private func postKeyTap(keyCode: CGKeyCode) {

--- a/apps/mac/Sources/Core/Overlays/ScreenOverlayActorHUDController.swift
+++ b/apps/mac/Sources/Core/Overlays/ScreenOverlayActorHUDController.swift
@@ -1,0 +1,168 @@
+import AppKit
+import WebKit
+
+final class ScreenOverlayActorHUDController {
+    static let shared = ScreenOverlayActorHUDController()
+
+    private var panel: NSPanel?
+    private var webView: WKWebView?
+    private var currentContentKey: String?
+
+    private init() {}
+
+    func show(actorID: ScreenOverlayLayerID, hud: ScreenOverlayActorHUD, near actorRect: CGRect) {
+        guard hud.hasContent else {
+            hide()
+            return
+        }
+
+        let size = CGSize(width: hud.width, height: hud.height)
+        let panel = ensurePanel(size: size)
+        let frame = positionedFrame(near: actorRect, size: size)
+        panel.setFrame(frame, display: true)
+        panel.title = hud.title ?? "Actor HUD"
+
+        let contentKey = "\(actorID.rawValue)|\(hud.contentKey)"
+        if currentContentKey != contentKey {
+            currentContentKey = contentKey
+            load(hud)
+        }
+
+        if !panel.isVisible {
+            panel.alphaValue = 0
+            panel.orderFrontRegardless()
+        }
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.10
+            panel.animator().alphaValue = 1
+        }
+    }
+
+    func hide() {
+        guard let panel, panel.isVisible else { return }
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.10
+            panel.animator().alphaValue = 0
+        } completionHandler: {
+            if panel.alphaValue <= 0.05 {
+                panel.orderOut(nil)
+            }
+        }
+    }
+
+    private func ensurePanel(size: CGSize) -> NSPanel {
+        if let panel {
+            if panel.frame.size != size {
+                panel.setContentSize(size)
+                panel.contentView?.frame = CGRect(origin: .zero, size: size)
+            }
+            return panel
+        }
+
+        let panel = NSPanel(
+            contentRect: CGRect(origin: .zero, size: size),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false
+        panel.ignoresMouseEvents = true
+        panel.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.maximumWindow)))
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
+        panel.hidesOnDeactivate = false
+        panel.animationBehavior = .none
+
+        let effectView = NSVisualEffectView(frame: CGRect(origin: .zero, size: size))
+        effectView.autoresizingMask = [.width, .height]
+        effectView.material = .hudWindow
+        effectView.blendingMode = .behindWindow
+        effectView.state = .active
+        effectView.wantsLayer = true
+        effectView.layer?.cornerRadius = 16
+        effectView.layer?.masksToBounds = true
+        effectView.layer?.borderWidth = 0.8
+        effectView.layer?.borderColor = NSColor.white.withAlphaComponent(0.18).cgColor
+        effectView.layer?.backgroundColor = NSColor.black.withAlphaComponent(0.10).cgColor
+
+        let configuration = WKWebViewConfiguration()
+        configuration.suppressesIncrementalRendering = false
+        let webView = WKWebView(frame: effectView.bounds.insetBy(dx: 1, dy: 1), configuration: configuration)
+        webView.autoresizingMask = [.width, .height]
+        webView.wantsLayer = true
+        webView.layer?.cornerRadius = 15
+        webView.layer?.masksToBounds = true
+        webView.layer?.backgroundColor = NSColor.clear.cgColor
+        webView.setValue(false, forKey: "drawsBackground")
+
+        effectView.addSubview(webView)
+        panel.contentView = effectView
+
+        self.panel = panel
+        self.webView = webView
+        return panel
+    }
+
+    private func load(_ hud: ScreenOverlayActorHUD) {
+        guard let webView else { return }
+        if let html = hud.html, !html.isEmpty {
+            webView.loadHTMLString(html, baseURL: nil)
+            return
+        }
+
+        guard let urlString = hud.url?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !urlString.isEmpty else { return }
+
+        let url: URL?
+        if urlString.hasPrefix("/") {
+            url = URL(fileURLWithPath: urlString)
+        } else {
+            url = URL(string: urlString)
+        }
+
+        guard let url else {
+            DiagnosticLog.shared.warn("ActorHUD: invalid HUD URL \(urlString)")
+            return
+        }
+
+        if url.isFileURL {
+            let readAccessURL = hud.readAccessPath
+                .map { URL(fileURLWithPath: ($0 as NSString).expandingTildeInPath) }
+                ?? url.deletingLastPathComponent()
+            webView.loadFileURL(url, allowingReadAccessTo: readAccessURL)
+        } else {
+            webView.load(URLRequest(url: url))
+        }
+    }
+
+    private func positionedFrame(near actorRect: CGRect, size: CGSize) -> CGRect {
+        let visibleFrame = screenVisibleFrame(containing: actorRect)
+        let margin: CGFloat = 12
+        let gap: CGFloat = 14
+        var x = actorRect.maxX + gap
+        if x + size.width > visibleFrame.maxX - margin {
+            x = actorRect.minX - size.width - gap
+        }
+        if x < visibleFrame.minX + margin {
+            x = min(max(actorRect.midX - size.width / 2, visibleFrame.minX + margin), visibleFrame.maxX - size.width - margin)
+        }
+
+        let y = min(
+            max(actorRect.midY - size.height / 2, visibleFrame.minY + margin),
+            visibleFrame.maxY - size.height - margin
+        )
+        return CGRect(origin: CGPoint(x: x, y: y), size: size)
+    }
+
+    private func screenVisibleFrame(containing rect: CGRect) -> CGRect {
+        let center = CGPoint(x: rect.midX, y: rect.midY)
+        if let screen = NSScreen.screens.first(where: { $0.frame.contains(center) }) {
+            return screen.visibleFrame
+        }
+        if let screen = NSScreen.screens.first(where: { $0.frame.intersects(rect) }) {
+            return screen.visibleFrame
+        }
+        return NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? CGRect(x: 0, y: 0, width: 1280, height: 800)
+    }
+}

--- a/apps/mac/Sources/Core/Overlays/ScreenOverlayCanvasController.swift
+++ b/apps/mac/Sources/Core/Overlays/ScreenOverlayCanvasController.swift
@@ -31,6 +31,36 @@ struct ScreenOverlayLayerSnapshot {
     let expiresAt: Date?
 }
 
+struct ScreenOverlayActorVisibilitySnapshot {
+    let hidden: Bool
+    let actorCount: Int
+
+    var visible: Bool { !hidden }
+}
+
+struct ScreenOverlayActorHUD {
+    let url: String?
+    let html: String?
+    let title: String?
+    let width: CGFloat
+    let height: CGFloat
+    let readAccessPath: String?
+
+    var hasContent: Bool {
+        (url?.isEmpty == false) || (html?.isEmpty == false)
+    }
+
+    var contentKey: String {
+        [
+            url ?? "",
+            html ?? "",
+            title ?? "",
+            "\(Int(width))x\(Int(height))",
+            readAccessPath ?? "",
+        ].joined(separator: "|")
+    }
+}
+
 enum ScreenOverlayPayload {
     case snapZones(ScreenOverlaySnapZonesPayload)
     case toast(ScreenOverlayTextPayload)
@@ -77,6 +107,13 @@ struct ScreenOverlayPetPayload {
     let state: String?
     let name: String?
     let message: String?
+    let targetApp: String?
+    let targetBundleIdentifier: String?
+    let targetAppPath: String?
+    let scale: CGFloat
+    let labelHidden: Bool
+    let closeOnActivate: Bool
+    let hud: ScreenOverlayActorHUD?
     let point: CGPoint?
     let placement: ScreenOverlayPlacement
     let style: ScreenOverlayStyle
@@ -90,10 +127,83 @@ struct ScreenOverlayPetPayload {
             state: nextState ?? state,
             name: name,
             message: message,
+            targetApp: targetApp,
+            targetBundleIdentifier: targetBundleIdentifier,
+            targetAppPath: targetAppPath,
+            scale: scale,
+            labelHidden: labelHidden,
+            closeOnActivate: closeOnActivate,
+            hud: hud,
             point: point,
             placement: .point,
             style: style,
             isDragging: nextIsDragging ?? isDragging,
+            dismissible: dismissible
+        )
+    }
+
+    func withLabelHidden(_ hidden: Bool) -> ScreenOverlayPetPayload {
+        ScreenOverlayPetPayload(
+            glyph: glyph,
+            petID: petID,
+            state: state,
+            name: name,
+            message: message,
+            targetApp: targetApp,
+            targetBundleIdentifier: targetBundleIdentifier,
+            targetAppPath: targetAppPath,
+            scale: scale,
+            labelHidden: hidden,
+            closeOnActivate: closeOnActivate,
+            hud: hud,
+            point: point,
+            placement: placement,
+            style: style,
+            isDragging: isDragging,
+            dismissible: dismissible
+        )
+    }
+
+    func withScale(_ nextScale: CGFloat) -> ScreenOverlayPetPayload {
+        ScreenOverlayPetPayload(
+            glyph: glyph,
+            petID: petID,
+            state: state,
+            name: name,
+            message: message,
+            targetApp: targetApp,
+            targetBundleIdentifier: targetBundleIdentifier,
+            targetAppPath: targetAppPath,
+            scale: max(0.55, min(nextScale, 1.35)),
+            labelHidden: labelHidden,
+            closeOnActivate: closeOnActivate,
+            hud: hud,
+            point: point,
+            placement: placement,
+            style: style,
+            isDragging: isDragging,
+            dismissible: dismissible
+        )
+    }
+
+    func withHUD(_ nextHUD: ScreenOverlayActorHUD?) -> ScreenOverlayPetPayload {
+        ScreenOverlayPetPayload(
+            glyph: glyph,
+            petID: petID,
+            state: state,
+            name: name,
+            message: message,
+            targetApp: targetApp,
+            targetBundleIdentifier: targetBundleIdentifier,
+            targetAppPath: targetAppPath,
+            scale: scale,
+            labelHidden: labelHidden,
+            closeOnActivate: closeOnActivate,
+            hud: nextHUD,
+            point: point,
+            placement: placement,
+            style: style,
+            isDragging: isDragging,
             dismissible: dismissible
         )
     }
@@ -126,6 +236,8 @@ final class ScreenOverlayCanvasController {
     private var localDismissMonitor: Any?
     private var dragState: OverlayActorDragState?
     private var actorDragTimeoutTimer: Timer?
+    private var hoveredActorID: ScreenOverlayLayerID?
+    private var menuActionTargets: [ActorMenuActionTarget] = []
     private var agentActorsHidden = false
     private let maxActorDragDuration: TimeInterval = 8.0
 
@@ -175,6 +287,10 @@ final class ScreenOverlayCanvasController {
     func removeLayer(id: ScreenOverlayLayerID) {
         layersByID.removeValue(forKey: id)
         motionsByLayerID.removeValue(forKey: id)
+        if hoveredActorID == id {
+            hoveredActorID = nil
+            ScreenOverlayActorHUDController.shared.hide()
+        }
         if dragState?.id == id {
             dragState = nil
             cancelActorDragTimeout()
@@ -188,6 +304,10 @@ final class ScreenOverlayCanvasController {
         let removedIDs = Set(layersByID.values.filter { $0.owner == owner }.map(\.id))
         layersByID = layersByID.filter { _, layer in layer.owner != owner }
         motionsByLayerID = motionsByLayerID.filter { id, _ in layersByID[id] != nil }
+        if let hoveredActorID, removedIDs.contains(hoveredActorID) {
+            self.hoveredActorID = nil
+            ScreenOverlayActorHUDController.shared.hide()
+        }
         if let dragState, removedIDs.contains(dragState.id) {
             self.dragState = nil
             cancelActorDragTimeout()
@@ -198,20 +318,38 @@ final class ScreenOverlayCanvasController {
     }
 
     func toggleAgentActorsVisibility() {
-        agentActorsHidden.toggle()
+        _ = setAgentActorsHidden(!agentActorsHidden, showFeedback: true)
+    }
+
+    @discardableResult
+    func setAgentActorsHidden(_ hidden: Bool, showFeedback: Bool = false) -> ScreenOverlayActorVisibilitySnapshot {
+        agentActorsHidden = hidden
         if agentActorsHidden {
+            hoveredActorID = nil
             dragState = nil
             cancelActorDragTimeout()
             resetPointerCapture()
+            ScreenOverlayActorHUDController.shared.hide()
         }
         render()
         updateLifecycleMonitors()
+        let snapshot = agentActorsVisibility()
+        if showFeedback {
+            showActorVisibilityFeedback(snapshot)
+        }
+        return snapshot
+    }
+
+    func agentActorsVisibility() -> ScreenOverlayActorVisibilitySnapshot {
+        let count = layersByID.values.filter(\.isParkableActor).count
+        return ScreenOverlayActorVisibilitySnapshot(hidden: agentActorsHidden, actorCount: count)
     }
 
     func resetInputCapture(reason: String) {
         dragState = nil
         cancelActorDragTimeout()
         resetPointerCapture()
+        ScreenOverlayActorHUDController.shared.hide()
         DiagnosticLog.shared.warn("ScreenOverlay: input capture reset for \(reason)")
     }
 
@@ -234,6 +372,19 @@ final class ScreenOverlayCanvasController {
             restingState: restingState
         )
         layersByID[id] = layer.replacingPayload(.pet(payload.moved(to: currentPoint, state: movingState)))
+        render()
+        updateLifecycleMonitors()
+        return true
+    }
+
+    @discardableResult
+    func setActorHUD(id: ScreenOverlayLayerID, hud: ScreenOverlayActorHUD?) -> Bool {
+        guard let layer = layersByID[id],
+              case .pet(let payload) = layer.payload else { return false }
+        layersByID[id] = layer.replacingPayload(.pet(payload.withHUD(hud)))
+        if hoveredActorID == id, hud?.hasContent != true {
+            ScreenOverlayActorHUDController.shared.hide()
+        }
         render()
         updateLifecycleMonitors()
         return true
@@ -280,6 +431,7 @@ final class ScreenOverlayCanvasController {
                 }
 
             window.overlayView.layers = visibleLayers
+            window.overlayView.hoveredLayerID = agentActorsHidden ? nil : hoveredActorID
             if visibleLayers.isEmpty {
                 window.alphaValue = 0
             } else {
@@ -434,7 +586,7 @@ final class ScreenOverlayCanvasController {
             updatePointerCapture(at: point)
             return false
         case .rightMouseDown:
-            if closeActor(at: point) {
+            if showActorContextMenu(at: point) {
                 return true
             }
             dismissAgentOverlays()
@@ -449,6 +601,8 @@ final class ScreenOverlayCanvasController {
 
     private func updatePointerCapture(at globalPoint: CGPoint) {
         if let dragState {
+            setHoveredActor(nil)
+            ScreenOverlayActorHUDController.shared.hide()
             for (screenID, window) in windowsByScreenID {
                 window.ignoresMouseEvents = screenID != dragState.screenID
             }
@@ -456,12 +610,32 @@ final class ScreenOverlayCanvasController {
         }
 
         guard let hit = hitActor(at: globalPoint) else {
+            setHoveredActor(nil)
+            ScreenOverlayActorHUDController.shared.hide()
             resetPointerCapture()
             return
         }
 
+        setHoveredActor(hit.id)
+        if let layer = layersByID[hit.id],
+           case .pet(let payload) = layer.payload,
+           let hud = payload.hud,
+           hud.hasContent {
+            let globalRect = hit.rect.offsetBy(dx: hit.window.frame.minX, dy: hit.window.frame.minY)
+            ScreenOverlayActorHUDController.shared.show(actorID: hit.id, hud: hud, near: globalRect)
+        } else {
+            ScreenOverlayActorHUDController.shared.hide()
+        }
         for (screenID, window) in windowsByScreenID {
             window.ignoresMouseEvents = screenID != hit.screenID
+        }
+    }
+
+    private func setHoveredActor(_ id: ScreenOverlayLayerID?) {
+        guard hoveredActorID != id else { return }
+        hoveredActorID = id
+        for window in windowsByScreenID.values {
+            window.overlayView.hoveredLayerID = id
         }
     }
 
@@ -476,6 +650,7 @@ final class ScreenOverlayCanvasController {
             id: hit.id,
             screenID: hit.screenID,
             offset: CGPoint(x: hit.localPoint.x - currentPoint.x, y: hit.localPoint.y - currentPoint.y),
+            startPoint: currentPoint,
             lastPoint: currentPoint,
             startedAt: Date()
         )
@@ -517,12 +692,80 @@ final class ScreenOverlayCanvasController {
             resetPointerCapture()
             return
         }
-        layersByID[dragState.id] = layer.replacingPayload(.pet(payload.moved(to: dragState.lastPoint, state: "idle", isDragging: false)))
+        let settledPayload = payload.moved(to: dragState.lastPoint, state: "idle", isDragging: false)
+        let clickDistance = hypot(dragState.lastPoint.x - dragState.startPoint.x, dragState.lastPoint.y - dragState.startPoint.y)
+        if clickDistance < 6, activateActorTarget(settledPayload) {
+            if settledPayload.closeOnActivate {
+                layersByID.removeValue(forKey: dragState.id)
+                motionsByLayerID.removeValue(forKey: dragState.id)
+            } else {
+                layersByID[dragState.id] = layer.replacingPayload(.pet(settledPayload))
+            }
+            self.dragState = nil
+            cancelActorDragTimeout()
+            render()
+            updateLifecycleMonitors()
+            resetPointerCapture()
+            return
+        }
+
+        layersByID[dragState.id] = layer.replacingPayload(.pet(settledPayload))
         self.dragState = nil
         cancelActorDragTimeout()
         render()
         updateLifecycleMonitors()
         resetPointerCapture()
+    }
+
+    private func activateActorTarget(_ payload: ScreenOverlayPetPayload) -> Bool {
+        if let bundleID = payload.targetBundleIdentifier,
+           activateRunningApplication(bundleIdentifier: bundleID) {
+            return true
+        }
+        if let appName = payload.targetApp,
+           activateRunningApplication(named: appName) {
+            return true
+        }
+        if let appPath = payload.targetAppPath {
+            let url = URL(fileURLWithPath: appPath)
+            let config = NSWorkspace.OpenConfiguration()
+            NSWorkspace.shared.openApplication(at: url, configuration: config, completionHandler: nil)
+            DiagnosticLog.shared.info("ScreenOverlay: opened actor target app at \(appPath)")
+            return true
+        }
+        if let bundleID = payload.targetBundleIdentifier,
+           let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) {
+            let config = NSWorkspace.OpenConfiguration()
+            NSWorkspace.shared.openApplication(at: url, configuration: config, completionHandler: nil)
+            DiagnosticLog.shared.info("ScreenOverlay: opened actor target bundle \(bundleID)")
+            return true
+        }
+        if let appName = payload.targetApp {
+            NSWorkspace.shared.launchApplication(appName)
+            DiagnosticLog.shared.info("ScreenOverlay: launched actor target app \(appName)")
+            return true
+        }
+        return false
+    }
+
+    private func activateRunningApplication(bundleIdentifier: String) -> Bool {
+        guard let app = NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier).first else {
+            return false
+        }
+        app.activate(options: [.activateIgnoringOtherApps, .activateAllWindows])
+        DiagnosticLog.shared.info("ScreenOverlay: activated actor target bundle \(bundleIdentifier)")
+        return true
+    }
+
+    private func activateRunningApplication(named appName: String) -> Bool {
+        guard let app = NSWorkspace.shared.runningApplications.first(where: { runningApp in
+            runningApp.localizedName?.localizedCaseInsensitiveCompare(appName) == .orderedSame
+        }) else {
+            return false
+        }
+        app.activate(options: [.activateIgnoringOtherApps, .activateAllWindows])
+        DiagnosticLog.shared.info("ScreenOverlay: activated actor target app \(appName)")
+        return true
     }
 
     private func clearStaleActorDragIfNeeded() {
@@ -569,6 +812,114 @@ final class ScreenOverlayCanvasController {
         return true
     }
 
+    private func showActorContextMenu(at globalPoint: CGPoint) -> Bool {
+        guard let hit = hitActor(at: globalPoint),
+              let layer = layersByID[hit.id],
+              layer.owner == .agentApi,
+              case .pet(let payload) = layer.payload else { return false }
+
+        menuActionTargets.removeAll()
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+
+        if payload.hasActivationTarget {
+            menu.addItem(menuItem(title: "Switch to \(payload.targetDisplayName)", action: { [weak self] in
+                _ = self?.activateActorTarget(payload)
+            }))
+            menu.addItem(.separator())
+        }
+
+        menu.addItem(menuItem(title: payload.labelHidden ? "Show Label" : "Hide Label", action: { [weak self] in
+            self?.setActorLabelHidden(id: hit.id, hidden: !payload.labelHidden)
+        }))
+
+        let sizeMenu = NSMenu()
+        sizeMenu.autoenablesItems = false
+        sizeMenu.addItem(menuItem(title: "Small", action: { [weak self] in
+            self?.setActorScale(id: hit.id, scale: 0.72)
+        }))
+        sizeMenu.addItem(menuItem(title: "Normal", action: { [weak self] in
+            self?.setActorScale(id: hit.id, scale: 1.0)
+        }))
+        sizeMenu.addItem(menuItem(title: "Large", action: { [weak self] in
+            self?.setActorScale(id: hit.id, scale: 1.18)
+        }))
+        let sizeItem = NSMenuItem(title: "Size", action: nil, keyEquivalent: "")
+        menu.addItem(sizeItem)
+        menu.setSubmenu(sizeMenu, for: sizeItem)
+
+        menu.addItem(.separator())
+        menu.addItem(menuItem(title: "Hide Actor Layer", action: { [weak self] in
+            _ = self?.setAgentActorsHidden(true, showFeedback: true)
+        }))
+        menu.addItem(menuItem(title: "Remove Actor", action: { [weak self] in
+            self?.removeActor(id: hit.id)
+        }))
+
+        menu.popUp(positioning: nil, at: hit.localPoint, in: hit.window.overlayView)
+        return true
+    }
+
+    private func menuItem(title: String, action: @escaping () -> Void) -> NSMenuItem {
+        let target = ActorMenuActionTarget(action)
+        menuActionTargets.append(target)
+        let item = NSMenuItem(title: title, action: #selector(ActorMenuActionTarget.invokeMenuAction), keyEquivalent: "")
+        item.target = target
+        return item
+    }
+
+    private func setActorLabelHidden(id: ScreenOverlayLayerID, hidden: Bool) {
+        guard let layer = layersByID[id],
+              case .pet(let payload) = layer.payload else { return }
+        layersByID[id] = layer.replacingPayload(.pet(payload.withLabelHidden(hidden)))
+        render()
+        updateLifecycleMonitors()
+    }
+
+    private func setActorScale(id: ScreenOverlayLayerID, scale: CGFloat) {
+        guard let layer = layersByID[id],
+              case .pet(let payload) = layer.payload else { return }
+        layersByID[id] = layer.replacingPayload(.pet(payload.withScale(scale)))
+        render()
+        updateLifecycleMonitors()
+    }
+
+    private func removeActor(id: ScreenOverlayLayerID) {
+        layersByID.removeValue(forKey: id)
+        motionsByLayerID.removeValue(forKey: id)
+        if hoveredActorID == id {
+            hoveredActorID = nil
+        }
+        if dragState?.id == id {
+            dragState = nil
+            cancelActorDragTimeout()
+        }
+        render()
+        updateLifecycleMonitors()
+        resetPointerCapture()
+    }
+
+    private func showActorVisibilityFeedback(_ snapshot: ScreenOverlayActorVisibilitySnapshot) {
+        let text = snapshot.hidden ? "Actor notes hidden" : "Actor notes shown"
+        let detail = snapshot.hidden ? "Press Hyper+B to bring them back." : "\(snapshot.actorCount) actor\(snapshot.actorCount == 1 ? "" : "s") available."
+        let layer = ScreenOverlayLayerSnapshot(
+            id: ScreenOverlayLayerID("actor-layer-visibility-feedback"),
+            owner: .agentApi,
+            screen: .all,
+            zIndex: 700,
+            opacity: 1,
+            payload: .toast(ScreenOverlayTextPayload(
+                text: text,
+                detail: detail,
+                point: nil,
+                placement: .bottom,
+                style: .info
+            )),
+            expiresAt: Date().addingTimeInterval(1.6)
+        )
+        publishLayer(layer)
+    }
+
     private func hitActor(at globalPoint: CGPoint) -> (id: ScreenOverlayLayerID, window: ScreenOverlayWindow, screenID: String, localPoint: CGPoint, rect: CGRect)? {
         guard let hit = screenLocalPoint(for: globalPoint) else { return nil }
         guard let layerHit = hit.window.overlayView.layerHit(at: hit.localPoint) else { return nil }
@@ -607,6 +958,10 @@ final class ScreenOverlayCanvasController {
             cancelActorDragTimeout()
             resetPointerCapture()
         }
+        if let hoveredActorID, layersByID[hoveredActorID] == nil {
+            self.hoveredActorID = nil
+            ScreenOverlayActorHUDController.shared.hide()
+        }
         guard layersByID.count != before else { return }
         render()
         updateLifecycleMonitors()
@@ -617,8 +972,21 @@ private struct OverlayActorDragState {
     let id: ScreenOverlayLayerID
     var screenID: String
     let offset: CGPoint
+    let startPoint: CGPoint
     var lastPoint: CGPoint
     let startedAt: Date
+}
+
+private final class ActorMenuActionTarget: NSObject {
+    private let action: () -> Void
+
+    init(_ action: @escaping () -> Void) {
+        self.action = action
+    }
+
+    @objc func invokeMenuAction() {
+        action()
+    }
 }
 
 private extension ScreenOverlayLayerSnapshot {
@@ -645,6 +1013,16 @@ private extension ScreenOverlayLayerSnapshot {
             payload: payload,
             expiresAt: expiresAt
         )
+    }
+}
+
+private extension ScreenOverlayPetPayload {
+    var hasActivationTarget: Bool {
+        targetBundleIdentifier != nil || targetApp != nil || targetAppPath != nil
+    }
+
+    var targetDisplayName: String {
+        targetApp ?? targetBundleIdentifier ?? targetAppPath.map { URL(fileURLWithPath: $0).deletingPathExtension().lastPathComponent } ?? "App"
     }
 }
 
@@ -746,6 +1124,9 @@ private final class ScreenOverlayCanvasView: NSView {
     var layers: [ScreenOverlayLayerSnapshot] = [] {
         didSet { needsDisplay = true }
     }
+    var hoveredLayerID: ScreenOverlayLayerID? {
+        didSet { needsDisplay = true }
+    }
     private var interactiveRectsByLayerID: [ScreenOverlayLayerID: CGRect] = [:]
 
     override init(frame frameRect: NSRect) {
@@ -778,7 +1159,7 @@ private final class ScreenOverlayCanvasView: NSView {
             case .highlight(let payload):
                 drawHighlight(payload, opacity: layer.opacity)
             case .pet(let payload):
-                drawPet(payload, id: layer.id, opacity: layer.opacity)
+                drawPet(payload, id: layer.id, opacity: layer.opacity, isHovered: hoveredLayerID == layer.id)
             }
             NSGraphicsContext.restoreGraphicsState()
         }
@@ -859,16 +1240,17 @@ private final class ScreenOverlayCanvasView: NSView {
         }
     }
 
-    private func drawPet(_ payload: ScreenOverlayPetPayload, id: ScreenOverlayLayerID, opacity: CGFloat) {
+    private func drawPet(_ payload: ScreenOverlayPetPayload, id: ScreenOverlayLayerID, opacity: CGFloat, isHovered: Bool) {
         let glyphFont = NSFont.systemFont(ofSize: 44, weight: .regular)
         let nameFont = NSFont.systemFont(ofSize: 12, weight: .semibold)
         let messageFont = NSFont.systemFont(ofSize: 12, weight: .regular)
         let glyph = attributed(payload.glyph, font: glyphFont, color: NSColor.white.withAlphaComponent(0.96 * opacity))
-        let name = payload.name.map { attributed($0, font: nameFont, color: NSColor.white.withAlphaComponent(0.96 * opacity)) }
-        let message = payload.message.map {
+        let name = payload.labelHidden ? nil : payload.name.map { attributed($0, font: nameFont, color: NSColor.white.withAlphaComponent(0.96 * opacity)) }
+        let message = payload.labelHidden ? nil : payload.message.map {
             attributed($0, font: messageFont, color: NSColor.white.withAlphaComponent(0.86 * opacity))
         }
-        let artSize = CGSize(width: 96, height: 104)
+        let actorScale = max(0.55, min(payload.scale, 1.35))
+        let artSize = CGSize(width: 96 * actorScale, height: 104 * actorScale)
         let textWidth: CGFloat = (name == nil && message == nil) ? 0 : 228
         let textHeight = textPlateHeight(name: name, message: message, width: textWidth)
         let bubbleWidth = artSize.width + (textWidth > 0 ? textWidth + 10 : 0)
@@ -893,7 +1275,13 @@ private final class ScreenOverlayCanvasView: NSView {
             : 0
         let dragScaleX: CGFloat = payload.isDragging ? 1.05 + CGFloat(sin(dragPhase * 0.9)) * 0.018 : 1
         let dragScaleY: CGFloat = payload.isDragging ? 0.98 + CGFloat(cos(dragPhase * 0.9)) * 0.018 : 1
-        let bodyRect = artRect.offsetBy(dx: 0, dy: dragLift)
+        let hoverLift: CGFloat = isHovered && !payload.isDragging ? 4 : 0
+        let hoverInset: CGFloat = isHovered && !payload.isDragging ? -3 : 0
+        let bodyRect = artRect.insetBy(dx: hoverInset, dy: hoverInset).offsetBy(dx: 0, dy: dragLift + hoverLift)
+
+        if isHovered {
+            drawActorHoverHalo(around: artRect.offsetBy(dx: 0, dy: hoverLift), style: payload.style, opacity: opacity)
+        }
 
         NSGraphicsContext.saveGraphicsState()
         if payload.isDragging {
@@ -922,8 +1310,8 @@ private final class ScreenOverlayCanvasView: NSView {
         }
         NSGraphicsContext.restoreGraphicsState()
 
+        interactiveRectsByLayerID[id] = artRect.insetBy(dx: -8, dy: -8)
         guard textWidth > 0 else {
-            interactiveRectsByLayerID[id] = artRect.insetBy(dx: -8, dy: -8)
             return
         }
         let textRect = CGRect(
@@ -932,8 +1320,7 @@ private final class ScreenOverlayCanvasView: NSView {
             width: textWidth,
             height: textHeight
         )
-        interactiveRectsByLayerID[id] = artRect.union(textRect).insetBy(dx: -8, dy: -8)
-        drawTranslucentTextWash(textRect, opacity: opacity)
+        drawTranslucentTextWash(textRect, style: payload.style, opacity: opacity, isHovered: isHovered)
 
         var cursorY = textRect.maxY - 10
         if let name {
@@ -956,13 +1343,69 @@ private final class ScreenOverlayCanvasView: NSView {
         return max(38, (name == nil ? 0 : 20) + (message == nil ? 0 : ceil(messageSize.height) + 10) + 18)
     }
 
-    private func drawTranslucentTextWash(_ rect: CGRect, opacity: CGFloat) {
-        let path = NSBezierPath(roundedRect: rect, xRadius: 8, yRadius: 8)
-        NSColor(calibratedWhite: 0.02, alpha: 0.34 * opacity).setFill()
+    private func drawActorHoverHalo(around rect: CGRect, style: ScreenOverlayStyle, opacity: CGFloat) {
+        let tint = color(for: style)
+        let haloRect = rect.insetBy(dx: -8, dy: -8)
+        let path = NSBezierPath(ovalIn: haloRect)
+        let shadow = NSShadow()
+        shadow.shadowBlurRadius = 18
+        shadow.shadowOffset = .zero
+        shadow.shadowColor = tint.withAlphaComponent(0.30 * opacity)
+
+        NSGraphicsContext.saveGraphicsState()
+        shadow.set()
+        tint.withAlphaComponent(0.12 * opacity).setFill()
+        path.fill()
+        NSGraphicsContext.restoreGraphicsState()
+    }
+
+    private func drawTranslucentTextWash(_ rect: CGRect, style: ScreenOverlayStyle, opacity: CGFloat, isHovered: Bool) {
+        let radius: CGFloat = 12
+        let path = NSBezierPath(roundedRect: rect, xRadius: radius, yRadius: radius)
+        let tint = color(for: style)
+        let hoverBoost: CGFloat = isHovered ? 1.16 : 1.0
+
+        let shadow = NSShadow()
+        shadow.shadowBlurRadius = isHovered ? 26 : 22
+        shadow.shadowOffset = NSSize(width: 0, height: -5)
+        shadow.shadowColor = NSColor.black.withAlphaComponent(0.18 * hoverBoost * opacity)
+
+        NSGraphicsContext.saveGraphicsState()
+        shadow.set()
+        NSColor(calibratedRed: 0.035, green: 0.045, blue: 0.060, alpha: 0.28 * hoverBoost * opacity).setFill()
+        path.fill()
+        NSGraphicsContext.restoreGraphicsState()
+
+        NSGraphicsContext.saveGraphicsState()
+        path.addClip()
+        NSGradient(
+            starting: NSColor(calibratedRed: 0.18, green: 0.22, blue: 0.28, alpha: 0.32 * hoverBoost * opacity),
+            ending: NSColor(calibratedRed: 0.055, green: 0.070, blue: 0.092, alpha: 0.34 * hoverBoost * opacity)
+        )?.draw(in: rect, angle: -90)
+
+        tint.withAlphaComponent((isHovered ? 0.12 : 0.08) * opacity).setFill()
         path.fill()
 
-        path.lineWidth = 0.5
-        NSColor.white.withAlphaComponent(0.10 * opacity).setStroke()
+        let lowerWash = CGRect(x: rect.minX, y: rect.minY, width: rect.width, height: rect.height * 0.52)
+        NSGradient(
+            starting: NSColor.black.withAlphaComponent(0.04 * opacity),
+            ending: NSColor.black.withAlphaComponent(0.16 * opacity)
+        )?.draw(in: lowerWash, angle: -90)
+
+        let glossRect = CGRect(x: rect.minX + 1, y: rect.midY, width: rect.width - 2, height: rect.height * 0.45)
+        NSGradient(
+            starting: NSColor.white.withAlphaComponent(0.18 * opacity),
+            ending: NSColor.white.withAlphaComponent(0.02 * opacity)
+        )?.draw(in: glossRect, angle: -90)
+        NSGraphicsContext.restoreGraphicsState()
+
+        let innerPath = NSBezierPath(roundedRect: rect.insetBy(dx: 0.5, dy: 0.5), xRadius: radius - 0.5, yRadius: radius - 0.5)
+        innerPath.lineWidth = 0.8
+        NSColor.white.withAlphaComponent(0.26 * opacity).setStroke()
+        innerPath.stroke()
+
+        path.lineWidth = 1
+        tint.withAlphaComponent((isHovered ? 0.38 : 0.24) * opacity).setStroke()
         path.stroke()
     }
 
@@ -970,7 +1413,7 @@ private final class ScreenOverlayCanvasView: NSView {
         let shadow = NSShadow()
         shadow.shadowBlurRadius = 2
         shadow.shadowOffset = NSSize(width: 0, height: -1)
-        shadow.shadowColor = NSColor.black.withAlphaComponent(0.72 * opacity)
+        shadow.shadowColor = NSColor.black.withAlphaComponent(0.68 * opacity)
 
         NSGraphicsContext.saveGraphicsState()
         shadow.set()
@@ -978,7 +1421,7 @@ private final class ScreenOverlayCanvasView: NSView {
         NSGraphicsContext.restoreGraphicsState()
 
         let halo = NSMutableAttributedString(attributedString: text)
-        halo.addAttribute(.foregroundColor, value: NSColor.black.withAlphaComponent(0.36 * opacity), range: NSRange(location: 0, length: halo.length))
+        halo.addAttribute(.foregroundColor, value: NSColor.black.withAlphaComponent(0.32 * opacity), range: NSRange(location: 0, length: halo.length))
         halo.draw(with: rect.offsetBy(dx: 0.5, dy: -0.5), options: [.usesLineFragmentOrigin, .truncatesLastVisibleLine])
         halo.draw(with: rect.offsetBy(dx: -0.5, dy: -0.5), options: [.usesLineFragmentOrigin, .truncatesLastVisibleLine])
 

--- a/bin/lattices.ts
+++ b/bin/lattices.ts
@@ -2,8 +2,8 @@
 
 import { createHash } from "node:crypto";
 import { execSync } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { basename, resolve } from "node:path";
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { basename, dirname, isAbsolute, resolve } from "node:path";
 import { homedir } from "node:os";
 
 // Daemon client (lazy-loaded to avoid blocking startup for TTY commands)
@@ -93,6 +93,52 @@ function toSessionName(dir: string): string {
 
 function esc(str: string): string {
   return str.replace(/'/g, "'\\''");
+}
+
+function appleScriptString(str: string): string {
+  return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function slugify(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/\.app$/i, "")
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "app";
+}
+
+function parseFlagValue(args: string[], name: string): string | undefined {
+  const prefix = `--${name}=`;
+  const exact = `--${name}`;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i].startsWith(prefix)) return args[i].slice(prefix.length);
+    if (args[i] === exact) return args[i + 1];
+  }
+  return undefined;
+}
+
+function hasFlag(args: string[], name: string): boolean {
+  return args.includes(`--${name}`);
+}
+
+function nonFlagArgs(args: string[]): string[] {
+  const valueFlags = new Set([
+    "id", "state", "ttl", "ttlMs", "x", "y", "gap", "placement", "style", "name", "scale",
+    "hud-url", "hudUrl", "hud-html", "hudHTML", "hudHtml", "hud-title", "hudTitle",
+    "hud-width", "hudWidth", "hud-height", "hudHeight", "width", "height",
+    "manifest", "root", "max-depth", "maxDepth", "read-access", "readAccess",
+  ]);
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg.startsWith("--")) {
+      out.push(arg);
+      continue;
+    }
+    const flagName = arg.slice(2);
+    if (!arg.includes("=") && valueFlags.has(flagName)) i++;
+  }
+  return out;
 }
 
 // ── Config ───────────────────────────────────────────────────────────
@@ -1226,6 +1272,787 @@ async function callCommand(method?: string, ...rest: string[]): Promise<void> {
   }
 }
 
+interface AppActorAsset {
+  id: string;
+  appName: string;
+  appPath: string;
+  bundleIdentifier?: string;
+  iconPath: string;
+  assetDir: string;
+}
+
+function plistValue(plistPath: string, key: string): string | undefined {
+  const value = runQuiet(`/usr/libexec/PlistBuddy -c 'Print :${esc(key)}' '${esc(plistPath)}' 2>/dev/null`);
+  return value?.trim() || undefined;
+}
+
+function resolveApplication(appQuery: string): string | undefined {
+  const directPath = appQuery.endsWith(".app") ? resolve(appQuery) : undefined;
+  if (directPath && existsSync(directPath)) return directPath.replace(/\/$/, "");
+
+  const script = `POSIX path of (path to application "${appleScriptString(appQuery.replace(/\.app$/i, ""))}")`;
+  const fromLaunchServices = runQuiet(`osascript -e '${esc(script)}' 2>/dev/null`);
+  if (fromLaunchServices) return fromLaunchServices.trim().replace(/\/$/, "");
+
+  const appName = appQuery.endsWith(".app") ? appQuery : `${appQuery}.app`;
+  const fromFind = runQuiet(
+    `find /Applications /System/Applications '${esc(resolve(homedir(), "Applications"))}' -maxdepth 5 -iname '${esc(appName)}' -print -quit 2>/dev/null`
+  );
+  return fromFind?.trim().replace(/\/$/, "") || undefined;
+}
+
+function resolveApplicationByBundleIdentifier(bundleIdentifier: string): string | undefined {
+  const script = `POSIX path of (path to application id "${appleScriptString(bundleIdentifier)}")`;
+  const fromLaunchServices = runQuiet(`osascript -e '${esc(script)}' 2>/dev/null`);
+  return fromLaunchServices?.trim().replace(/\/$/, "") || undefined;
+}
+
+function iconPathForApplication(appPath: string): string | undefined {
+  const resourcesDir = resolve(appPath, "Contents", "Resources");
+  const infoPlist = resolve(appPath, "Contents", "Info.plist");
+  const iconFile = plistValue(infoPlist, "CFBundleIconFile");
+  const candidates: string[] = [];
+  if (iconFile) {
+    candidates.push(resolve(resourcesDir, iconFile));
+    if (!/\.[a-z0-9]+$/i.test(iconFile)) {
+      candidates.push(resolve(resourcesDir, `${iconFile}.icns`));
+    }
+  }
+  candidates.push(
+    resolve(resourcesDir, "AppIcon.icns"),
+    resolve(resourcesDir, "icon.icns"),
+    resolve(resourcesDir, "electron.icns")
+  );
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  const firstIcns = runQuiet(`find '${esc(resourcesDir)}' -maxdepth 1 -iname '*.icns' -print -quit 2>/dev/null`);
+  return firstIcns?.trim() || undefined;
+}
+
+function ensureAppActorAsset(appQuery: string): AppActorAsset {
+  const appPath = resolveApplication(appQuery);
+  if (!appPath) {
+    throw new Error(`Could not find application: ${appQuery}`);
+  }
+
+  const appName = basename(appPath, ".app");
+  const iconPath = iconPathForApplication(appPath);
+  if (!iconPath) {
+    throw new Error(`Could not find an icon resource in ${appPath}`);
+  }
+
+  const id = `${slugify(appName)}-icon`;
+  const assetDir = resolve(homedir(), ".codex", "pets", id);
+  const spritesheetPath = resolve(assetDir, "spritesheet.png");
+  mkdirSync(assetDir, { recursive: true });
+  run(`sips -s format png -Z 192 '${esc(iconPath)}' --out '${esc(spritesheetPath)}' >/dev/null`);
+
+  const metadata = {
+    id,
+    displayName: `${appName} Icon`,
+    description: `A one-frame overlay actor made from the ${appName} application icon.`,
+    spritesheetPath: "spritesheet.png",
+    states: {
+      idle: { row: 0, frames: 1, frameWidth: 192, frameHeight: 192 },
+      thinking: { row: 0, frames: 1, frameWidth: 192, frameHeight: 192 },
+      working: { row: 0, frames: 1, frameWidth: 192, frameHeight: 192 },
+      listening: { row: 0, frames: 1, frameWidth: 192, frameHeight: 192 },
+      waiting: { row: 0, frames: 1, frameWidth: 192, frameHeight: 192 },
+      ready: { row: 0, frames: 1, frameWidth: 192, frameHeight: 192 },
+    },
+  };
+  writeFileSync(resolve(assetDir, "pet.json"), `${JSON.stringify(metadata, null, 2)}\n`);
+
+  const bundleIdentifier = plistValue(resolve(appPath, "Contents", "Info.plist"), "CFBundleIdentifier");
+  return { id, appName, appPath, bundleIdentifier, iconPath, assetDir };
+}
+
+function ensureIconActorAsset(idSeed: string, displayName: string, iconPath: string): string {
+  if (!existsSync(iconPath)) {
+    throw new Error(`HUD icon does not exist: ${iconPath}`);
+  }
+
+  const id = `${slugify(idSeed)}-hud-icon`;
+  const assetDir = resolve(homedir(), ".codex", "pets", id);
+  const spritesheetPath = resolve(assetDir, "spritesheet.png");
+  mkdirSync(assetDir, { recursive: true });
+  run(`sips -s format png -Z 192 '${esc(iconPath)}' --out '${esc(spritesheetPath)}' >/dev/null`);
+
+  const metadata = {
+    id,
+    displayName: `${displayName} HUD Icon`,
+    description: `A one-frame overlay actor icon for the ${displayName} HUD.`,
+    spritesheetPath: "spritesheet.png",
+    states: {
+      idle: { row: 0, frames: 1, frameWidth: 192, frameHeight: 192 },
+      thinking: { row: 0, frames: 1, frameWidth: 192, frameHeight: 192 },
+      working: { row: 0, frames: 1, frameWidth: 192, frameHeight: 192 },
+      listening: { row: 0, frames: 1, frameWidth: 192, frameHeight: 192 },
+      waiting: { row: 0, frames: 1, frameWidth: 192, frameHeight: 192 },
+      ready: { row: 0, frames: 1, frameWidth: 192, frameHeight: 192 },
+    },
+  };
+  writeFileSync(resolve(assetDir, "pet.json"), `${JSON.stringify(metadata, null, 2)}\n`);
+  return id;
+}
+
+function actorUsage(): void {
+  console.log(`Usage:
+  lattices actor app <app-name> [message] [--state=idle] [--x=520 --y=340] [--show-label]
+  lattices actor switcher [app-name ...] [--x=420 --y=220 --gap=270] [--show-label]
+  lattices actor hud <actor-id> <url> [--hud-width=360 --hud-height=240]
+  lattices actor show|hide|toggle|status
+
+Examples:
+  lattices actor app Codex "Building the release"
+  lattices actor app Talkie "Hover for latest state" --hud-url=http://localhost:5173
+  lattices actor hud switch-talkie http://localhost:5173
+  lattices actor switcher Codex Talkie
+  lattices actor toggle
+  lattices actor switcher "Google Chrome" Codex Talkie --show-label --scale=0.8
+`);
+}
+
+async function actorCommand(sub?: string, ...rest: string[]): Promise<void> {
+  if (sub === "app") {
+    await actorAppCommand(rest);
+    return;
+  }
+  if (sub === "switcher") {
+    await actorSwitcherCommand(rest);
+    return;
+  }
+  if (sub === "hud") {
+    await actorHUDCommand(rest);
+    return;
+  }
+  if (sub === "show" || sub === "hide" || sub === "toggle" || sub === "status") {
+    await actorVisibilityCommand(sub, rest);
+    return;
+  }
+  actorUsage();
+}
+
+function actorHUDOptions(rest: string[]): Record<string, unknown> {
+  const hudUrl = parseFlagValue(rest, "hud-url") || parseFlagValue(rest, "hudUrl");
+  const hudHTML = parseFlagValue(rest, "hud-html") || parseFlagValue(rest, "hudHTML") || parseFlagValue(rest, "hudHtml");
+  const hudTitle = parseFlagValue(rest, "hud-title") || parseFlagValue(rest, "hudTitle");
+  const hudWidth = parseFlagValue(rest, "hud-width") || parseFlagValue(rest, "hudWidth") || parseFlagValue(rest, "width");
+  const hudHeight = parseFlagValue(rest, "hud-height") || parseFlagValue(rest, "hudHeight") || parseFlagValue(rest, "height");
+  return {
+    ...(hudUrl ? { hudUrl } : {}),
+    ...(hudHTML ? { hudHTML } : {}),
+    ...(hudTitle ? { hudTitle } : {}),
+    ...(hudWidth ? { hudWidth: Number(hudWidth) } : {}),
+    ...(hudHeight ? { hudHeight: Number(hudHeight) } : {}),
+  };
+}
+
+function shouldHideActorLabel(rest: string[]): boolean {
+  if (hasFlag(rest, "show-label") || hasFlag(rest, "showLabel")) return false;
+  return true;
+}
+
+async function actorHUDCommand(rest: string[]): Promise<void> {
+  const positional = nonFlagArgs(rest);
+  const id = positional[0];
+  if (!id) {
+    actorUsage();
+    return;
+  }
+
+  const { daemonCall } = await getDaemonClient();
+  const url = positional[1];
+  const clear = hasFlag(rest, "clear");
+  const result = await daemonCall("overlay.actor.hud", {
+    id,
+    clear,
+    ...(url && !clear ? { hudUrl: url } : {}),
+    ...actorHUDOptions(rest),
+  }, 15000) as any;
+
+  if (hasFlag(rest, "json")) {
+    console.log(JSON.stringify(result, null, 2));
+  } else if (clear) {
+    console.log(`Cleared HUD for ${id}.`);
+  } else {
+    console.log(`Attached hover HUD to ${id}.`);
+  }
+}
+
+async function actorVisibilityCommand(action: string, rest: string[]): Promise<void> {
+  const { daemonCall } = await getDaemonClient();
+  const result = await daemonCall("overlay.actor.visibility", {
+    action,
+    feedback: !hasFlag(rest, "quiet") && action !== "status",
+  }, 15000) as any;
+
+  if (hasFlag(rest, "json")) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  const state = result.visible ? "shown" : "hidden";
+  const count = Number(result.actorCount ?? 0);
+  console.log(`Actor layer ${state} (${count} actor${count === 1 ? "" : "s"}).`);
+}
+
+async function actorAppCommand(rest: string[]): Promise<void> {
+  const positional = nonFlagArgs(rest);
+  const appQuery = positional[0];
+  if (!appQuery) {
+    actorUsage();
+    return;
+  }
+  const message = positional.slice(1).join(" ") || `Tap to switch to ${appQuery}.`;
+  const asset = ensureAppActorAsset(appQuery);
+  const { daemonCall } = await getDaemonClient();
+  const id = parseFlagValue(rest, "id") || `app-${slugify(asset.appName)}`;
+  const state = parseFlagValue(rest, "state") || "idle";
+  const ttlMs = Number(parseFlagValue(rest, "ttl") || parseFlagValue(rest, "ttlMs") || 0);
+  const x = Number(parseFlagValue(rest, "x") || 520);
+  const y = Number(parseFlagValue(rest, "y") || 340);
+  const placement = parseFlagValue(rest, "placement") || "point";
+  const style = parseFlagValue(rest, "style") || "playful";
+  const dismissible = hasFlag(rest, "dismissible");
+  const labelHidden = shouldHideActorLabel(rest);
+  const closeOnActivate = hasFlag(rest, "close-on-activate") || hasFlag(rest, "closeOnActivate");
+  const scale = Number(parseFlagValue(rest, "scale") || 1);
+
+  const result = await daemonCall("overlay.actor.publish", {
+    id,
+    renderer: "sprite",
+    asset: asset.id,
+    state,
+    name: parseFlagValue(rest, "name") || asset.appName,
+    message,
+    placement,
+    x,
+    y,
+    style,
+    ttlMs,
+    dismissible,
+    labelHidden,
+    closeOnActivate,
+    scale,
+    ...actorHUDOptions(rest),
+    targetApp: asset.appName,
+    targetBundleId: asset.bundleIdentifier,
+    targetAppPath: asset.appPath,
+  }, 15000) as any;
+
+  if (!hasFlag(rest, "no-move")) {
+    await daemonCall("overlay.actor.moveTo", {
+      id,
+      x: x + 40,
+      y: y + 50,
+      durationMs: 700,
+      easing: "spring",
+    }, 15000);
+  }
+
+  if (hasFlag(rest, "json")) {
+    console.log(JSON.stringify({ ...result, asset: asset.id, appPath: asset.appPath }, null, 2));
+  } else {
+    console.log(`Published ${asset.appName} actor (${id}). Click it to switch to ${asset.appName}.`);
+  }
+}
+
+async function actorSwitcherCommand(rest: string[]): Promise<void> {
+  const appNames = nonFlagArgs(rest);
+  const apps = appNames.length ? appNames : ["Codex", "Talkie"];
+  const { daemonCall } = await getDaemonClient();
+  const startX = Number(parseFlagValue(rest, "x") || 420);
+  const y = Number(parseFlagValue(rest, "y") || 220);
+  const gap = Number(parseFlagValue(rest, "gap") || 270);
+  const ttlMs = Number(parseFlagValue(rest, "ttl") || parseFlagValue(rest, "ttlMs") || 0);
+  const style = parseFlagValue(rest, "style") || "info";
+  const dismissible = hasFlag(rest, "dismissible");
+  const labelHidden = shouldHideActorLabel(rest);
+  const closeOnActivate = hasFlag(rest, "close-on-activate") || hasFlag(rest, "closeOnActivate");
+  const scale = Number(parseFlagValue(rest, "scale") || 1);
+  const results: any[] = [];
+
+  for (let i = 0; i < apps.length; i++) {
+    const asset = ensureAppActorAsset(apps[i]);
+    const id = `switch-${slugify(asset.appName)}`;
+    const x = startX + i * gap;
+    const result = await daemonCall("overlay.actor.publish", {
+      id,
+      renderer: "sprite",
+      asset: asset.id,
+      state: "ready",
+      name: asset.appName,
+      message: `Tap to switch to ${asset.appName}.`,
+      placement: "point",
+      x,
+      y,
+      style,
+      ttlMs,
+      dismissible,
+      labelHidden,
+      closeOnActivate,
+      scale,
+      ...actorHUDOptions(rest),
+      targetApp: asset.appName,
+      targetBundleId: asset.bundleIdentifier,
+      targetAppPath: asset.appPath,
+    }, 15000) as any;
+    results.push({ ...result, asset: asset.id, appPath: asset.appPath });
+    await daemonCall("overlay.actor.moveTo", {
+      id,
+      x: x + 28,
+      y: y + 36,
+      durationMs: 650,
+      easing: "spring",
+    }, 15000);
+  }
+
+  if (hasFlag(rest, "json")) {
+    console.log(JSON.stringify(results, null, 2));
+  } else {
+    console.log(`Published app switcher for ${apps.join(", ")}.`);
+  }
+}
+
+type HUDPathField = string | {
+  path?: string;
+  format?: string;
+  schema?: string;
+  presentation?: string;
+  title?: string;
+  description?: string;
+  pollMs?: number;
+};
+
+interface HUDManifest {
+  version?: number;
+  manifestVersion?: number;
+  id?: string;
+  name?: string;
+  bundleId?: string;
+  bundleIdentifier?: string;
+  app?: string;
+  appPath?: string;
+  icon?: string;
+  entry?: string;
+  readAccess?: string | string[];
+  state?: HUDPathField;
+  events?: HUDPathField | HUDPathField[];
+  log?: HUDPathField;
+  logs?: HUDPathField[];
+  sources?: HUDPathField[] | Record<string, HUDPathField>;
+  surface?: {
+    width?: number;
+    height?: number;
+    title?: string;
+    transparent?: boolean;
+  };
+  actor?: {
+    id?: string;
+    message?: string;
+    state?: string;
+    x?: number;
+    y?: number;
+    placement?: string;
+    style?: string;
+    scale?: number;
+    labelHidden?: boolean;
+    closeOnActivate?: boolean;
+    click?: string | { type?: string };
+  };
+}
+
+interface ResolvedHUDManifest {
+  manifestPath: string;
+  rootDir: string;
+  manifest: HUDManifest;
+  id: string;
+  name: string;
+  entry: string;
+  iconPath?: string;
+  appPath?: string;
+  bundleIdentifier?: string;
+  readAccessPath?: string;
+}
+
+interface HUDRegistryEntry {
+  id: string;
+  name?: string;
+  bundleIdentifier?: string;
+  manifestPath: string;
+  registeredAt: string;
+  lastPublishedAt?: string;
+}
+
+interface HUDRegistry {
+  version: 1;
+  entries: HUDRegistryEntry[];
+}
+
+function hudUsage(): void {
+  console.log(`Usage:
+  lattices hud register [manifest] [--publish]   Register .lattices/hud/manifest.json
+  lattices hud publish [manifest-or-id]          Publish one HUD actor now
+  lattices hud sync                              Publish all registered HUD actors
+  lattices hud list                              List registered HUDs
+  lattices hud discover [root] [--register]      Find HUD manifests under a folder
+
+Manifest:
+  .lattices/hud/manifest.json
+
+Examples:
+  lattices hud register .lattices/hud/manifest.json --publish
+  lattices hud publish talkie --x=520 --y=340
+  lattices hud sync
+`);
+}
+
+function hudRegistryPath(): string {
+  return resolve(homedir(), ".lattices", "huds.json");
+}
+
+function readHUDRegistry(): HUDRegistry {
+  const path = hudRegistryPath();
+  if (!existsSync(path)) return { version: 1, entries: [] };
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<HUDRegistry>;
+    return {
+      version: 1,
+      entries: Array.isArray(parsed.entries) ? parsed.entries : [],
+    };
+  } catch (e: unknown) {
+    throw new Error(`Invalid HUD registry ${path}: ${(e as Error).message}`);
+  }
+}
+
+function writeHUDRegistry(registry: HUDRegistry): void {
+  const path = hudRegistryPath();
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(registry, null, 2)}\n`);
+}
+
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function isURLLike(value: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:/i.test(value);
+}
+
+function resolveHUDPath(rootDir: string, value: HUDPathField | undefined, fallback?: string): string | undefined {
+  const raw = typeof value === "string" ? value : value?.path;
+  const path = raw || fallback;
+  if (!path) return undefined;
+  if (isURLLike(path)) return path;
+  if (path.startsWith("~/")) return resolve(homedir(), path.slice(2));
+  return isAbsolute(path) ? path : resolve(rootDir, path);
+}
+
+function resolveHUDReadAccess(rootDir: string, manifest: HUDManifest, rest: string[] = []): string {
+  const flagValue = parseFlagValue(rest, "read-access") || parseFlagValue(rest, "readAccess");
+  const declared = flagValue
+    ?? (Array.isArray(manifest.readAccess) ? manifest.readAccess[0] : manifest.readAccess);
+  if (!declared) return rootDir;
+  if (isURLLike(declared)) return rootDir;
+  if (declared.startsWith("~/")) return resolve(homedir(), declared.slice(2));
+  return isAbsolute(declared) ? declared : resolve(rootDir, declared);
+}
+
+function resolveHUDManifestInput(input?: string): string {
+  if (!input) {
+    const defaultPath = resolve(process.cwd(), ".lattices", "hud", "manifest.json");
+    if (existsSync(defaultPath)) return defaultPath;
+    throw new Error("No manifest provided and .lattices/hud/manifest.json was not found.");
+  }
+
+  const candidate = resolve(input);
+  if (existsSync(candidate)) {
+    return isDirectory(candidate) ? resolve(candidate, "manifest.json") : candidate;
+  }
+
+  const registry = readHUDRegistry();
+  const entry = registry.entries.find((item) => item.id === input);
+  if (entry) return entry.manifestPath;
+
+  throw new Error(`HUD manifest or registered id not found: ${input}`);
+}
+
+function readHUDManifest(input?: string): ResolvedHUDManifest {
+  const manifestPath = resolveHUDManifestInput(input);
+  if (!existsSync(manifestPath)) {
+    throw new Error(`HUD manifest does not exist: ${manifestPath}`);
+  }
+
+  const rootDir = dirname(manifestPath);
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as HUDManifest;
+  const id = manifest.actor?.id || manifest.id;
+  if (!id) throw new Error(`HUD manifest is missing id: ${manifestPath}`);
+
+  const name = manifest.name || id;
+  const entry = resolveHUDPath(rootDir, manifest.entry, "./index.html");
+  if (!entry) throw new Error(`HUD manifest is missing entry: ${manifestPath}`);
+  if (!isURLLike(entry) && !existsSync(entry)) {
+    throw new Error(`HUD entry does not exist: ${entry}`);
+  }
+
+  const iconPath = resolveHUDPath(rootDir, manifest.icon);
+  const appPath = resolveHUDPath(rootDir, manifest.appPath)
+    ?? (manifest.bundleId || manifest.bundleIdentifier
+      ? resolveApplicationByBundleIdentifier(manifest.bundleId || manifest.bundleIdentifier || "")
+      : undefined)
+    ?? (manifest.app ? resolveApplication(manifest.app) : undefined);
+  const bundleIdentifier = manifest.bundleId
+    ?? manifest.bundleIdentifier
+    ?? (appPath ? plistValue(resolve(appPath, "Contents", "Info.plist"), "CFBundleIdentifier") : undefined);
+
+  return {
+    manifestPath,
+    rootDir,
+    manifest,
+    id,
+    name,
+    entry,
+    iconPath: iconPath && !isURLLike(iconPath) ? iconPath : undefined,
+    appPath: appPath && !isURLLike(appPath) ? appPath : undefined,
+    bundleIdentifier,
+    readAccessPath: resolveHUDReadAccess(rootDir, manifest),
+  };
+}
+
+function numberFlag(rest: string[], name: string, fallback: number): number {
+  const raw = parseFlagValue(rest, name);
+  if (!raw) return fallback;
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function numberFlagAny(rest: string[], names: string[], fallback: number): number {
+  for (const name of names) {
+    const raw = parseFlagValue(rest, name);
+    if (!raw) continue;
+    const value = Number(raw);
+    if (Number.isFinite(value)) return value;
+  }
+  return fallback;
+}
+
+function hudActorAsset(resolved: ResolvedHUDManifest): string | undefined {
+  if (resolved.iconPath) {
+    return ensureIconActorAsset(resolved.id, resolved.name, resolved.iconPath);
+  }
+
+  const appQuery = resolved.appPath || resolved.manifest.app;
+  if (!appQuery) return undefined;
+
+  try {
+    return ensureAppActorAsset(appQuery).id;
+  } catch {
+    return undefined;
+  }
+}
+
+function hudClickType(manifest: HUDManifest): string {
+  const click = manifest.actor?.click;
+  if (!click) return "activateApp";
+  return typeof click === "string" ? click : click.type || "activateApp";
+}
+
+function hudPublishPayload(resolved: ResolvedHUDManifest, rest: string[], index = 0): Record<string, unknown> {
+  const manifest = resolved.manifest;
+  const actor = manifest.actor ?? {};
+  const surface = manifest.surface ?? {};
+  const targetEnabled = hudClickType(manifest) !== "none";
+  const asset = hudActorAsset(resolved);
+  const x = numberFlag(rest, "x", actor.x ?? 420 + index * 112);
+  const y = numberFlag(rest, "y", actor.y ?? 220);
+
+  return {
+    id: resolved.id,
+    renderer: "sprite",
+    ...(asset ? { asset } : {}),
+    state: parseFlagValue(rest, "state") || actor.state || "ready",
+    name: parseFlagValue(rest, "name") || resolved.name,
+    message: actor.message || `Hover for ${resolved.name} status.`,
+    placement: parseFlagValue(rest, "placement") || actor.placement || "point",
+    x,
+    y,
+    style: parseFlagValue(rest, "style") || actor.style || "info",
+    labelHidden: actor.labelHidden ?? true,
+    closeOnActivate: actor.closeOnActivate ?? false,
+    scale: numberFlag(rest, "scale", actor.scale ?? 1),
+    hudUrl: resolved.entry,
+    hudTitle: surface.title || resolved.name,
+    hudWidth: numberFlagAny(rest, ["hud-width", "hudWidth", "width"], surface.width ?? 380),
+    hudHeight: numberFlagAny(rest, ["hud-height", "hudHeight", "height"], surface.height ?? 260),
+    hudReadAccess: resolveHUDReadAccess(resolved.rootDir, manifest, rest),
+    ...(targetEnabled && resolved.bundleIdentifier ? { targetBundleId: resolved.bundleIdentifier } : {}),
+    ...(targetEnabled && resolved.appPath ? { targetAppPath: resolved.appPath } : {}),
+    ...(targetEnabled && manifest.app ? { targetApp: manifest.app } : {}),
+  };
+}
+
+function upsertHUDRegistryEntry(resolved: ResolvedHUDManifest, published = false): HUDRegistryEntry {
+  const registry = readHUDRegistry();
+  const now = new Date().toISOString();
+  const existing = registry.entries.find((entry) => entry.id === resolved.id);
+  const next: HUDRegistryEntry = {
+    id: resolved.id,
+    name: resolved.name,
+    bundleIdentifier: resolved.bundleIdentifier,
+    manifestPath: resolved.manifestPath,
+    registeredAt: existing?.registeredAt ?? now,
+    lastPublishedAt: published ? now : existing?.lastPublishedAt,
+  };
+  registry.entries = [
+    next,
+    ...registry.entries.filter((entry) => entry.id !== resolved.id),
+  ].sort((a, b) => a.id.localeCompare(b.id));
+  writeHUDRegistry(registry);
+  return next;
+}
+
+async function publishHUDManifest(resolved: ResolvedHUDManifest, rest: string[], index = 0): Promise<Record<string, unknown>> {
+  const { daemonCall } = await getDaemonClient();
+  const payload = hudPublishPayload(resolved, rest, index);
+  const result = await daemonCall("overlay.actor.publish", payload, 15000) as Record<string, unknown>;
+  if (!hasFlag(rest, "no-move")) {
+    await daemonCall("overlay.actor.moveTo", {
+      id: resolved.id,
+      x: Number(payload.x) + 24,
+      y: Number(payload.y) + 30,
+      durationMs: 600,
+      easing: "spring",
+    }, 15000);
+  }
+  upsertHUDRegistryEntry(resolved, true);
+  return result;
+}
+
+async function hudRegisterCommand(rest: string[]): Promise<void> {
+  const manifestArg = nonFlagArgs(rest)[0] || parseFlagValue(rest, "manifest");
+  const resolved = readHUDManifest(manifestArg);
+  const entry = upsertHUDRegistryEntry(resolved, false);
+
+  if (hasFlag(rest, "publish")) {
+    await publishHUDManifest(resolved, rest);
+  }
+
+  const published = hasFlag(rest, "publish");
+  if (hasFlag(rest, "json")) {
+    console.log(JSON.stringify(entry, null, 2));
+  } else {
+    console.log(`${published ? "Registered and published" : "Registered"} HUD ${resolved.id} -> ${resolved.manifestPath}`);
+  }
+}
+
+async function hudPublishCommand(rest: string[]): Promise<void> {
+  const manifestArg = nonFlagArgs(rest)[0] || parseFlagValue(rest, "manifest");
+  const resolved = readHUDManifest(manifestArg);
+  const result = await publishHUDManifest(resolved, rest);
+
+  if (hasFlag(rest, "json")) {
+    console.log(JSON.stringify({ ...result, manifestPath: resolved.manifestPath }, null, 2));
+  } else {
+    console.log(`Published HUD actor ${resolved.id}. Hover it for ${resolved.name}.`);
+  }
+}
+
+async function hudSyncCommand(rest: string[]): Promise<void> {
+  const registry = readHUDRegistry();
+  const results: Record<string, unknown>[] = [];
+  for (let i = 0; i < registry.entries.length; i++) {
+    const resolved = readHUDManifest(registry.entries[i].id);
+    results.push(await publishHUDManifest(resolved, rest, i));
+  }
+
+  if (hasFlag(rest, "json")) {
+    console.log(JSON.stringify(results, null, 2));
+  } else {
+    console.log(`Published ${results.length} registered HUD actor${results.length === 1 ? "" : "s"}.`);
+  }
+}
+
+function hudListCommand(rest: string[]): void {
+  const registry = readHUDRegistry();
+  if (hasFlag(rest, "json")) {
+    console.log(JSON.stringify(registry, null, 2));
+    return;
+  }
+  if (!registry.entries.length) {
+    console.log("No registered HUDs. Run lattices hud register .lattices/hud/manifest.json");
+    return;
+  }
+  console.log("Registered HUDs:\n");
+  for (const entry of registry.entries) {
+    console.log(`  ${entry.id}${entry.name ? ` (${entry.name})` : ""}`);
+    console.log(`    manifest: ${entry.manifestPath}`);
+    if (entry.bundleIdentifier) console.log(`    bundle:   ${entry.bundleIdentifier}`);
+    if (entry.lastPublishedAt) console.log(`    shown:    ${entry.lastPublishedAt}`);
+    console.log();
+  }
+}
+
+function hudDiscoverCommand(rest: string[]): void {
+  const root = resolve(nonFlagArgs(rest)[0] || parseFlagValue(rest, "root") || process.cwd());
+  const maxDepth = Number(parseFlagValue(rest, "max-depth") || parseFlagValue(rest, "maxDepth") || 6);
+  const out = runQuiet(`find '${esc(root)}' -maxdepth ${maxDepth} -path '*/.lattices/hud/manifest.json' -print 2>/dev/null`);
+  const manifests = out ? out.split("\n").filter(Boolean) : [];
+
+  if (hasFlag(rest, "register")) {
+    for (const manifestPath of manifests) {
+      upsertHUDRegistryEntry(readHUDManifest(manifestPath), false);
+    }
+  }
+
+  if (hasFlag(rest, "json")) {
+    console.log(JSON.stringify(manifests, null, 2));
+    return;
+  }
+
+  if (!manifests.length) {
+    console.log(`No HUD manifests found under ${root}`);
+    return;
+  }
+  for (const manifestPath of manifests) console.log(manifestPath);
+  if (hasFlag(rest, "register")) {
+    console.log(`\nRegistered ${manifests.length} HUD manifest${manifests.length === 1 ? "" : "s"}.`);
+  }
+}
+
+async function hudCommand(sub?: string, ...rest: string[]): Promise<void> {
+  try {
+    switch (sub) {
+    case "register":
+      await hudRegisterCommand(rest);
+      return;
+    case "publish":
+    case "show":
+      await hudPublishCommand(rest);
+      return;
+    case "sync":
+      await hudSyncCommand(rest);
+      return;
+    case "list":
+    case "ls":
+      hudListCommand(rest);
+      return;
+    case "discover":
+      hudDiscoverCommand(rest);
+      return;
+    default:
+      hudUsage();
+    }
+  } catch (e: unknown) {
+    console.log(`Error: ${(e as Error).message}`);
+  }
+}
+
 async function layerCommand(sub?: string, ...rest: string[]): Promise<void> {
   try {
     const { daemonCall } = await getDaemonClient();
@@ -1749,6 +2576,12 @@ Usage:
   lattices voice status       Voice provider status
   lattices voice simulate <t> Parse and execute a voice command
   lattices voice intents      List all available intents
+  lattices actor app <app> [message]  Show a clickable app-icon actor
+  lattices actor switcher [apps...]   Show a clickable app switcher row
+  lattices actor hud <id> <url>       Attach a hover web HUD to an actor
+  lattices actor toggle       Hide/show the sticky actor layer
+  lattices hud register [manifest]    Register a .lattices/hud/manifest.json
+  lattices hud publish [id|manifest]  Publish a registered/static HUD actor
   lattices assistant plan <t> Preview the TS assistant planner
   lattices call <method> [p]  Raw daemon API call (params as JSON)
   lattices scan               Show text from all visible windows
@@ -2287,6 +3120,14 @@ switch (command) {
     break;
   case "voice":
     await voiceCommand(args[1], ...args.slice(2));
+    break;
+  case "actor":
+  case "actors":
+    await actorCommand(args[1], ...args.slice(2));
+    break;
+  case "hud":
+  case "huds":
+    await hudCommand(args[1], ...args.slice(2));
     break;
   case "assistant":
     await assistantCommand(args[1], ...args.slice(2));

--- a/docs/api.md
+++ b/docs/api.md
@@ -168,7 +168,7 @@ and `overlay.actor.*` for persistent, movable actor surfaces.
 
 Persistent actors are useful for representing agents or processes on the
 desktop. Each actor has a stable `id`, can be moved independently through the
-API, dragged by the user, hidden/restored with **Hyper+8**, and closed with
+API, dragged by the user, hidden/restored with **Hyper+B**, and closed with
 right-click. Click event callbacks and action surfaces are planned follow-on
 capabilities.
 
@@ -178,6 +178,8 @@ capabilities.
 | `overlay.clear` | write | Clear one overlay layer by id, or clear an owner namespace |
 | `overlay.actor.publish` | write | Create or update a persistent generative overlay actor |
 | `overlay.actor.moveTo` | write | Move an actor with app-owned easing |
+| `overlay.actor.hud` | write | Attach, update, or clear a hover web HUD for an actor |
+| `overlay.actor.visibility` | write | Show, hide, toggle, or inspect the sticky actor layer |
 
 #### `overlay.publish`
 
@@ -230,6 +232,17 @@ omit `ttlMs` or pass `0`, and `dismissible` defaults to `false`.
 | `state` | string | no | Actor state or animation name |
 | `name` | string | no | Actor display name |
 | `message` | string | no | Attached message text |
+| `targetApp` | string | no | App name to activate when the actor is clicked |
+| `targetBundleId` | string | no | Bundle identifier to activate when the actor is clicked |
+| `targetAppPath` | string | no | `.app` bundle path to open when the actor is clicked |
+| `scale` | double | no | Actor scale multiplier |
+| `labelHidden` | bool | no | Hide the actor label/message |
+| `closeOnActivate` | bool | no | Remove the actor after activating its target app |
+| `hudUrl` | string | no | URL to render in a transparent hover HUD web view |
+| `hudHTML` | string | no | Inline HTML to render in a transparent hover HUD web view |
+| `hudWidth` | double | no | Hover HUD width |
+| `hudHeight` | double | no | Hover HUD height |
+| `hudReadAccess` | string | no | Local folder a file-backed HUD may read |
 | `placement` | string | no | `top`, `bottom`, `center`, `cursor`, or `point` |
 | `x`, `y` | double | no | Screen-local point for `point` placement |
 | `ttlMs` | int | no | Time to live; `0` means persistent |
@@ -284,6 +297,117 @@ await daemonCall('overlay.actor.moveTo', {
   easing: 'spring'
 })
 ```
+
+#### `overlay.actor.hud`
+
+Attach a transparent, blurred hover HUD to an actor. The HUD is backed by a
+native `WKWebView`, so apps can point it at a local static HTML dashboard or,
+in development, a local URL.
+
+**Params**:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | yes | Actor id |
+| `hudUrl` | string | no | URL or file path to render |
+| `hudHTML` | string | no | Inline HTML to render instead of a URL |
+| `hudTitle` | string | no | HUD title metadata |
+| `hudWidth` | double | no | HUD width |
+| `hudHeight` | double | no | HUD height |
+| `hudReadAccess` | string | no | Local folder a file-backed HUD may read |
+| `clear` | bool | no | Remove the actor HUD |
+
+Example:
+
+```js
+await daemonCall('overlay.actor.hud', {
+  id: 'switch-talkie',
+  hudUrl: '/Users/you/dev/talkie/.lattices/hud/index.html',
+  hudReadAccess: '/Users/you/Library/Application Support/Talkie/HUD',
+  hudWidth: 380,
+  hudHeight: 260
+})
+```
+
+#### `overlay.actor.visibility`
+
+Show, hide, toggle, or inspect the persistent actor layer without destroying
+the actors. This is the daemon equivalent of the app's **Hyper+B** shortcut.
+
+**Params**:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `action` | string | no | `show`, `hide`, `toggle`, or `status` |
+| `visible` | bool | no | Set layer visibility directly |
+| `hidden` | bool | no | Set layer hidden state directly |
+| `feedback` | bool | no | Show a short desktop feedback toast |
+
+Example:
+
+```js
+await daemonCall('overlay.actor.visibility', { action: 'toggle' })
+```
+
+### Static HUD Manifests
+
+Apps and projects can expose a local hover dashboard without running a web
+server by publishing a static bundle at:
+
+```txt
+.lattices/hud/
+  manifest.json
+  index.html
+  assets/
+```
+
+Minimal manifest:
+
+```json
+{
+  "version": 1,
+  "id": "talkie",
+  "name": "Talkie",
+  "bundleId": "com.usabletalkie.Talkie",
+  "icon": "./assets/icon.png",
+  "entry": "./index.html",
+  "readAccess": "~/Library/Application Support/Talkie/HUD",
+  "surface": { "width": 380, "height": 260 },
+  "actor": {
+    "labelHidden": true,
+    "click": "activateApp"
+  },
+  "sources": [
+    {
+      "path": "~/Library/Application Support/Talkie/HUD/activity.jsonl",
+      "format": "jsonl",
+      "schema": "talkie.activity.v1",
+      "presentation": "timeline"
+    }
+  ]
+}
+```
+
+The CLI resolves this manifest into `overlay.actor.publish` with a file-backed
+HUD URL. The macOS app loads `entry` through `WKWebView.loadFileURL`, allowing
+read access to the HUD folder by default, or to the manifest's `readAccess`
+folder when one is declared.
+
+`sources` is descriptive metadata for app-owned state, logs, or event streams.
+Lattices does not append to those logs. The app writes them in its normal
+runtime location, and the custom HUD renderer decides how to present them.
+
+Useful commands:
+
+```bash
+lattices hud register .lattices/hud/manifest.json --publish
+lattices hud publish talkie
+lattices hud sync
+lattices hud discover ~/dev --register
+```
+
+For packaged apps, keep the renderer files in the app bundle and point mutable
+sources at an app-owned folder such as `~/Library/Application Support/...`.
 
 ---
 

--- a/docs/app.md
+++ b/docs/app.md
@@ -79,6 +79,27 @@ Available when `layers` are configured in `~/.lattices/workspace.json`
 | Refresh Projects  | Re-scan for .lattices.json configs        |
 | Quit Lattices      | Exit the menu bar app                    |
 
+## Overlay actors and HUDs
+
+Persistent overlay actors can be hidden or restored with **Hyper+B**. Apps can
+publish a static hover dashboard by exposing:
+
+```txt
+.lattices/hud/manifest.json
+```
+
+Register and publish one:
+
+```bash
+lattices hud register .lattices/hud/manifest.json --publish
+```
+
+The manifest points to a local `index.html`, optional icon, app activation
+target, HUD dimensions, and optional app-owned `sources` metadata for logs or
+state files. Lattices hosts the actor and loads the dashboard through a
+transparent `WKWebView`; the app owns the renderer and writes its own logs in
+the places it already uses.
+
 ## Project discovery
 
 The app scans a configurable root directory (up to 3 levels deep)
@@ -229,7 +250,7 @@ Shows keyboard shortcut reference:
 | Hyper+4            | Desktop inventory    |
 | Hyper+5            | Omni search          |
 | Hyper+6            | Cheat sheet          |
-| Hyper+8            | Hide/show persistent overlay actors |
+| Hyper+B            | Hide/show persistent overlay actors |
 | Cmd+Option+1/2/3  | Switch workspace layer |
 | Ctrl+B  D         | Detach from session  |
 | Ctrl+B  X         | Kill current pane    |

--- a/docs/config.md
+++ b/docs/config.md
@@ -146,6 +146,10 @@ Run `lattices init` in your project directory to generate a starter
 | `lattices windows [--json]`  | List all visible windows                          |
 | `lattices window assign <wid> <layer>` | Tag a window to a layer                |
 | `lattices window map [--json]` | Show all window→layer assignments                |
+| `lattices actor toggle`      | Hide/show persistent overlay actors               |
+| `lattices hud register [manifest]` | Register a `.lattices/hud/manifest.json`   |
+| `lattices hud publish [id\|manifest]` | Publish a static HUD actor to the desktop |
+| `lattices hud sync`          | Publish all registered HUD actors                 |
 | `lattices search <query>`      | Search windows by title, app, session, OCR       |
 | `lattices search <q> --deep`   | Deep search: index + live terminal inspection    |
 | `lattices search <q> --wid`    | Print matching window IDs only (pipeable)        |

--- a/docs/proposals/LAT-004-interactive-overlay-actors.md
+++ b/docs/proposals/LAT-004-interactive-overlay-actors.md
@@ -192,7 +192,7 @@ Expected interactions:
 
 Dismissal should normally dismiss the current message/surface, not delete the actor.
 Persistent actors can be parked globally with the overlay actor hotkey
-without clearing their ids or state. The initial shortcut is **Hyper+8**.
+without clearing their ids or state. The initial shortcut is **Hyper+B**.
 
 ## Motion
 


### PR DESCRIPTION
## Summary
- Add persistent app-icon overlay actors with click-to-activate behavior, drag handling, context menu controls, hover styling, and Hyper+B visibility toggling.
- Add transparent WebView-backed actor HUDs, including file-backed HUD loading with explicit read-access roots.
- Add `.lattices/hud/manifest.json` registration/publish/discovery commands so apps can expose app-owned presence surfaces without running a web server.
- Document the HUD manifest contract and update the actor proposal/docs to use Hyper+B.

## Status
This is intentionally a draft. The primitive feels useful enough to bring back toward main, but the API and product boundaries should still get review before treating it as fully settled.

## Verification
- `bun run check:types`
- `bun run check:app`
- `git diff --check`
- Temp `.lattices/hud/manifest.json` discovery smoke test
- Rebuilt and relaunched the macOS app; daemon came back up on `ws://127.0.0.1:9399`

## Notes
- HUD event/log data stays app-owned. Lattices reads the manifest and hosts the surface; it does not provide a command-line logger for app activity.
- Swift build currently emits pre-existing deprecation/no-usage warnings around app launch and window APIs.