### PR TITLE
✨ Register handsoff.run daemon endpoint

### DIFF
--- a/apps/mac/Sources/AppShell/AppDelegate.swift
+++ b/apps/mac/Sources/AppShell/AppDelegate.swift
@@ -203,11 +203,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             .first { $0 != "/" }?
             .lowercased()
 
-        guard host == "companion" else {
+        switch host {
+        case "companion":
+            handleCompanionDeepLink(action: action)
+        case "daemon":
+            handleDaemonDeepLink(action: action)
+        default:
             SettingsWindowController.shared.show()
-            return
         }
+    }
 
+    private func handleCompanionDeepLink(action: String?) {
         switch action {
         case "enable", "start":
             Preferences.shared.companionBridgeEnabled = true
@@ -218,6 +224,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         default:
             SettingsWindowController.shared.showCompanion()
         }
+    }
+
+    private func handleDaemonDeepLink(action: String?) {
+        // The daemon runs in-process with the app. If this handler fires, the
+        // app is up — which means the daemon is up. No UI pop required.
+        DiagnosticLog.shared.info(
+            "DeepLink: lattices://daemon/\(action ?? "") — daemon already running"
+        )
     }
 
 }

--- a/apps/mac/Sources/AppShell/MainView.swift
+++ b/apps/mac/Sources/AppShell/MainView.swift
@@ -384,6 +384,15 @@ struct MainView: View {
                 ScreenMapWindowController.shared.showPage(.desktopInventory)
             }
             ActionRow(
+                label: "Assistant",
+                detail: "Open the workspace assistant",
+                hotkeyTokens: [],
+                icon: "bubble.left.and.bubble.right",
+                accentColor: Palette.textDim
+            ) {
+                ScreenMapWindowController.shared.showPage(.pi)
+            }
+            ActionRow(
                 label: "Command Palette",
                 detail: "Launch, attach, and control projects",
                 hotkeyTokens: hotkeyTokens(.palette),

--- a/apps/mac/Sources/Core/Daemon/LatticesApi.swift
+++ b/apps/mac/Sources/Core/Daemon/LatticesApi.swift
@@ -2207,6 +2207,61 @@ final class LatticesApi {
             }
         ))
 
+        api.register(Endpoint(
+            method: "handsoff.run",
+            description: "Run a transcript through the real hands-off LLM pipeline, silently and dry-run by default. Same code path voice uses. Optional `snapshot` override feeds the model a synthetic desktop. No actions are executed; no chat log or handsoff.jsonl pollution. Dev builds also write a rich trace to ~/.lattices/handsoff-debug.jsonl.",
+            access: .read,
+            params: [
+                Param(name: "text", type: "string", required: true, description: "Transcript to process"),
+                Param(name: "snapshot", type: "object", required: false, description: "Override snapshot. If omitted, the live buildSnapshot() is used."),
+            ],
+            returns: .custom("Worker response: { data: { actions, spoken, _meta }, ... }"),
+            handler: { params in
+                guard let text = params?["text"]?.stringValue, !text.isEmpty else {
+                    throw RouterError.missingParam("text")
+                }
+
+                // Decode optional snapshot override (JSON.object → [String: Any])
+                var snapshotOverride: [String: Any]? = nil
+                if let snapshotJson = params?["snapshot"],
+                   case .object = snapshotJson {
+                    let data = try JSONEncoder().encode(snapshotJson)
+                    if let any = try JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                        snapshotOverride = any
+                    }
+                }
+
+                let semaphore = DispatchSemaphore(value: 0)
+                var workerResponse: [String: Any]?
+                var rpcError: Error?
+
+                HandsOffSession.shared.runRpc(
+                    transcript: text,
+                    snapshotOverride: snapshotOverride
+                ) { result in
+                    switch result {
+                    case .success(let response): workerResponse = response
+                    case .failure(let err): rpcError = err
+                    }
+                    semaphore.signal()
+                }
+
+                // Generous timeout — LLM turns can be several seconds.
+                let timeout = DispatchTime.now() + .seconds(60)
+                if semaphore.wait(timeout: timeout) == .timedOut {
+                    throw RouterError.custom("handsoff.run: timed out waiting for worker")
+                }
+
+                if let rpcError { throw rpcError }
+                guard let workerResponse else {
+                    throw RouterError.custom("handsoff.run: empty response")
+                }
+
+                let data = try JSONSerialization.data(withJSONObject: workerResponse)
+                return try JSONDecoder().decode(JSON.self, from: data)
+            }
+        ))
+
         // ── Meta endpoint ───────────────────────────────────────
 
         // ── Mouse Finder ────────────────────────────────────────

--- a/apps/mac/Sources/Core/Voice/HandsOffSession.swift
+++ b/apps/mac/Sources/Core/Voice/HandsOffSession.swift
@@ -120,6 +120,11 @@ final class HandsOffSession: ObservableObject {
     /// JSONL log for full turn data — ~/.lattices/handsoff.jsonl
     private let turnLogPath = NSHomeDirectory() + "/.lattices/handsoff.jsonl"
 
+    /// Dev-only rich trace log written on every `runRpc` call.
+    /// Captures snapshot source, request cmd, raw worker response, and timings
+    /// so the studio's MethodInspector can unpack the whole loop.
+    private let rpcDebugLogPath = NSHomeDirectory() + "/.lattices/handsoff-debug.jsonl"
+
     private init() {}
 
     // MARK: - Chat Log
@@ -281,6 +286,11 @@ final class HandsOffSession: ObservableObject {
     // MARK: - Worker communication
 
     private var pendingCallback: (([String: Any]) -> Void)?
+    /// When true, the worker response should be returned to the callback
+    /// WITHOUT touching live state — no chatLog append, no executeActions,
+    /// no @Published mutations, no state-machine reset. Set by RPC paths
+    /// (e.g. `runRpc`); the audio-driven voice path leaves this false.
+    private var pendingCallbackDryRun = false
     private var turnTimeoutWork: DispatchWorkItem?
     private static let turnTimeoutSeconds: TimeInterval = 30
 
@@ -293,8 +303,13 @@ final class HandsOffSession: ObservableObject {
         }
     }
 
-    private func sendToWorkerWithCallback(_ dict: [String: Any], callback: @escaping ([String: Any]) -> Void) {
+    private func sendToWorkerWithCallback(
+        _ dict: [String: Any],
+        dryRun: Bool = false,
+        callback: @escaping ([String: Any]) -> Void
+    ) {
         pendingCallback = callback
+        pendingCallbackDryRun = dryRun
         sendToWorker(dict)
     }
 
@@ -319,7 +334,9 @@ final class HandsOffSession: ObservableObject {
             let spoken = dataObj?["spoken"] as? String
             let actions = dataObj?["actions"] as? [[String: Any]]
             let cb = pendingCallback
+            let isDryRun = pendingCallbackDryRun
             pendingCallback = nil
+            pendingCallbackDryRun = false
 
             // Build chat entries off-main
             var chatEntries: [(VoiceChatEntry.Role, String)] = []
@@ -338,22 +355,24 @@ final class HandsOffSession: ObservableObject {
             }
 
             // Single dispatch — all @Published mutations in one block.
-            // The pending callback also mutates @Published state, so it must
-            // run on main with the rest of the turn completion.
+            // For dry-run RPC turns (studio etc.), skip every side effect
+            // and just fire the callback. The voice path runs the full body.
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
-                if let spoken { self.lastResponse = spoken }
-                for (role, text) in chatEntries {
-                    self.chatLog.append(VoiceChatEntry(timestamp: Date(), role: role, text: text, detail: nil))
+                if !isDryRun {
+                    if let spoken { self.lastResponse = spoken }
+                    for (role, text) in chatEntries {
+                        self.chatLog.append(VoiceChatEntry(timestamp: Date(), role: role, text: text, detail: nil))
+                    }
+                    if self.chatLog.count > self.maxChatEntries {
+                        self.chatLog.removeFirst(self.chatLog.count - self.maxChatEntries)
+                    }
+                    if let actions, !actions.isEmpty {
+                        self.recentActions = actions
+                        self.executeActions(actions)
+                    }
+                    self.state = .idle
                 }
-                if self.chatLog.count > self.maxChatEntries {
-                    self.chatLog.removeFirst(self.chatLog.count - self.maxChatEntries)
-                }
-                if let actions, !actions.isEmpty {
-                    self.recentActions = actions
-                    self.executeActions(actions)
-                }
-                self.state = .idle
                 cb?(json)
             }
         }
@@ -496,6 +515,115 @@ final class HandsOffSession: ObservableObject {
                 }
             }
         )
+    }
+
+    // MARK: - RPC entry (silent, dry-run)
+
+    enum RpcError: Error, LocalizedError {
+        case busy
+        case workerUnavailable
+        var errorDescription: String? {
+            switch self {
+            case .busy:
+                return "Hands-off session is busy — try again once the current turn finishes."
+            case .workerUnavailable:
+                return "Hands-off worker is unavailable (bun missing or script not found)."
+            }
+        }
+    }
+
+    /// Run a transcript through the same worker pipeline voice uses, but
+    /// silently — no state-machine change, no TTS, no chat-log append, no
+    /// row in `handsoff.jsonl`, no action execution. Optional snapshot
+    /// override feeds the LLM a synthetic desktop (for studio mocks).
+    ///
+    /// In dev builds, every call writes a rich trace to
+    /// `~/.lattices/handsoff-debug.jsonl` that the studio can unpack.
+    func runRpc(
+        transcript: String,
+        snapshotOverride: [String: Any]? = nil,
+        completion: @escaping (Result<[String: Any], Error>) -> Void
+    ) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else {
+                completion(.failure(RpcError.workerUnavailable))
+                return
+            }
+
+            // Refuse to step on a live voice turn.
+            if self.state != .idle || self.pendingCallback != nil {
+                completion(.failure(RpcError.busy))
+                return
+            }
+
+            guard self.startWorker() else {
+                completion(.failure(RpcError.workerUnavailable))
+                return
+            }
+
+            let snapshot = snapshotOverride ?? self.buildSnapshot()
+            let snapshotSource = snapshotOverride == nil ? "live" : "override"
+
+            let turnCmd: [String: Any] = [
+                "cmd": "turn",
+                "transcript": transcript,
+                "snapshot": snapshot,
+                "history": [],
+            ]
+
+            let startedAt = Date()
+            DiagnosticLog.shared.info(
+                "HandsOff.RPC: ⏱ '\(transcript)' (snapshot: \(snapshotSource))"
+            )
+
+            self.sendToWorkerWithCallback(turnCmd, dryRun: true) { [weak self] response in
+                let durationMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+                if LatticesRuntime.isDevBuild {
+                    self?.writeRpcDebugArtifact(
+                        transcript: transcript,
+                        snapshotSource: snapshotSource,
+                        snapshot: snapshot,
+                        request: turnCmd,
+                        response: response,
+                        durationMs: durationMs
+                    )
+                }
+                completion(.success(response))
+            }
+        }
+    }
+
+    private func writeRpcDebugArtifact(
+        transcript: String,
+        snapshotSource: String,
+        snapshot: [String: Any],
+        request: [String: Any],
+        response: [String: Any],
+        durationMs: Int
+    ) {
+        let record: [String: Any] = [
+            "kind": "handsoff.run",
+            "ts": ISO8601DateFormatter().string(from: Date()),
+            "transcript": transcript,
+            "snapshotSource": snapshotSource,
+            "snapshot": snapshot,
+            "request": request,
+            "response": response,
+            "durationMs": durationMs,
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: record),
+              var line = String(data: data, encoding: .utf8) else { return }
+        line += "\n"
+        if let handle = FileHandle(forWritingAtPath: rpcDebugLogPath) {
+            handle.seekToEndOfFile()
+            handle.write(line.data(using: .utf8)!)
+            handle.closeFile()
+        } else {
+            FileManager.default.createFile(
+                atPath: rpcDebugLogPath,
+                contents: line.data(using: .utf8)
+            )
+        }
     }
 
     /// Deliver transcript exactly once — called from both session.final and completion.


### PR DESCRIPTION
## What

Registers the `handsoff.run` daemon endpoint — the backend the Studio `HandsoffStudio` panel calls. The panel already exists on main but the endpoint was never registered, so its "run" was dead.

## How

- **`LatticesApi.swift`** — registers `handsoff.run` (read access). Runs a transcript through the real hands-off LLM pipeline (the same path voice uses), **silently and dry-run by default**: returns the worker response (`actions`, `spoken`, `_meta`) without executing anything or polluting the chat log / `handsoff.jsonl`. Accepts an optional `snapshot` override to feed the model a synthetic desktop; otherwise uses the live `buildSnapshot()`. 60s timeout for LLM turns.
- **`HandsOffSession.swift`** — adds the `runRpc(transcript:snapshotOverride:)` plumbing, plus a dev-only rich trace at `~/.lattices/handsoff-debug.jsonl` that MethodInspector can unpack.
- **`AppDelegate.swift`** — routes `lattices://daemon/...` deep links.
- **`MainView.swift`** — adds an Assistant action row.

## Scope note

Pure Swift / daemon change — **no `package.json`, workspaces, or lockfile churn**. `apps/studio` runs standalone (`cd apps/studio && bun run dev`) and needs no root wiring, so none was added.

## Verification

`swift build -c release` — builds clean.

Final piece of the one-feature-per-PR decomposition of the closed #42 stash-recovery branch.