### PR TITLE
Workspace Assistant on Hudson: shell, streaming, shared renderer + ScreenCaptureKit

### DIFF
--- a/apps/mac/Package.swift
+++ b/apps/mac/Package.swift
@@ -1,17 +1,25 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.2
 import PackageDescription
 
 let package = Package(
     name: "Lattices",
-    platforms: [.macOS(.v13)],
+    platforms: [.macOS(.v26)],
     dependencies: [
-        .package(path: "../../swift")
+        .package(path: "../../swift"),
+        // HudsonKit spike — local path for fast iteration. Mirror vox/app's
+        // git dependency (git@github.com:arach/hudson.git, branch: main) for
+        // real adoption. HudsonVoice requires HUDSONKIT_WITH_VOICE=1 at build time.
+        .package(path: "../../../hudson"),
     ],
     targets: [
         .executableTarget(
             name: "Lattices",
             dependencies: [
-                .product(name: "DeckKit", package: "swift")
+                .product(name: "DeckKit", package: "swift"),
+                .product(name: "HudsonUI", package: "hudson"),
+                .product(name: "HudsonAI", package: "hudson"),
+                .product(name: "HudsonVoice", package: "hudson"),
+                .product(name: "HudsonShell", package: "hudson"),
             ],
             path: "Sources",
             resources: [
@@ -23,5 +31,8 @@ let package = Package(
             name: "LatticesTests",
             path: "Tests"
         )
-    ]
+    ],
+    // Stay in Swift 5 language mode: adopt macOS 26 / the 6.2 toolchain without
+    // forcing a Swift 6 strict-concurrency migration across the existing app.
+    swiftLanguageModes: [.v5]
 )

--- a/apps/mac/Sources/AppShell/AppShellView.swift
+++ b/apps/mac/Sources/AppShell/AppShellView.swift
@@ -1,4 +1,6 @@
 import SwiftUI
+import HudsonShell
+import HudsonUI
 
 // MARK: - Navigation Pages
 
@@ -47,21 +49,48 @@ enum AppPage: String, CaseIterable {
 struct AppShellView: View {
     @ObservedObject var controller: ScreenMapController
     @ObservedObject var windowController = ScreenMapWindowController.shared
+    @ObservedObject private var scanner = ProjectScanner.shared
     @StateObject private var commandState = CommandModeState()
 
-    var body: some View {
-        VStack(spacing: 0) {
-            // Tab bar (only on primary pages)
-            if AppPage.primaryTabs.contains(windowController.activePage) {
-                tabBar
-                Rectangle().fill(Palette.border).frame(height: 0.5)
-            }
+    /// Sidebar starts expanded (labels visible); the rail header toggles compact.
+    @State private var sidebarCompact = false
 
+    private var manifest: HudAppManifest {
+        HudAppManifest(name: "Lattices", accent: Palette.running, targetLabel: "Machine")
+    }
+
+    /// Hudson rail ↔ our `activePage`. Selecting a rail item routes through the
+    /// same `showPage` path the old tabs used; non-primary pages (Settings, Docs)
+    /// leave the rail with no selection.
+    private var selection: Binding<AppPage?> {
+        Binding(
+            get: { AppPage.primaryTabs.contains(windowController.activePage) ? windowController.activePage : nil },
+            set: { if let page = $0 { windowController.showPage(page) } }
+        )
+    }
+
+    private var entries: [HudSidebarEntry<AppPage>] {
+        AppPage.primaryTabs.map { page in
+            .item(HudSidebarItem(id: page, title: page.label, icon: page.icon))
+        }
+    }
+
+    var body: some View {
+        HudAppShell {
+            navigationSidebar
+        } trailing: {
+            EmptyView()
+        } content: {
             contentArea
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        } statusBar: {
+            statusBar
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        .background(Palette.bg)
+        // Full Hudson window chrome: transparent full-size title bar, no separator.
+        // Keep the window non-draggable-by-background so content clicks aren't
+        // swallowed (Lattices manages its own window placement).
+        .background(HudWindowChrome(colorScheme: .dark, isMovableByWindowBackground: false))
+        .hudsonAppManifest(manifest)
         .onAppear {
             commandState.onDismiss = { windowController.activePage = .home }
             syncPageState(windowController.activePage)
@@ -69,6 +98,55 @@ struct AppShellView: View {
         .onChange(of: windowController.activePage) { page in
             syncPageState(page)
             clearRelevantDismissals(for: page)
+        }
+    }
+
+    // MARK: - Navigation Rail
+
+    private var navigationSidebar: some View {
+        HudNavigationSidebar(
+            selection: selection,
+            entries: entries,
+            isCompact: sidebarCompact,
+            accent: Palette.running,
+            onHeaderTap: {
+                withAnimation(HudMotion.chromeSpring) { sidebarCompact.toggle() }
+            }
+        ) {
+            // railHeader — kept clear so the traffic lights float over empty space.
+            Color.clear
+        } labelHeader: {
+            Text("Lattices")
+                .font(Typo.title(15))
+                .foregroundColor(Palette.text)
+        }
+    }
+
+    // MARK: - Status Bar
+
+    private var statusBar: some View {
+        let running = scanner.projects.filter(\.isRunning).count
+        return HStack(spacing: 14) {
+            statusItem(icon: "circle.fill", text: "\(running) running", tint: Palette.running)
+            statusItem(icon: "folder", text: "\(scanner.projects.count) projects", tint: Palette.textMuted)
+            Spacer()
+            Text(windowController.activePage.label)
+                .font(Typo.geistMonoBold(9))
+                .foregroundColor(Palette.textDim)
+        }
+        .padding(.horizontal, 14)
+        .frame(height: 26)
+        .background(Palette.bg)
+    }
+
+    private func statusItem(icon: String, text: String, tint: Color) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: icon)
+                .font(.system(size: 7))
+                .foregroundColor(tint)
+            Text(text)
+                .font(Typo.mono(10))
+                .foregroundColor(Palette.textMuted)
         }
     }
 
@@ -84,47 +162,6 @@ struct AppShellView: View {
         default:
             break
         }
-    }
-
-    // MARK: - Tab Bar
-
-    private var tabBar: some View {
-        HStack(spacing: 0) {
-            ForEach(AppPage.primaryTabs, id: \.rawValue) { tab in
-                tabButton(tab)
-            }
-
-            Spacer()
-        }
-        .padding(.horizontal, 12)
-        .padding(.top, 30)
-        .padding(.bottom, 4)
-    }
-
-    private func tabButton(_ tab: AppPage) -> some View {
-        let isActive = windowController.activePage == tab
-
-        return Button {
-            windowController.showPage(tab)
-            if tab == .screenMap { controller.enter() }
-            if tab == .desktopInventory { commandState.enter() }
-        } label: {
-            HStack(spacing: 5) {
-                Image(systemName: tab.icon)
-                    .font(.system(size: 10))
-                Text(tab.label)
-                    .font(Typo.monoBold(11))
-            }
-            .foregroundColor(isActive ? Palette.text : Palette.textMuted)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
-            .contentShape(Rectangle())
-            .background(
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(isActive ? Palette.surfaceHov : Color.clear)
-            )
-        }
-        .buttonStyle(.plain)
     }
 
     // MARK: - Content Area

--- a/apps/mac/Sources/AppShell/HomeDashboardView.swift
+++ b/apps/mac/Sources/AppShell/HomeDashboardView.swift
@@ -102,7 +102,8 @@ struct HomeDashboardView: View {
             }
         }
         .padding(.horizontal, 16)
-        .padding(.vertical, 16)
+        .padding(.top, 10)
+        .padding(.bottom, 16)
         .background(
             LinearGradient(
                 colors: [

--- a/apps/mac/Sources/AppShell/MainView.swift
+++ b/apps/mac/Sources/AppShell/MainView.swift
@@ -132,34 +132,9 @@ struct MainView: View {
                 .padding(.horizontal, 18)
                 .padding(.top, 18)
                 .padding(.bottom, 12)
-            } else {
-                // Search
-                HStack(spacing: 8) {
-                    Image(systemName: "magnifyingglass")
-                        .foregroundColor(Palette.textMuted)
-                        .font(.system(size: 11))
-                    TextField("Search projects...", text: $searchText)
-                        .textFieldStyle(.plain)
-                        .font(Typo.body(13))
-                        .foregroundColor(Palette.text)
-                    if !searchText.isEmpty {
-                        Button { searchText = "" } label: {
-                            Image(systemName: "xmark.circle.fill")
-                                .foregroundColor(Palette.textMuted)
-                                .font(.system(size: 11))
-                        }
-                        .buttonStyle(.plain)
-                    }
-                }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
-                .background(
-                    RoundedRectangle(cornerRadius: 4)
-                        .fill(Palette.surface)
-                )
-                .padding(.horizontal, 14)
-                .padding(.bottom, 10)
             }
+            // Projects spotlight removed for now — embedded layout goes straight
+            // from the hero into the project area.
 
             // Permission banner — only when something is missing AND not snoozed
             if !visiblyMissingCapabilities.isEmpty {

--- a/apps/mac/Sources/Core/Desktop/OcrModel.swift
+++ b/apps/mac/Sources/Core/Desktop/OcrModel.swift
@@ -198,7 +198,7 @@ final class OcrModel: ObservableObject {
         scanGeneration += 1
         let generation = scanGeneration
 
-        queue.async { [weak self] in
+        Task.detached(priority: .background) { [weak self] in
             guard let self else { return }
             var windows = self.enumerateWindows()
             let limit = self.prefs.ocrDeepLimit
@@ -213,7 +213,7 @@ final class OcrModel: ObservableObject {
 
             // Phase 1: capture + hash all windows (cheap)
             for win in windows {
-                if let cgImage = WindowCapture.image(
+                if let cgImage = await WindowCapture.image(
                     listOption: .optionIncludingWindow,
                     windowID: CGWindowID(win.wid),
                     imageOption: [.boundsIgnoreFraming, .bestResolution]
@@ -259,7 +259,7 @@ final class OcrModel: ObservableObject {
             DiagnosticLog.shared.info("OcrModel: deep scan budget=\(budget), changed=\(changedWindows.count), scanning=\(toScan.count)/\(windows.count)")
 
             // Phase 3: OCR only the budgeted windows
-            self.processNextWindow(
+            await self.processNextWindow(
                 windows: toScan,
                 index: 0,
                 generation: generation,
@@ -273,8 +273,8 @@ final class OcrModel: ObservableObject {
         }
     }
 
-    /// Process one window at a time, yielding back to the queue between each.
-    /// This lets GCD schedule higher-priority work between windows.
+    /// Process one window at a time, yielding between each capture/OCR pass.
+    /// This keeps higher-priority work responsive between windows.
     private func processNextWindow(
         windows: [WindowEntry],
         index: Int,
@@ -285,7 +285,7 @@ final class OcrModel: ObservableObject {
         totalBlocks: Int,
         changedResults: [OcrWindowResult],
         updateLastScanned: Bool = false
-    ) {
+    ) async {
         // Stale scan — a newer one started, abandon this one
         guard generation == scanGeneration else {
             DispatchQueue.main.async { self.isScanning = false }
@@ -319,11 +319,16 @@ final class OcrModel: ObservableObject {
 
         let win = windows[index]
 
-        if let cgImage = WindowCapture.image(
+        if let cgImage = await WindowCapture.image(
             listOption: .optionIncludingWindow,
             windowID: CGWindowID(win.wid),
             imageOption: [.boundsIgnoreFraming, .bestResolution]
         ) {
+            guard generation == scanGeneration else {
+                DispatchQueue.main.async { self.isScanning = false }
+                return
+            }
+
             let hash = imageHash(cgImage)
             newHashes[win.wid] = hash
 
@@ -363,19 +368,18 @@ final class OcrModel: ObservableObject {
         }
 
         // Throttle: 100ms delay between windows to reduce CPU bursts
-        queue.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-            self?.processNextWindow(
-                windows: windows,
-                index: index + 1,
-                generation: generation,
-                previousResults: previousResults,
-                fresh: fresh,
-                newHashes: newHashes,
-                totalBlocks: totalBlocks,
-                changedResults: changedResults,
-                updateLastScanned: updateLastScanned
-            )
-        }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        await processNextWindow(
+            windows: windows,
+            index: index + 1,
+            generation: generation,
+            previousResults: previousResults,
+            fresh: fresh,
+            newHashes: newHashes,
+            totalBlocks: totalBlocks,
+            changedResults: changedResults,
+            updateLastScanned: updateLastScanned
+        )
     }
 
     // MARK: - Window Enumeration

--- a/apps/mac/Sources/Core/Desktop/WindowCapture.swift
+++ b/apps/mac/Sources/Core/Desktop/WindowCapture.swift
@@ -1,33 +1,99 @@
 import CoreGraphics
-import Darwin
+import ScreenCaptureKit
 
 enum WindowCapture {
-    // Transitional wrapper for the old CoreGraphics window snapshot API.
-    // macOS 26 rejects direct references because ScreenCaptureKit is the supported path;
-    // this can return nil if Apple removes the symbol, so preview/OCR callers must degrade.
-    private typealias CGWindowListCreateImageFn = @convention(c) (
-        CGRect,
-        CGWindowListOption,
-        CGWindowID,
-        CGWindowImageOption
-    ) -> Unmanaged<CGImage>?
-
-    private static let createImage: CGWindowListCreateImageFn? = {
-        guard let handle = dlopen("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics", RTLD_LAZY) else {
-            return nil
-        }
-        guard let symbol = dlsym(handle, "CGWindowListCreateImage") else {
-            return nil
-        }
-        return unsafeBitCast(symbol, to: CGWindowListCreateImageFn.self)
-    }()
-
+    // ScreenCaptureKit replacement for the macOS-26-removed
+    // CGWindowListCreateImage window snapshot path. Callers still pass the
+    // same CoreGraphics-style options, but unsupported combinations degrade
+    // to nil instead of falling back to private/dlsym'd CoreGraphics symbols.
     static func image(
         bounds: CGRect = .null,
         listOption: CGWindowListOption,
         windowID: CGWindowID,
         imageOption: CGWindowImageOption
-    ) -> CGImage? {
-        createImage?(bounds, listOption, windowID, imageOption)?.takeRetainedValue()
+    ) async -> CGImage? {
+        _ = listOption
+
+        do {
+            let content = try await SCShareableContent.current
+            guard let window = content.windows.first(where: { $0.windowID == windowID }) else {
+                return nil
+            }
+
+            let filter = SCContentFilter(desktopIndependentWindow: window)
+            let contentInfo = SCShareableContent.info(for: filter)
+            let configuration = SCStreamConfiguration()
+
+            if let sourceRect = sourceRect(from: bounds) {
+                configuration.sourceRect = sourceRect
+            }
+
+            let pointSize = captureSize(
+                bounds: bounds,
+                contentRect: contentInfo.contentRect,
+                windowFrame: window.frame
+            )
+            let scale = outputScale(for: imageOption, contentInfo: contentInfo)
+            configuration.width = max(1, Int((pointSize.width * scale).rounded(.up)))
+            configuration.height = max(1, Int((pointSize.height * scale).rounded(.up)))
+            configuration.captureResolution = captureResolution(for: imageOption)
+            configuration.scalesToFit = true
+            configuration.preservesAspectRatio = true
+            configuration.showsCursor = false
+            configuration.ignoreShadowsSingleWindow = imageOption.contains(.boundsIgnoreFraming)
+            configuration.ignoreGlobalClipSingleWindow = true
+            configuration.capturesShadowsOnly = imageOption.contains(.onlyShadows)
+            configuration.shouldBeOpaque = imageOption.contains(.shouldBeOpaque)
+
+            return try await SCScreenshotManager.captureImage(
+                contentFilter: filter,
+                configuration: configuration
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func sourceRect(from bounds: CGRect) -> CGRect? {
+        guard !bounds.isNull, !bounds.isInfinite, !bounds.isEmpty else {
+            return nil
+        }
+        return bounds
+    }
+
+    private static func captureSize(
+        bounds: CGRect,
+        contentRect: CGRect,
+        windowFrame: CGRect
+    ) -> CGSize {
+        if let sourceRect = sourceRect(from: bounds) {
+            return sourceRect.size
+        }
+        if !contentRect.isNull, !contentRect.isEmpty {
+            return contentRect.size
+        }
+        return windowFrame.size
+    }
+
+    private static func captureResolution(
+        for imageOption: CGWindowImageOption
+    ) -> SCCaptureResolutionType {
+        if imageOption.contains(.bestResolution) {
+            return .best
+        }
+        if imageOption.contains(.nominalResolution) {
+            return .nominal
+        }
+        return .automatic
+    }
+
+    private static func outputScale(
+        for imageOption: CGWindowImageOption,
+        contentInfo: SCShareableContentInfo
+    ) -> CGFloat {
+        if imageOption.contains(.nominalResolution) {
+            return 1
+        }
+        return max(CGFloat(contentInfo.pointPixelScale), 1)
     }
 }

--- a/apps/mac/Sources/Core/Desktop/WindowPreviewStore.swift
+++ b/apps/mac/Sources/Core/Desktop/WindowPreviewStore.swift
@@ -53,31 +53,35 @@ final class WindowPreviewStore: ObservableObject {
         queue.async { [weak self] in
             guard let self else { return }
 
-            let cgImage = WindowCapture.image(
-                listOption: .optionIncludingWindow,
-                windowID: CGWindowID(wid),
-                imageOption: [.boundsIgnoreFraming, .nominalResolution]
-            )
+            Task { [weak self] in
+                guard let self else { return }
 
-            let image = cgImage.map {
-                NSImage(
-                    cgImage: $0,
-                    size: self.previewSize(for: frame)
+                let cgImage = await WindowCapture.image(
+                    listOption: .optionIncludingWindow,
+                    windowID: CGWindowID(wid),
+                    imageOption: [.boundsIgnoreFraming, .nominalResolution]
                 )
-            }
 
-            DispatchQueue.main.async {
-                self.loading.remove(wid)
-                let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
-                if let image {
-                    self.images[wid] = image
-                    self.touchLRU(wid)
-                    self.evictIfNeeded()
-                    if elapsedMs >= 80 {
-                        DiagnosticLog.shared.info("HUDPreview: captured wid=\(wid) in \(elapsedMs)ms")
+                let image = cgImage.map {
+                    NSImage(
+                        cgImage: $0,
+                        size: self.previewSize(for: frame)
+                    )
+                }
+
+                DispatchQueue.main.async {
+                    self.loading.remove(wid)
+                    let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+                    if let image {
+                        self.images[wid] = image
+                        self.touchLRU(wid)
+                        self.evictIfNeeded()
+                        if elapsedMs >= 80 {
+                            DiagnosticLog.shared.info("HUDPreview: captured wid=\(wid) in \(elapsedMs)ms")
+                        }
+                    } else {
+                        DiagnosticLog.shared.info("HUDPreview: capture unavailable wid=\(wid) after \(elapsedMs)ms")
                     }
-                } else {
-                    DiagnosticLog.shared.info("HUDPreview: capture unavailable wid=\(wid) after \(elapsedMs)ms")
                 }
             }
         }

--- a/apps/mac/Sources/Core/HudsonKit/HudsonKitBridge.swift
+++ b/apps/mac/Sources/Core/HudsonKit/HudsonKitBridge.swift
@@ -1,0 +1,55 @@
+import Foundation
+import SwiftUI
+
+#if canImport(HudsonVoice)
+import HudsonVoice
+#endif
+
+/// Spike switch for migrating Lattices surfaces onto HudsonKit.
+///
+/// HudsonKit (git@github.com:arach/hudson.git) was extracted from Lattices'
+/// own surface patterns, so its `HudsonShell` / `HudsonUI` / `HudsonVoice` /
+/// `HudAI` modules map almost 1:1 onto Lattices' local overlays. This flag lets
+/// us bring those up one surface at a time without a big-bang cutover.
+///
+/// Flip at runtime:  `defaults write dev.lattices.app useHudsonKit -bool YES`
+enum HudsonKitSwitch {
+    static var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: "useHudsonKit")
+    }
+
+    /// Route the workspace-assistant chat through HudsonKit's `HudAIClient`
+    /// (with pi as a `HudAIProviderAdapter`) instead of driving `PiRpcRuntime`
+    /// directly. Independent of the voice switch so each surface can be cut over
+    /// on its own.
+    ///
+    /// Flip at runtime:  `defaults write dev.lattices.app useHudAIChat -bool YES`
+    static var useHudAIChat: Bool {
+        UserDefaults.standard.bool(forKey: "useHudAIChat")
+    }
+
+    /// Whether the HudsonKit voice surface is compiled in
+    /// (the `HudsonVoice` product only exists when the app is built with
+    /// `HUDSONKIT_WITH_VOICE=1`).
+    static var voiceAvailable: Bool {
+        #if canImport(HudsonVoice)
+        return true
+        #else
+        return false
+        #endif
+    }
+}
+
+#if canImport(HudsonVoice)
+/// The HudsonKit-backed voice surface. `HudVoicePanel` manages its own live
+/// session against the local voxd daemon — by default `127.0.0.1:42137`, the
+/// exact endpoint Lattices' own `VoxClient` discovers via `~/.vox/runtime.json`,
+/// so it lights up against the same daemon with no extra wiring.
+struct HudsonVoiceSurface: View {
+    var onClose: () -> Void
+
+    var body: some View {
+        HudVoicePanel()
+    }
+}
+#endif

--- a/apps/mac/Sources/Core/Overlays/AppWindowShell.swift
+++ b/apps/mac/Sources/Core/Overlays/AppWindowShell.swift
@@ -13,6 +13,10 @@ struct AppWindowShell {
         var minSize: NSSize
         var maxSize: NSSize
         var miniaturizable: Bool = true
+        /// Let content fill the whole window, including under the title bar, so
+        /// chrome (e.g. a tab strip) can sit in the traffic-light row instead of
+        /// below a reserved title band.
+        var fullSizeContent: Bool = false
     }
 
     /// Create a styled NSWindow hosting a SwiftUI root view.
@@ -27,6 +31,7 @@ struct AppWindowShell {
 
         var styleMask: NSWindow.StyleMask = [.titled, .closable, .resizable]
         if config.miniaturizable { styleMask.insert(.miniaturizable) }
+        if config.fullSizeContent { styleMask.insert(.fullSizeContentView) }
 
         let w = NSWindow(
             contentRect: NSRect(origin: .zero, size: config.initialSize),

--- a/apps/mac/Sources/Core/Overlays/HUD/DesktopCapture.swift
+++ b/apps/mac/Sources/Core/Overlays/HUD/DesktopCapture.swift
@@ -1,6 +1,7 @@
 import AppKit
 import CoreImage
 import Foundation
+import ScreenCaptureKit
 
 // Grabs a snapshot of the screen region under the HUD panels (before they become visible)
 // and runs a CIFilter pipeline to produce a blurred, desaturated "desktop impression".
@@ -10,14 +11,17 @@ final class DesktopCapture {
 
     private let ciContext = CIContext(options: [.useSoftwareRenderer: false])
 
-    func captureScreen(_ screen: NSScreen) -> NSImage? {
+    // ScreenCaptureKit replaces the macOS-26-removed CGWindowListCreateImage.
+    // Capture is async; the only caller (HUDController.captureDesktop) already
+    // runs it off the main thread and assigns the result asynchronously.
+    func captureScreen(_ screen: NSScreen) async -> NSImage? {
         // Panels are at alpha=0 when this fires, so the capture naturally excludes them.
-        guard let cgImage = CGWindowListCreateImage(
-            screen.frame,
-            .optionOnScreenOnly,
-            kCGNullWindowID,
-            .bestResolution
-        ) else { return nil }
+        let cgImage: CGImage? = await withCheckedContinuation { continuation in
+            SCScreenshotManager.captureImage(in: screen.frame) { image, _ in
+                continuation.resume(returning: image)
+            }
+        }
+        guard let cgImage else { return nil }
         return filtered(cgImage)
     }
 

--- a/apps/mac/Sources/Core/Overlays/HUD/HUDController.swift
+++ b/apps/mac/Sources/Core/Overlays/HUD/HUDController.swift
@@ -1258,9 +1258,9 @@ final class HUDController {
 
     private func captureDesktop() {
         guard let screen = positionedScreen ?? NSScreen.main ?? NSScreen.screens.first else { return }
-        DispatchQueue.global(qos: .userInitiated).async {
-            let image = DesktopCapture.shared.captureScreen(screen)
-            DispatchQueue.main.async {
+        Task {
+            let image = await DesktopCapture.shared.captureScreen(screen)
+            await MainActor.run {
                 HUDExperienceStore.shared.capturedBackground = image
             }
         }

--- a/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapState.swift
+++ b/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapState.swift
@@ -2758,20 +2758,26 @@ final class ScreenMapController: ObservableObject {
         let visible = ed.focusedVisibleWindows
         guard !visible.isEmpty else { flash("No windows to preview"); return }
 
-        var captures: [UInt32: NSImage] = [:]
-        for win in visible {
-            if let cgImage = WindowCapture.image(
-                listOption: .optionIncludingWindow,
-                windowID: CGWindowID(win.id),
-                imageOption: [.boundsIgnoreFraming, .bestResolution]
-            ) {
-                captures[win.id] = NSImage(cgImage: cgImage,
-                    size: NSSize(width: win.virtualFrame.width, height: win.virtualFrame.height))
+        Task { [weak self, weak ed] in
+            var captures: [UInt32: NSImage] = [:]
+            for win in visible {
+                if let cgImage = await WindowCapture.image(
+                    listOption: .optionIncludingWindow,
+                    windowID: CGWindowID(win.id),
+                    imageOption: [.boundsIgnoreFraming, .bestResolution]
+                ) {
+                    captures[win.id] = NSImage(cgImage: cgImage,
+                        size: NSSize(width: win.virtualFrame.width, height: win.virtualFrame.height))
+                }
+            }
+
+            await MainActor.run {
+                guard let self, let ed, self.editor === ed, !ed.isPreviewing else { return }
+                self.previewCaptures = captures
+                ed.isPreviewing = true
+                self.objectWillChange.send()
             }
         }
-        previewCaptures = captures
-        ed.isPreviewing = true
-        objectWillChange.send()
     }
 
     func showPreviewWindow(contentView: NSView, frame: NSRect) {
@@ -2891,7 +2897,8 @@ final class WindowBezel {
     var isVisible: Bool { panel?.isVisible ?? false }
 
     /// Show or update bezel for a known ScreenMapWindowEntry.
-    func show(for win: ScreenMapWindowEntry, editor: ScreenMapEditorState) {
+    @MainActor
+    func show(for win: ScreenMapWindowEntry, editor: ScreenMapEditorState) async {
         let screens = NSScreen.screens
         guard !screens.isEmpty else { return }
         let primaryHeight = screens.first!.frame.height
@@ -2985,14 +2992,14 @@ final class WindowBezel {
         let tightSize = CGSize(width: tightFrame.width, height: tightFrame.height)
 
         // Capture window content for screenshot tool compositing
-        let windowSnapshot: NSImage? = {
-            guard let cgImage = WindowCapture.image(
-                listOption: .optionIncludingWindow,
-                windowID: win.id,
-                imageOption: [.bestResolution, .boundsIgnoreFraming]
-            ) else { return nil }
-            return NSImage(cgImage: cgImage, size: NSSize(width: cgFrame.width, height: cgFrame.height))
-        }()
+        let snapshotCGImage = await WindowCapture.image(
+            listOption: .optionIncludingWindow,
+            windowID: win.id,
+            imageOption: [.bestResolution, .boundsIgnoreFraming]
+        )
+        let windowSnapshot = snapshotCGImage.map {
+            NSImage(cgImage: $0, size: NSSize(width: cgFrame.width, height: cgFrame.height))
+        }
 
         let bezelView = ShowOnScreenBezelView(
             appName: win.app,
@@ -3050,7 +3057,7 @@ final class WindowBezel {
                 p.orderFrontRegardless()
             }
 
-            NSAnimationContext.runAnimationGroup { ctx in
+            await NSAnimationContext.runAnimationGroup { ctx in
                 ctx.duration = 0.15
                 p.animator().alphaValue = 1.0
             }
@@ -3060,7 +3067,7 @@ final class WindowBezel {
                 p.order(.below, relativeTo: targetWinNum)
             }
 
-            NSAnimationContext.runAnimationGroup { ctx in
+            await NSAnimationContext.runAnimationGroup { ctx in
                 ctx.duration = 0.2
                 ctx.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
                 p.animator().setFrame(tightFrame, display: true)
@@ -3106,7 +3113,9 @@ final class WindowBezel {
         guard let ed = ctrl.editor,
               let win = ed.windows.first(where: { $0.id == wid }) else { return }
 
-        shared.show(for: win, editor: ed)
+        Task { @MainActor in
+            await shared.show(for: win, editor: ed)
+        }
     }
 
     func dismiss() {

--- a/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapWindowController.swift
+++ b/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapWindowController.swift
@@ -74,9 +74,11 @@ final class ScreenMapWindowController: ObservableObject {
         let w = AppWindowShell.makeWindow(
             config: .init(
                 title: "Lattices",
+                titleVisible: false,
                 initialSize: initialSize,
                 minSize: NSSize(width: 600, height: 400),
-                maxSize: NSSize(width: 2400, height: 1600)
+                maxSize: NSSize(width: 2400, height: 1600),
+                fullSizeContent: true
             ),
             rootView: view
         )

--- a/apps/mac/Sources/Core/Overlays/Voice/VoiceCommandWindow.swift
+++ b/apps/mac/Sources/Core/Overlays/Voice/VoiceCommandWindow.swift
@@ -22,6 +22,13 @@ final class VoiceCommandWindow {
     }
 
     func show() {
+        #if canImport(HudsonVoice)
+        if HudsonKitSwitch.isEnabled {
+            showHudsonVoice()
+            return
+        }
+        #endif
+
         // If panel exists but is hidden, just re-show it
         if let p = panel, state != nil {
             p.alphaValue = 0
@@ -82,6 +89,62 @@ final class VoiceCommandWindow {
         // Auto-start listening immediately
         voiceState.startListening()
     }
+
+    #if canImport(HudsonVoice)
+    /// HudsonKit voice surface (spike). Hosts `HudVoicePanel`, which runs its
+    /// own live session against the same voxd daemon Lattices uses. Escape
+    /// dismisses directly (no `VoiceCommandState` is involved in this path).
+    private func showHudsonVoice() {
+        if let p = panel {
+            p.alphaValue = 0
+            p.orderFrontRegardless()
+            NSAnimationContext.runAnimationGroup { ctx in
+                ctx.duration = 0.15
+                p.animator().alphaValue = 1.0
+            }
+            return
+        }
+
+        let view = HudsonVoiceSurface { [weak self] in self?.dismiss() }
+            .preferredColorScheme(.dark)
+
+        let mouseLocation = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first(where: { $0.frame.contains(mouseLocation) })
+            ?? NSScreen.main
+            ?? NSScreen.screens.first!
+        let visible = screen.visibleFrame
+        let panelWidth: CGFloat = min(900, visible.width - 80)
+        let panelHeight: CGFloat = min(560, visible.height - 80)
+
+        let p = OverlayPanelShell.makePanel(
+            config: .init(
+                size: NSSize(width: panelWidth, height: panelHeight),
+                styleMask: [.titled, .nonactivatingPanel],
+                titleVisible: .hidden,
+                titlebarAppearsTransparent: true,
+                background: .clear,
+                hidesOnDeactivate: false,
+                isMovableByWindowBackground: true,
+                activatesOnMouseDown: true,
+                onKeyDown: { [weak self] event in
+                    if event.keyCode == 53 { self?.dismiss() }  // Escape
+                },
+                onFlagsChanged: { _ in }
+            ),
+            rootView: view
+        )
+        OverlayPanelShell.position(p, placement: .topCenter(margin: 40))
+
+        p.alphaValue = 0
+        OverlayPanelShell.present(p, activate: true, makeKey: true, orderFrontRegardless: true)
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = 0.15
+            p.animator().alphaValue = 1.0
+        }
+
+        self.panel = p
+    }
+    #endif
 
     func dismiss() {
         guard let p = panel else { return }

--- a/apps/mac/Sources/Core/Pi/AgentTurnView.swift
+++ b/apps/mac/Sources/Core/Pi/AgentTurnView.swift
@@ -1,0 +1,193 @@
+import SwiftUI
+
+// Agent-session turn rendering — a self-contained Swift component for drawing a
+// single turn in an agent conversation (user prompt, assistant response, or a
+// system note). It is deliberately transport-agnostic: it renders a plain
+// `AgentTurn` value and knows nothing about PiChatSession, pi RPC, HudAIClient,
+// or any broker. Feed it a value, get a rendered turn.
+//
+// This is the slice worth sharing across surfaces (and eventually lifting into
+// HudsonUI, themed via hudTheme). For now it renders with Lattices' Palette/Typo
+// and composes the existing markdown / streaming / indicator atoms.
+
+// MARK: - Model
+
+enum AgentTurnRole: Equatable {
+    case user
+    case assistant
+    case system
+}
+
+/// One turn in an agent conversation. A pure value — the rendering unit's only
+/// input. Adapters (e.g. `PiChatMessageRow`) map their own message types onto it.
+struct AgentTurn: Identifiable, Equatable {
+    let id: UUID
+    var role: AgentTurnRole
+    /// Display label for the speaker — "You", "Assistant", or an agent name.
+    var author: String
+    var timestamp: Date
+    var text: String
+    /// True while this turn is still being produced (drives streaming visuals).
+    var isStreaming: Bool
+    /// Name of a tool the agent is currently running, if any.
+    var toolActivity: String?
+
+    init(
+        id: UUID,
+        role: AgentTurnRole,
+        author: String,
+        timestamp: Date,
+        text: String,
+        isStreaming: Bool = false,
+        toolActivity: String? = nil
+    ) {
+        self.id = id
+        self.role = role
+        self.author = author
+        self.timestamp = timestamp
+        self.text = text
+        self.isStreaming = isStreaming
+        self.toolActivity = toolActivity
+    }
+}
+
+// MARK: - View
+
+struct AgentTurnView: View, Equatable {
+    let turn: AgentTurn
+    var style: PiChatStyle = .workspace
+
+    static func == (lhs: AgentTurnView, rhs: AgentTurnView) -> Bool {
+        lhs.turn == rhs.turn && lhs.style == rhs.style
+    }
+
+    var body: some View {
+        switch turn.role {
+        case .system:    systemRow
+        case .user:      speakerRow(isAssistant: false)
+        case .assistant: speakerRow(isAssistant: true)
+        }
+    }
+
+    // MARK: System
+
+    private var systemRow: some View {
+        HStack {
+            Spacer(minLength: 0)
+            Text(turn.text)
+                .font(Typo.caption(11))
+                .foregroundColor(Palette.textDim)
+                .multilineTextAlignment(.center)
+                .textSelection(.enabled)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(Color.white.opacity(0.03))
+                        .overlay(
+                            Capsule(style: .continuous)
+                                .strokeBorder(Palette.border, lineWidth: 0.5)
+                        )
+                )
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 2)
+    }
+
+    // MARK: User / Assistant
+    //
+    // Flat editorial thread (ported from OpenScout's HUDAssistantView): a glyph
+    // + label + timestamp header, then the body indented beneath it. No bubbles,
+    // no glow — hierarchy comes from the label row and the hanging indent, the
+    // way a printed transcript reads.
+
+    private var streaming: Bool { turn.isStreaming }
+
+    @ViewBuilder
+    private func speakerRow(isAssistant: Bool) -> some View {
+        VStack(alignment: .leading, spacing: isAssistant ? 6 : 4) {
+            header(isAssistant: isAssistant)
+
+            if isAssistant, streaming, let tool = turn.toolActivity {
+                PiChatToolChip(name: tool, compact: true)
+                    .padding(.leading, 23)
+            }
+
+            bodyContent(isAssistant: isAssistant)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.leading, 23)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(threadCard(streaming: isAssistant && streaming))
+    }
+
+    @ViewBuilder
+    private func header(isAssistant: Bool) -> some View {
+        HStack(alignment: .center, spacing: 7) {
+            if isAssistant {
+                LatticesMarkAvatar(size: 16, tint: Palette.running, isActive: streaming)
+            } else {
+                Image(systemName: "person.fill")
+                    .font(.system(size: 8, weight: .semibold))
+                    .foregroundColor(Palette.bg)
+                    .frame(width: 16, height: 16)
+                    .background(Circle().fill(Palette.text.opacity(0.55)))
+            }
+
+            Text(turn.author)
+                .font(Typo.geistMonoBold(10))
+                .tracking(0.3)
+                .foregroundColor(authorColor(isAssistant: isAssistant))
+
+            if isAssistant {
+                if streaming {
+                    PiChatStreamingBadge()
+                } else if let tool = turn.toolActivity {
+                    PiChatToolChip(name: tool)
+                }
+            }
+
+            Spacer(minLength: 8)
+
+            Text(PiChatFormat.time(turn.timestamp))
+                .font(Typo.mono(9))
+                .foregroundColor(Palette.textMuted.opacity(isAssistant ? 0.75 : 0.8))
+        }
+    }
+
+    @ViewBuilder
+    private func bodyContent(isAssistant: Bool) -> some View {
+        if isAssistant {
+            if turn.text.isEmpty, streaming {
+                PiChatWorkingIndicator(label: "Composing")
+            } else {
+                PiChatFormattedText(turn.text, style: style, isStreaming: streaming)
+            }
+        } else {
+            Text(turn.text)
+                .font(Typo.reading(style.bodySize))
+                .foregroundColor(Palette.text)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func authorColor(isAssistant: Bool) -> Color {
+        guard isAssistant else { return Palette.text }
+        return streaming ? Palette.running.opacity(0.95) : Palette.textDim
+    }
+
+    // Full-width turn container — a little structure without heavy bubbles: a
+    // faint fill + hairline, brightening slightly while the assistant streams.
+    private func threadCard(streaming: Bool) -> some View {
+        RoundedRectangle(cornerRadius: 11, style: .continuous)
+            .fill(Color.white.opacity(streaming ? 0.032 : 0.020))
+            .overlay(
+                RoundedRectangle(cornerRadius: 11, style: .continuous)
+                    .strokeBorder(streaming ? Palette.running.opacity(0.22) : Palette.border, lineWidth: 0.5)
+            )
+    }
+}

--- a/apps/mac/Sources/Core/Pi/PiChatMarkdown.swift
+++ b/apps/mac/Sources/Core/Pi/PiChatMarkdown.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+import HudsonUI
+
+// Lattices message markdown now renders through HudsonUI's shared
+// `HudMarkdownView` — the block parser + renderer that originated here (ported
+// from OpenScout's MessageMarkupParser/CommsMessageMarkup) was donated upstream
+// into HudsonUI so Lattices and OpenScout share one themed renderer instead of
+// each maintaining a drifting copy. This thin adapter keeps existing call sites
+// stable and maps Lattices' content sizing onto the shared component.
+
+struct PiChatMarkdownView: View {
+    let text: String
+    var style: PiChatStyle = .workspace
+
+    var body: some View {
+        HudMarkdownView(text: text, contentSize: style.bodySize)
+    }
+}

--- a/apps/mac/Sources/Core/Pi/PiChatSession.swift
+++ b/apps/mac/Sources/Core/Pi/PiChatSession.swift
@@ -1,5 +1,9 @@
 import AppKit
+import Combine
 import Foundation
+#if canImport(HudsonAI)
+import HudsonAI
+#endif
 
 struct PiChatMessage: Identifiable, Equatable {
     enum Role {
@@ -206,9 +210,18 @@ final class PiChatSession: ObservableObject {
     private var voiceRuntimeProviderID: String?
 
     private var streamingMessageID: UUID?
-    private var streamingPendingText: String?
-    private var streamingFlushScheduled: Bool = false
-    private static let streamingFlushInterval: TimeInterval = 1.0 / 30.0
+    // Display drain — decouples on-screen reveal from network arrival cadence so
+    // chunky provider bursts flow in smoothly (and a wait-then-dump final still
+    // animates in). `targetText` is everything received so far; `displayedCount`
+    // is how many characters have been revealed; a 60Hz timer eases the gap shut.
+    private var streamingTargetText: String = ""
+    private var streamingDisplayedCount: Int = 0
+    private var streamingClosing: Bool = false
+    private var streamingDrainTimer: Timer?
+    // Ticks to idle before revealing more — used to add a natural reading beat
+    // after sentence/clause punctuation so the stream doesn't read robotically.
+    private var streamingHoldTicks: Int = 0
+    private static let streamingDrainInterval: TimeInterval = 1.0 / 60.0
 
     private static let selectedProviderDefaultsKey = "PiChatSelectedProvider"
     private static let voiceInferenceTimeout: TimeInterval = 45
@@ -225,6 +238,11 @@ final class PiChatSession: ObservableObject {
         Respond concisely. Follow the response format requested in each prompt exactly.
         """
     private static let dockHeightDefaultsKey = "PiChatDockHeight"
+
+    #if canImport(HudsonVoice)
+    /// Drains finalized voice transcripts from the Hudson-powered mic into the composer draft.
+    private var voiceInputCancellable: AnyCancellable?
+    #endif
 
     private init() {
         let fm = FileManager.default
@@ -252,6 +270,20 @@ final class PiChatSession: ObservableObject {
         reloadAuthState()
         refreshBinaryAvailability()
         cleanupLingeringAuthHelpers()
+
+        #if canImport(HudsonVoice)
+        // Splice finalized voice transcripts into the draft (one-shot, then drain),
+        // mirroring OpenScout's HUDDockState lastFinalText subscription.
+        voiceInputCancellable = WorkspaceVoiceInput.shared.$lastFinalText
+            .receive(on: RunLoop.main)
+            .sink { [weak self] text in
+                guard let self else { return }
+                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else { return }
+                self.draft = WorkspaceDictationBuffer.appending(trimmed, to: self.draft)
+                WorkspaceVoiceInput.shared.consumeFinalText()
+            }
+        #endif
     }
 
     var hasPiBinary: Bool {
@@ -524,8 +556,21 @@ final class PiChatSession: ObservableObject {
         ))
 
         streamingMessageID = messageID
-        streamingPendingText = nil
-        streamingFlushScheduled = false
+        resetStreamingDrain()
+
+        #if canImport(HudsonAI)
+        if HudsonKitSwitch.useHudAIChat {
+            sendViaHudAIClient(
+                prompt: prompt,
+                runtime: runtime,
+                providerName: provider.name,
+                modelID: provider.id,
+                messageID: messageID,
+                inferenceTimer: inferenceTimer
+            )
+            return
+        }
+        #endif
 
         var streamedText = ""
         runtime.promptAndFetchAssistantText(
@@ -571,6 +616,81 @@ final class PiChatSession: ObservableObject {
             }
         }
     }
+
+    #if canImport(HudsonAI)
+    /// Drive a chat turn through HudsonKit's `HudAIClient` with pi as the
+    /// provider adapter, instead of calling `PiRpcRuntime` directly. Gated on
+    /// `HudsonKitSwitch.useHudAIChat`. Feeds the same 30fps-coalesced streaming
+    /// commit path as the native pi route, so the rendered result is identical —
+    /// this is the seam where pi becomes "one of the providers HudAIClient
+    /// supports", alongside the HTTP adapters.
+    private func sendViaHudAIClient(
+        prompt: String,
+        runtime: PiRpcRuntime,
+        providerName: String,
+        modelID: String,
+        messageID: UUID,
+        inferenceTimer: DiagnosticLog.TimedAction
+    ) {
+        let adapter = PiHudAIAdapter(
+            displayName: providerName,
+            defaultModel: modelID,
+            runtimeProvider: { runtime }
+        )
+        let client = HudAIClient(
+            provider: adapter,
+            vault: NullHudAICredentialSource(),
+            defaults: HudAIDefaults(timeout: 120),
+            routeDefault: .local
+        )
+        let request = HudAIRequest(messages: [.user(prompt)])
+
+        Task {
+            var streamed = ""
+            do {
+                for try await event in client.stream(request) {
+                    switch event {
+                    case .textDelta(_, let text):
+                        streamed += text
+                        let snapshot = streamed
+                        DispatchQueue.main.async { [weak self] in
+                            guard let self else { return }
+                            if self.statusText == "thinking..." { self.statusText = "streaming..." }
+                            self.commitStreamingText(snapshot)
+                        }
+                    case .toolCallStarted(_, let name):
+                        DispatchQueue.main.async { [weak self] in self?.statusText = "tool: \(name)" }
+                    case .completed(let response):
+                        let final = response.text.isEmpty ? streamed : response.text
+                        DispatchQueue.main.async { [weak self] in
+                            guard let self else { return }
+                            self.isSending = false
+                            self.statusText = "idle"
+                            DiagnosticLog.shared.finish(inferenceTimer)
+                            self.finalizeStreaming(finalText: final)
+                        }
+                    case .failed:
+                        // HudAIClient always finishes(throwing:) right after .failed,
+                        // so the catch below owns failure handling (avoids double-fire).
+                        break
+                    default:
+                        break
+                    }
+                }
+            } catch {
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { return }
+                    self.isSending = false
+                    DiagnosticLog.shared.error("Chat inference (HudAIClient) failed: \(error.localizedDescription)")
+                    self.cancelPendingStreamingFlush()
+                    self.removeMessageIfEmpty(id: messageID)
+                    self.streamingMessageID = nil
+                    self.handleInferenceFailure(error.localizedDescription)
+                }
+            }
+        }
+    }
+    #endif
 
     func askVoiceAdvisor(transcript: String, matched: String, callback: @escaping (AgentResponse?) -> Void) {
         runVoiceInference(
@@ -697,34 +817,124 @@ final class PiChatSession: ObservableObject {
         messages[index].text = text
     }
 
+    /// Record the latest accumulated snapshot as the drain target. The reveal
+    /// itself happens on the drain timer, not here — so a chunky burst doesn't
+    /// snap onto the screen all at once.
     private func commitStreamingText(_ text: String) {
-        streamingPendingText = text
-        if streamingFlushScheduled { return }
-        streamingFlushScheduled = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + Self.streamingFlushInterval) { [weak self] in
-            self?.flushPendingStreamingText()
+        streamingTargetText = text
+        startStreamingDrainIfNeeded()
+    }
+
+    private func resetStreamingDrain() {
+        streamingDrainTimer?.invalidate()
+        streamingDrainTimer = nil
+        streamingTargetText = ""
+        streamingDisplayedCount = 0
+        streamingClosing = false
+        streamingHoldTicks = 0
+    }
+
+    private func startStreamingDrainIfNeeded() {
+        guard streamingDrainTimer == nil else { return }
+        let timer = Timer.scheduledTimer(withTimeInterval: Self.streamingDrainInterval, repeats: true) { [weak self] _ in
+            self?.tickStreamingDrain()
+        }
+        // .common so the drain keeps ticking during scroll/tracking runloops.
+        RunLoop.main.add(timer, forMode: .common)
+        streamingDrainTimer = timer
+    }
+
+    /// One reveal step: ease the displayed length toward the target, snapping to
+    /// a word boundary so words land whole. Faster while closing so the message
+    /// settles promptly once the network is done.
+    private func tickStreamingDrain() {
+        guard let id = streamingMessageID else {
+            streamingDrainTimer?.invalidate()
+            streamingDrainTimer = nil
+            return
+        }
+
+        // Honor a pending reading beat (skip this tick) before revealing more.
+        if streamingHoldTicks > 0 {
+            streamingHoldTicks -= 1
+            return
+        }
+
+        let target = streamingTargetText
+        let targetCount = target.count
+
+        if streamingDisplayedCount >= targetCount {
+            if streamingClosing {
+                updateAssistantMessage(id: id, text: target)
+                streamingDrainTimer?.invalidate()
+                streamingDrainTimer = nil
+                streamingMessageID = nil
+            }
+            return
+        }
+
+        let gap = targetCount - streamingDisplayedCount
+        let fraction = streamingClosing ? 0.45 : 0.22
+        let minStep = streamingClosing ? 6 : 2
+        var step = max(minStep, Int((Double(gap) * fraction).rounded()))
+        step = min(step, gap)
+        let proposed = streamingDisplayedCount + step
+        streamingDisplayedCount = snapToWordBoundary(in: target, proposed: proposed)
+        updateAssistantMessage(id: id, text: String(target.prefix(streamingDisplayedCount)))
+
+        // After landing on a word boundary, add a reading beat if we just
+        // finished a sentence or clause — but never while racing to settle, and
+        // never if there's a huge backlog to catch up on.
+        if !streamingClosing, gap < 240 {
+            streamingHoldTicks = readingBeat(in: target, revealedCount: streamingDisplayedCount)
         }
     }
 
-    private func flushPendingStreamingText() {
-        streamingFlushScheduled = false
-        guard let id = streamingMessageID,
-              let text = streamingPendingText else { return }
-        streamingPendingText = nil
-        updateAssistantMessage(id: id, text: text)
+    /// Pause length (in 60Hz ticks) after the most recently revealed token:
+    /// a longer beat after sentence enders, a shorter one after clause marks.
+    private func readingBeat(in text: String, revealedCount: Int) -> Int {
+        let chars = Array(text)
+        // The boundary lands just past a space, so the sentence punctuation is a
+        // couple of characters back. Scan the last few non-space chars.
+        var idx = revealedCount - 1
+        var skippedSpace = false
+        while idx >= 0, idx >= revealedCount - 3 {
+            let c = chars[idx]
+            if c == " " || c == "\n" { skippedSpace = true; idx -= 1; continue }
+            guard skippedSpace || idx == revealedCount - 1 else { break }
+            switch c {
+            case ".", "!", "?":  return 10   // ~165ms — end of sentence
+            case ",", ";", ":":  return 5    // ~80ms  — clause break
+            default:             return 0
+            }
+        }
+        return 0
+    }
+
+    /// Extend `proposed` forward to just past the next space/newline (within a
+    /// small window) so the reveal doesn't stop mid-token.
+    private func snapToWordBoundary(in text: String, proposed: Int) -> Int {
+        let chars = Array(text)
+        guard proposed < chars.count else { return chars.count }
+        var i = proposed
+        let limit = min(chars.count, proposed + 16)
+        while i < limit {
+            if chars[i] == " " || chars[i] == "\n" { return i + 1 }
+            i += 1
+        }
+        return proposed
     }
 
     private func cancelPendingStreamingFlush() {
-        streamingPendingText = nil
-        streamingFlushScheduled = false
+        resetStreamingDrain()
     }
 
+    /// Hand the drain the final text and let it finish revealing. The drain
+    /// settles the message exactly and clears `streamingMessageID` once caught up.
     private func finalizeStreaming(finalText: String) {
-        cancelPendingStreamingFlush()
-        if let id = streamingMessageID {
-            updateAssistantMessage(id: id, text: finalText)
-        }
-        streamingMessageID = nil
+        streamingTargetText = finalText
+        streamingClosing = true
+        startStreamingDrainIfNeeded()
     }
 
     private func removeMessageIfEmpty(id: UUID) {

--- a/apps/mac/Sources/Core/Pi/PiChatUI.swift
+++ b/apps/mac/Sources/Core/Pi/PiChatUI.swift
@@ -1,4 +1,8 @@
 import SwiftUI
+import HudsonUI
+#if canImport(HudsonVoice)
+import HudsonVoice
+#endif
 
 // MARK: - Lattices mark
 
@@ -116,9 +120,20 @@ struct PiChatDotGrid: View {
 
 // MARK: - Transcript
 
+/// Scroll sample used to tell a user's upward scroll apart from content growth.
+private struct ScrollProbe: Equatable {
+    var offsetY: CGFloat
+    var atBottom: Bool
+}
+
 struct PiChatTranscript: View {
     @ObservedObject var session: PiChatSession
     var style: PiChatStyle = .workspace
+
+    /// True while the viewport is at (or near) the bottom. Auto-follow only
+    /// happens while pinned; scrolling up detaches and stops the chase until
+    /// the user returns to the bottom.
+    @State private var isPinnedToBottom = true
 
     var body: some View {
         if showsEmptyState {
@@ -177,17 +192,33 @@ struct PiChatTranscript: View {
             .scrollIndicators(.visible)
             .background(transcriptBackground)
             .animation(.spring(response: 0.34, dampingFraction: 0.86), value: session.messages.count)
-            .onAppear { scrollToEnd(proxy: proxy, animated: false) }
-            .onChange(of: session.messages.count) { _ in
-                scrollToEnd(proxy: proxy, animated: true)
-            }
-            .onChange(of: session.messages.last?.text) { _ in
-                if session.isSending {
-                    scrollToEnd(proxy: proxy, animated: false)
+            // Detach only on a genuine *upward* scroll — never because content
+            // grew underneath us (that would un-pin us mid-stream and stop the
+            // follow). Re-pin when the user lands back near the bottom.
+            .onScrollGeometryChange(for: ScrollProbe.self) { geo in
+                let maxOffset = geo.contentSize.height - geo.containerSize.height + geo.contentInsets.bottom
+                return ScrollProbe(offsetY: geo.contentOffset.y, atBottom: geo.contentOffset.y >= maxOffset - 48)
+            } action: { old, new in
+                if new.offsetY < old.offsetY - 2 {
+                    isPinnedToBottom = false          // user scrolled up
+                } else if new.atBottom {
+                    isPinnedToBottom = true            // user returned to the end
                 }
             }
+            .onAppear { scrollToEnd(proxy: proxy, animated: false) }
+            .onChange(of: session.messages.count) { _ in
+                // New message: follow only if the user is still pinned to the end.
+                if isPinnedToBottom { scrollToEnd(proxy: proxy, animated: true) }
+            }
+            .onChange(of: session.messages.last?.text) { _ in
+                // Chase the live edge while pinned. Not gated on isSending: the
+                // closing drain reveals the tail *after* isSending flips false.
+                if isPinnedToBottom { scrollToEnd(proxy: proxy, animated: false) }
+            }
             .onChange(of: session.isSending) { sending in
+                // Sending re-pins: a fresh turn always snaps you back to the end.
                 if sending {
+                    isPinnedToBottom = true
                     scrollToEnd(proxy: proxy, animated: true)
                 }
             }
@@ -270,8 +301,6 @@ private struct PiChatEmptyState: View {
 
     var body: some View {
         VStack(spacing: 28) {
-            Spacer(minLength: 8)
-
             VStack(spacing: 14) {
                 LatticesMarkAvatar(size: 56, tint: Palette.running)
                     .shadow(color: Palette.running.opacity(0.30), radius: 18, y: 4)
@@ -281,7 +310,7 @@ private struct PiChatEmptyState: View {
                         .font(Typo.title(20))
                         .foregroundColor(Palette.text)
                     Text(headerSubtitle)
-                        .font(Typo.body(12.5))
+                        .font(Typo.body(12))
                         .foregroundColor(Palette.textDim)
                         .multilineTextAlignment(.center)
                         .fixedSize(horizontal: false, vertical: true)
@@ -313,7 +342,9 @@ private struct PiChatEmptyState: View {
             Spacer(minLength: 0)
         }
         .padding(.horizontal, 32)
-        .padding(.vertical, 24)
+        .padding(.top, 40)
+        .padding(.bottom, 24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
 
     private var headerSubtitle: String {
@@ -333,10 +364,10 @@ private struct PiChatEmptyState: View {
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(starter.title)
-                    .font(.system(size: 12.5, weight: .semibold, design: .rounded))
+                    .font(.system(size: 12, weight: .semibold, design: .rounded))
                     .foregroundColor(Palette.text)
                 Text(starter.subtitle)
-                    .font(Typo.caption(10.5))
+                    .font(Typo.caption(10))
                     .foregroundColor(Palette.textDim)
                     .lineLimit(2)
                     .multilineTextAlignment(.leading)
@@ -402,186 +433,39 @@ struct PiChatMessageRow: View, Equatable {
     }
 
     var body: some View {
+        AgentTurnView(turn: turn, style: style)
+    }
+
+    /// Map this transport-specific message onto the transport-agnostic turn
+    /// model the renderer consumes.
+    private var turn: AgentTurn {
+        AgentTurn(
+            id: message.id,
+            role: agentRole,
+            author: agentAuthor,
+            timestamp: message.timestamp,
+            text: message.text,
+            isStreaming: isStreaming,
+            toolActivity: activeToolName
+        )
+    }
+
+    private var agentRole: AgentTurnRole {
         switch message.role {
-        case .system:
-            systemRow
-        case .user:
-            userRow
-        case .assistant:
-            assistantRow
+        case .system:    return .system
+        case .user:      return .user
+        case .assistant: return .assistant
         }
     }
 
-    private var systemRow: some View {
-        HStack {
-            Spacer(minLength: 0)
-            Text(message.text)
-                .font(Typo.caption(11))
-                .foregroundColor(Palette.textDim)
-                .multilineTextAlignment(.center)
-                .textSelection(.enabled)
-                .padding(.horizontal, 16)
-                .padding(.vertical, 10)
-                .background(
-                    Capsule(style: .continuous)
-                        .fill(Color.white.opacity(0.03))
-                        .overlay(
-                            Capsule(style: .continuous)
-                                .strokeBorder(Palette.border, lineWidth: 0.5)
-                        )
-                )
-            Spacer(minLength: 0)
-        }
-        .padding(.vertical, 2)
-    }
-
-    private var userRow: some View {
-        HStack(alignment: .bottom, spacing: 10) {
-            Spacer(minLength: style == .workspace ? 96 : 48)
-
-            VStack(alignment: .trailing, spacing: 5) {
-                Text(message.text)
-                    .font(Typo.body(style.bodySize))
-                    .foregroundColor(Palette.text)
-                    .multilineTextAlignment(.trailing)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: 540, alignment: .trailing)
-
-                Text(PiChatFormat.time(message.timestamp))
-                    .font(Typo.caption(9))
-                    .foregroundColor(Palette.textMuted.opacity(0.85))
-            }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 11)
-            .background(userBubbleBackground)
-
-            LatticesMarkAvatar(size: 28, tint: Color.white.opacity(0.55), isActive: false)
+    private var agentAuthor: String {
+        switch message.role {
+        case .system:    return ""
+        case .user:      return "You"
+        case .assistant: return "Assistant"
         }
     }
 
-    private var userBubbleBackground: some View {
-        RoundedRectangle(cornerRadius: 16, style: .continuous)
-            .fill(
-                LinearGradient(
-                    colors: [
-                        Color.white.opacity(0.11),
-                        Color.white.opacity(0.06),
-                    ],
-                    startPoint: .topLeading,
-                    endPoint: .bottomTrailing
-                )
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .strokeBorder(Color.white.opacity(0.10), lineWidth: 0.5)
-            )
-    }
-
-    private var assistantRow: some View {
-        HStack(alignment: .top, spacing: 10) {
-            LatticesMarkAvatar(size: 32, tint: Palette.running, isActive: isStreaming)
-
-            VStack(alignment: .leading, spacing: 8) {
-                HStack(spacing: 8) {
-                    Text("Assistant")
-                        .font(Typo.geistMonoBold(10))
-                        .tracking(0.4)
-                        .foregroundColor(isStreaming ? Palette.running.opacity(0.95) : Palette.textDim)
-
-                    if isStreaming {
-                        PiChatStreamingBadge()
-                    } else if let activeToolName {
-                        PiChatToolChip(name: activeToolName)
-                    }
-
-                    Spacer(minLength: 0)
-
-                    Text(PiChatFormat.time(message.timestamp))
-                        .font(Typo.caption(9))
-                        .foregroundColor(Palette.textMuted.opacity(0.75))
-                }
-
-                if isStreaming, let activeToolName {
-                    PiChatToolChip(name: activeToolName, compact: true)
-                }
-
-                Group {
-                    if message.text.isEmpty, isStreaming {
-                        PiChatWorkingIndicator(label: workingLabel)
-                    } else {
-                        PiChatFormattedText(
-                            message.text,
-                            style: style,
-                            isStreaming: isStreaming
-                        )
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 12)
-            .background(assistantBubbleBackground)
-
-            Spacer(minLength: style == .workspace ? 60 : 24)
-        }
-    }
-
-    private var workingLabel: String {
-        isStreaming ? "Composing" : "Working"
-    }
-
-    private var assistantBubbleBackground: some View {
-        RoundedRectangle(cornerRadius: 16, style: .continuous)
-            .fill(
-                LinearGradient(
-                    colors: isStreaming
-                        ? [Color.white.opacity(0.06), Color.white.opacity(0.025)]
-                        : [Color.white.opacity(0.04), Color.white.opacity(0.018)],
-                    startPoint: .top,
-                    endPoint: .bottom
-                )
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .fill(
-                        LinearGradient(
-                            colors: isStreaming
-                                ? [Palette.running.opacity(0.12), Color.white.opacity(0.02), Color.clear]
-                                : [Color.white.opacity(0.03), Color.clear],
-                            startPoint: .top,
-                            endPoint: .center
-                        )
-                    )
-            )
-            .overlay(alignment: .leading) {
-                if isStreaming {
-                    Rectangle()
-                        .fill(
-                            LinearGradient(
-                                colors: [Palette.running.opacity(0.65), Palette.running.opacity(0.10)],
-                                startPoint: .top,
-                                endPoint: .bottom
-                            )
-                        )
-                        .frame(width: 2)
-                        .padding(.vertical, 6)
-                        .clipShape(Capsule())
-                }
-            }
-            .overlay(
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .strokeBorder(
-                        isStreaming ? Palette.running.opacity(0.32) : Palette.border,
-                        lineWidth: 0.5
-                    )
-            )
-            .shadow(
-                color: isStreaming ? Palette.running.opacity(0.18) : .clear,
-                radius: 18,
-                y: 4
-            )
-            .animation(.easeInOut(duration: 0.28), value: isStreaming)
-    }
 }
 
 // MARK: - Tool chip
@@ -647,6 +531,8 @@ struct PiChatFormattedText: View, Equatable {
     var style: PiChatStyle = .workspace
     var isStreaming: Bool = false
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     init(_ text: String, style: PiChatStyle = .workspace, isStreaming: Bool = false) {
         self.text = text
         self.style = style
@@ -660,32 +546,56 @@ struct PiChatFormattedText: View, Equatable {
     var body: some View {
         if isStreaming {
             streamingText
-        } else if let rendered = renderBlocks() {
-            rendered
         } else {
-            fallbackText
+            PiChatMarkdownView(text: text, style: style)
         }
     }
 
     private var fallbackText: some View {
         Text(text)
-            .font(Typo.body(style.bodySize))
+            .font(Typo.reading(style.bodySize))
             .foregroundColor(Palette.text)
             .textSelection(.enabled)
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var streamingText: some View {
-        HStack(alignment: .lastTextBaseline, spacing: 0) {
-            Text(text)
-                .font(Typo.body(style.bodySize))
-                .foregroundColor(Palette.text)
-                .textSelection(.enabled)
+        // Split the (drained) text into stanzas. Word-level growth happens within
+        // the trailing stanza — that just updates its Text, no transition. A new
+        // stanza appearing is an insertion, so it fades + slides up as a unit:
+        // the "settle" motion. The cursor rides the last stanza.
+        let stanzas = text.components(separatedBy: "\n\n")
+        return VStack(alignment: .leading, spacing: 8) {
+            ForEach(Array(stanzas.enumerated()), id: \.offset) { index, stanza in
+                HStack(alignment: .lastTextBaseline, spacing: 0) {
+                    Text(stanza)
+                        .font(Typo.reading(style.bodySize))
+                        .foregroundColor(Palette.text)
+                        .textSelection(.enabled)
 
-            PiChatStreamCursor()
-                .padding(.leading, 1)
+                    if index == stanzas.count - 1 {
+                        PiChatStreamCursor()
+                            .padding(.leading, 1)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .transition(reduceMotion
+                    ? .opacity
+                    : .asymmetric(
+                        insertion: .opacity
+                            .combined(with: .move(edge: .bottom))
+                            .combined(with: .scale(scale: 0.97, anchor: .leading)),
+                        removal: .opacity
+                    ))
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        // Animate only on stanza-count changes, so per-word growth stays smooth
+        // (no layout jitter) while a landing stanza settles with a soft spring.
+        .animation(
+            reduceMotion ? nil : .spring(response: 0.32, dampingFraction: 0.82),
+            value: stanzas.count
+        )
     }
 
     /// Render the text as a vertical stack of either paragraph or code-block
@@ -812,422 +722,13 @@ struct PiChatCodeBlock: View {
     let language: String?
     let source: String
 
-    private var tokens: [PiChatCodeToken] {
-        PiChatSyntax.tokenize(source, language: language)
-    }
-
+    // Renders through HudsonUI's shared `HudCodeBlock` — the tokenizer that
+    // lived here was donated upstream (as `HudCodeSyntax`) so highlighting is
+    // maintained once, in the kit. Thin adapter; call sites stay stable.
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            HStack(spacing: 8) {
-                HStack(spacing: 5) {
-                    Circle().fill(Color(red: 0.93, green: 0.36, blue: 0.36)).frame(width: 6, height: 6)
-                    Circle().fill(Color(red: 0.96, green: 0.74, blue: 0.18)).frame(width: 6, height: 6)
-                    Circle().fill(Color(red: 0.30, green: 0.78, blue: 0.45)).frame(width: 6, height: 6)
-                }
-                Text((language ?? "code").uppercased())
-                    .font(Typo.geistMonoBold(8))
-                    .tracking(0.6)
-                    .foregroundColor(Palette.textMuted)
-                Spacer()
-                Button {
-                    let pb = NSPasteboard.general
-                    pb.clearContents()
-                    pb.setString(source, forType: .string)
-                } label: {
-                    Image(systemName: "doc.on.doc")
-                        .font(.system(size: 9, weight: .semibold))
-                        .foregroundColor(Palette.textMuted)
-                        .padding(4)
-                        .background(
-                            Circle()
-                                .fill(Color.white.opacity(0.04))
-                                .overlay(Circle().strokeBorder(Palette.border, lineWidth: 0.5))
-                        )
-                }
-                .buttonStyle(.plain)
-                .help("Copy code")
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background(Color.white.opacity(0.025))
-
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(alignment: .top, spacing: 0) {
-                    formattedBody
-                        .font(Typo.mono(12))
-                        .lineSpacing(2)
-                        .textSelection(.enabled)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 10)
-                }
-            }
-            .background(Color.black.opacity(0.32))
-        }
-        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .strokeBorder(Palette.border, lineWidth: 0.5)
-        )
-    }
-
-    private var formattedBody: Text {
-        var combined = Text("")
-        for token in tokens {
-            combined = combined + Text(token.text)
-                .foregroundColor(token.color)
-                .font(Typo.mono(12))
-        }
-        return combined
+        HudCodeBlock(language: language, source: source)
     }
 }
-
-struct PiChatCodeToken {
-    let text: String
-    let color: Color
-}
-
-/// Minimal hand-rolled syntax highlighter for the chat code blocks. Color
-/// choices match the lattices-green theme used elsewhere.
-enum PiChatSyntax {
-    private static let keyword = Palette.running
-    private static let string = Color(red: 0.85, green: 0.78, blue: 0.55)
-    private static let number = Color(red: 0.96, green: 0.65, blue: 0.14)
-    private static let comment = Palette.textMuted
-    private static let identifier = Color(red: 0.72, green: 0.83, blue: 0.92)
-    private static let punctuation = Palette.textDim
-
-    private static let jsLikeKeywords: Set<String> = [
-        "const", "let", "var", "function", "return", "if", "else", "for", "while",
-        "do", "switch", "case", "break", "continue", "import", "export", "from",
-        "as", "default", "class", "extends", "new", "this", "await", "async",
-        "yield", "try", "catch", "finally", "throw", "typeof", "instanceof",
-        "true", "false", "null", "undefined", "in", "of",
-    ]
-
-    private static let swiftKeywords: Set<String> = [
-        "func", "let", "var", "if", "else", "guard", "return", "for", "in",
-        "while", "do", "switch", "case", "break", "continue", "import", "struct",
-        "class", "enum", "protocol", "extension", "private", "public", "internal",
-        "fileprivate", "open", "static", "final", "lazy", "weak", "unowned",
-        "self", "Self", "init", "deinit", "throws", "throw", "try", "catch",
-        "rethrows", "async", "await", "true", "false", "nil", "some", "any",
-    ]
-
-    private static let shellKeywords: Set<String> = [
-        "if", "then", "else", "elif", "fi", "for", "do", "done", "while",
-        "case", "esac", "function", "return", "in", "export", "local",
-    ]
-
-    private static let jsonKeywords: Set<String> = [
-        "true", "false", "null",
-    ]
-
-    static func tokenize(_ source: String, language: String?) -> [PiChatCodeToken] {
-        let lang = (language ?? "").lowercased()
-        if lang == "json" {
-            return tokenizeJSON(source)
-        }
-        if lang == "bash" || lang == "sh" || lang == "shell" || lang == "zsh" {
-            return tokenizeShell(source)
-        }
-        if lang == "swift" {
-            return tokenizeSwift(source)
-        }
-        return tokenizeGeneric(source)
-    }
-
-    private static func tokenizeGeneric(_ source: String) -> [PiChatCodeToken] {
-        var tokens: [PiChatCodeToken] = []
-        var buffer = ""
-        var inString = false
-        var stringDelimiter: Character = "\""
-        var inLineComment = false
-
-        func pushBufferAsWord() {
-            guard !buffer.isEmpty else { return }
-            if jsLikeKeywords.contains(buffer) {
-                tokens.append(PiChatCodeToken(text: buffer, color: keyword))
-            } else {
-                tokens.append(PiChatCodeToken(text: buffer, color: Palette.text))
-            }
-            buffer.removeAll(keepingCapacity: true)
-        }
-
-        func pushBufferAsNumber() {
-            guard !buffer.isEmpty else { return }
-            tokens.append(PiChatCodeToken(text: buffer, color: number))
-            buffer.removeAll(keepingCapacity: true)
-        }
-
-        func pushBufferAsString() {
-            guard !buffer.isEmpty else { return }
-            tokens.append(PiChatCodeToken(text: buffer, color: string))
-            buffer.removeAll(keepingCapacity: true)
-        }
-
-        func pushBufferAsPunct() {
-            guard !buffer.isEmpty else { return }
-            tokens.append(PiChatCodeToken(text: buffer, color: punctuation))
-            buffer.removeAll(keepingCapacity: true)
-        }
-
-        func pushBufferAsPlain() {
-            guard !buffer.isEmpty else { return }
-            tokens.append(PiChatCodeToken(text: buffer, color: Palette.text))
-            buffer.removeAll(keepingCapacity: true)
-        }
-
-        let chars = Array(source)
-        var i = 0
-        while i < chars.count {
-            let ch = chars[i]
-
-            if inLineComment {
-                buffer.append(ch)
-                if ch == "\n" {
-                    tokens.append(PiChatCodeToken(text: buffer, color: comment))
-                    buffer.removeAll(keepingCapacity: true)
-                    inLineComment = false
-                }
-                i += 1
-                continue
-            }
-
-            if inString {
-                buffer.append(ch)
-                if ch == stringDelimiter {
-                    pushBufferAsString()
-                    inString = false
-                }
-                i += 1
-                continue
-            }
-
-            if ch == "/" && i + 1 < chars.count && chars[i + 1] == "/" {
-                inLineComment = true
-                buffer = "//"
-                i += 2
-                continue
-            }
-
-            if ch == "\"" || ch == "'" || ch == "`" {
-                inString = true
-                stringDelimiter = ch
-                buffer = String(ch)
-                i += 1
-                continue
-            }
-
-            if ch.isNumber {
-                buffer.append(ch)
-                var j = i + 1
-                while j < chars.count, chars[j].isNumber || chars[j] == "." || chars[j] == "_" {
-                    buffer.append(chars[j])
-                    j += 1
-                }
-                pushBufferAsNumber()
-                i = j
-                continue
-            }
-
-            if ch.isLetter || ch == "_" || ch == "$" {
-                buffer.append(ch)
-                var j = i + 1
-                while j < chars.count, chars[j].isLetter || chars[j].isNumber || chars[j] == "_" || chars[j] == "$" {
-                    buffer.append(chars[j])
-                    j += 1
-                }
-                pushBufferAsWord()
-                i = j
-                continue
-            }
-
-            if ch.isWhitespace {
-                pushBufferAsPlain()
-                tokens.append(PiChatCodeToken(text: String(ch), color: Palette.text))
-                i += 1
-                continue
-            }
-
-            buffer.append(ch)
-            pushBufferAsPunct()
-            i += 1
-        }
-
-        if !buffer.isEmpty {
-            if inString {
-                pushBufferAsString()
-            } else if inLineComment {
-                tokens.append(PiChatCodeToken(text: buffer, color: comment))
-            } else {
-                pushBufferAsPlain()
-            }
-        }
-
-        return tokens
-    }
-
-    private static func tokenizeJSON(_ source: String) -> [PiChatCodeToken] {
-        var tokens: [PiChatCodeToken] = []
-        var current = ""
-        var inString = false
-        var escape = false
-        var pendingKey = false
-
-        func flushString() {
-            tokens.append(PiChatCodeToken(text: current, color: pendingKey ? identifier : string))
-            current.removeAll(keepingCapacity: true)
-            pendingKey = false
-        }
-
-        for ch in source {
-            if inString {
-                current.append(ch)
-                if escape {
-                    escape = false
-                } else if ch == "\\" {
-                    escape = true
-                } else if ch == "\"" {
-                    flushString()
-                    inString = false
-                }
-                continue
-            }
-
-            if ch == "\"" {
-                inString = true
-                current = "\""
-                pendingKey = lastNonSpace() == "{"
-                continue
-            }
-
-            if ch.isNumber || (ch == "-" && (current.isEmpty || current == ":")) {
-                current.append(ch)
-                continue
-            }
-            if ch.isNumber == false && !current.isEmpty && current.allSatisfy({ $0.isNumber || $0 == "-" || $0 == "." }) {
-                tokens.append(PiChatCodeToken(text: current, color: number))
-                current.removeAll(keepingCapacity: true)
-            }
-
-            if ch == "{" || ch == "}" || ch == "[" || ch == "]" || ch == "," || ch == ":" {
-                if !current.isEmpty {
-                    if jsonKeywords.contains(current) {
-                        tokens.append(PiChatCodeToken(text: current, color: keyword))
-                    } else {
-                        tokens.append(PiChatCodeToken(text: current, color: Palette.text))
-                    }
-                    current.removeAll(keepingCapacity: true)
-                }
-                tokens.append(PiChatCodeToken(text: String(ch), color: punctuation))
-                continue
-            }
-
-            current.append(ch)
-        }
-
-        if !current.isEmpty {
-            if jsonKeywords.contains(current) {
-                tokens.append(PiChatCodeToken(text: current, color: keyword))
-            } else {
-                tokens.append(PiChatCodeToken(text: current, color: Palette.text))
-            }
-        }
-
-        return tokens
-    }
-
-    private static func lastNonSpace() -> Character? {
-        return nil
-    }
-
-    private static func tokenizeShell(_ source: String) -> [PiChatCodeToken] {
-        var tokens: [PiChatCodeToken] = []
-        var current = ""
-        var inSingle = false
-        var inDouble = false
-        var inComment = false
-
-        for ch in source {
-            if inComment {
-                current.append(ch)
-                continue
-            }
-            if inSingle {
-                current.append(ch)
-                if ch == "'" { inSingle = false }
-                continue
-            }
-            if inDouble {
-                current.append(ch)
-                if ch == "\"" { inDouble = false }
-                continue
-            }
-            if ch == "#" {
-                if !current.isEmpty {
-                    tokens.append(PiChatCodeToken(text: current, color: Palette.text))
-                    current.removeAll()
-                }
-                inComment = true
-                current = "#"
-                continue
-            }
-            if ch == "'" {
-                inSingle = true
-                current.append(ch)
-                continue
-            }
-            if ch == "\"" {
-                inDouble = true
-                current.append(ch)
-                continue
-            }
-            if ch == "$" || ch.isWhitespace || ch == "|" || ch == "&" || ch == ";" {
-                if !current.isEmpty {
-                    if shellKeywords.contains(current) {
-                        tokens.append(PiChatCodeToken(text: current, color: keyword))
-                    } else if current.hasPrefix("$") {
-                        tokens.append(PiChatCodeToken(text: current, color: number))
-                    } else {
-                        tokens.append(PiChatCodeToken(text: current, color: Palette.text))
-                    }
-                    current.removeAll()
-                }
-                if ch == "$" {
-                    tokens.append(PiChatCodeToken(text: "$", color: number))
-                } else if ch.isWhitespace {
-                    tokens.append(PiChatCodeToken(text: String(ch), color: Palette.text))
-                } else {
-                    tokens.append(PiChatCodeToken(text: String(ch), color: punctuation))
-                }
-                continue
-            }
-            current.append(ch)
-        }
-        if !current.isEmpty {
-            if inComment {
-                tokens.append(PiChatCodeToken(text: current, color: comment))
-            } else {
-                tokens.append(PiChatCodeToken(text: current, color: Palette.text))
-            }
-        }
-        return tokens
-    }
-
-    private static func tokenizeSwift(_ source: String) -> [PiChatCodeToken] {
-        // Swift and JS share most tokenization rules; route through generic
-        // and remap the keyword set lazily by post-processing colors.
-        var tokens = tokenizeGeneric(source)
-        for index in tokens.indices where tokens[index].color == keyword {
-            let raw = tokens[index].text
-            if swiftKeywords.contains(raw) {
-                tokens[index] = PiChatCodeToken(text: raw, color: keyword)
-            }
-        }
-        return tokens
-    }
-}
-
 // MARK: - Composer
 
 struct PiChatComposer: View {
@@ -1235,9 +736,23 @@ struct PiChatComposer: View {
     var style: PiChatStyle = .workspace
     var focus: FocusState<Bool>.Binding
 
+    #if canImport(HudsonVoice)
+    @ObservedObject private var voice = WorkspaceVoiceInput.shared
+    #endif
+
     var body: some View {
         VStack(spacing: 8) {
-            HStack(alignment: .bottom, spacing: 10) {
+            #if canImport(HudsonVoice)
+            if voice.state.isCaptureActive || voice.state.isProcessing, !voice.partial.isEmpty {
+                dictationLivePreview
+            }
+            #endif
+
+            HStack(alignment: .center, spacing: 10) {
+                #if canImport(HudsonVoice)
+                micButton
+                #endif
+
                 TextField(
                     style.placeholder,
                     text: $session.draft,
@@ -1254,93 +769,125 @@ struct PiChatComposer: View {
                     }
                 }
 
-                Button {
-                    session.sendDraft()
-                } label: {
-                    Group {
-                        if session.isSending {
-                            PiChatSendSpinner()
-                        } else {
-                            Image(systemName: "arrow.up")
-                                .font(.system(size: 12, weight: .bold))
-                        }
-                    }
-                    .frame(width: 30, height: 30)
-                    .background(
-                        Circle()
-                            .fill(
-                                canSend
-                                    ? AnyShapeStyle(
-                                        LinearGradient(
-                                            colors: [Palette.running, Palette.running.opacity(0.85)],
-                                            startPoint: .top,
-                                            endPoint: .bottom
-                                        )
-                                    )
-                                    : AnyShapeStyle(Palette.surfaceHov)
-                            )
-                            .shadow(color: canSend ? Palette.running.opacity(0.35) : .clear, radius: 10, y: 2)
-                    )
-                    .foregroundColor(canSend ? Palette.bg : Palette.textMuted)
-                }
-                .buttonStyle(.plain)
-                .disabled(!canSend)
+                sendChip
             }
             .padding(.horizontal, 14)
-            .padding(.vertical, 12)
+            .padding(.vertical, 10)
             .background(composerFieldBackground)
-            .animation(.easeInOut(duration: 0.18), value: focus.wrappedValue)
-
-            HStack(spacing: 8) {
-                modelChip
-                Spacer()
-                if !focus.wrappedValue {
-                    Text("↩ send")
-                        .font(Typo.caption(9))
-                        .foregroundColor(Palette.textMuted.opacity(0.7))
-                }
-            }
         }
         .padding(.horizontal, style.horizontalPadding)
         .padding(.vertical, style.verticalPadding)
         .background(composerChrome)
     }
 
-    private var modelChip: some View {
-        HStack(spacing: 5) {
-            if session.isSending {
-                PiChatStatusPulse(color: statusColor)
-            } else {
-                Circle()
-                    .fill(statusColor)
-                    .frame(width: 6, height: 6)
-            }
-            Text(statusLabel)
-                .font(Typo.caption(10))
+    #if canImport(HudsonVoice)
+    /// HudsonVoice-powered mic. Tap to dictate into the draft; tap again to commit.
+    private var micButton: some View {
+        Button {
+            voice.toggle()
+        } label: {
+            Image(systemName: micSymbol)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(micTint)
+                .frame(width: 30, height: 30)
+                .background(
+                    Circle()
+                        .fill(voice.state.isCaptureActive ? Palette.kill.opacity(0.14) : Color.white.opacity(0.04))
+                        .overlay(
+                            Circle().strokeBorder(
+                                voice.state.isCaptureActive ? Palette.kill.opacity(0.45) : Palette.border,
+                                lineWidth: voice.state.isCaptureActive ? 1 : 0.5
+                            )
+                        )
+                )
+        }
+        .buttonStyle(.plain)
+        .help(micTooltip)
+        .disabled(session.isSending)
+        .animation(.easeInOut(duration: 0.18), value: voice.state)
+    }
+
+    private var dictationLivePreview: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "waveform")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(Palette.kill.opacity(0.8))
+            Text(voice.partial)
+                .font(Typo.body(style.composerSize))
                 .foregroundColor(Palette.textMuted)
+                .italic()
+                .lineLimit(2)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .transition(.opacity)
+    }
+
+    private var micSymbol: String {
+        switch voice.state {
+        case .recording, .starting: return "mic.fill"
+        case .processing: return "waveform"
+        case .unavailable: return "mic.slash"
+        case .idle: return "mic"
         }
     }
 
+    private var micTint: Color {
+        switch voice.state {
+        case .recording, .starting: return Palette.kill
+        case .processing: return Palette.detach
+        case .unavailable: return Palette.textMuted.opacity(0.6)
+        case .idle: return Palette.textMuted
+        }
+    }
+
+    private var micTooltip: String {
+        switch voice.state {
+        case .idle: return "Tap to dictate"
+        case .starting: return "Starting…"
+        case .recording: return "Recording — tap to commit"
+        case .processing: return "Transcribing…"
+        case .unavailable(let reason): return reason
+        }
+    }
+    #endif
+
+    /// `↵ SEND` text chip (ported from OpenScout's MessageSendChip) — replaces
+    /// the old up-arrow circle. Mono, no fill, just a keycap + label.
+    private var sendChip: some View {
+        Button {
+            session.sendDraft()
+        } label: {
+            HStack(spacing: 4) {
+                Text(session.isSending ? "…" : "↵")
+                    .font(Typo.monoBold(11))
+                Text(session.isSending ? "SENDING" : "SEND")
+                    .font(Typo.monoBold(9))
+                    .tracking(1.4)
+            }
+            .foregroundColor(canSend ? Palette.running : Palette.textMuted.opacity(0.6))
+            .padding(.horizontal, 9)
+            .padding(.vertical, 6)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!canSend)
+        .help(canSend ? "Send (↵)" : "")
+    }
+
+    // Flat composer field — hairline border, no focus glow, no running-tinted
+    // halo. The "glowy" look the operator flagged is gone; affordance comes
+    // from a single 0.5pt border that brightens slightly on focus.
     private var composerFieldBackground: some View {
-        RoundedRectangle(cornerRadius: 14, style: .continuous)
-            .fill(.ultraThinMaterial)
-            .opacity(0.34)
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+            .fill(Color.white.opacity(0.025))
             .overlay(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(Color.black.opacity(0.22))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(Color.white.opacity(0.028))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
                     .strokeBorder(
-                        focus.wrappedValue ? Palette.running.opacity(0.45) : Palette.border,
-                        lineWidth: focus.wrappedValue ? 1 : 0.5
+                        focus.wrappedValue ? Palette.borderLit : Palette.border,
+                        lineWidth: 0.5
                     )
             )
-            .shadow(color: focus.wrappedValue ? Palette.running.opacity(0.18) : .clear, radius: 18, y: 2)
     }
 
     private var composerChrome: some View {
@@ -1356,6 +903,42 @@ struct PiChatComposer: View {
     private var canSend: Bool {
         !session.isSending && !session.draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
+}
+
+// MARK: - Model chip (header)
+
+/// Compact provider/status indicator, now living in the header next to the
+/// gear instead of under the composer. A live status dot + provider name;
+/// shows the streaming/tool phase while a turn is in flight.
+struct PiChatModelChip: View {
+    @ObservedObject var session: PiChatSession
+
+    var body: some View {
+        HStack(spacing: 6) {
+            if session.isSending {
+                PiChatStatusPulse(color: statusColor)
+            } else {
+                Circle()
+                    .fill(statusColor)
+                    .frame(width: 5, height: 5)
+            }
+            Text(session.currentProvider.name)
+                .font(Typo.mono(10))
+                .foregroundColor(Palette.textDim)
+            if let detail = providerStatusDetail {
+                Text("· " + detail)
+                    .font(Typo.mono(9))
+                    .foregroundColor(Palette.textMuted)
+            }
+        }
+        .padding(.horizontal, 9)
+        .padding(.vertical, 5)
+        .overlay(
+            Capsule(style: .continuous)
+                .strokeBorder(Palette.border, lineWidth: 0.5)
+        )
+        .help("Provider: \(session.currentProvider.name)")
+    }
 
     private var statusColor: Color {
         if session.isSending { return Palette.detach }
@@ -1363,19 +946,13 @@ struct PiChatComposer: View {
         return Palette.running
     }
 
-    private var statusLabel: String {
-        if session.isSending {
-            switch session.statusText {
-            case "streaming...": return "Streaming · \(session.currentProvider.name)"
-            case "tool:": return session.statusText + " · \(session.currentProvider.name)"
-            default:
-                if session.statusText.hasPrefix("tool:") {
-                    return "\(session.statusText) · \(session.currentProvider.name)"
-                }
-                return "Working · \(session.currentProvider.name)"
-            }
+    private var providerStatusDetail: String? {
+        guard session.isSending else { return nil }
+        if session.statusText == "streaming..." { return "streaming" }
+        if session.statusText.hasPrefix("tool:") {
+            return session.statusText.replacingOccurrences(of: "tool: ", with: "tool · ")
         }
-        return session.currentProvider.name
+        return "working"
     }
 }
 
@@ -1406,14 +983,15 @@ struct PiChatWaveDots: View {
             let time = timeline.date.timeIntervalSinceReferenceDate
             HStack(spacing: spacing) {
                 ForEach(0..<3, id: \.self) { index in
-                    let wave = sin(time * 3.6 + Double(index) * 0.85)
-                    let phase = (wave + 1) / 2
-                    let scale = 0.68 + 0.34 * phase
-                    let opacity = 0.32 + 0.68 * phase
+                    // Opacity-only: dots never change size or position, so the
+                    // label beside them can't be shoved around. A soft highlight
+                    // travels across the three dots — calm, no motion artifacts.
+                    let wave = sin(time * 2.6 - Double(index) * 0.9)
+                    let opacity = 0.30 + 0.45 * (wave + 1) / 2
 
                     Circle()
                         .fill(Palette.running.opacity(opacity))
-                        .frame(width: dotSize * scale, height: dotSize * scale)
+                        .frame(width: dotSize, height: dotSize)
                 }
             }
             .frame(height: dotSize, alignment: .center)
@@ -1509,7 +1087,7 @@ enum PiChatStyle: Equatable {
 
     var maxContentWidth: CGFloat {
         switch self {
-        case .workspace: return 720
+        case .workspace: return .infinity
         case .dock: return .infinity
         }
     }
@@ -1537,8 +1115,8 @@ enum PiChatStyle: Equatable {
 
     var bodySize: CGFloat {
         switch self {
-        case .workspace: return 13.5
-        case .dock: return 12
+        case .workspace: return 12
+        case .dock: return 11
         }
     }
 
@@ -1575,7 +1153,12 @@ enum PiChatFormat {
     static func markdownText(_ source: String, size: CGFloat) -> Text? {
         let normalized = normalizeMarkdownTables(source)
         var options = AttributedString.MarkdownParsingOptions()
-        options.interpretedSyntax = .full
+        // .full flattens block structure — SwiftUI's Text(AttributedString)
+        // ignores paragraph/list presentation intents, so multi-line and
+        // bulleted replies collapse into one run-on blob. Preserving the
+        // source whitespace keeps newlines/lists intact while still rendering
+        // inline bold/italic/code.
+        options.interpretedSyntax = .inlineOnlyPreservingWhitespace
         guard let attributed = try? AttributedString(markdown: normalized, options: options) else {
             return nil
         }

--- a/apps/mac/Sources/Core/Pi/PiHudAIAdapter.swift
+++ b/apps/mac/Sources/Core/Pi/PiHudAIAdapter.swift
@@ -1,0 +1,174 @@
+import Foundation
+import HudsonAI
+
+// Bridges the local `pi --mode rpc` runtime into HudsonKit's HudAIClient as a
+// first-class provider adapter. This is the architecture the workspace assistant
+// is moving to: HudAIClient is the single chat surface, and pi — with its own
+// multi-provider routing and auth — becomes "one of the many providers" behind
+// it, exactly like the HTTP adapters (OpenAI/Anthropic/OpenRouter), only driven
+// over RPC instead of a URL.
+//
+// Two impedance mismatches with the HTTP adapters, handled deliberately:
+//   1. State. pi sessions are stateful (the session dir holds prior turns), but
+//      HudAIRequest carries the full message history each call. We send only the
+//      latest user turn as pi's `prompt`; pi already remembers the rest.
+//   2. Auth. pi authenticates its own downstream providers (OAuth device-code,
+//      API keys). So this adapter ignores HudAIAdapterContext credentials — the
+//      HudAI credential vault is not in the loop for pi. (Surfacing pi's auth
+//      through HudAI credentials is a separate, later step.)
+
+extension HudAIProviderID {
+    static let pi = HudAIProviderID(rawValue: "pi")
+}
+
+/// `HudAIClient` requires a credential source, but the pi adapter never queries
+/// it — pi owns auth for its downstream providers. This satisfies the type
+/// without putting the HudAI vault in the loop. (Replaced when pi's auth is
+/// surfaced through HudAI credentials.)
+struct NullHudAICredentialSource: HudAICredentialSource {
+    func get(_ key: String) async throws -> Data? { nil }
+}
+
+struct PiHudAIAdapter: HudAIProviderAdapter, @unchecked Sendable {
+    let providerID: HudAIProviderID
+    let displayName: String
+    let defaultModel: String
+    let credentialKey: String
+
+    /// Supplies a started/ready `PiRpcRuntime` configured for the desired
+    /// provider/model/session. The lattices chat session owns runtime lifecycle,
+    /// so the adapter asks for one on demand rather than constructing it.
+    private let runtimeProvider: @Sendable () -> PiRpcRuntime
+
+    init(
+        providerID: HudAIProviderID = .pi,
+        displayName: String = "Pi",
+        defaultModel: String = "",
+        credentialKey: String = "pi",
+        runtimeProvider: @escaping @Sendable () -> PiRpcRuntime
+    ) {
+        self.providerID = providerID
+        self.displayName = displayName
+        self.defaultModel = defaultModel
+        self.credentialKey = credentialKey
+        self.runtimeProvider = runtimeProvider
+    }
+
+    // MARK: - HudAIProviderAdapter
+
+    func complete(_ request: HudAIRequest, context: HudAIAdapterContext) async throws -> HudAIResponse {
+        let model = request.model ?? defaultModel
+        let prompt = Self.promptText(from: request)
+        let runtime = runtimeProvider()
+        let text: String = try await withCheckedThrowingContinuation { continuation in
+            runtime.promptAndFetchAssistantText(prompt, timeout: context.defaults.timeout) { result in
+                switch result {
+                case .success(let text): continuation.resume(returning: text)
+                case .failure(let error): continuation.resume(throwing: Self.map(error))
+                }
+            }
+        }
+        return Self.response(id: UUID().uuidString, model: model, text: text)
+    }
+
+    func stream(_ request: HudAIRequest, context: HudAIAdapterContext) -> AsyncThrowingStream<HudAIStreamEvent, Error> {
+        let model = request.model ?? defaultModel
+        let prompt = Self.promptText(from: request)
+        let runtime = runtimeProvider()
+        let requestID = UUID().uuidString
+
+        return AsyncThrowingStream { continuation in
+            continuation.yield(.started(requestID: requestID, provider: providerID, model: model))
+
+            // pi may emit either incremental `text_delta`s or full-text snapshots.
+            // Normalize both into HudAI textDeltas; for snapshots we diff against
+            // what we've already emitted so the consumer only ever sees forward
+            // deltas (never a re-sent prefix).
+            var emitted = ""
+
+            runtime.promptAndFetchAssistantText(
+                prompt,
+                onEvent: { event in
+                    if let delta = PiRpcRuntime.streamingDelta(from: event), !delta.isEmpty {
+                        emitted += delta
+                        continuation.yield(.textDelta(contentBlockID: "message_0", text: delta))
+                    } else if let snapshot = PiRpcRuntime.streamingSnapshot(from: event) {
+                        if snapshot.count > emitted.count, snapshot.hasPrefix(emitted) {
+                            let delta = String(snapshot.dropFirst(emitted.count))
+                            emitted = snapshot
+                            continuation.yield(.textDelta(contentBlockID: "message_0", text: delta))
+                        } else if snapshot != emitted {
+                            emitted = snapshot
+                        }
+                    } else if event["type"] as? String == "tool_execution_start",
+                              let toolName = event["toolName"] as? String {
+                        let toolID = event["toolCallId"] as? String ?? event["id"] as? String ?? "pi_tool_\(toolName)"
+                        continuation.yield(.toolCallStarted(toolCallID: toolID, name: toolName))
+                    }
+                },
+                timeout: context.defaults.timeout
+            ) { result in
+                switch result {
+                case .success(let text):
+                    let final = text.isEmpty ? emitted : text
+                    continuation.yield(.completed(Self.response(id: requestID, model: model, text: final)))
+                    continuation.finish()
+                case .failure(let error):
+                    let mapped = Self.map(error)
+                    continuation.yield(.failed(mapped))
+                    continuation.finish(throwing: mapped)
+                }
+            }
+        }
+    }
+
+    func listModels(context: HudAIAdapterContext) async throws -> [HudAIModelInfo] {
+        // pi owns provider/model routing; HudAI-side model enumeration is not
+        // wired yet. Surface the default so the picker has at least one entry.
+        guard !defaultModel.isEmpty else { return [] }
+        return [HudAIModelInfo(id: defaultModel, provider: providerID, displayName: displayName)]
+    }
+
+    // MARK: - Helpers
+
+    /// pi is stateful per session, so a turn is just the latest user message.
+    private static func promptText(from request: HudAIRequest) -> String {
+        guard let lastUser = request.messages.last(where: { $0.role == .user }) else {
+            return request.messages.flatMap { textParts($0.content) }.joined(separator: "\n")
+        }
+        return textParts(lastUser.content).joined(separator: "\n")
+    }
+
+    private static func textParts(_ content: [HudAIContentPart]) -> [String] {
+        content.compactMap { part in
+            if case .text(let text) = part { return text }
+            return nil
+        }
+    }
+
+    private static func response(id: String, model: String, text: String) -> HudAIResponse {
+        HudAIResponse(
+            id: id,
+            provider: .pi,
+            model: model,
+            text: text,
+            content: text.isEmpty ? [] : [.text(text)],
+            toolCalls: [],
+            usage: HudAIUsage(),
+            finishReason: .stop
+        )
+    }
+
+    private static func map(_ error: Error) -> HudAIError {
+        if let error = error as? HudAIError { return error }
+        if let runtimeError = error as? PiRpcRuntime.RuntimeError {
+            switch runtimeError {
+            case .timedOut(let detail):
+                return .timeout(provider: .pi, message: detail)
+            case .notStarted, .processExited, .commandFailed, .invalidResponse, .emptyAssistantText:
+                return .providerProtocolError(provider: .pi, requestID: nil, message: runtimeError.localizedDescription)
+            }
+        }
+        return .providerProtocolError(provider: .pi, requestID: nil, message: error.localizedDescription)
+    }
+}

--- a/apps/mac/Sources/Core/Pi/PiWorkspaceView.swift
+++ b/apps/mac/Sources/Core/Pi/PiWorkspaceView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct PiWorkspaceView: View {
@@ -31,13 +32,16 @@ struct PiWorkspaceView: View {
             }
         }
         .background(Palette.bg)
+        .background(WorkspaceFocusActivator())
+        .onReceive(NotificationCenter.default.publisher(for: .workspaceComposerFocus)) { _ in
+            // Fired exactly when the hosting window becomes key, so setting the
+            // caret here actually renders it — no timed guessing.
+            if session.hasPiBinary && !session.needsProviderSetup {
+                composerFocused = true
+            }
+        }
         .onAppear {
             session.prepareForDisplay()
-            if session.hasPiBinary && !session.needsProviderSetup {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                    composerFocused = true
-                }
-            }
         }
     }
 
@@ -62,7 +66,9 @@ struct PiWorkspaceView: View {
 
             Spacer()
 
-            HStack(spacing: 6) {
+            HStack(spacing: 8) {
+                PiChatModelChip(session: session)
+
                 headerIconButton(symbol: "gearshape") {
                     SettingsWindowController.shared.showAssistant()
                 }
@@ -75,7 +81,8 @@ struct PiWorkspaceView: View {
             }
         }
         .padding(.horizontal, 24)
-        .padding(.vertical, 16)
+        .padding(.top, 10)
+        .padding(.bottom, 14)
     }
 
     private var headerSubtitle: String {
@@ -191,5 +198,48 @@ struct PiWorkspaceView: View {
                     .fill(Color.white.opacity(0.04))
                     .overlay(Capsule().strokeBorder(Palette.border, lineWidth: 0.5))
             )
+    }
+}
+
+extension Notification.Name {
+    /// Posted when the assistant's hosting window becomes key, so the composer
+    /// can take the caret at the exact moment it can actually render one.
+    static let workspaceComposerFocus = Notification.Name("dev.lattices.workspaceComposerFocus")
+}
+
+/// Zero-size bridge that activates the app + makes the hosting window key on
+/// attach, and re-signals focus every time the window becomes key.
+private struct WorkspaceFocusActivator: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView { FocusTrackerView() }
+    func updateNSView(_ nsView: NSView, context: Context) {}
+
+    final class FocusTrackerView: NSView {
+        private var observer: Any?
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            guard let window else { return }
+            NSApp.activate(ignoringOtherApps: true)
+            window.makeKeyAndOrderFront(nil)
+            if observer == nil {
+                observer = NotificationCenter.default.addObserver(
+                    forName: NSWindow.didBecomeKeyNotification,
+                    object: window,
+                    queue: .main
+                ) { _ in
+                    NotificationCenter.default.post(name: .workspaceComposerFocus, object: nil)
+                }
+            }
+            // If it's already key (tab switch within a focused window), signal now.
+            if window.isKeyWindow {
+                DispatchQueue.main.async {
+                    NotificationCenter.default.post(name: .workspaceComposerFocus, object: nil)
+                }
+            }
+        }
+
+        deinit {
+            if let observer { NotificationCenter.default.removeObserver(observer) }
+        }
     }
 }

--- a/apps/mac/Sources/Core/Pi/WorkspaceVoiceInput.swift
+++ b/apps/mac/Sources/Core/Pi/WorkspaceVoiceInput.swift
@@ -1,0 +1,180 @@
+import Combine
+import Foundation
+#if canImport(HudsonVoice)
+import HudsonVoice
+#endif
+
+// Voice-enabled message input for the Workspace Assistant — powered by HudsonVoice.
+//
+// Modeled on OpenScout's HUD dictation (ScoutVoxService + HUDDockState + MicButton):
+// tap-to-start, live `session.partial` preview, `session.final` spliced once into
+// the composer draft. The difference is the transport: instead of OpenScout's
+// hand-rolled HTTP/NDJSON wrapper, this drives HudsonKit's native HudVoxLiveSession,
+// whose default endpoint (127.0.0.1:42137) is exactly the voxd daemon Lattices
+// already runs — so it lights up with no extra wiring.
+//
+// Mic capture lives entirely in the Vox daemon process, so the Lattices app needs
+// no NSMicrophoneUsageDescription — the OS prompt belongs to Vox.
+
+enum WorkspaceVoiceState: Equatable {
+    case idle
+    case starting
+    case recording
+    case processing
+    case unavailable(reason: String)
+
+    /// Mic is hot (recording or spinning up) — tapping again commits.
+    var isCaptureActive: Bool { self == .starting || self == .recording }
+    var isProcessing: Bool { self == .processing }
+    var isUnavailable: Bool {
+        if case .unavailable = self { return true }
+        return false
+    }
+}
+
+/// Splice a dictated phrase into an existing buffer: empty → set; non-empty →
+/// append with a single separating space. Mirrors OpenScout's ScoutDictationBuffer.
+enum WorkspaceDictationBuffer {
+    static func appending(_ phrase: String, to current: String) -> String {
+        let trimmed = phrase.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return current }
+        guard !current.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return trimmed }
+        let trailingSpace = current.last?.isWhitespace ?? false
+        return current + (trailingSpace ? "" : " ") + trimmed
+    }
+}
+
+#if canImport(HudsonVoice)
+
+/// One-session-at-a-time dictation controller backed by HudVoxLiveSession.
+/// Tap the mic to start; tap again to commit and surface the transcript on
+/// `lastFinalText`, which the chat session drains into the composer draft.
+final class WorkspaceVoiceInput: ObservableObject {
+    static let shared = WorkspaceVoiceInput()
+
+    /// Mic-button visual state.
+    @Published private(set) var state: WorkspaceVoiceState = .idle
+    /// Live partial transcript while recording. Cleared on commit.
+    @Published private(set) var partial: String = ""
+    /// Most recent final transcript. The chat session observes this and splices
+    /// it into the draft, then calls `consumeFinalText()` so it fires once.
+    @Published private(set) var lastFinalText: String = ""
+
+    private var session: HudVoxLiveSession?
+    private var pumpTask: Task<Void, Never>?
+    private var finalDelivered = false
+
+    private init() {}
+
+    /// Mic-tap action: idle/unavailable → start, hot → stop, processing → ignore.
+    func toggle() {
+        switch state {
+        case .idle, .unavailable:
+            start()
+        case .starting, .recording:
+            stop()
+        case .processing:
+            break
+        }
+    }
+
+    func start() {
+        guard session == nil else { return }
+        partial = ""
+        finalDelivered = false
+        state = .starting
+
+        let session = HudVoxLiveSession(
+            options: HudVoxLiveSessionOptions(clientId: "lattices", mode: .pushToTalk)
+        )
+        self.session = session
+
+        pumpTask = Task { [weak self] in
+            do {
+                let stream = try await session.start()
+                for try await event in stream {
+                    await MainActor.run { self?.handle(event) }
+                }
+                await MainActor.run { self?.streamEnded(error: nil) }
+            } catch {
+                await MainActor.run { self?.streamEnded(error: error) }
+            }
+        }
+    }
+
+    func stop() {
+        guard state.isCaptureActive else { return }
+        state = .processing
+        let session = self.session
+        Task { try? await session?.stop() }
+    }
+
+    func cancel() {
+        let session = self.session
+        finalDelivered = true   // suppress any trailing final
+        partial = ""
+        if !state.isUnavailable { state = .idle }
+        self.session = nil
+        pumpTask?.cancel()
+        pumpTask = nil
+        Task { try? await session?.cancel() }
+    }
+
+    /// Drain the one-shot final signal after the consumer has appended it.
+    func consumeFinalText() {
+        lastFinalText = ""
+    }
+
+    // MARK: - Event handling (main actor)
+
+    @MainActor
+    private func handle(_ event: HudVoiceEvent) {
+        switch event {
+        case .state(let s):
+            switch s.state {
+            case .recording:
+                state = .recording
+            case .processing:
+                state = .processing
+            case .error:
+                state = .unavailable(reason: "Vox reported a session error.")
+            case .cancelled:
+                if !state.isUnavailable { state = .idle }
+            case .starting:
+                if state != .recording { state = .starting }
+            case .done:
+                break
+            }
+        case .partial(let p):
+            partial = p.text
+        case .final(let f):
+            deliverFinal(f.text)
+        case .raw:
+            break
+        }
+    }
+
+    @MainActor
+    private func deliverFinal(_ text: String) {
+        guard !finalDelivered else { return }
+        finalDelivered = true
+        partial = ""
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { lastFinalText = text }
+        state = .idle
+        session?.close()
+    }
+
+    @MainActor
+    private func streamEnded(error: Error?) {
+        if let error, !finalDelivered {
+            state = .unavailable(reason: error.localizedDescription)
+        } else if !finalDelivered, !state.isUnavailable {
+            state = .idle
+        }
+        session = nil
+        pumpTask = nil
+    }
+}
+
+#endif

--- a/apps/mac/Sources/UI/Theme.swift
+++ b/apps/mac/Sources/UI/Theme.swift
@@ -42,6 +42,13 @@ enum Typo {
         .system(size: size, weight: .regular, design: .rounded)
     }
 
+    /// Reading font for message *content* (assistant/user prose) — JetBrains
+    /// Mono, deliberately distinct from the rounded SF used for UI chrome so
+    /// conversation text reads as monospaced terminal-grade copy, not interface.
+    static func reading(_ size: CGFloat = 13, weight: Font.Weight = .regular) -> Font {
+        Font.custom(jetbrains, size: size).weight(weight)
+    }
+
     static func caption(_ size: CGFloat = 10) -> Font {
         .system(size: size, weight: .medium, design: .rounded)
     }


### PR DESCRIPTION
Lands this session's Workspace Assistant work plus the ScreenCaptureKit window-capture migration. Three focused commits.

### 1. Workspace Assistant: Hudson AI client, voice, and streaming reveal
- Adopt **pi as a `HudAIProviderAdapter`** behind HudsonKit's `HudAIClient` (`PiHudAIAdapter`), gated via `HudsonKitBridge` switches.
- **HudsonVoice mic** (`WorkspaceVoiceInput`) driving `HudVoxLiveSession` against the local voxd endpoint — tap-to-talk, live partial, final spliced into the draft.
- **Streaming reveal**: display is decoupled from network arrival via a 60Hz drain (word-whole steps, sentence/clause reading beats), each stanza settles with a spring, and the transcript follows the live edge but detaches on upward scroll.
- Turn rendering extracted into **`AgentTurnView`** over a transport-agnostic `AgentTurn` model. Message content rendered in mono (`Typo.reading`).
- Adopt HudsonUI's **`HudMarkdownView` / `HudCodeBlock`** (see arach/hudson#114); `PiChatMarkdown`/`PiChatCodeBlock` become thin adapters and the local parser + tokenizer are removed.

### 2. Adopt Hudson shell chrome for the unified window
- `AppShellView` renders through **`HudAppShell`**: a left navigation rail (`HudNavigationSidebar`) + status bar, replacing the top tab strip.
- **`HudWindowChrome`** via `AppWindowShell` (full-size content, transparent titlebar, no separator) — navigation no longer fights the title-bar safe area.
- Tighten Home/Assistant headers; remove the projects spotlight.

### 3. Migrate window capture to ScreenCaptureKit
- Replace CGWindowList capture with `SCShareableContent` / `SCContentFilter` / `SCScreenshotManager` in `WindowCapture` + `DesktopCapture`, with corresponding updates to the OCR model, preview store, HUD controller, screen-map state, and voice command window.

### Companion
- Renderer donor: **arach/hudson#114** (HudsonUI `HudMarkdownView` + `HudCodeBlock`). This branch consumes it via the local path dependency.