### PR TITLE
🐛 Stop telling users to reinstall Pi when it's just a provider mismatch

### DIFF
--- a/apps/mac/Sources/Core/Pi/PiChatSession.swift
+++ b/apps/mac/Sources/Core/Pi/PiChatSession.swift
@@ -2164,6 +2164,22 @@ final class PiChatSession: ObservableObject {
         }
 
         storedCredentialKinds = kinds
+        autoSelectConnectedProviderIfNeeded()
+    }
+
+    /// If the selected provider has no stored credential but another provider is
+    /// already connected, switch to the first connected one (in supported order).
+    /// Keeps the assistant usable instead of stranding the user on a setup screen
+    /// for a provider they never authenticated — e.g. the default `openai-codex`
+    /// when only `github-copilot` is signed in. Skipped while an auth flow is in
+    /// progress so we never yank the user mid-setup. Goes through the normal
+    /// `authProviderID` setter so it persists and refreshes exactly like a manual
+    /// provider switch.
+    private func autoSelectConnectedProviderIfNeeded() {
+        guard !isAuthenticating else { return }
+        guard storedCredentialKinds[authProviderID] == nil else { return }
+        guard let connected = PiProvider.supported.first(where: { storedCredentialKinds[$0.id] != nil }) else { return }
+        authProviderID = connected.id
     }
 
     private func reconcileAuthState() {

--- a/apps/mac/Sources/Core/Pi/PiWorkspaceView.swift
+++ b/apps/mac/Sources/Core/Pi/PiWorkspaceView.swift
@@ -130,7 +130,7 @@ struct PiWorkspaceView: View {
     private var setupPlaceholder: some View {
         VStack {
             Spacer()
-            PiInstallCallout(session: session, compact: false)
+            PiProviderSetupCallout(session: session, compact: false)
                 .padding(.horizontal, 28)
             Spacer()
         }


### PR DESCRIPTION
## The bug

If `pi` is installed but the selected provider has no stored credential (e.g. the default `openai-codex` while you've only signed into `github-copilot`/`minimax`), the Workspace Assistant rendered the **"PI REQUIRED → `npm install -g --ignore-scripts @earendil-works/pi-coding-agent@latest`"** block — telling you to reinstall the agent from scratch over what is purely a provider-selection problem.

**Root cause:** `PiWorkspaceView.setupPlaceholder` (the `needsProviderSetup` state) was wired to `PiInstallCallout` — the component meant for a genuinely missing binary. The name said "setup," the body said "install from scratch."

## The fix

1. **Right callout for the right state.** `setupPlaceholder` now uses `PiProviderSetupCallout` (an amber "SET UP YOUR AI" component that already existed but was orphaned/never mounted). `PiInstallCallout` is now used **only** for `!hasPiBinary`. The dock and Settings mounts already gated correctly; this was the one wrong site.

2. **Auto-select a connected provider.** In `reloadAuthState()`, if the selected provider has no stored credential but another provider is connected, switch to the first connected one (in `PiProvider.supported` order). This runs inside `PiChatSession.init`, so it fires before any setup state can render — the assistant just works on a provider you're already signed into instead of stranding you on a setup screen. Routed through the normal `authProviderID` setter (persists + refreshes like a manual switch); skipped while an auth flow is in progress.

## Verification

- `swift build -c release` — builds clean; app relaunches.
- Logic verified by inspection. Live UI flip isn't auto-confirmable from outside the app (lazy `.shared` instantiation + lazy `UserDefaults` flush; and the readOnly popover hardening blanks screenshots), so this is best eyeballed in-app: open the assistant → it should land on GitHub Copilot chat. Sign out of every provider and you'll get the amber "SET UP YOUR AI" callout — never the install-from-scratch block — as long as the binary is present.

## Notes

This is purely the UX bug. Separately, the installed agent is `0.74.0` vs `0.78.1` latest — worth bumping, but unrelated to this fix.