### PR TITLE
🔒 Mark overlay panels and popover as readOnly sharing

### DIFF
--- a/apps/mac/Sources/AppShell/MenuBarController.swift
+++ b/apps/mac/Sources/AppShell/MenuBarController.swift
@@ -43,6 +43,7 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
         guard let button = statusItem?.button else { return }
         let popover = makePopover()
         popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        popover.contentViewController?.view.window?.sharingType = .readOnly
         popover.contentViewController?.view.window?.makeKey()
     }
 

--- a/apps/mac/Sources/Core/Overlays/CommandMode/CommandModeWindow.swift
+++ b/apps/mac/Sources/Core/Overlays/CommandMode/CommandModeWindow.swift
@@ -108,6 +108,7 @@ final class CommandModeWindow {
         panel.becomesKeyOnlyIfNeeded = false
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         panel.isReleasedWhenClosed = false
+        panel.sharingType = .readOnly
 
         let cornerRadius: CGFloat = 14
 

--- a/apps/mac/Sources/Core/Overlays/OverlayPanelShell.swift
+++ b/apps/mac/Sources/Core/Overlays/OverlayPanelShell.swift
@@ -98,6 +98,7 @@ struct OverlayPanelShell {
         panel.hasShadow = config.hasShadow
         panel.hidesOnDeactivate = config.hidesOnDeactivate
         panel.isReleasedWhenClosed = config.isReleasedWhenClosed
+        panel.sharingType = .readOnly
         panel.isMovableByWindowBackground = config.isMovableByWindowBackground
         panel.collectionBehavior = config.collectionBehavior
         panel.activatesOnMouseDown = config.activatesOnMouseDown


### PR DESCRIPTION
## What

Sets `NSWindow.sharingType = .readOnly` on Lattices' floating overlays so other apps' screen-capture / window-sharing APIs (screen recorders, video-call screen share, screenshot tools) can't read their contents.

## Why

These overlays — command palette, voice input, OmniSearch, launcher HUD, command-mode window, and the menu-bar popover — are where you type commands, dictate, and may surface sensitive text (API keys, search results). They shouldn't bleed into a screen recording or a shared call.

## How

Three lines, full coverage:

- **`OverlayPanelShell.makePanel`** — the shared factory, so one line covers CommandPalette, Voice, OmniSearch, and LauncherHUD at once.
- **`CommandModeWindow`** — builds its own panel (doesn't go through the shell), flagged directly.
- **`MenuBarController`** — the `NSPopover` is created by AppKit, so its backing window is flagged right after `popover.show(...)`.

## Verification

`swift build -c release` — builds clean.

Part of a one-feature-per-PR decomposition of the closed #42 stash-recovery branch.