### PR TITLE
✨ Hyperspace: drag-to-place intent layer, full-screen Place & new-layer flow

### DIFF
--- a/apps/mac/Sources/Core/Overlays/Motion/NewLayerPanel.swift
+++ b/apps/mac/Sources/Core/Overlays/Motion/NewLayerPanel.swift
@@ -1,0 +1,178 @@
+import AppKit
+import SwiftUI
+
+// MARK: - NewLayerPanel
+//
+// The "create a new layer" authoring flow for Hyperspace. Tapping the ＋ pile opens this:
+// name the layer and choose which apps define it (rule-backed membership — the same model as
+// the rest of Studio). It must be its own key panel because the survey's screen-panels can't
+// become key, so a TextField hosted there wouldn't take input. Floats above the survey (level
+// +2) with a scrim that dims it; Esc / click-away / Cancel close it.
+
+final class NewLayerPanel: NSPanel {
+    struct Candidate: Identifiable {
+        let id = UUID()
+        let app: String
+        let image: NSImage?
+        let count: Int          // windows of this app on the active display
+    }
+
+    private let onCreate: (String, [String]) -> Void
+    private let onCancel: () -> Void
+
+    init(candidates: [Candidate], preselected: Set<String>, defaultName: String,
+         onCreate: @escaping (String, [String]) -> Void, onCancel: @escaping () -> Void) {
+        self.onCreate = onCreate
+        self.onCancel = onCancel
+        super.init(contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+                   styleMask: [.borderless, .nonactivatingPanel], backing: .buffered, defer: false)
+        isFloatingPanel = true
+        level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()) + 2)   // above the survey panels
+        backgroundColor = .clear
+        isOpaque = false
+        hasShadow = false
+        let form = NewLayerForm(
+            candidates: candidates, preselected: preselected, defaultName: defaultName,
+            onCreate: { [weak self] name, apps in self?.onCreate(name, apps); self?.close() },
+            onCancel: { [weak self] in self?.onCancel(); self?.close() })
+        let host = NSHostingView(rootView: form)
+        host.frame = NSRect(origin: .zero, size: frame.size)
+        host.autoresizingMask = [.width, .height]
+        contentView = host
+    }
+
+    @available(*, unavailable) required init?(coder: NSCoder) { fatalError() }
+    override var canBecomeKey: Bool { true }
+
+    func present(on screen: NSScreen) {
+        setFrame(screen.frame, display: true)
+        NSApp.activate(ignoringOtherApps: true)
+        makeKeyAndOrderFront(nil)
+    }
+}
+
+// MARK: - NewLayerForm
+
+private struct NewLayerForm: View {
+    let candidates: [NewLayerPanel.Candidate]
+    @State private var selected: Set<String>
+    @State private var name: String
+    @FocusState private var nameFocused: Bool
+    let onCreate: (String, [String]) -> Void
+    let onCancel: () -> Void
+
+    init(candidates: [NewLayerPanel.Candidate], preselected: Set<String>, defaultName: String,
+         onCreate: @escaping (String, [String]) -> Void, onCancel: @escaping () -> Void) {
+        self.candidates = candidates
+        _selected = State(initialValue: preselected)
+        _name = State(initialValue: defaultName)
+        self.onCreate = onCreate
+        self.onCancel = onCancel
+    }
+
+    // Selected apps in the candidate order, the live match count, and the create gate.
+    private var selectedApps: [String] { candidates.map(\.app).filter { selected.contains($0) } }
+    private var matchCount: Int { candidates.filter { selected.contains($0.app) }.reduce(0) { $0 + $1.count } }
+    private var canCreate: Bool {
+        !selected.isEmpty && !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func create() { if canCreate { onCreate(name, selectedApps) } }
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.62).ignoresSafeArea()
+                .contentShape(Rectangle())
+                .onTapGesture { onCancel() }            // click-away cancels
+            vessel
+        }
+    }
+
+    private var vessel: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 8) {
+                Image(systemName: "square.stack.3d.up.fill")
+                    .font(.system(size: 13, weight: .semibold)).foregroundColor(Palette.running)
+                Text("New Layer").font(Typo.monoBold(14)).foregroundColor(.white)
+                Spacer()
+                Text("esc").font(Typo.mono(9)).foregroundColor(.white.opacity(0.4))
+            }
+            VStack(alignment: .leading, spacing: 5) {
+                Text("NAME").font(Typo.mono(8.5)).tracking(0.6).foregroundColor(.white.opacity(0.4))
+                TextField("Layer name", text: $name)
+                    .textFieldStyle(.plain).font(Typo.heading(15)).foregroundColor(.white)
+                    .focused($nameFocused)
+                    .onSubmit(create)
+                    .onExitCommand(perform: onCancel)
+                    .padding(.horizontal, 10).padding(.vertical, 8)
+                    .background(RoundedRectangle(cornerRadius: 8).fill(Color.white.opacity(0.06))
+                        .overlay(RoundedRectangle(cornerRadius: 8)
+                            .strokeBorder(Palette.running.opacity(0.45), lineWidth: 1)))
+            }
+            VStack(alignment: .leading, spacing: 7) {
+                Text("DEFINED BY  ·  tap to toggle")
+                    .font(Typo.mono(8.5)).tracking(0.6).foregroundColor(.white.opacity(0.4))
+                if candidates.isEmpty {
+                    Text("No windows on this display to define a rule.")
+                        .font(Typo.mono(10)).foregroundColor(.white.opacity(0.4))
+                } else {
+                    FlowLayout(spacing: 7, lineSpacing: 7, alignment: .leading) {
+                        ForEach(candidates) { appChip($0) }
+                    }
+                }
+            }
+            HStack(spacing: 12) {
+                Text(selected.isEmpty ? "pick at least one app"
+                                      : "matches \(matchCount) window\(matchCount == 1 ? "" : "s") now")
+                    .font(Typo.mono(9)).foregroundColor(.white.opacity(0.45))
+                Spacer(minLength: 0)
+                Button(action: onCancel) {
+                    Text("Cancel").font(Typo.monoBold(11)).foregroundColor(.white.opacity(0.7))
+                        .padding(.horizontal, 12).padding(.vertical, 7)
+                }.buttonStyle(.plain)
+                Button(action: create) {
+                    Text("Create Layer")
+                        .font(Typo.monoBold(11)).foregroundColor(canCreate ? Palette.bg : .white.opacity(0.4))
+                        .padding(.horizontal, 14).padding(.vertical, 7)
+                        .background(Capsule().fill(canCreate ? Palette.running : Color.white.opacity(0.08)))
+                }.buttonStyle(.plain).disabled(!canCreate)
+            }
+        }
+        .padding(22)
+        .frame(width: 460)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(Color(red: 0.06, green: 0.07, blue: 0.09))
+                .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .strokeBorder(.white.opacity(0.12), lineWidth: 1))
+                .shadow(color: .black.opacity(0.6), radius: 44, y: 20)
+        )
+        .onAppear { nameFocused = true }
+    }
+
+    private func appChip(_ c: NewLayerPanel.Candidate) -> some View {
+        let on = selected.contains(c.app)
+        return Button {
+            if on { selected.remove(c.app) } else { selected.insert(c.app) }
+        } label: {
+            HStack(spacing: 6) {
+                if let img = c.image {
+                    Image(nsImage: img).resizable().aspectRatio(contentMode: .fill)
+                        .frame(width: 20, height: 14)
+                        .clipShape(RoundedRectangle(cornerRadius: 3, style: .continuous))
+                }
+                Text(c.app).font(Typo.mono(11)).foregroundColor(on ? Palette.bg : .white.opacity(0.85)).lineLimit(1)
+                if c.count > 1 {
+                    Text("\(c.count)").font(Typo.monoBold(8))
+                        .foregroundColor(on ? Palette.bg.opacity(0.7) : .white.opacity(0.4))
+                }
+                Image(systemName: on ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 10)).foregroundColor(on ? Palette.bg : .white.opacity(0.35))
+            }
+            .padding(.horizontal, 9).padding(.vertical, 6)
+            .background(Capsule().fill(on ? Palette.running : Color.white.opacity(0.06))
+                .overlay(Capsule().strokeBorder(on ? Palette.running : Palette.border, lineWidth: 1)))
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/apps/mac/Sources/Core/Overlays/Motion/WindowMotionMode.swift
+++ b/apps/mac/Sources/Core/Overlays/Motion/WindowMotionMode.swift
@@ -94,6 +94,142 @@ private enum MotionKeys {
     }
 }
 
+private final class HyperspaceScreenPanel: NSPanel {
+    init(screen: NSScreen) {
+        super.init(contentRect: screen.frame, styleMask: [.borderless, .nonactivatingPanel], backing: .buffered, defer: false)
+        isFloatingPanel = true
+        level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()) + 1)
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = false
+        ignoresMouseEvents = false
+        hidesOnDeactivate = false
+        collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary, .ignoresCycle]
+        setFrame(screen.frame, display: true)
+    }
+
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+}
+
+// MARK: - Expose canvas (zoom/pan)
+//
+// Ephemeral navigation state for the screenshot survey: a pure view transform over
+// the already-laid-out lattice — no reflow, no real windows move. Owned by the panel
+// (so it survives the frequent ExposeView rebuilds) and observed by ExposeView, which
+// applies it as a scaleEffect + offset. Separate axis from the persisted "size" dial:
+// size changes how big tiles are laid out; this magnifies whatever is laid out.
+final class ExposeCanvas: ObservableObject {
+    @Published var zoom: CGFloat = 1     // 1 = fit (floor). Pan only matters when > 1.
+    @Published var pan: CGSize = .zero   // points, in SwiftUI offset space (+x right, +y down)
+    let minZoom: CGFloat = 1.0
+    let maxZoom: CGFloat = 4.0
+
+    func reset() { zoom = 1; pan = .zero }
+}
+
+// MARK: - Drag & drop "intent layer" (design/hyperspace-drag-drop.md)
+
+/// Resolution of the Lattice drop grid. Each step is a plain CxR grid you drop a
+/// window onto; the cell maps straight to `PlacementSpec.grid`. Default is quarters;
+/// modifiers (⇧ halves · ⌥ thirds · ⌘ fine) override the selector while held.
+enum LatticeRes: Int, CaseIterable {
+    case halves, thirds, quarters, fine
+
+    var dims: (cols: Int, rows: Int) {
+        switch self {
+        case .halves:   return (2, 1)
+        case .thirds:   return (3, 1)
+        case .quarters: return (2, 2)
+        case .fine:     return (4, 4)
+        }
+    }
+    var glyph: String {
+        switch self {
+        case .halves:   return "½"
+        case .thirds:   return "⅓"
+        case .quarters: return "¼"
+        case .fine:     return "▦"
+        }
+    }
+    var name: String {
+        switch self {
+        case .halves:   return "halves"
+        case .thirds:   return "thirds"
+        case .quarters: return "quarters"
+        case .fine:     return "fine"
+        }
+    }
+    /// Map a grid's dims back to its selector glyph (for staged badges).
+    static func glyph(cols: Int, rows: Int) -> String {
+        LatticeRes.allCases.first { $0.dims == (cols, rows) }?.glyph ?? "▦"
+    }
+}
+
+/// A cell coordinate in the lattice grid (0-indexed, top-left origin) — matches
+/// `GridPlacement(column:row:)`.
+struct HoverCell: Equatable { let col: Int; let row: Int }
+
+/// Ephemeral drag state for the intent layer. Owned by `MotionPanel` (so it
+/// survives the frequent ExposeView rebuilds) and observed by every screen's
+/// ExposeView. The drag is scoped to one screen via `screenID`; only that screen
+/// renders the ghost and accepts a drop. Nothing real moves here — a drop only
+/// stages a destination (committed later on gather).
+final class HyperspaceDrag: ObservableObject {
+    @Published var wid: UInt32?              // window being dragged (nil = idle/tap-only)
+    @Published var image: NSImage?           // ghost thumbnail following the cursor
+    @Published var tileSize: CGSize = .zero
+    @Published var location: CGPoint = .zero // cursor, in ExposeView's root space
+    @Published var res: LatticeRes = .quarters   // effective resolution (modifier ?? base)
+    @Published var baseRes: LatticeRes = .quarters // selector choice; modifiers override live
+    @Published var hoverCell: HoverCell?     // cell under the cursor in the lattice grid
+    @Published var hoverLayer: String?       // layer pile under the cursor (layer id, or newLayerKey)
+    @Published var inspectLayer: String?     // pile under a plain mouse hover (no drag) — reveals its roster
+    @Published var inspectScreen: String?    // which screen that hovered pile is on
+    @Published var screenID: String = ""     // which screen owns the in-flight drag
+
+    // Right-click "place me" mode: a tile was secondary-clicked, opening a life-size
+    // interactive stage to pick its grid spot (mouse-only alternative to drag → Grid).
+    @Published var placeWid: UInt32?         // window in placement mode (nil = off)
+    @Published var placeScreen: String?      // which screen its stage shows on
+    @Published var placeCell: HoverCell?     // cell under the cursor on the stage
+    var isPlacing: Bool { placeWid != nil }
+    func beginPlacing(_ wid: UInt32, on screen: String) { placeWid = wid; placeScreen = screen; placeCell = nil }
+    func endPlacing() { placeWid = nil; placeScreen = nil; placeCell = nil }
+
+    var latticeFrames: [String: CGRect] = [:]              // per-screen lattice grid frame (root space)
+    var layerFrames: [String: [String: CGRect]] = [:]      // [screenID: [layerKey: frame]] (root space)
+
+    static let newLayerKey = "+new"          // sentinel for the ＋ "new layer" pile
+
+    // A one-shot "landing" beat fired at the drop target the instant you release, so a
+    // drop reads as confirmed even though the target's hover highlight has cleared.
+    struct DropPulse: Equatable { let id: Int; let frame: CGRect }
+    @Published var dropPulse: DropPulse?
+    private var pulseCounter = 0
+
+    var isActive: Bool { wid != nil }
+
+    func reset() {
+        wid = nil
+        image = nil
+        hoverCell = nil
+        hoverLayer = nil
+    }
+
+    /// Flash a ring at `frame` (root space) and auto-clear it after the beat. Tokened
+    /// so each drop restarts the animation even on the same target.
+    func firePulse(at frame: CGRect) {
+        guard frame.width > 1 else { return }
+        pulseCounter += 1
+        let id = pulseCounter
+        dropPulse = DropPulse(id: id, frame: frame)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            if self?.dropPulse?.id == id { self?.dropPulse = nil }
+        }
+    }
+}
+
 // MARK: - MotionPanel
 
 private final class MotionPanel: NSPanel {
@@ -116,6 +252,7 @@ private final class MotionPanel: NSPanel {
     private var lastSide: MotionSide?
     private var cycleStep = 0
     private var ignoreResign = false        // swallow the transient key-resign while raising windows
+    private var didMoveWindows = false       // did we move/raise any real window? (gates the Esc restore)
     private let tileGap: CGFloat = 0.02     // even margin for the 2nd-tap "floating half"
     private let exposeGap: CGFloat = 0.012  // gutter between cells in the Exposé spread
     private let nudgeStep: CGFloat = 60
@@ -129,15 +266,49 @@ private final class MotionPanel: NSPanel {
     private var thumbInFlight: Set<UInt32> = []          // de-dupe in-flight captures
     private let stackMargin: CGFloat = 24
     private var keyObserver: Any?
+    private var scrollMonitor: Any?
+    private var mouseUpMonitor: Any?    // re-claims key focus after a survey click/drag
+    private var keyMonitor: Any?        // catches Enter/Esc even when a survey panel holds key
+    private var newLayerPanel: NewLayerPanel?   // the "create a new layer" authoring flow, when open
 
     // Selection order — `group` is membership, `pickOrder` is the order picks were
     // made, which is what the slot numbers (and the gather grid) follow.
     private var pickOrder: [UInt32] = []
 
+    // Drag & drop "intent layer" (design/hyperspace-drag-drop.md). Each window can
+    // be staged across three orthogonal axes; nothing real moves until the gather
+    // commit. Populated by the drag UI (Phase 1+); committed in gatherInPlace().
+    struct StagedIntent {
+        var layers: Set<String> = []        // StudioLayer ids — multi-membership (Phase 2)
+        var newLayer: Bool = false          // stage a fresh layer seeded from this window (＋ pile)
+        var location: PlacementSpec?         // where on the active screen (Phase 1)
+        var space: Int?                      // target macOS Space (Phase 3)
+        var isEmpty: Bool { layers.isEmpty && !newLayer && location == nil && space == nil }
+    }
+    private var stagedIntents: [UInt32: StagedIntent] = [:]
+
+    // Live drag state for the intent layer — owned here so it outlives the frequent
+    // ExposeView rebuilds, observed by every screen's spread.
+    private let dragModel = HyperspaceDrag()
+
     // Screenshot Exposé: real windows never move during the survey. We render a
     // clustered lattice of live captures and pluck by home-row hint key; only the
     // gather (⏎ / G) moves real windows.
     private var exposeHost: NSHostingView<ExposeView>?
+    private var exposeHostsByScreenID: [String: NSHostingView<ExposeView>] = [:]
+    private var exposePanelsByScreenID: [String: HyperspaceScreenPanel] = [:]
+    private var canvasByScreenID: [String: ExposeCanvas] = [:]
+    private var activeScreenID: String?
+    private var pickOrderByScreen: [String: [UInt32]] = [:]
+    private var exposeClustersByScreen: [String: [ExposeCluster]] = [:]
+    private var exposeOrderByScreen: [String: [UInt32]] = [:]
+    private var exposeAimByScreen: [String: Int] = [:]
+    private var hintForByScreen: [String: [UInt32: String]] = [:]
+    private var hintMapByScreen: [String: [String: UInt32]] = [:]
+    private var clusterHintForByScreen: [String: [Int: String]] = [:]
+    private var clusterHintMapByScreen: [String: [String: Int]] = [:]
+    private var exposeTileWByScreen: [String: CGFloat] = [:]
+    private var exposeFramesByScreen: [String: [UInt32: CGRect]] = [:]
     private var exposeClusters: [ExposeCluster] = []      // structural clusters for the spread
     private var exposeOrder: [UInt32] = []                // wids in spread layout order
     private var exposeAim = 0                             // highlighted tile (Tab/Space fallback)
@@ -151,6 +322,18 @@ private final class MotionPanel: NSPanel {
     private lazy var handKeysMode = UserDefaults.standard.bool(forKey: "hyperspace.handKeys")
 
     private var activeEntry: WindowEntry { eligible[reticle] }
+    private var activeSurveyScreen: NSScreen? {
+        if let activeScreenID,
+           let screen = NSScreen.screens.first(where: { MotionPanel.screenID($0) == activeScreenID }) {
+            return screen
+        }
+        return screen(for: activeEntry)
+    }
+
+    private var activeSurveyMembers: [WindowEntry] {
+        guard let screen = activeSurveyScreen else { return [] }
+        return eligible.filter { entry($0, isOn: screen) }
+    }
 
     init(eligible: [WindowEntry]) {
         self.eligible = eligible
@@ -184,6 +367,7 @@ private final class MotionPanel: NSPanel {
 
         clusterRules = MotionPanel.loadClusterRules()
         seedActiveFromFocus()
+        activeScreenID = activeSurveyScreen.map(MotionPanel.screenID)
         installLegend(on: host)
         installStack(on: host)
         refreshBorders()
@@ -235,6 +419,46 @@ private final class MotionPanel: NSPanel {
             guard let self, !self.ignoreResign else { return }
             self.onExit?()
         }
+        // Survey zoom/pan: a local scroll monitor (gated to this panel) so ⌘-scroll /
+        // scroll reach us even though the SwiftUI host would otherwise swallow them.
+        scrollMonitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { [weak self] event in
+            guard let self,
+                  event.window === self || self.exposePanelsByScreenID.values.contains(where: { event.window === $0 }) else {
+                return event
+            }
+            return self.handleScroll(event) ? nil : event
+        }
+        // A click or drag on a survey screen-panel (canBecomeKey == false) can leave the
+        // app with *no* key window, so Enter/Esc fall on the floor. After any mouse-up on
+        // one of our panels, re-claim key on the next runloop turn (after the gesture's
+        // onEnded settles) so the keyboard keeps working — the reported "couldn't hit
+        // enter to confirm" bug.
+        mouseUpMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseUp) { [weak self] event in
+            guard let self,
+                  event.window === self || self.exposePanelsByScreenID.values.contains(where: { event.window === $0 }) else {
+                return event
+            }
+            DispatchQueue.main.async { [weak self] in
+                guard let self, self.exposed, !self.isKeyWindow else { return }
+                self.makeKey()
+            }
+            return event   // don't swallow — the click/drag still needs to process
+        }
+        // Belt-and-suspenders for the "couldn't hit Enter to confirm" bug: if a survey
+        // screen-panel (canBecomeKey == false) or nothing holds key, the MotionPanel's own
+        // keyDown never fires. Catch Enter/Esc here and route them so they never fall on the
+        // floor. When the MotionPanel *is* key, defer to its keyDown (don't double-handle).
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            // Stand down while the New Layer panel is up — it owns the keyboard (text field).
+            guard let self, self.exposed, !self.isKeyWindow, self.newLayerPanel == nil else { return event }
+            switch event.keyCode {
+            case 53:
+                if self.dragModel.isPlacing { self.dragModel.endPlacing() } else { self.undoAndExit() }
+                return nil                                          // Esc — close stage, else cancel
+            case 36, 76:      self.keyDown(with: event); return nil   // Return / keypad Enter — confirm
+            default:          return event
+            }
+        }
         // Hyperspace lands you straight in the survey. E collapses back to plain
         // motion; expose() no-ops to plain mode if there's <2 windows to lay out.
         expose()
@@ -243,7 +467,16 @@ private final class MotionPanel: NSPanel {
     func dismiss() {
         if let keyObserver { NotificationCenter.default.removeObserver(keyObserver) }
         keyObserver = nil
+        if let scrollMonitor { NSEvent.removeMonitor(scrollMonitor) }
+        scrollMonitor = nil
+        if let mouseUpMonitor { NSEvent.removeMonitor(mouseUpMonitor) }
+        mouseUpMonitor = nil
+        if let keyMonitor { NSEvent.removeMonitor(keyMonitor) }
+        keyMonitor = nil
+        newLayerPanel?.close()
+        newLayerPanel = nil
         animators.values.forEach { $0.cancel() }
+        removeExposeHost()
         orderOut(nil)
     }
 
@@ -279,13 +512,89 @@ private final class MotionPanel: NSPanel {
         updateStack()
     }
 
+    // MARK: - Canvas zoom/pan (survey only)
+    //
+    // ⌘-scroll zooms toward the pointer; plain scroll pans once zoomed past fit. This
+    // is a pure view transform on the screenshot lattice — nothing here moves a real
+    // window. State lives per display; ExposeView observes it and applies the
+    // scaleEffect + offset. Driven by a local .scrollWheel monitor (installed in
+    // present()) rather than a scrollWheel override, since NSHostingView swallows
+    // unhandled scroll — matching the ScreenMap/Studio canvas idiom.
+    //
+    // Returns true when the survey consumed the scroll (the monitor then swallows it).
+    private func handleScroll(_ event: NSEvent) -> Bool {
+        guard exposed,
+              let screen = validSurveyScreen(screenForEvent(event)) ?? activeSurveyScreen,
+              let host = exposeHostsByScreenID[MotionPanel.screenID(screen)] else { return false }
+        let screenCanvas = canvasForScreen(screen)
+        if activeSurveyScreen.map(MotionPanel.screenID) != MotionPanel.screenID(screen) {
+            setActiveSurveyScreen(screen)
+        }
+        if event.modifierFlags.contains(.command) {
+            let step = event.scrollingDeltaY * (event.hasPreciseScrollingDeltas ? 0.01 : 0.05)
+            zoomCanvas(screenCanvas, by: step, towardWindowPoint: event.locationInWindow, host: host)
+            return true
+        }
+        guard screenCanvas.zoom > 1.0001 else { return false }        // nothing to pan at fit
+        // Sign matches the ScreenMap canvas (+x right, −y to follow natural scroll).
+        screenCanvas.pan = clampPan(CGSize(width:  screenCanvas.pan.width  + event.scrollingDeltaX,
+                                           height: screenCanvas.pan.height - event.scrollingDeltaY),
+                                    zoom: screenCanvas.zoom, host: host)
+        return true
+    }
+
+    /// Zoom by `delta`, keeping the survey point under `windowPoint` fixed (cursor anchor).
+    /// `windowPoint` is panel/window coords (bottom-left origin); the survey offset is
+    /// top-left/+y-down, so the vertical component is flipped into host space first.
+    private func zoomCanvas(_ canvas: ExposeCanvas, by delta: CGFloat, towardWindowPoint windowPoint: CGPoint, host: NSView) {
+        let z0 = canvas.zoom
+        let z1 = min(max(z0 + delta, canvas.minZoom), canvas.maxZoom)
+        guard z1 != z0 else { return }
+        let ratio = z1 / z0
+        // Cursor vector from the container centre, in SwiftUI offset axes (+x right, +y down).
+        let cx = windowPoint.x - host.frame.minX
+        let cyTop = host.frame.maxY - windowPoint.y
+        let d = CGSize(width: cx - host.frame.width / 2, height: cyTop - host.frame.height / 2)
+        let pan0 = canvas.pan
+        canvas.zoom = z1
+        canvas.pan = clampPan(CGSize(width:  d.width  - ratio * (d.width  - pan0.width),
+                                     height: d.height - ratio * (d.height - pan0.height)),
+                              zoom: z1, host: host)
+    }
+
+    /// Keyboard zoom — step toward the survey centre (no pointer), scaling the current
+    /// pan proportionally so the framing holds, then re-clamp.
+    private func zoomCanvasStep(_ delta: CGFloat) {
+        guard let screen = activeSurveyScreen,
+              let host = exposeHostsByScreenID[MotionPanel.screenID(screen)] else { return }
+        zoomCanvas(canvasForScreen(screen), by: delta, towardWindowPoint: CGPoint(x: host.frame.midX, y: host.frame.midY), host: host)
+    }
+
+    /// Keep the centre-scaled lattice from sliding past its own edges (no empty gutters).
+    private func clampPan(_ pan: CGSize, zoom: CGFloat, host: NSView) -> CGSize {
+        let maxX = max(0, (zoom - 1) * host.frame.width  / 2)
+        let maxY = max(0, (zoom - 1) * host.frame.height / 2)
+        return CGSize(width:  min(max(pan.width,  -maxX), maxX),
+                      height: min(max(pan.height, -maxY), maxY))
+    }
+
     override func keyDown(with event: NSEvent) {
         let code = event.keyCode
-        if code == 53 { undoAndExit(); return }             // Esc — cancel: revert all changes + leave
+        if code == 53 {                                     // Esc — close the placement stage first, else leave
+            if dragModel.isPlacing { dragModel.endPlacing(); return }
+            undoAndExit(); return
+        }
         if code == 36 || code == 76 {                       // Return / keypad Enter — confirm: keep + leave
             if exposed {                                    // gather the plucked, send the rest home, then leave
-                DiagnosticLog.shared.info("Motion confirm — gather \(group.count) from Exposé + exit")
-                gatherAndExit()
+                let screen = validSurveyScreen(screenForPointer())
+                    ?? validSurveyScreen(screenForEvent(event))
+                    ?? activeSurveyScreen
+                if let screen {
+                    let count = pickOrderByScreen[MotionPanel.screenID(screen)]?.count ?? 0
+                    DiagnosticLog.shared.info("Motion confirm — gather \(count) from Exposé + exit")
+                    gatherInPlace(on: screen)
+                    onExit?()
+                }
             } else {
                 // Deferred gridding: lay the picked set out now (if any), then leave.
                 if !group.isEmpty {
@@ -305,19 +614,41 @@ private final class MotionPanel: NSPanel {
         // G gathers in place, E collapses back. Nothing here moves a real window
         // except the gather (G), matching the "survey on screenshots" model.
         if exposed {
+            let eventScreen = validSurveyScreen(screenForPointer())
+                ?? validSurveyScreen(screenForEvent(event))
+                ?? activeSurveyScreen
+            if let eventScreen,
+               activeSurveyScreen.map(MotionPanel.screenID) != MotionPanel.screenID(eventScreen) {
+                setActiveSurveyScreen(eventScreen)
+            }
+            let screenID = eventScreen.map(MotionPanel.screenID)
             switch code {
-            case 48: exposeAimStep(mods.contains(.shift) ? -1 : 1); return   // Tab — move highlight
+            case 48:                                                         // Tab — move highlight
+                if let eventScreen { exposeAimStep(mods.contains(.shift) ? -1 : 1, on: eventScreen) }
+                return
             case 49:                                                         // Space — pluck highlighted
-                if let wid = exposeOrder[safe: exposeAim] { exposeToggle(wid) }
+                if let eventScreen, let id = screenID {
+                    let aim = exposeAimByScreen[id] ?? 0
+                    if let wid = exposeOrderByScreen[id]?[safe: aim] { exposeToggle(wid, on: eventScreen) }
+                }
                 return
             case 14 where !mods.contains(.shift): collapseExpose(); return  // E — collapse survey
-            case 5  where !mods.contains(.shift): gatherInPlace(); return   // G — gather, stay in mode
+            case 5  where !mods.contains(.shift):                            // G — gather, stay in mode
+                if let eventScreen { gatherInPlace(on: eventScreen) }
+                return
+            case 24: zoomCanvasStep(0.2); return                            // = / +  — zoom in
+            case 27: zoomCanvasStep(-0.2); return                           // −      — zoom out
+            case 29:
+                if let eventScreen { canvasForScreen(eventScreen).reset() }  // 0      — reset to fit
+                return
             default:
                 let ch = event.charactersIgnoringModifiers?.lowercased()
-                if mods.contains(.shift), let ch, let cid = clusterHintMap[ch] {
-                    exposeToggleCluster(cid)                                 // ⇧a–z — pluck a whole group
-                } else if let ch, let wid = hintMap[ch] {
-                    exposeToggle(wid)                                        // a–z — pluck by hint
+                if let eventScreen, let id = screenID,
+                   mods.contains(.shift), let ch, let cid = clusterHintMapByScreen[id]?[ch] {
+                    exposeToggleCluster(cid, on: eventScreen)                // ⇧a–z — pluck a whole group
+                } else if let eventScreen, let id = screenID,
+                          let ch, let wid = hintMapByScreen[id]?[ch] {
+                    exposeToggle(wid, on: eventScreen)                       // a–z — pluck by hint
                 } else {
                     NSSound.beep()
                 }
@@ -365,8 +696,14 @@ private final class MotionPanel: NSPanel {
     // MARK: - Selection
 
     private func moveReticle(_ delta: Int) {
-        let n = eligible.count
-        reticle = ((reticle + delta) % n + n) % n
+        let members = activeSurveyMembers
+        guard !members.isEmpty else { NSSound.beep(); return }
+        let currentWid = activeEntry.wid
+        let current = members.firstIndex { $0.wid == currentWid } ?? 0
+        let next = ((current + delta) % members.count + members.count) % members.count
+        if let idx = eligible.firstIndex(where: { $0.wid == members[next].wid }) {
+            reticle = idx
+        }
         lastSide = nil
         _ = ax(for: activeEntry)          // resolve + cache
         updateLegend()
@@ -395,12 +732,25 @@ private final class MotionPanel: NSPanel {
             pickOrder.append(wid)
             if let e = eligible.first(where: { $0.wid == wid }) { _ = ax(for: e) }
         }
+        savePickStateForActiveScreen()
     }
 
     /// The picked windows in pick order — the order their slot numbers run and the
     /// order they fill the balanced gather grid (so slot N lands in cell N).
     private func orderedGroup() -> [WindowEntry] {
-        pickOrder.compactMap { wid in eligible.first { $0.wid == wid } }
+        let activeIDs = Set(activeSurveyMembers.map(\.wid))
+        return pickOrder.compactMap { wid in
+            guard activeIDs.contains(wid) else { return nil }
+            return eligible.first { $0.wid == wid }
+        }
+    }
+
+    /// The picked windows that should fall into the balanced gather grid — i.e.
+    /// the group minus any window that was drag-staged to a specific location
+    /// (that one honours its dropped cell instead of the grid). No-op outside the
+    /// survey, where nothing is ever staged.
+    private func gatherMembers() -> [WindowEntry] {
+        orderedGroup().filter { stagedIntents[$0.wid]?.location == nil }
     }
 
     /// ⌘L — remember the current plucked set as a rule-backed Studio layer. The
@@ -527,15 +877,18 @@ private final class MotionPanel: NSPanel {
         }
     }
 
-    /// Esc: restore every window we moved back to where it started — frame *and*
-    /// stacking order — so nothing the session touched is left ahead, then leave.
+    /// Esc: leave immediately, then restore anything we actually moved. The overlay tears
+    /// down *first* so dismissal feels instant; the (slow) per-window AX restore only runs
+    /// if we touched real windows this session — a pure survey/preview Esc skips it entirely
+    /// instead of needlessly re-raising every window (the "Esc takes forever" bug).
     private func undoAndExit() {
+        onExit?()                                   // instant visual dismiss
+        guard didMoveWindows else { return }        // nothing real changed → done
         for (wid, frame) in originalFrames {
             guard let entry = eligible.first(where: { $0.wid == wid }), let el = ax(for: entry) else { continue }
             RealWindowAnimator.setFrameRobust(el, frame, pid: entry.pid)
         }
         restoreOriginalOrder()
-        onExit?()
     }
 
     /// Re-stack every window in the front-to-back order it had when the mode
@@ -581,8 +934,8 @@ private final class MotionPanel: NSPanel {
     /// raised. Called on every pluck/unpluck so a position opens up as soon as
     /// you add a window. Moves are real but revertible (Enter confirms, Esc resets).
     private func relayoutGroup() {
-        let members = orderedGroup()
-        guard let screen = screen(for: activeEntry), !members.isEmpty else { return }
+        let members = gatherMembers()
+        guard let screen = activeSurveyScreen, !members.isEmpty else { return }
         if members.count == 1 {
             if let el = ax(for: members[0]) { raising { RealWindowAnimator.raise(el) } }
             return
@@ -627,18 +980,24 @@ private final class MotionPanel: NSPanel {
     /// size the tiles, show the spread overlay, and kick off live captures. No
     /// real window is touched — this is a screenshot survey.
     private func expose() {
-        guard let screen = screen(for: activeEntry) else { return }
+        guard let screen = activeSurveyScreen else { return }
+        let screens = surveyScreens()
         let members = eligible.filter { entry($0, isOn: screen) }
-        guard members.count > 1 else { NSSound.beep(); return }   // nothing to survey
+        let allMembers = screens.flatMap { surveyMembers(on: $0) }
+        guard !members.isEmpty else { NSSound.beep(); return }    // nothing to survey
 
         exposed = true
-        exposeFrames.removeAll()                                  // stale positions from a prior survey
-        exposeClusters = buildClusters(members)
-        assignHints()
-        exposeTileW = autoTileWidth(count: members.count, screen: screen)
-        installExposeHost(on: screen)
-        captureCount = members.count
-        members.forEach { captureThumb(for: $0) }                 // seed from the shared cache; capture only misses
+        ignoresMouseEvents = true
+        resetSurveyState(for: screens)
+        for surveyScreen in screens {
+            rebuildSurveyState(for: surveyScreen, resetAim: true)
+            canvasForScreen(surveyScreen).reset()
+        }
+        restorePickState(for: screen)
+        syncActiveSurveyState(from: screen)
+        installExposeHosts()
+        captureCount = allMembers.count
+        allMembers.forEach { captureThumb(for: $0) }              // seed from the shared cache; capture only misses
         rebuildExposeView()
         checkCapturesSettled()                                     // every tile a cache hit → already done
 
@@ -652,7 +1011,7 @@ private final class MotionPanel: NSPanel {
             }
         }
 
-        DiagnosticLog.shared.info("Motion expose — survey \(members.count) windows in \(exposeClusters.count) clusters")
+        DiagnosticLog.shared.info("Motion expose — survey \(allMembers.count) windows across \(screens.count) displays; active \(members.count) windows in \(exposeClusters.count) clusters")
         updateLegend()
         updateStack()
         refreshBorders()                                          // clears real-window chrome while surveying
@@ -663,9 +1022,194 @@ private final class MotionPanel: NSPanel {
     private func collapseExpose() {
         removeExposeHost()
         exposed = false
+        ignoresMouseEvents = false
         updateLegend()
         refreshBorders()
         updateStack()
+    }
+
+    /// A tile was dropped in the survey. A non-nil placement stages a location for
+    /// that window (badge shows; nothing real moves until gather); nil means the
+    /// drop missed every target — no change, we just rebuild to clear the drag
+    /// placeholder. Either way the rebuild here un-suppresses the spread (rebuilds
+    /// are skipped while a drag is in flight so the SwiftUI gesture survives).
+    private func handleDrop(_ wid: UInt32, _ placement: PlacementSpec?) {
+        if let placement {
+            stagedIntents[wid, default: StagedIntent()].location = placement
+            DiagnosticLog.shared.info("Hyperspace stage — wid=\(wid) location \(placement.wireValue)")
+        }
+        rebuildExposeView()
+    }
+
+    /// A tile was dropped on a Layers pile. The ＋ pile stages a brand-new layer; any
+    /// other pile toggles a staged join (multi-membership). Only *stages* — nothing is
+    /// written to StudioLayerStore until gather, so Esc still discards cleanly.
+    private func handleLayerDrop(_ wid: UInt32, _ layerKey: String) {
+        if layerKey == HyperspaceDrag.newLayerKey {
+            stagedIntents[wid, default: StagedIntent()].newLayer.toggle()
+        } else if stagedIntents[wid]?.layers.contains(layerKey) == true {
+            stagedIntents[wid]?.layers.remove(layerKey)
+        } else {
+            stagedIntents[wid, default: StagedIntent()].layers.insert(layerKey)
+        }
+        DiagnosticLog.shared.info("Hyperspace stage — wid=\(wid) layer \(layerKey)")
+        rebuildExposeView()
+    }
+
+    /// The ＋ pile's authoring flow: open the New Layer panel seeded with the apps on the active
+    /// display (the plucked apps preselected, if any), let the user name it and pick which apps
+    /// define it, then write a rule-backed StudioLayer. A real flow vs the drag-onto-＋ quick path.
+    private func presentNewLayer() {
+        guard exposed, newLayerPanel == nil,
+              let screen = validSurveyScreen(activeSurveyScreen) ?? surveyScreens().first else { return }
+        let id = MotionPanel.screenID(screen)
+        let members = surveyMembers(on: screen)
+        let plucked = Set(pickOrderByScreen[id] ?? [])
+
+        // Unique apps on this display, each with a sample thumbnail + window count, in survey order.
+        var order: [String] = []
+        var img: [String: NSImage] = [:]
+        var count: [String: Int] = [:]
+        for w in members {
+            if count[w.app] == nil { order.append(w.app) }
+            count[w.app, default: 0] += 1
+            if img[w.app] == nil, let t = thumbs[w.wid] { img[w.app] = t }
+        }
+        let candidates = order.map { NewLayerPanel.Candidate(app: $0, image: img[$0], count: count[$0] ?? 0) }
+        let pluckedApps = Set(members.filter { plucked.contains($0.wid) }.map(\.app))
+        let defaultName = Self.defaultLayerName(forApps: order.filter { pluckedApps.contains($0) })
+
+        ignoreResign = true                         // making the panel key resigns ours — don't exit
+        let panel = NewLayerPanel(
+            candidates: candidates, preselected: pluckedApps, defaultName: defaultName,
+            onCreate: { [weak self] name, apps in
+                guard let self else { return }
+                let clauses = apps.map { StudioLayerClause(app: $0, titleContains: nil) }
+                let layer = StudioLayerStore.shared.add(
+                    name: name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "Layer" : name,
+                    match: clauses.isEmpty ? [StudioLayerClause()] : clauses)
+                DiagnosticLog.shared.info("Hyperspace — created layer '\(layer.name)' from \(apps.count) app(s)")
+                self.finishNewLayer()
+                self.rebuildExposeView()            // the new pile appears in the band
+            },
+            onCancel: { [weak self] in self?.finishNewLayer() })
+        newLayerPanel = panel
+        panel.present(on: screen)
+    }
+
+    private func finishNewLayer() {
+        newLayerPanel = nil
+        ignoreResign = false
+        makeKey()                                   // reclaim key so the survey keeps responding
+    }
+
+    /// A friendly default name from the apps that seed the layer (mirrors StudioLayerStore's).
+    private static func defaultLayerName(forApps apps: [String]) -> String {
+        switch apps.count {
+        case 0:  return "Layer"
+        case 1:  return apps[0]
+        case 2:  return "\(apps[0]) + \(apps[1])"
+        default: return "\(apps[0]) +\(apps.count - 1)"
+        }
+    }
+
+    /// Build the Layers section view-models for a screen: each rule-backed layer as a
+    /// pile whose preview is a *screen-map* of its member windows on this display (cheap
+    /// per-monitor scoping — same layer can appear on both displays, each showing its
+    /// local slice), plus a trailing ＋ pile. A pile reads as "staged" while any window
+    /// holds a pending join to it.
+    private func layerPiles(on screen: NSScreen) -> [ExposeView.LayerPile] {
+        let store = StudioLayerStore.shared
+        let screenAX = MotionPanel.axRect(of: screen)
+        var piles = store.layers.map { layer -> ExposeView.LayerPile in
+            let onScreen = store.resolve(layer).filter { entry($0, isOn: screen) }
+            let members = onScreen.map { w -> ExposeView.LayerMember in
+                ExposeView.LayerMember(
+                    id: w.wid,
+                    frac: MotionPanel.frac(of: w.frame, in: screenAX),
+                    tint: Color(nsColor: MotionPanel.tint(for: w.app)),
+                    image: thumbs[w.wid])
+            }
+            let stagedCount = stagedIntents.values.filter { $0.layers.contains(layer.id) }.count
+            return ExposeView.LayerPile(id: layer.id, name: layer.name, count: onScreen.count,
+                                        members: members, rule: layer.summary, isNew: false,
+                                        staged: stagedCount > 0, stagedCount: stagedCount)
+        }
+        let newCount = stagedIntents.values.filter { $0.newLayer }.count
+        piles.append(ExposeView.LayerPile(id: HyperspaceDrag.newLayerKey, name: "new", count: 0,
+                                          isNew: true, staged: newCount > 0, stagedCount: newCount))
+        return piles
+    }
+
+    /// Every window currently on a screen, as fractional footprints — the Preview's
+    /// always-on baseline ("what this display looks like right now").
+    private func currentLayout(on screen: NSScreen) -> [ExposeView.LayerMember] {
+        let screenAX = MotionPanel.axRect(of: screen)
+        return surveyMembers(on: screen).map { w in
+            ExposeView.LayerMember(
+                id: w.wid,
+                frac: MotionPanel.frac(of: w.frame, in: screenAX),
+                tint: Color(nsColor: MotionPanel.tint(for: w.app)),
+                image: thumbs[w.wid])
+        }
+    }
+
+    /// Staged *locations* on a given screen, as fractional footprints for the Lattice
+    /// preview — persistent evidence of where each dragged window will land.
+    private func stagedPlan(on screen: NSScreen) -> [ExposeView.StagedMarker] {
+        let members = Set(surveyMembers(on: screen).map(\.wid))
+        return stagedIntents.compactMap { wid, intent -> ExposeView.StagedMarker? in
+            guard members.contains(wid), let loc = intent.location,
+                  let w = eligible.first(where: { $0.wid == wid }) else { return nil }
+            let f = loc.fractions
+            return ExposeView.StagedMarker(
+                id: wid,
+                frac: CGRect(x: f.0, y: f.1, width: f.2, height: f.3),
+                tint: Color(nsColor: MotionPanel.tint(for: w.app)),
+                image: thumbs[wid],
+                label: stagedLabel(for: wid) ?? "")
+        }
+    }
+
+    /// Commit the drag & drop intent plan (design/hyperspace-drag-drop.md). Location
+    /// moves the window; layer joins are written to StudioLayerStore; ＋ piles seed a
+    /// fresh layer. (Space axis is Phase 3.) No-op until `stagedIntents` is populated,
+    /// so it's safe to call on every gather.
+    private func commitStagedIntents(on screen: NSScreen) {
+        var newLayerSeeds: [WindowEntry] = []
+        for (wid, intent) in stagedIntents where !intent.isEmpty {
+            guard let entry = eligible.first(where: { $0.wid == wid }) else { continue }
+            if let placement = intent.location {
+                if originalFrames[wid] == nil, let el = ax(for: entry),
+                   let cur = RealWindowAnimator.axFrame(el) {
+                    originalFrames[wid] = cur
+                }
+                WindowTiler.tileWindowById(wid: wid, pid: entry.pid, to: placement, on: screen)
+                didMoveWindows = true        // a real move → Esc must restore
+            }
+            for layerID in intent.layers {
+                addAppToLayer(entry.app, layerID: layerID)
+            }
+            if intent.newLayer { newLayerSeeds.append(entry) }
+            // Phase 3: intent.space → WindowTiler.moveViaCGS
+        }
+        if !newLayerSeeds.isEmpty {
+            let layer = StudioLayerStore.shared.saveFromPluck(newLayerSeeds)
+            DiagnosticLog.shared.info("Hyperspace commit — new layer '\(layer.name)' from \(newLayerSeeds.count) window(s)")
+        }
+    }
+
+    /// Add an app clause to a layer's rule so it (and future windows of that app)
+    /// join the layer. Rule-backed membership — coarse by design, like saveFromPluck.
+    /// No-op if the layer already matches the app.
+    private func addAppToLayer(_ app: String, layerID: String) {
+        let store = StudioLayerStore.shared
+        guard var layer = store.layers.first(where: { $0.id == layerID }) else { return }
+        let already = layer.match.contains { $0.titleContains == nil && $0.app?.localizedCaseInsensitiveCompare(app) == .orderedSame }
+        guard !already else { return }
+        layer.match.append(StudioLayerClause(app: app, titleContains: nil))
+        store.update(layer)
+        DiagnosticLog.shared.info("Hyperspace commit — layer '\(layer.name)' += app '\(app)'")
     }
 
     /// Gather the picked set into a balanced grid on the active display (the only
@@ -673,16 +1217,24 @@ private final class MotionPanel: NSPanel {
     /// exactly where they are — in the survey they never moved. Shared by G and ⏎.
     private func gatherInPlace() {
         removeExposeHost()
-        let members = orderedGroup()
+        let screen = activeSurveyScreen ?? NSScreen.main ?? NSScreen.screens[0]
+        commitStagedIntents(on: screen)   // drag & drop plan; no-op until staged
+        let members = gatherMembers()
         if members.count >= 2 {
             relayoutGroup()                                       // picked set snaps into the grid, on top
         } else if let only = members.first, let el = ax(for: only) {
             raising { RealWindowAnimator.raise(el) }              // a single pick just comes forward
         }
         exposed = false
+        ignoresMouseEvents = false
         updateLegend()
         refreshBorders()
         updateStack()
+    }
+
+    private func gatherInPlace(on screen: NSScreen) {
+        setActiveSurveyScreen(screen)
+        gatherInPlace()
     }
 
     private func gatherAndExit() {
@@ -724,6 +1276,101 @@ private final class MotionPanel: NSPanel {
     /// before the hint logic). Kept out of every hint pool below, so ⇧E/⇧G carry no
     /// cluster meaning and the bare keys always mean their command.
     private static let reservedKeys: Set<Character> = ["e", "g"]
+
+    private func resetSurveyState(for screens: [NSScreen]) {
+        let validIDs = Set(screens.map(MotionPanel.screenID))
+        pickOrderByScreen = pickOrderByScreen.filter { validIDs.contains($0.key) }
+        exposeClustersByScreen.removeAll()
+        exposeOrderByScreen.removeAll()
+        exposeAimByScreen.removeAll()
+        hintForByScreen.removeAll()
+        hintMapByScreen.removeAll()
+        clusterHintForByScreen.removeAll()
+        clusterHintMapByScreen.removeAll()
+        exposeTileWByScreen.removeAll()
+        exposeFramesByScreen.removeAll()
+        canvasByScreenID = canvasByScreenID.filter { validIDs.contains($0.key) }
+    }
+
+    private func rebuildSurveyState(for screen: NSScreen, resetAim: Bool = false) {
+        let id = MotionPanel.screenID(screen)
+        let members = surveyMembers(on: screen)
+        let clusters = buildClusters(members)
+        let order = clusters.flatMap { $0.members.map(\.wid) }
+        let oldAim = exposeAimByScreen[id] ?? 0
+        let frames = exposeFramesByScreen[id] ?? [:]
+        let (hf, hm) = (handKeysMode && frames.count >= order.count)
+            ? computeHandHints(order: order, frames: frames)
+            : readingHints(for: order)
+        let (chf, chm) = clusterHints(for: clusters)
+
+        exposeClustersByScreen[id] = clusters
+        exposeOrderByScreen[id] = order
+        exposeAimByScreen[id] = resetAim ? 0 : min(oldAim, max(order.count - 1, 0))
+        hintForByScreen[id] = hf
+        hintMapByScreen[id] = hm
+        clusterHintForByScreen[id] = chf
+        clusterHintMapByScreen[id] = chm
+        exposeTileWByScreen[id] = autoTileWidth(count: members.count, screen: screen)
+
+        let memberIDs = Set(members.map(\.wid))
+        pickOrderByScreen[id] = (pickOrderByScreen[id] ?? []).filter { memberIDs.contains($0) }
+    }
+
+    private func syncActiveSurveyState(from screen: NSScreen) {
+        let id = MotionPanel.screenID(screen)
+        exposeClusters = exposeClustersByScreen[id] ?? []
+        exposeOrder = exposeOrderByScreen[id] ?? []
+        exposeAim = exposeAimByScreen[id] ?? 0
+        hintFor = hintForByScreen[id] ?? [:]
+        hintMap = hintMapByScreen[id] ?? [:]
+        clusterHintFor = clusterHintForByScreen[id] ?? [:]
+        clusterHintMap = clusterHintMapByScreen[id] ?? [:]
+        exposeTileW = exposeTileWByScreen[id] ?? autoTileWidth(count: surveyMembers(on: screen).count, screen: screen)
+        exposeFrames = exposeFramesByScreen[id] ?? [:]
+        restorePickState(for: screen)
+    }
+
+    private func readingHints(for order: [UInt32]) -> ([UInt32: String], [String: UInt32]) {
+        let homerow = Array("asdfghjklqwertyuiopzxcvbnm").filter { !MotionPanel.reservedKeys.contains($0) }
+        var hf: [UInt32: String] = [:], hm: [String: UInt32] = [:]
+        for (i, wid) in order.enumerated() where i < homerow.count {
+            let h = String(homerow[i]); hf[wid] = h; hm[h] = wid
+        }
+        return (hf, hm)
+    }
+
+    private func computeHandHints(order: [UInt32], frames: [UInt32: CGRect]) -> ([UInt32: String], [String: UInt32]) {
+        let rightKeys = Array("jkluiophynm;").filter  { !MotionPanel.reservedKeys.contains($0) }
+        let leftKeys  = Array("fdsarewqgtvcxzb").filter { !MotionPanel.reservedKeys.contains($0) }
+        let placed = order.compactMap { wid in frames[wid].map { (wid: wid, rect: $0) } }
+        guard !placed.isEmpty else { return readingHints(for: order) }
+        let mids = placed.map { $0.rect.midX }
+        let mid = (mids.min()! + mids.max()!) / 2
+        func sortKey(_ r: CGRect) -> (CGFloat, CGFloat) { (abs(r.midX - mid), r.minY) }
+        let left  = placed.filter { $0.rect.midX <= mid }.sorted { sortKey($0.rect) < sortKey($1.rect) }
+        let right = placed.filter { $0.rect.midX >  mid }.sorted { sortKey($0.rect) < sortKey($1.rect) }
+        var hf: [UInt32: String] = [:], hm: [String: UInt32] = [:]
+        for (i, t) in left.enumerated()  where i < leftKeys.count  { let h = String(leftKeys[i]);  hf[t.wid] = h; hm[h] = t.wid }
+        for (i, t) in right.enumerated() where i < rightKeys.count { let h = String(rightKeys[i]); hf[t.wid] = h; hm[h] = t.wid }
+        return (hf, hm)
+    }
+
+    private func clusterHints(for clusters: [ExposeCluster]) -> ([Int: String], [String: Int]) {
+        var hf: [Int: String] = [:], hm: [String: Int] = [:]
+        var used = Set<String>()
+        let alphabet = "abcdefghijklmnopqrstuvwxyz".map(String.init)
+        for box in clusters {
+            let fromName = box.name.lowercased().filter { $0.isLetter }.map(String.init)
+            guard let letter = (fromName + alphabet).first(where: {
+                !used.contains($0) && !MotionPanel.reservedKeys.contains(Character($0))
+            }) else { continue }
+            used.insert(letter)
+            hf[box.id] = letter.uppercased()
+            hm[letter] = box.id
+        }
+        return (hf, hm)
+    }
 
     /// Assign the spread's layout order and per-window hint letters. Two schemes:
     /// reading-order (clusters in display order) or — when hand-keys mode is on and
@@ -771,11 +1418,25 @@ private final class MotionPanel: NSPanel {
     /// Recompute per-window hints after the spread lays out, or when the mode flips.
     /// Idempotent — only rebuilds the view if the letters actually changed.
     private func reassignHandHints() {
+        guard let screen = activeSurveyScreen else { return }
+        reassignHandHints(on: screen)
+    }
+
+    private func reassignHandHints(on screen: NSScreen) {
         guard exposed else { return }
-        let (hf, hm) = (handKeysMode && exposeFrames.count >= exposeOrder.count)
-            ? computeHandHints(exposeFrames) : readingHints()
-        guard hf != hintFor else { return }
-        hintFor = hf; hintMap = hm
+        let id = MotionPanel.screenID(screen)
+        let order = exposeOrderByScreen[id] ?? []
+        let frames = exposeFramesByScreen[id] ?? [:]
+        let (hf, hm) = (handKeysMode && frames.count >= order.count)
+            ? computeHandHints(order: order, frames: frames)
+            : readingHints(for: order)
+        guard hf != hintForByScreen[id] else { return }
+        hintForByScreen[id] = hf
+        hintMapByScreen[id] = hm
+        if activeSurveyScreen.map(MotionPanel.screenID) == id {
+            hintFor = hf
+            hintMap = hm
+        }
         rebuildExposeView()
     }
 
@@ -802,11 +1463,21 @@ private final class MotionPanel: NSPanel {
     /// A free-grid fit over the display's working area — try every column count and
     /// keep the width that best uses both axes — then a packing margin and clamps so
     /// the clustered layout (a little less dense than a bare grid) still fits cleanly.
+    /// Height of the top intent band on a given display. Shared by the survey
+    /// fit (so tiles never run under the band) and ExposeView (which draws it).
+    private func bandHeight(for screen: NSScreen) -> CGFloat {
+        // Reserve a touch under the top third for the intent band so the survey
+        // grid gets the bottom ~2/3 (design/hyperspace-drag-drop.md). Floored so the
+        // Layers/Lattice/Spaces cards still fit on a short display, capped so it
+        // doesn't bloat on a tall external one.
+        max(196, min(screen.frame.height * 0.30, 420))
+    }
+
     private func autoTileWidth(count n: Int, screen: NSScreen) -> CGFloat {
         let area = screen.frame
         let pad: CGFloat = 72            // 36pt survey padding each side
         let availW = max(200, area.width - pad)
-        let availH = max(200, area.height - pad)
+        let availH = max(200, area.height - pad - bandHeight(for: screen))   // reserve the intent band
         let aspect: CGFloat = 0.62       // tile height / width
         let gap: CGFloat = 26            // tile gaps + cluster chrome, averaged
         let count = max(1, n)
@@ -833,20 +1504,36 @@ private final class MotionPanel: NSPanel {
 
     // MARK: - Survey overlay (SwiftUI spread)
 
-    private func installExposeHost(on screen: NSScreen) {
-        let hosting = NSHostingView(rootView: ExposeView(clusters: [], tileWidth: exposeTileW))
-        hosting.frame = panelLocal(screen.frame)                  // dim + spread the active display
-        // Sit beneath the legend/minimap HUDs so they stay readable over the survey.
-        if let below = legendHost ?? stackHost {
-            contentView?.addSubview(hosting, positioned: .below, relativeTo: below)
-        } else {
-            contentView?.addSubview(hosting)
+    private func installExposeHosts() {
+        removeExposeHost()
+        for screen in surveyScreens() {
+            let id = MotionPanel.screenID(screen)
+            let hosting = NSHostingView(rootView: ExposeView(
+                clusters: [],
+                tileWidth: autoTileWidth(count: max(1, surveyMembers(on: screen).count), screen: screen),
+                canvas: canvasForScreen(screen),
+                drag: dragModel,
+                screenID: id,
+                bandHeight: bandHeight(for: screen),
+                screenAspect: screen.visibleFrame.width / max(1, screen.visibleFrame.height),
+                usableInset: MotionPanel.usableInset(of: screen),
+                onNewLayer: { [weak self] in self?.presentNewLayer() }))
+            hosting.frame = NSRect(origin: .zero, size: screen.frame.size)
+            hosting.autoresizingMask = [.width, .height]
+            let panel = HyperspaceScreenPanel(screen: screen)
+            panel.contentView = hosting
+            panel.orderFrontRegardless()
+            exposeHostsByScreenID[id] = hosting
+            exposePanelsByScreenID[id] = panel
         }
-        exposeHost = hosting
+        exposeHost = activeSurveyScreen.flatMap { exposeHostsByScreenID[MotionPanel.screenID($0)] }
     }
 
     private func removeExposeHost() {
-        exposeHost?.removeFromSuperview()
+        exposePanelsByScreenID.values.forEach { $0.close() }
+        exposePanelsByScreenID.removeAll()
+        exposeHostsByScreenID.values.forEach { $0.removeFromSuperview() }
+        exposeHostsByScreenID.removeAll()
         exposeHost = nil
     }
 
@@ -854,31 +1541,67 @@ private final class MotionPanel: NSPanel {
     /// the cluster *structure* is fixed for the life of a survey; only the per-tile
     /// pick slot, highlight, and image change.
     private func rebuildExposeView() {
-        guard exposed, let exposeHost else { return }
-        let vm = exposeClusters.map { box in
-            ExposeView.Cluster(
-                id: box.id, name: box.name, rule: box.rule, userDefined: box.userDefined,
-                hint: clusterHintFor[box.id] ?? "",
-                tiles: box.members.map { tileVM($0) }
-            )
+        guard exposed else { return }
+        // Replacing host.rootView mid-drag would tear down the in-flight SwiftUI
+        // gesture and abort the drag. Skip while a drag is live; handleDrop()
+        // rebuilds once it ends.
+        guard !dragModel.isActive else { return }
+        if exposeHostsByScreenID.isEmpty { installExposeHosts() }
+        exposeHost = activeSurveyScreen.flatMap { exposeHostsByScreenID[MotionPanel.screenID($0)] }
+
+        for screen in surveyScreens() {
+            let id = MotionPanel.screenID(screen)
+            guard let host = exposeHostsByScreenID[id] else { continue }
+            let members = surveyMembers(on: screen)
+            if exposeClustersByScreen[id] == nil {
+                rebuildSurveyState(for: screen, resetAim: true)
+            }
+            let clusters = exposeClustersByScreen[id] ?? []
+            let screenHintFor = hintForByScreen[id] ?? [:]
+            let screenClusterHintFor = clusterHintForByScreen[id] ?? [:]
+            let vm = clusters.map { box in
+                ExposeView.Cluster(
+                    id: box.id,
+                    name: box.name,
+                    rule: box.rule,
+                    userDefined: box.userDefined,
+                    hint: screenClusterHintFor[box.id] ?? "",
+                    tiles: box.members.map { tileVM($0, on: screen, hints: screenHintFor) }
+                )
+            }
+            host.rootView = ExposeView(
+                clusters: vm,
+                tileWidth: exposeTileWByScreen[id] ?? autoTileWidth(count: members.count, screen: screen),
+                canvas: canvasForScreen(screen),
+                drag: dragModel,
+                screenID: id,
+                bandHeight: bandHeight(for: screen),
+                screenAspect: screen.visibleFrame.width / max(1, screen.visibleFrame.height),
+                usableInset: MotionPanel.usableInset(of: screen),
+                onPick: { [weak self] wid in self?.exposeToggle(wid, on: screen) },
+                onDrop: { [weak self] wid, spec in self?.handleDrop(wid, spec) },
+                onDropLayer: { [weak self] wid, key in self?.handleLayerDrop(wid, key) },
+                layers: layerPiles(on: screen),
+                stagedPlan: stagedPlan(on: screen),
+                currentLayout: currentLayout(on: screen),
+                displayScope: exposeDisplayScope(for: screen),
+                onLayout: { [weak self] frames in
+                    guard let self else { return }
+                    DispatchQueue.main.async {
+                        guard self.exposed, frames != self.exposeFramesByScreen[id] else { return }
+                        self.exposeFramesByScreen[id] = frames
+                        if self.handKeysMode { self.reassignHandHints(on: screen) }
+                    }
+                },
+                onHandKeys: { [weak self] on in
+                    guard let self else { return }
+                    self.handKeysMode = on
+                    self.surveyScreens().forEach { self.reassignHandHints(on: $0) }
+                },
+                onExit: { [weak self] in self?.onExit?() },   // ✕ — leave, keep what's on screen
+                onNewLayer: { [weak self] in self?.presentNewLayer() },
+                loadSummary: loadSummaryText())
         }
-        exposeHost.rootView = ExposeView(
-            clusters: vm, tileWidth: exposeTileW,
-            onPick: { [weak self] wid in self?.exposeToggle(wid) },
-            onLayout: { [weak self] frames in
-                guard let self else { return }
-                DispatchQueue.main.async {
-                    guard self.exposed, frames != self.exposeFrames else { return }
-                    self.exposeFrames = frames
-                    if self.handKeysMode { self.reassignHandHints() }
-                }
-            },
-            onHandKeys: { [weak self] on in
-                guard let self else { return }
-                self.handKeysMode = on
-                self.reassignHandHints()
-            },
-            loadSummary: loadSummaryText())
     }
 
     /// Compact load readout for the survey: time-to-first-paint and time-to-all-
@@ -900,9 +1623,67 @@ private final class MotionPanel: NSPanel {
         )
     }
 
+    private func tileVM(_ w: WindowEntry, on screen: NSScreen, hints: [UInt32: String]) -> ExposeView.Tile {
+        let id = MotionPanel.screenID(screen)
+        let savedOrder = pickOrderByScreen[id] ?? []
+        let order = exposeOrderByScreen[id] ?? []
+        let aim = exposeAimByScreen[id] ?? 0
+        return ExposeView.Tile(
+            id: w.wid, app: w.app, title: w.title,
+            tint: Color(nsColor: MotionPanel.tint(for: w.app)),
+            image: thumbs[w.wid],
+            hint: hints[w.wid] ?? "",
+            pickSlot: savedOrder.firstIndex(of: w.wid).map { $0 + 1 },
+            isAimed: order[safe: aim] == w.wid,
+            staged: stagedLabel(for: w.wid),
+            layerTags: layerTags(for: w.wid)
+        )
+    }
+
+    /// Names of the layers a window is staged to join (plus "new" for a staged ＋),
+    /// shown as labels along the tile's bottom. Empty when nothing layer-ish is staged.
+    private func layerTags(for wid: UInt32) -> [String] {
+        guard let intent = stagedIntents[wid] else { return [] }
+        let names = StudioLayerStore.shared.layers
+            .filter { intent.layers.contains($0.id) }
+            .map(\.name)
+        return intent.newLayer ? names + ["new"] : names
+    }
+
+    /// Compact badge for a window's staged *location*, e.g. "¼ 1,0". Layer membership
+    /// is shown separately as bottom labels (see layerTags) — a tag, not a move.
+    private func stagedLabel(for wid: UInt32) -> String? {
+        guard let loc = stagedIntents[wid]?.location else { return nil }
+        if case let .grid(g) = loc {
+            return "\(LatticeRes.glyph(cols: g.columns, rows: g.rows)) \(g.column),\(g.row)"
+        }
+        return loc.wireValue
+    }
+
     /// Pluck a tile by wid (hint key or click) and refresh the survey + minimap.
     private func exposeToggle(_ wid: UInt32) {
         togglePicked(wid)
+        rebuildExposeView()
+        updateLegend()
+        updateStack()
+    }
+
+    private func exposeToggle(_ wid: UInt32, on screen: NSScreen) {
+        let id = MotionPanel.screenID(screen)
+        var order = pickOrderByScreen[id] ?? []
+        if order.contains(wid) {
+            order.removeAll { $0 == wid }
+        } else {
+            order.append(wid)
+            if let e = eligible.first(where: { $0.wid == wid }) { _ = ax(for: e) }
+        }
+        let memberIDs = Set(surveyMembers(on: screen).map(\.wid))
+        pickOrderByScreen[id] = order.filter { memberIDs.contains($0) }
+        if activeSurveyScreen.map(MotionPanel.screenID) != id {
+            setActiveSurveyScreen(screen)
+        } else {
+            restorePickState(for: screen)
+        }
         rebuildExposeView()
         updateLegend()
         updateStack()
@@ -927,6 +1708,156 @@ private final class MotionPanel: NSPanel {
         updateStack()
     }
 
+    private func exposeToggleCluster(_ clusterID: Int, on screen: NSScreen) {
+        let screenID = MotionPanel.screenID(screen)
+        guard let box = exposeClustersByScreen[screenID]?.first(where: { $0.id == clusterID }) else {
+            NSSound.beep()
+            return
+        }
+        let wids = box.members.map { $0.wid }
+        guard !wids.isEmpty else { return }
+        var order = pickOrderByScreen[screenID] ?? []
+        let selected = Set(order)
+        let allPicked = wids.allSatisfy { selected.contains($0) }
+        if allPicked {
+            order.removeAll { wids.contains($0) }
+        } else {
+            for wid in wids where !order.contains(wid) {
+                order.append(wid)
+                if let e = eligible.first(where: { $0.wid == wid }) { _ = ax(for: e) }
+            }
+        }
+        pickOrderByScreen[screenID] = order
+        if activeSurveyScreen.map(MotionPanel.screenID) != screenID {
+            setActiveSurveyScreen(screen)
+        } else {
+            restorePickState(for: screen)
+        }
+        rebuildExposeView()
+        updateLegend()
+        updateStack()
+    }
+
+    // MARK: - Display-scoped survey
+
+    private func surveyScreens() -> [NSScreen] {
+        NSScreen.screens.filter { screen in
+            !surveyMembers(on: screen).isEmpty
+        }
+    }
+
+    private func surveyMembers(on screen: NSScreen) -> [WindowEntry] {
+        eligible.filter { entry($0, isOn: screen) }
+    }
+
+    private func engageSurveyScreen(_ screen: NSScreen, toggling wid: UInt32? = nil) {
+        let targetID = MotionPanel.screenID(screen)
+        let currentID = activeSurveyScreen.map(MotionPanel.screenID)
+        if currentID != targetID {
+            savePickStateForActiveScreen()
+            setActiveSurveyScreen(screen)
+        }
+        if let wid {
+            exposeToggle(wid)
+        }
+    }
+
+    private func screenForEvent(_ event: NSEvent) -> NSScreen? {
+        if let window = event.window,
+           let screenID = exposePanelsByScreenID.first(where: { window === $0.value })?.key,
+           let screen = NSScreen.screens.first(where: { MotionPanel.screenID($0) == screenID }) {
+            return screen
+        }
+        let point = event.locationInWindow
+        let global = CGPoint(x: point.x + frame.origin.x, y: point.y + frame.origin.y)
+        return NSScreen.screens.first(where: { $0.frame.contains(global) })
+    }
+
+    private func screenForPointer() -> NSScreen? {
+        let point = NSEvent.mouseLocation
+        return NSScreen.screens.first(where: { $0.frame.contains(point) })
+    }
+
+    private func validSurveyScreen(_ screen: NSScreen?) -> NSScreen? {
+        guard let screen, !surveyMembers(on: screen).isEmpty else { return nil }
+        return screen
+    }
+
+    private func setActiveSurveyScreen(_ screen: NSScreen) {
+        if activeSurveyScreen.map(MotionPanel.screenID) != MotionPanel.screenID(screen) {
+            savePickStateForActiveScreen()
+        }
+        activeScreenID = MotionPanel.screenID(screen)
+
+        let members = eligible.enumerated().filter { _, entry in self.entry(entry, isOn: screen) }
+        let allMembers = surveyScreens().flatMap { surveyMembers(on: $0) }
+        guard let first = members.first else { NSSound.beep(); return }
+        if !entry(activeEntry, isOn: screen) {
+            reticle = first.offset
+        }
+
+        lastSide = nil
+        restorePickState(for: screen)
+
+        if exposed {
+            captureCount = allMembers.count
+            if exposeClustersByScreen[MotionPanel.screenID(screen)] == nil {
+                rebuildSurveyState(for: screen, resetAim: true)
+            }
+            syncActiveSurveyState(from: screen)
+            if exposeHostsByScreenID.isEmpty {
+                installExposeHosts()
+            }
+            allMembers.forEach { captureThumb(for: $0) }
+            rebuildExposeView()
+            checkCapturesSettled()
+        }
+
+        updateLegend()
+        updateStack()
+        refreshBorders()
+    }
+
+    private func savePickStateForActiveScreen() {
+        guard let screen = activeSurveyScreen else { return }
+        let memberIDs = Set(eligible.filter { entry($0, isOn: screen) }.map(\.wid))
+        pickOrderByScreen[MotionPanel.screenID(screen)] = pickOrder.filter { memberIDs.contains($0) }
+    }
+
+    private func restorePickState(for screen: NSScreen) {
+        let memberIDs = Set(eligible.filter { entry($0, isOn: screen) }.map(\.wid))
+        let savedOrder = (pickOrderByScreen[MotionPanel.screenID(screen)] ?? []).filter { memberIDs.contains($0) }
+        pickOrder = savedOrder
+        group = Set(savedOrder)
+    }
+
+    private func canvasForScreen(_ screen: NSScreen) -> ExposeCanvas {
+        let id = MotionPanel.screenID(screen)
+        if let existing = canvasByScreenID[id] {
+            return existing
+        }
+        let newCanvas = ExposeCanvas()
+        canvasByScreenID[id] = newCanvas
+        return newCanvas
+    }
+
+    private func exposeDisplayScope(for screen: NSScreen) -> ExposeView.DisplayScope? {
+        let screens = surveyScreens()
+        let screenID = MotionPanel.screenID(screen)
+        guard let index = screens.firstIndex(where: { MotionPanel.screenID($0) == screenID }) else {
+            return nil
+        }
+        let physicalIndex = NSScreen.screens.firstIndex(where: { MotionPanel.screenID($0) == screenID }) ?? index
+        let windows = surveyMembers(on: screen).count
+        return ExposeView.DisplayScope(
+            index: physicalIndex,
+            count: screens.count,
+            label: physicalIndex == 0 ? "Main" : "Display \(physicalIndex + 1)",
+            windowCount: windows,
+            isActive: activeSurveyScreen.map(MotionPanel.screenID) == screenID
+        )
+    }
+
     /// Clicking a minimap cell deselects it — the requested "unpluck with the
     /// mouse" path, working in both the survey and plain motion mode.
     private func minimapToggle(_ wid: UInt32) {
@@ -945,17 +1876,30 @@ private final class MotionPanel: NSPanel {
         rebuildExposeView()
     }
 
+    private func exposeAimStep(_ delta: Int, on screen: NSScreen) {
+        let id = MotionPanel.screenID(screen)
+        let order = exposeOrderByScreen[id] ?? []
+        guard !order.isEmpty else { return }
+        let current = exposeAimByScreen[id] ?? 0
+        exposeAimByScreen[id] = ((current + delta) % order.count + order.count) % order.count
+        if activeSurveyScreen.map(MotionPanel.screenID) != id {
+            setActiveSurveyScreen(screen)
+        } else {
+            exposeAim = exposeAimByScreen[id] ?? 0
+        }
+        rebuildExposeView()
+    }
+
     /// True if the window's center sits on `screen` (AppKit coords, like screen(for:)).
     private func entry(_ e: WindowEntry, isOn screen: NSScreen) -> Bool {
-        let primaryH = NSScreen.screens.first?.frame.height ?? 0
-        let center = CGPoint(x: e.frame.x + e.frame.w / 2, y: primaryH - (e.frame.y + e.frame.h / 2))
-        return screen.frame.contains(center)
+        MotionPanel.screenID(WindowTiler.screenForWindowFrame(e.frame)) == MotionPanel.screenID(screen)
     }
 
     /// Run window-raising work while swallowing the transient key-resign it can
     /// trigger, so the overlay doesn't auto-exit mid-operation.
     private func raising(_ body: () -> Void) {
         ignoreResign = true
+        didMoveWindows = true        // every real move/raise funnels through here
         body()
         DispatchQueue.main.async { [weak self] in self?.ignoreResign = false }
     }
@@ -1079,15 +2023,52 @@ private final class MotionPanel: NSPanel {
     }
 
     private func screen(for entry: WindowEntry) -> NSScreen? {
-        let primaryH = NSScreen.screens.first?.frame.height ?? 0
-        let cx = entry.frame.x + entry.frame.w / 2
-        let cy = primaryH - (entry.frame.y + entry.frame.h / 2)
-        let center = CGPoint(x: cx, y: cy)
-        return NSScreen.screens.first(where: { $0.frame.contains(center) }) ?? NSScreen.main ?? NSScreen.screens.first
+        WindowTiler.screenForWindowFrame(entry.frame)
+    }
+
+    private static func screenID(_ screen: NSScreen) -> String {
+        if let number = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber {
+            return "display-\(number.intValue)"
+        }
+        let f = screen.frame
+        return "display-\(Int(f.minX))-\(Int(f.minY))-\(Int(f.width))-\(Int(f.height))"
     }
 
     private static func screensUnion() -> NSRect {
         NSScreen.screens.reduce(NSRect.zero) { $0.union($1.frame) }
+    }
+
+    /// A screen's *usable* area (visibleFrame — below the menu bar, above the Dock) in AX/CG
+    /// (top-left origin) coords — the same space as `WindowEntry.frame` AND the same rect
+    /// `WindowTiler.tileFrame` divides into grid cells. Using visibleFrame (not the full frame)
+    /// keeps the placement preview 1:1 with where windows actually land (no size mismatch).
+    static func axRect(of screen: NSScreen) -> CGRect {
+        let primaryH = NSScreen.screens.first?.frame.height ?? screen.frame.height
+        let vf = screen.visibleFrame
+        let axTop = primaryH - vf.maxY
+        return CGRect(x: vf.minX, y: axTop, width: vf.width, height: vf.height)
+    }
+
+    /// The inset from a screen's full frame to its usable visibleFrame, in SwiftUI top-left
+    /// coords — so an overlay sized to the full panel can place content inside the menu bar/Dock.
+    static func usableInset(of screen: NSScreen) -> EdgeInsets {
+        let f = screen.frame, v = screen.visibleFrame
+        return EdgeInsets(top: max(0, f.maxY - v.maxY),
+                          leading: max(0, v.minX - f.minX),
+                          bottom: max(0, v.minY - f.minY),
+                          trailing: max(0, f.maxX - v.maxX))
+    }
+
+    /// A window frame as a top-origin fractional rect within `screenAX`, clamped to the
+    /// unit square so off-screen spill doesn't blow out the map.
+    static func frac(of frame: WindowFrame, in screenAX: CGRect) -> CGRect {
+        guard screenAX.width > 1, screenAX.height > 1 else { return .zero }
+        let x = (CGFloat(frame.x) - screenAX.minX) / screenAX.width
+        let y = (CGFloat(frame.y) - screenAX.minY) / screenAX.height
+        let cx = min(max(x, 0), 1), cy = min(max(y, 0), 1)
+        return CGRect(x: cx, y: cy,
+                      width: min(CGFloat(frame.w) / screenAX.width, 1 - cx),
+                      height: min(CGFloat(frame.h) / screenAX.height, 1 - cy))
     }
 
     static func tint(for app: String) -> NSColor {
@@ -1102,7 +2083,7 @@ private final class MotionPanel: NSPanel {
     private func installLegend(on host: NSView) {
         let hosting = NSHostingView(rootView: legendModel())
         let size = hosting.fittingSize
-        let screenFrame = (screen(for: activeEntry) ?? NSScreen.main)?.frame ?? frame
+        let screenFrame = (activeSurveyScreen ?? screen(for: activeEntry) ?? NSScreen.main)?.frame ?? frame
         let x = screenFrame.midX - size.width / 2 - frame.origin.x
         let y = screenFrame.minY + 70 - frame.origin.y
         hosting.frame = NSRect(x: x, y: y, width: size.width, height: size.height)
@@ -1114,7 +2095,7 @@ private final class MotionPanel: NSPanel {
         legendHost?.rootView = legendModel()
         if let hosting = legendHost {
             let size = hosting.fittingSize
-            let screenFrame = (screen(for: activeEntry) ?? NSScreen.main)?.frame ?? frame
+            let screenFrame = (activeSurveyScreen ?? screen(for: activeEntry) ?? NSScreen.main)?.frame ?? frame
             hosting.frame = NSRect(x: screenFrame.midX - size.width / 2 - frame.origin.x,
                                    y: screenFrame.minY + 70 - frame.origin.y,
                                    width: size.width, height: size.height)
@@ -1134,7 +2115,8 @@ private final class MotionPanel: NSPanel {
         MotionLegend(app: activeEntry.app,
                      tint: Color(nsColor: MotionPanel.tint(for: activeEntry.app)),
                      groupCount: group.count,
-                     exposed: exposed)
+                     exposed: exposed,
+                     displayCount: surveyScreens().count)
     }
 
     // MARK: - Snapshot stack (bottom-left)
@@ -1175,7 +2157,7 @@ private final class MotionPanel: NSPanel {
                 isActive: m.wid == activeWid
             )
         }
-        let screenFrame = (screen(for: activeEntry) ?? NSScreen.main)?.frame ?? frame
+        let screenFrame = (activeSurveyScreen ?? screen(for: activeEntry) ?? NSScreen.main)?.frame ?? frame
         let aspect = screenFrame.height > 0 ? screenFrame.width / screenFrame.height : 1.6
 
         stackHost.rootView = MotionStack(cells: cells, aspect: aspect,
@@ -1191,7 +2173,7 @@ private final class MotionPanel: NSPanel {
     /// Bottom-left, anchored at the bottom so the stack grows upward as it fills.
     private func positionStack() {
         guard let stackHost else { return }
-        let screenFrame = (screen(for: activeEntry) ?? NSScreen.main)?.frame ?? frame
+        let screenFrame = (activeSurveyScreen ?? screen(for: activeEntry) ?? NSScreen.main)?.frame ?? frame
         let size = stackHost.fittingSize
         stackHost.frame = NSRect(
             x: screenFrame.minX + stackMargin - frame.origin.x,
@@ -1251,6 +2233,7 @@ private struct MotionLegend: View {
     let tint: Color
     let groupCount: Int
     var exposed: Bool = false
+    var displayCount: Int = 1
 
     var body: some View {
         HStack(spacing: 12) {
@@ -1273,6 +2256,7 @@ private struct MotionLegend: View {
                 keyHint("a–z", "pluck")
                 keyHint("⇧a–z", "group")
                 keyHint("Tab", "aim")
+                keyHint("⌘scroll", "zoom")
                 keyHint("⏎", "gather")
                 if groupCount > 0 { keyHint("⌘L", "save layer") }
                 keyHint("E", "collapse")
@@ -1552,6 +2536,44 @@ private struct TileFramesKey: PreferenceKey {
     }
 }
 
+/// Reports the Lattice drop-grid's frame (in the root coordinate space) so a drop
+/// can be hit-tested to a cell.
+private struct LatticeFrameKey: PreferenceKey {
+    static let defaultValue: CGRect = .zero
+    static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
+        let next = nextValue()
+        if next != .zero { value = next }
+    }
+}
+
+/// Collects each Layers pile's frame (root space, keyed by layer id / newLayerKey)
+/// so a drop can be hit-tested to a pile.
+private struct LayerFrameKey: PreferenceKey {
+    static let defaultValue: [String: CGRect] = [:]
+    static func reduce(value: inout [String: CGRect], nextValue: () -> [String: CGRect]) {
+        value.merge(nextValue()) { _, new in new }
+    }
+}
+
+/// The one-shot "landed" ring flashed at a drop target. Expands and fades on appear;
+/// keyed by the pulse token (`.id`) so each drop replays it from scratch.
+private struct DropPulseRing: View {
+    let frame: CGRect
+    let tint: Color
+    @State private var on = false
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 6, style: .continuous)
+            .strokeBorder(tint, lineWidth: 2.5)
+            .frame(width: frame.width, height: frame.height)
+            .scaleEffect(on ? 1.35 : 0.92)
+            .opacity(on ? 0 : 0.95)
+            .position(x: frame.midX, y: frame.midY)
+            .allowsHitTesting(false)
+            .onAppear { withAnimation(.easeOut(duration: 0.45)) { on = true } }
+    }
+}
+
 /// Live frame-cadence stats for the survey perf harness. `record` is fed each
 /// animation tick; the EMA keeps the readout steady, worst-frame surfaces
 /// hitches. Reset between A/B runs for a clean comparison.
@@ -1589,6 +2611,8 @@ struct ExposeView: View {
         let hint: String
         let pickSlot: Int?
         let isAimed: Bool
+        var staged: String? = nil      // drag-staged location badge, e.g. "¼ 1,0"
+        var layerTags: [String] = []   // staged layer memberships (names) — shown as bottom labels
     }
 
     struct Cluster: Identifiable {
@@ -1600,15 +2624,73 @@ struct ExposeView: View {
         let tiles: [Tile]
     }
 
+    struct DisplayScope {
+        let index: Int
+        let count: Int
+        let label: String
+        let windowCount: Int
+        let isActive: Bool
+    }
+
+    // A member window of a layer, placed on its screen-map preview at its real
+    // (screen-relative, top-origin) fractional rect.
+    struct LayerMember: Identifiable {
+        let id: UInt32
+        let frac: CGRect
+        let tint: Color
+        let image: NSImage?
+    }
+
+    // A layer rendered as a drop "pile": a screen-map preview of its member windows
+    // (so you see *what the layer looks like*), its name + on-screen count + rule.
+    // `staged` marks a pending join (highlight). The ＋ pile uses
+    // HyperspaceDrag.newLayerKey as its id.
+    struct LayerPile: Identifiable {
+        let id: String
+        let name: String
+        let count: Int                       // members on the active screen
+        var members: [LayerMember] = []      // for the screen-map preview
+        var rule: String = ""                // human-readable match rule, e.g. "Chrome · ~dev"
+        var isNew: Bool = false
+        var staged: Bool = false
+        var stagedCount: Int = 0             // how many windows are staged to join this pile
+    }
+
+    // A window's staged *location* drawn into the Lattice preview as proof of the plan:
+    // a translucent app-tinted footprint at its fractional target rect (resolution-
+    // agnostic), so the band shows where everything will land before you commit.
+    struct StagedMarker: Identifiable {
+        let id: UInt32          // wid
+        let frac: CGRect        // x,y,w,h in 0…1, top-origin (PlacementSpec.fractions)
+        let tint: Color
+        let image: NSImage?
+        let label: String       // e.g. "¼ 1,0"
+    }
+
     let clusters: [Cluster]
     let tileWidth: CGFloat
+    @ObservedObject var canvas: ExposeCanvas
+    @ObservedObject var drag: HyperspaceDrag
+    var screenID: String = ""
+    var bandHeight: CGFloat = 200
+    var screenAspect: CGFloat = 1.6
+    var usableInset = EdgeInsets()   // full panel(frame) → visibleFrame, so the Place stage clears the menu bar/Dock
     var onPick: (UInt32) -> Void = { _ in }
+    var onDrop: (UInt32, PlacementSpec?) -> Void = { _, _ in }
+    var onDropLayer: (UInt32, String) -> Void = { _, _ in }
+    var layers: [LayerPile] = []
+    var stagedPlan: [StagedMarker] = []
+    var currentLayout: [LayerMember] = []   // every window on this display — context for the Place stage
+    var displayScope: DisplayScope?
     var onLayout: ([UInt32: CGRect]) -> Void = { _ in }
     var onHandKeys: (Bool) -> Void = { _ in }
+    var onExit: () -> Void = { }              // mouse-driven leave (the ✕ button)
+    var onNewLayer: () -> Void = { }          // tap the ＋ pile → open the New Layer authoring flow
     var loadSummary: String = ""
 
     private let ink = Color(red: 0.02, green: 0.03, blue: 0.05)
     static let surveySpace = "hyperspace.survey"
+    static let rootSpace = "hyperspace.root"   // band + survey + ghost share this space
 
     // The lighting rig — all persisted, all live. The survey is lit like a room:
     // an ambient floor, one directional key light you can aim, a focus spotlight
@@ -1631,39 +2713,370 @@ struct ExposeView: View {
 
     // Perf A/B harness (diagnostic, not persisted): A = a plain dark-gray fill,
     // B = the full frosted stack. The HUD reads live frame cadence.
+    // The visual-settings rig (lighting/size/zoom/keys/perf) lives behind a gear
+    // in the top-right; collapsed by default so it doesn't cover the intent band.
+    @State private var dialsOpen = false
+
     @State private var perfMode = false
     @State private var perfFlat = false                  // A = true, B = false
     @StateObject private var perf = PerfStats()
 
     var body: some View {
         ZStack {
-            if perfMode {
-                // Continuous repaint so the cadence reflects sustained paint cost,
-                // and a gently drifting grid gives the renderer real work to do.
-                TimelineView(.animation) { ctx in
-                    surveyContent(phase: ctx.date.timeIntervalSinceReferenceDate)
-                        .onChange(of: ctx.date) { _, d in perf.record(d.timeIntervalSinceReferenceDate) }
-                }
-            } else {
-                surveyContent(phase: 0)
+            backdrop                                    // full-bleed lit scrim
+            VStack(spacing: 0) {
+                intentBand                              // top: Layers · Grid
+                    .frame(height: bandHeight)
+                survey                                  // bottom: the window lattice (the preview surface)
+            }
+            placementStage                              // "Place…" → full-screen, click where it goes
+            ghostOverlay                                // the dragged thumbnail
+            dropPulseOverlay                            // the "landed" ring at the drop target
+        }
+        .coordinateSpace(name: ExposeView.rootSpace)    // band, survey, ghost share one space
+        .animation(.spring(response: 0.26, dampingFraction: 0.82), value: rosterPileID)
+        .animation(.spring(response: 0.26, dampingFraction: 0.82), value: drag.placeWid)
+        .animation(.spring(response: 0.2, dampingFraction: 0.74), value: drag.placeCell)
+        .overlay(alignment: .topLeading) {
+            if let displayScope, !drag.isPlacing {
+                displayBadge(displayScope)
+                    .padding(20)
             }
         }
-        .overlay(alignment: .topTrailing) { dials.padding(20) }
-        .overlay(alignment: .top) { if perfMode { perfHUD.padding(.top, 22) } }
+        .overlay(alignment: .topTrailing) {
+            if !drag.isPlacing {                            // the Place stage owns the screen
+                VStack(alignment: .trailing, spacing: 8) {
+                    exitButton
+                    settingsToggle
+                    if dialsOpen { dials }
+                }
+                .padding(20)
+            }
+        }
+        .overlay(alignment: .top) {
+            if perfMode {
+                perfHUD.padding(.top, 22)
+            }
+        }
+        .overlay(alignment: .top) {
+            if !drag.isPlacing {
+                planSummaryBar.padding(.top, bandHeight + 4)   // sits just under the intent band
+            }
+        }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    private func surveyContent(phase: Double) -> some View {
-        ZStack {
-            scrim(phase: phase)
-            FlowLayout(spacing: 18, lineSpacing: 18) {
-                ForEach(clusters) { clusterBox($0) }
+    // A one-line readout of the whole staged plan, so the grouped intent reads at a
+    // glance and the commit/discard affordance is always in view. Shown only when
+    // something is staged. Derived from the on-screen tiles (single-screen drag).
+    @ViewBuilder
+    private var planSummaryBar: some View {
+        let tiles = clusters.flatMap(\.tiles)
+        let placed = tiles.filter { $0.staged != nil }.count
+        let tagged = tiles.filter { !$0.layerTags.isEmpty }.count
+        if placed + tagged > 0 {
+            HStack(spacing: 10) {
+                if placed > 0 { planChip("▦", "\(placed) placed") }
+                if tagged > 0 { planChip("▢", "\(tagged) tagged") }
+                Rectangle().fill(Palette.border).frame(width: 0.5, height: 12)
+                Text("⏎ commit").font(Typo.monoBold(9)).foregroundColor(Palette.running)
+                Text("esc discard").font(Typo.mono(9)).foregroundColor(.white.opacity(0.4))
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .padding(36)
-            .coordinateSpace(name: ExposeView.surveySpace)
-            .onPreferenceChange(TileFramesKey.self) { onLayout($0) }
+            .padding(.horizontal, 12).padding(.vertical, 7)
+            .background(
+                Capsule().fill(Color.black.opacity(0.6))
+                    .overlay(Capsule().strokeBorder(Palette.running.opacity(0.4), lineWidth: 0.5))
+            )
+            .transition(.move(edge: .top).combined(with: .opacity))
+            .animation(.spring(response: 0.32, dampingFraction: 0.78), value: placed + tagged)
         }
+    }
+
+    private func planChip(_ glyph: String, _ label: String) -> some View {
+        HStack(spacing: 4) {
+            Text(glyph).font(.system(size: 10)).foregroundColor(Palette.running)
+            Text(label).font(Typo.monoBold(9)).foregroundColor(.white.opacity(0.85))
+        }
+    }
+
+    // The lit room behind everything. Under the perf harness it repaints every
+    // frame (and feeds the cadence meter); otherwise it's a static pass.
+    @ViewBuilder
+    private var backdrop: some View {
+        if perfMode {
+            TimelineView(.animation) { ctx in
+                scrim(phase: ctx.date.timeIntervalSinceReferenceDate)
+                    .onChange(of: ctx.date) { _, d in perf.record(d.timeIntervalSinceReferenceDate) }
+            }
+        } else {
+            scrim(phase: 0)
+        }
+    }
+
+    // The window lattice — the bottom two-thirds. Top-anchored (frame alignment .top)
+    // so the lattice sits just under the intent band instead of being centred in the
+    // bottom region with a gap above it. Pure view transform (zoom/pan); no real
+    // window moves here.
+    private var survey: some View {
+        FlowLayout(spacing: 18, lineSpacing: 18, vAlign: .top) {
+            ForEach(clusters) { clusterBox($0) }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .padding(.horizontal, 36)
+        .padding(.top, 20)
+        .padding(.bottom, 36)
+        .coordinateSpace(name: ExposeView.surveySpace)   // tile frames measured here stay un-scaled
+        .scaleEffect(canvas.zoom, anchor: .center)        // canvas zoom — transform sits OUTSIDE the space
+        .offset(canvas.pan)
+        .onPreferenceChange(TileFramesKey.self) { onLayout($0) }
+    }
+
+    // MARK: - Placement stage — right-click a window, pick its spot life-size
+    //
+    // A modal, life-size stage over the desktop area: the screen with its current windows drawn
+    // faint for context, the right-clicked window as a bright ghost, and a grid of the active
+    // resolution you *click* to place it. Mouse-only twin of drag → Grid — clicking a cell runs
+    // the same `onDrop` staging path. Click-away or Esc cancels.
+    @ViewBuilder
+    private var placementStage: some View {
+        if let wid = drag.placeWid, drag.placeScreen == screenID {
+            let target = currentLayout.first { $0.id == wid }
+            GeometryReader { geo in
+                // A miniature of *this* monitor — bezel + screen — floating in a heavy scrim that
+                // swallows the desktop noise. The screen shows the **projected future** layout (staged
+                // moves applied), divided into clickable sections. A contained object, not a takeover:
+                // it can't leak off-screen and it reads as a deliberate control.
+                let screen = aspectFit(in: CGSize(width: geo.size.width * 0.52,
+                                                  height: geo.size.height * 0.56), aspect: screenAspect)
+                ZStack {
+                    Color.black.opacity(0.96)                          // swallow the noise around the vessel
+                        .contentShape(Rectangle())
+                        .onTapGesture { drag.endPlacing() }            // click-away cancels
+                    // Monitor centred in the screen; caption floats just above it (an overlay, so it
+                    // doesn't push the monitor off-centre).
+                    monitorVessel(screen: screen, wid: wid, target: target)
+                        .overlay(alignment: .top) {
+                            placementCaption(wid: wid).fixedSize().offset(y: -34)
+                        }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            .ignoresSafeArea()
+            .transition(.opacity)
+        }
+    }
+
+    // The miniature monitor: a bezel framing a screen that shows the *projected future* layout —
+    // unchanged windows faint, staged moves bright at their new spots, the window being placed
+    // tracking the hovered section. The bezel + heavy surrounding scrim make it read as an object.
+    private func monitorVessel(screen: CGSize, wid: UInt32, target: ExposeView.LayerMember?) -> some View {
+        let bezel: CGFloat = 16
+        let screenShape = RoundedRectangle(cornerRadius: 9, style: .continuous)
+        let stagedById = Dictionary(stagedPlan.map { ($0.id, $0) }, uniquingKeysWith: { a, _ in a })
+        return ZStack(alignment: .topLeading) {
+            screenShape.fill(Color(red: 0.05, green: 0.06, blue: 0.08))           // opaque "screen" — no see-through
+                .overlay(screenShape.fill(LinearGradient(colors: [.white.opacity(0.06), .clear],
+                                                         startPoint: .top, endPoint: .bottom)))
+            // The projected future screen: every window where it *will* be after commit.
+            ForEach(currentLayout.filter { $0.id != wid }) { m in
+                if let s = stagedById[m.id] {
+                    zoneRect(s.frac, s.tint, s.image, screen, .staged)     // a staged move — bright, at its new spot
+                } else {
+                    zoneRect(m.frac, m.tint, nil, screen, .baseline)       // unchanged — a faint footprint
+                }
+            }
+            placementGrid(wid: wid, stage: screen, tint: target?.tint ?? Palette.running)
+            placementGhost(target: target, stage: screen)                  // the window being placed
+        }
+        .frame(width: screen.width, height: screen.height)
+        .clipShape(screenShape)
+        .overlay(screenShape.strokeBorder(.white.opacity(0.16), lineWidth: 1))
+        .padding(.horizontal, bezel).padding(.top, bezel).padding(.bottom, bezel + 10)   // bezel + chin
+        .background(
+            RoundedRectangle(cornerRadius: bezel + 8, style: .continuous)
+                .fill(Color(white: 0.07))
+                .overlay(RoundedRectangle(cornerRadius: bezel + 8, style: .continuous)
+                    .strokeBorder(.white.opacity(0.12), lineWidth: 1))
+                .shadow(color: .black.opacity(0.6), radius: 40, y: 18)
+        )
+        .overlay(alignment: .bottom) {                                     // a little brand dot on the chin
+            Circle().fill(.white.opacity(0.22)).frame(width: 5, height: 5).padding(.bottom, 6)
+        }
+    }
+
+    // The clickable grid laid over the stage at the active resolution. Hover lights a cell;
+    // click stages that position for the window and closes the stage.
+    private func placementGrid(wid: UInt32, stage: CGSize, tint: Color) -> some View {
+        let (cols, rows) = drag.baseRes.dims
+        let cw = stage.width / CGFloat(cols)
+        let ch = stage.height / CGFloat(rows)
+        return ZStack(alignment: .topLeading) {
+            ForEach(0..<rows, id: \.self) { r in
+                ForEach(0..<cols, id: \.self) { c in
+                    let cell = HoverCell(col: c, row: r)
+                    let lit = drag.placeCell == cell
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .fill(lit ? tint.opacity(0.18) : Color.white.opacity(0.04))
+                        .overlay(RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            .strokeBorder(lit ? tint : .white.opacity(0.22), lineWidth: lit ? 2.5 : 1))
+                        .frame(width: cw - 6, height: ch - 6)
+                        .contentShape(Rectangle())
+                        .onHover { if $0 { drag.placeCell = cell } }
+                        .onTapGesture { commitPlacement(wid: wid, col: c, row: r) }
+                        .position(x: CGFloat(c) * cw + cw / 2, y: CGFloat(r) * ch + ch / 2)
+                }
+            }
+        }
+        .frame(width: stage.width, height: stage.height)
+    }
+
+    // The window being placed. While hovering a section the preview snaps to it, *exactly*
+    // section-sized (never bigger than the spot). At rest it's just a quiet dashed outline at the
+    // window's current/projected spot — so you see which window you're moving and where it is now.
+    @ViewBuilder
+    private func placementGhost(target: ExposeView.LayerMember?, stage: CGSize) -> some View {
+        let tint = target?.tint ?? Palette.running
+        let shape = RoundedRectangle(cornerRadius: 8, style: .continuous)
+        if let cell = drag.placeCell {
+            let (cols, rows) = drag.baseRes.dims
+            let frac = CGRect(x: CGFloat(cell.col) / CGFloat(cols), y: CGFloat(cell.row) / CGFloat(rows),
+                              width: 1 / CGFloat(cols), height: 1 / CGFloat(rows))
+            let r = CGRect(x: frac.minX * stage.width, y: frac.minY * stage.height,
+                           width: frac.width * stage.width, height: frac.height * stage.height)
+            ZStack {
+                shape.fill(tint.opacity(0.26))
+                if let img = target?.image {
+                    Image(nsImage: img).resizable().aspectRatio(contentMode: .fill).opacity(0.45)
+                }
+            }
+            .frame(width: max(8, r.width - 8), height: max(8, r.height - 8))
+            .clipShape(shape)
+            .overlay(shape.strokeBorder(tint, lineWidth: 3))
+            .shadow(color: tint.opacity(0.5), radius: 14)
+            .position(x: r.midX, y: r.midY)
+            .allowsHitTesting(false)
+        } else {
+            let restFrac: CGRect? = {
+                if let wid = drag.placeWid, let s = stagedPlan.first(where: { $0.id == wid }) { return s.frac }
+                return target?.frac
+            }()
+            if let f = restFrac {
+                let r = CGRect(x: f.minX * stage.width, y: f.minY * stage.height,
+                               width: f.width * stage.width, height: f.height * stage.height)
+                shape.fill(tint.opacity(0.10))
+                    .overlay(shape.strokeBorder(tint.opacity(0.75), style: StrokeStyle(lineWidth: 1.5, dash: [5, 4])))
+                    .frame(width: max(8, r.width - 6), height: max(8, r.height - 6))
+                    .position(x: r.midX, y: r.midY)
+                    .allowsHitTesting(false)
+            }
+        }
+    }
+
+    private func placementCaption(wid: UInt32) -> some View {
+        let t = clusters.flatMap(\.tiles).first { $0.id == wid }
+        return HStack(spacing: 10) {
+            HStack(spacing: 6) {
+                Image(systemName: "hand.point.up.left.fill")
+                    .font(.system(size: 10, weight: .semibold)).foregroundColor(Palette.running)
+                Text("Place \(t?.app ?? "window")").font(Typo.monoBold(11)).foregroundColor(.white)
+                if let title = t?.title, !title.isEmpty {
+                    Text(title).font(Typo.mono(9)).foregroundColor(Palette.textMuted).lineLimit(1)
+                }
+            }
+            Rectangle().fill(Palette.border).frame(width: 0.5, height: 14)
+            placeResSelector
+            Rectangle().fill(Palette.border).frame(width: 0.5, height: 14)
+            Text("click a section · esc cancel").font(Typo.mono(9)).foregroundColor(.white.opacity(0.4))
+        }
+        .padding(.horizontal, 12).padding(.vertical, 7)
+        .background(Capsule().fill(Color.black.opacity(0.6))
+            .overlay(Capsule().strokeBorder(Palette.running.opacity(0.4), lineWidth: 0.5)))
+    }
+
+    @ViewBuilder
+    private var placeResSelector: some View {
+        ForEach(LatticeRes.allCases, id: \.rawValue) { r in
+            let active = drag.baseRes == r
+            Button { drag.baseRes = r; drag.placeCell = nil } label: {
+                resIcon(r, active: active)
+                    .padding(.horizontal, 5).frame(height: 20)
+                    .background(RoundedRectangle(cornerRadius: 5).fill(active ? Palette.running : Color.white.opacity(0.07)))
+                    .overlay(RoundedRectangle(cornerRadius: 5)
+                        .strokeBorder(active ? Palette.running : Palette.border, lineWidth: active ? 1 : 0.5))
+            }
+            .buttonStyle(.plain)
+            .help(r.name)
+        }
+    }
+
+    private func commitPlacement(wid: UInt32, col: Int, row: Int) {
+        let (cols, rows) = drag.baseRes.dims
+        let spec = GridPlacement(columns: cols, rows: rows, column: col, row: row).map(PlacementSpec.grid)
+        drag.endPlacing()
+        onDrop(wid, spec)
+    }
+
+    private func displayBadge(_ scope: DisplayScope) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: scope.index == 0 ? "display" : "rectangle.on.rectangle")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(Palette.running)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(scope.label)
+                    .font(Typo.monoBold(10))
+                    .foregroundColor(Palette.text)
+                Text("\(scope.windowCount) \(scope.windowCount == 1 ? "window" : "windows")")
+                    .font(Typo.caption(8.5))
+                    .foregroundColor(Palette.textMuted)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.black.opacity(0.58))
+                .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous).strokeBorder(Palette.running.opacity(0.55), lineWidth: 0.5))
+        )
+    }
+
+    // Mouse-driven leave: the keyboard has Enter (commit) / Esc (discard), but there was no
+    // way out with the trackpad. This ✕ just *closes* the survey, keeping whatever's on screen
+    // (Esc remains the explicit discard/revert). Top-right, above the gear.
+    private var exitButton: some View {
+        Button { onExit() } label: {
+            Image(systemName: "xmark")
+                .font(.system(size: 12, weight: .bold))
+                .foregroundColor(.white.opacity(0.8))
+                .frame(width: 30, height: 30)
+                .background(
+                    RoundedRectangle(cornerRadius: 9, style: .continuous)
+                        .fill(Color.black.opacity(0.5))
+                        .overlay(RoundedRectangle(cornerRadius: 9, style: .continuous)
+                            .strokeBorder(Palette.border, lineWidth: 0.5))
+                )
+        }
+        .buttonStyle(.plain)
+        .help("Exit Hyperspace")
+    }
+
+    // The gear that reveals the control rig. Small by default so the intent band
+    // and the upper third of the survey stay visible.
+    private var settingsToggle: some View {
+        Button { dialsOpen.toggle() } label: {
+            Image(systemName: "slider.horizontal.3")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(dialsOpen ? Palette.bg : .white.opacity(0.7))
+                .frame(width: 30, height: 30)
+                .background(
+                    RoundedRectangle(cornerRadius: 9, style: .continuous)
+                        .fill(dialsOpen ? Palette.running : Color.black.opacity(0.5))
+                        .overlay(RoundedRectangle(cornerRadius: 9, style: .continuous)
+                            .strokeBorder(Palette.border, lineWidth: 0.5))
+                )
+        }
+        .buttonStyle(.plain)
+        .help("Visual settings")
     }
 
     // The control rig — a compact stack top-right, clear of the legend (bottom)
@@ -1676,6 +3089,7 @@ struct ExposeView: View {
             dial("thermometer.medium", "temp", $temp) { _ in temp < 0.45 ? "cool" : temp > 0.55 ? "warm" : "·" }
             divider
             sizeRow
+            zoomRow
             twoWay("rectangle.grid.2x2", "scan", "tall", isFirst: !layoutTall) { layoutTall = !$0 }
             twoWay("keyboard", "read", "hands", isFirst: !handKeys) { handKeys = !$0; onHandKeys(handKeys) }
             divider
@@ -1736,6 +3150,22 @@ struct ExposeView: View {
                 .opacity(sizeAuto ? 0.35 : 1)
             pill("auto", sizeAuto) { sizeAuto.toggle() }
             Text(sizeAuto ? "auto" : String(format: "%.2f×", tileScale))
+                .font(Typo.mono(9)).foregroundColor(.white.opacity(0.5)).frame(width: 30, alignment: .trailing)
+        }
+    }
+
+    // Canvas zoom — driven by ⌘-scroll / =/− (not a slider), so this is a live readout
+    // plus a "fit" pill that snaps back to 1×. Separate axis from the size dial above:
+    // size lays tiles bigger/smaller; zoom magnifies the whole spread to lean into a region.
+    private var zoomRow: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 10)).foregroundColor(.white.opacity(0.6)).frame(width: 14)
+            Text("zoom").font(Typo.mono(9)).foregroundColor(.white.opacity(0.45)).frame(width: 28, alignment: .leading)
+            Text("⌘scroll").font(Typo.mono(9)).foregroundColor(.white.opacity(0.3))
+            Spacer(minLength: 0)
+            pill("fit", canvas.zoom <= 1.0001) { canvas.reset() }
+            Text(String(format: "%.1f×", canvas.zoom))
                 .font(Typo.mono(9)).foregroundColor(.white.opacity(0.5)).frame(width: 30, alignment: .trailing)
         }
     }
@@ -1910,6 +3340,533 @@ struct ExposeView: View {
         .buttonStyle(.plain)
     }
 
+    // MARK: - Intent band (drag targets)
+    //
+    // The top third: three sections you drag a window thumbnail up into. Layers and
+    // Spaces are scaffolded for Phase 2/3; Lattice is live — drop a tile on a cell to
+    // stage a location (nothing real moves until gather). See
+    // design/hyperspace-drag-drop.md.
+
+    private var intentBand: some View {
+        // Two slots: Layers (pick/tag) · Grid (drop a position). No preview canvas — the survey
+        // *is* the preview: a staged move badges its tile, and hovering a layer lights its windows
+        // in place. Centred. design/hyperspace-drag-drop.md
+        HStack(alignment: .top, spacing: 14) {
+            layersSection.frame(width: layersWidth)
+            gridSection.frame(width: gridWidth)
+        }
+        .frame(maxWidth: .infinity)        // centre the cluster (not full-bleed)
+        .padding(.top, 16)
+        .padding(.bottom, 8)
+    }
+
+    // The Layers list hugs its pile count; Grid is a fixed, comfortable drop target.
+    private var layersWidth: CGFloat {
+        let pileSlot: CGFloat = 90
+        return min(max(CGFloat(min(max(layers.count, 1), 3)) * pileSlot + 24, 220), 340)
+    }
+    private var gridWidth: CGFloat { 320 }
+
+    // A not-yet-live section — visible so the three-axis model reads, dimmed so it's
+    // clearly inert. Replaced by real piles / a Spaces strip in later phases.
+    private func stubSection(_ title: String, _ icon: String, _ sub: String, _ phase: String) -> some View {
+        sectionCard(title: title, icon: icon, sub: sub, live: false) {
+            VStack(spacing: 6) {
+                Spacer(minLength: 0)
+                Text(phase)
+                    .font(Typo.monoBold(10)).foregroundColor(.white.opacity(0.35))
+                    .padding(.horizontal, 8).padding(.vertical, 3)
+                    .background(Capsule().fill(Color.white.opacity(0.05)))
+                    .overlay(Capsule().strokeBorder(Palette.border, lineWidth: 0.5))
+                Text("soon").font(Typo.mono(8)).foregroundColor(.white.opacity(0.25))
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(width: 220)
+        .opacity(0.6)
+    }
+
+    // The Layers section (Phase 2): rule-backed layers as drop "piles" — drag a window
+    // onto a pile to stage a join (multi-membership; drop again to un-stage), or onto
+    // the ＋ pile to stage a brand-new layer seeded from it. Drops only *stage* (badge
+    // the tile); StudioLayerStore is written on gather. design/hyperspace-drag-drop.md
+    private var layersSection: some View {
+        sectionCard(title: "Layers", icon: "square.stack.3d.up", sub: "tag · piles",
+                    live: true, armed: dragOnThisScreen && drag.hoverLayer != nil) {
+            VStack(alignment: .leading, spacing: 8) {
+                controlRow {                                   // mirrors the Lattice selector slot
+                    Text("\(max(0, layers.count - 1)) \(layers.count - 1 == 1 ? "layer" : "layers")")
+                        .font(Typo.mono(9)).foregroundColor(.white.opacity(0.55))
+                    Spacer(minLength: 6)
+                    Text("hover → preview · drop to tag")
+                        .font(Typo.mono(8.5)).foregroundColor(.white.opacity(0.35))
+                }
+                FlowLayout(spacing: 10, lineSpacing: 10, alignment: .leading) {
+                    ForEach(layers) { layerPileView($0) }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                .onPreferenceChange(LayerFrameKey.self) { drag.layerFrames[screenID] = $0 }
+            }
+        }
+    }
+
+    // Shared 26pt control-row slot so Layers and Lattice line up under their headers.
+    private func controlRow<C: View>(@ViewBuilder _ content: () -> C) -> some View {
+        HStack(spacing: 5) { content() }
+            .frame(height: 26)
+    }
+
+    /// True while a drag started on (and belongs to) this screen.
+    private var dragOnThisScreen: Bool { drag.isActive && drag.screenID == screenID }
+
+    // One layer pile — a compact *screen-map* of the layer's windows on this display, so
+    // you read what the layer looks like at a glance (design/hyperspace-drag-drop.md). The
+    // full-size formation renders in the middle Preview on hover / drop. Lights as a drop
+    // target and stays tinted while it holds a staged join. ＋ = a new-layer drop slot.
+    private func layerPileView(_ pile: LayerPile) -> some View {
+        let lit = dragOnThisScreen && drag.hoverLayer == pile.id
+        let on = lit || pile.staged
+        let mapW: CGFloat = 104
+        let mapH = layerMapHeight(for: mapW)
+        return VStack(spacing: 4) {
+            Group {
+                if pile.isNew {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            .fill(on ? Palette.running.opacity(0.9) : Color.white.opacity(0.05))
+                        Image(systemName: "plus")
+                            .font(.system(size: 18, weight: .semibold))
+                            .foregroundColor(on ? Palette.bg : .white.opacity(0.6))
+                    }
+                    .frame(width: mapW, height: mapH)
+                } else {
+                    layerMap(pile, width: mapW)            // the screen, with its windows
+                }
+            }
+            .overlay(                                       // the "monitor" bezel
+                RoundedRectangle(cornerRadius: 7, style: .continuous)
+                    .strokeBorder(on ? Palette.running : Palette.border, lineWidth: on ? 1.5 : 0.5)
+            )
+            .overlay(alignment: .topTrailing) {
+                if !pile.isNew && pile.count > 0 {
+                    Text("\(pile.count)")
+                        .font(Typo.monoBold(8)).foregroundColor(.white)
+                        .padding(.horizontal, 3).padding(.vertical, 0.5)
+                        .background(Capsule().fill(Color.black.opacity(0.6)))
+                        .padding(2)
+                }
+            }
+            .overlay(alignment: .topLeading) {       // evidence: how many windows staged to join
+                if pile.stagedCount > 0 {
+                    Text("＋\(pile.stagedCount)")
+                        .font(Typo.monoBold(8)).foregroundColor(Palette.bg)
+                        .padding(.horizontal, 3).padding(.vertical, 0.5)
+                        .background(Capsule().fill(Palette.running))
+                        .padding(2)
+                        .transition(.scale.combined(with: .opacity))
+                }
+            }
+            Text(pile.isNew ? "new" : pile.name)
+                .font(Typo.mono(9)).foregroundColor(.white.opacity(on ? 0.9 : 0.65))
+                .lineLimit(1).frame(maxWidth: mapW)
+        }
+        .animation(.spring(response: 0.3, dampingFraction: 0.7), value: pile.stagedCount)
+        .scaleEffect(lit ? 1.06 : 1)
+        .shadow(color: lit ? Palette.running.opacity(0.5) : .clear, radius: lit ? 8 : 0)
+        .animation(.spring(response: 0.24, dampingFraction: 0.72), value: lit)
+        .background(layerFrameReporter(pile.id))     // hit-test = the compact footprint
+        .onHover { hovering in
+            if hovering { drag.inspectLayer = pile.id; drag.inspectScreen = screenID }
+            else if drag.inspectLayer == pile.id { drag.inspectLayer = nil; drag.inspectScreen = nil }
+        }
+        .onTapGesture { if pile.isNew { onNewLayer() } }   // ＋ → author a new layer (name it, pick apps)
+    }
+
+    // Map height for a given width — the active screen's aspect, clamped so a very wide
+    // or very tall display still reads as a tidy tile.
+    private func layerMapHeight(for width: CGFloat) -> CGFloat {
+        (width / min(max(screenAspect, 1.2), 2.6)).rounded()
+    }
+
+    // A layer's screen-map: its member windows drawn as app-tinted rects at their real
+    // (screen-relative) positions — the "what does this layer look like" preview. `big`
+    // (the expanded map) fills rects with the live thumbnail.
+    private func layerMap(_ pile: LayerPile, width: CGFloat) -> some View {
+        let h = layerMapHeight(for: width)
+        let big = width > 160
+        return ZStack(alignment: .topLeading) {
+            RoundedRectangle(cornerRadius: big ? 8 : 7, style: .continuous)
+                .fill(Color.black.opacity(0.38))
+            if pile.members.isEmpty {
+                Image(systemName: "rectangle.dashed")
+                    .font(.system(size: width * 0.14))
+                    .foregroundColor(.white.opacity(0.22))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ForEach(pile.members) { m in
+                    let r = CGRect(x: m.frac.minX * width, y: m.frac.minY * h,
+                                   width: max(big ? 6 : 3, m.frac.width * width),
+                                   height: max(big ? 5 : 3, m.frac.height * h))
+                    layerMemberRect(m, big: big)
+                        .frame(width: r.width, height: r.height)
+                        .position(x: r.midX, y: r.midY)
+                }
+            }
+        }
+        .frame(width: width, height: h)
+        .clipShape(RoundedRectangle(cornerRadius: big ? 8 : 7, style: .continuous))
+    }
+
+    private func layerMemberRect(_ m: LayerMember, big: Bool) -> some View {
+        let shape = RoundedRectangle(cornerRadius: big ? 3 : 1.5, style: .continuous)
+        return shape
+            .fill(m.tint.opacity(0.5))
+            .overlay {
+                if big, let img = m.image {
+                    Image(nsImage: img).resizable().aspectRatio(contentMode: .fill)
+                        .clipShape(shape).opacity(0.6)
+                }
+            }
+            .overlay(shape.strokeBorder(m.tint, lineWidth: big ? 1 : 0.5))
+    }
+
+    // Reports a pile's frame (root space) keyed by its id so a drop can hit-test it.
+    private func layerFrameReporter(_ key: String) -> some View {
+        GeometryReader { g in
+            Color.clear.preference(key: LayerFrameKey.self,
+                                   value: [key: g.frame(in: .named(ExposeView.rootSpace))])
+        }
+    }
+
+    // Which pile's roster to reveal on this screen: the drop target while dragging,
+    // else a plain mouse-hovered pile. The ＋ pile has no roster.
+    private var rosterPileID: String? {
+        // Settle, don't chase the cursor: no live layer/placement preview while a drag is in
+        // flight — the preview only updates once something *lands* (a drop stages the plan).
+        if drag.isActive { return nil }
+        guard drag.inspectScreen == screenID, let i = drag.inspectLayer, i != HyperspaceDrag.newLayerKey else { return nil }
+        return i
+    }
+
+    // The window IDs of the layer being previewed (idle hover of a pile). Drives the
+    // bottom survey's dim/highlight: everything fades except this layer's windows.
+    private var highlightWids: Set<UInt32>? {
+        guard let id = rosterPileID, let p = layers.first(where: { $0.id == id }) else { return nil }
+        return Set(p.members.map(\.id))
+    }
+
+    // The Grid section (right): a resolution selector above a grid of drop positions.
+    // Dropping a window on a cell stages that position; the result renders in the middle
+    // Preview, so the grid here is purely the input (cells just light under the cursor).
+    private var gridSection: some View {
+        sectionCard(title: "Grid", icon: "rectangle.split.2x2", sub: "drop a position",
+                    live: true, armed: dragOnThisScreen && drag.hoverCell != nil) {
+            VStack(spacing: 8) {
+                controlRow { resSelector }
+                latticeGrid
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    // The placement-resolution picker. Each option is a *real mini-grid* of its own
+    // dims (2×1, 3×1, 2×2, 4×4) — far clearer than the old ½⅓¼▦ glyphs, where ▦ read as
+    // "fullscreen". Modifiers override it live mid-drag (⇧ halves · ⌥ thirds · ⌘ fine);
+    // releasing returns to the selection. A name readout sits at the trailing edge.
+    @ViewBuilder
+    private var resSelector: some View {
+        ForEach(LatticeRes.allCases, id: \.rawValue) { r in
+            let active = drag.res == r
+            Button {
+                drag.baseRes = r
+                if !drag.isActive || Self.modifierRes() == nil { drag.res = r }
+            } label: {
+                resIcon(r, active: active)
+                    .padding(.horizontal, 7).frame(height: 24)
+                    .background(RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(active ? Palette.running : Color.white.opacity(0.07)))
+                    .overlay(RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .strokeBorder(active ? Palette.running : Palette.border, lineWidth: active ? 1 : 0.5))
+            }
+            .buttonStyle(.plain)
+            .help(r.name)
+        }
+        Spacer(minLength: 6)
+        // Mode readout: the active resolution by name, with the held-modifier glyph when
+        // one is overriding the selector — so "⌘ fine" reads at a glance.
+        if let g = resOverrideGlyph {
+            Text(g).font(Typo.monoBold(9)).foregroundColor(Palette.running)
+        }
+        Text(drag.res.name)
+            .font(Typo.mono(9))
+            .foregroundColor(resOverrideGlyph != nil ? Palette.running : .white.opacity(0.5))
+            .animation(.easeOut(duration: 0.12), value: drag.res)
+    }
+
+    // A tiny true-to-life grid icon for a resolution: cols×rows cells in a screen-ish box.
+    private func resIcon(_ r: LatticeRes, active: Bool) -> some View {
+        let (cols, rows) = r.dims
+        let bw: CGFloat = 22, bh: CGFloat = 15, gap: CGFloat = 1.5
+        let cw = (bw - gap * CGFloat(cols - 1)) / CGFloat(cols)
+        let ch = (bh - gap * CGFloat(rows - 1)) / CGFloat(rows)
+        let color = active ? Palette.bg : Color.white.opacity(0.75)
+        return VStack(spacing: gap) {
+            ForEach(0..<rows, id: \.self) { _ in
+                HStack(spacing: gap) {
+                    ForEach(0..<cols, id: \.self) { _ in
+                        RoundedRectangle(cornerRadius: 1, style: .continuous)
+                            .fill(color).frame(width: cw, height: ch)
+                    }
+                }
+            }
+        }
+        .frame(width: bw, height: bh)
+    }
+
+    /// The glyph of the modifier currently overriding the resolution (mid-drag), or nil.
+    private var resOverrideGlyph: String? {
+        guard drag.isActive else { return nil }
+        switch Self.modifierRes() {
+        case .fine:    return "⌘"
+        case .thirds:  return "⌥"
+        case .halves:  return "⇧"
+        default:       return nil
+        }
+    }
+
+    // The drop grid: cols×rows cells laid out at the screen's aspect ratio, centered
+    // in the available space. Reports its frame (root space) for hit-testing; the cell
+    // under the cursor lights while dragging.
+    private var latticeGrid: some View {
+        let (cols, rows) = drag.res.dims
+        return GeometryReader { geo in
+            let box = aspectFit(in: geo.size, aspect: screenAspect)
+            let cw = box.width / CGFloat(cols)
+            let ch = box.height / CGFloat(rows)
+            let active = drag.isActive && drag.screenID == screenID
+            VStack(spacing: 3) {
+                ForEach(0..<rows, id: \.self) { r in
+                    HStack(spacing: 3) {
+                        ForEach(0..<cols, id: \.self) { c in
+                            gridCell(lit: active && drag.hoverCell == HoverCell(col: c, row: r),
+                                     w: max(8, cw - 3), h: max(8, ch - 3))
+                        }
+                    }
+                }
+            }
+            // Glide the highlight between cells instead of snapping.
+            .animation(.spring(response: 0.24, dampingFraction: 0.72), value: drag.hoverCell)
+            .frame(width: box.width, height: box.height)
+            .background(                                          // measure the fixed grid box…
+                GeometryReader { g in
+                    Color.clear.preference(key: LatticeFrameKey.self,
+                                           value: g.frame(in: .named(ExposeView.rootSpace)))
+                }
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)   // …then center it in the section
+        }
+        .onPreferenceChange(LatticeFrameKey.self) { drag.latticeFrames[screenID] = $0 }
+    }
+
+    // One drop-grid cell — a plain target that lights under the cursor. The actual
+    // placement preview now renders in the middle Preview canvas, not in the cell.
+    private func gridCell(lit: Bool, w: CGFloat, h: CGFloat) -> some View {
+        let shape = RoundedRectangle(cornerRadius: 4, style: .continuous)
+        return shape
+            .fill(lit ? Palette.running.opacity(0.32) : Color.white.opacity(0.05))
+            .overlay(shape.strokeBorder(lit ? Palette.running : Palette.border, lineWidth: lit ? 1.5 : 0.5))
+            .frame(width: w, height: h)
+            .scaleEffect(lit ? 1.07 : 1)
+            .shadow(color: lit ? Palette.running.opacity(0.55) : .clear, radius: lit ? 9 : 0)
+            .zIndex(lit ? 1 : 0)
+    }
+
+    // MARK: - Preview — a dedicated slot that always shows the screen's zones
+    //
+    // The middle band slot. Never empty: by default it renders the *current* layout of this
+    // display (so it's always useful), with staged moves and a hovered layer drawn on top.
+    // Display-only — drops still land on the Layers/Grid controls.
+
+    private enum ZoneStyle { case baseline, staged, live }
+
+    // A window zone on the placement stage. `baseline` = a faint "currently here" footprint;
+    // `staged` = a bright planned move; `live` = the spot you're about to pick.
+    private func zoneRect(_ frac: CGRect, _ tint: Color, _ image: NSImage?, _ box: CGSize, _ style: ZoneStyle) -> some View {
+        let shape = RoundedRectangle(cornerRadius: 4, style: .continuous)
+        let r = CGRect(x: frac.minX * box.width, y: frac.minY * box.height,
+                       width: max(8, frac.width * box.width), height: max(7, frac.height * box.height))
+        let fillOpacity: Double = style == .baseline ? 0.14 : (style == .live ? 0.34 : 0.42)
+        let imageOpacity: Double = style == .baseline ? 0.28 : 0.6
+        let strokeColor: Color = style == .baseline ? .white.opacity(0.18) : tint
+        let strokeW: CGFloat = style == .live ? 2 : (style == .baseline ? 0.75 : 1)
+        // Clip the *framed container*, not the image: with aspectRatio(.fill) the image scales up to
+        // cover (width-led), so clipping it directly lets its height overflow the zone. Framing the
+        // ZStack then clipping confines it to the zone in both dimensions.
+        return ZStack {
+            shape.fill(tint.opacity(fillOpacity))
+            if let image {
+                Image(nsImage: image).resizable().aspectRatio(contentMode: .fill).opacity(imageOpacity)
+            }
+        }
+        .frame(width: r.width - 2, height: r.height - 2)
+        .clipShape(shape)
+        .overlay(shape.strokeBorder(strokeColor, lineWidth: strokeW))
+        .position(x: r.midX, y: r.midY)
+    }
+
+    // Fit a rect of the given aspect (w/h) inside `size`, leaving a little air.
+    private func aspectFit(in size: CGSize, aspect: CGFloat) -> CGSize {
+        let avail = CGSize(width: max(1, size.width - 4), height: max(1, size.height - 4))
+        var w = avail.width
+        var h = w / max(0.1, aspect)
+        if h > avail.height { h = avail.height; w = h * aspect }
+        return CGSize(width: w, height: h)
+    }
+
+    // Shared chrome for a band section: a titled card. `live` tints it on-brand;
+    // `armed` lights it up while the cursor is over it mid-drag, so you can see which
+    // axis (location vs layer) you're about to commit.
+    private func sectionCard<Content: View>(title: String, icon: String, sub: String,
+                                            live: Bool, armed: Bool = false,
+                                            @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(spacing: 6) {
+                Image(systemName: icon)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(live ? Palette.running : .white.opacity(0.5))
+                Text(title)
+                    .font(Typo.monoBold(11)).foregroundColor(.white).tracking(0.3)
+                Text(sub)
+                    .font(Typo.mono(8.5)).foregroundColor(armed ? Palette.running : Palette.textMuted)
+                Spacer(minLength: 0)
+            }
+            content()
+        }
+        .padding(.horizontal, 12).padding(.top, 9).padding(.bottom, 11)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(armed ? Palette.running.opacity(0.14) : (live ? Palette.running.opacity(0.05) : Color.white.opacity(0.02)))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(armed ? Palette.running.opacity(0.75) : (live ? Palette.running.opacity(0.30) : Palette.border),
+                              lineWidth: armed ? 1.5 : 1)
+        )
+        .shadow(color: armed ? Palette.running.opacity(0.35) : .clear, radius: armed ? 12 : 0)
+        .animation(.easeOut(duration: 0.16), value: armed)
+    }
+
+    // The dragged thumbnail, following the cursor on the owning screen only. Over a
+    // live drop target (a grid cell or a layer pile) it shrinks — a clear "about to
+    // land here" tell that also previews how small the window reads in the target.
+    @ViewBuilder
+    private var ghostOverlay: some View {
+        if drag.isActive, drag.screenID == screenID, let img = drag.image {
+            let armed = drag.hoverCell != nil || drag.hoverLayer != nil
+            Image(nsImage: img)
+                .resizable().aspectRatio(contentMode: .fill)
+                .frame(width: drag.tileSize.width, height: drag.tileSize.height)
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                .overlay(RoundedRectangle(cornerRadius: 8, style: .continuous).strokeBorder(Palette.running, lineWidth: armed ? 2.5 : 2))
+                .shadow(color: .black.opacity(armed ? 0.6 : 0.5), radius: armed ? 10 : 16, x: 0, y: armed ? 4 : 8)
+                .scaleEffect(armed ? 0.6 : 1, anchor: .center)
+                .opacity(armed ? 1 : 0.9)
+                .animation(.spring(response: 0.22, dampingFraction: 0.72), value: armed)
+                .position(drag.location)
+                .allowsHitTesting(false)
+        }
+    }
+
+    // The "landed" ring at the last drop target — fires the instant you release, so a
+    // drop reads as confirmed even after the hover highlight has cleared.
+    @ViewBuilder
+    private var dropPulseOverlay: some View {
+        if let p = drag.dropPulse, drag.screenID == screenID {
+            DropPulseRing(frame: p.frame, tint: Palette.running)
+                .id(p.id)
+        }
+    }
+
+    // MARK: - Drag handling
+
+    /// Modifier-driven resolution while a drag is held — overrides the selector.
+    private static func modifierRes() -> LatticeRes? {
+        let f = NSEvent.modifierFlags
+        if f.contains(.command) { return .fine }
+        if f.contains(.option)  { return .thirds }
+        if f.contains(.shift)   { return .halves }
+        return nil
+    }
+
+    private func handleDragChange(_ t: Tile, _ v: DragGesture.Value) {
+        drag.location = v.location
+        let dist = hypot(v.translation.width, v.translation.height)
+        if drag.wid == nil {
+            guard dist >= 8 else { return }       // below threshold → still a potential tap
+            drag.wid = t.id
+            drag.image = t.image
+            drag.screenID = screenID
+            drag.tileSize = CGSize(width: tile, height: (tile * 0.62).rounded())
+        }
+        drag.res = Self.modifierRes() ?? drag.baseRes
+        updateHoverCell()
+        updateHoverLayer()
+    }
+
+    private func handleDragEnd(_ t: Tile, _ v: DragGesture.Value) {
+        let dist = hypot(v.translation.width, v.translation.height)
+        let wasDragging = drag.wid != nil
+        // Resolve the drop target before reset() clears the hover state. The Lattice
+        // grid wins if the cursor is over it; otherwise a layer pile; else a miss.
+        var spec: PlacementSpec?
+        var pulseFrame: CGRect?                   // where to flash the "landed" ring
+        if wasDragging,
+           let frame = drag.latticeFrames[screenID], frame.contains(v.location),
+           let cell = drag.hoverCell {
+            let (cols, rows) = drag.res.dims
+            spec = GridPlacement(columns: cols, rows: rows, column: cell.col, row: cell.row).map(PlacementSpec.grid)
+            let cw = frame.width / CGFloat(cols), ch = frame.height / CGFloat(rows)
+            pulseFrame = CGRect(x: frame.minX + CGFloat(cell.col) * cw,
+                                y: frame.minY + CGFloat(cell.row) * ch, width: cw, height: ch)
+        }
+        let layerKey = (wasDragging && spec == nil) ? drag.hoverLayer : nil
+        if let layerKey { pulseFrame = drag.layerFrames[screenID]?[layerKey] }
+        let wid = t.id
+        drag.reset()                              // clear FIRST so the panel rebuild isn't suppressed
+        if !wasDragging && dist < 8 {
+            onPick(wid)                           // a tap → pluck
+        } else if let layerKey {
+            onDropLayer(wid, layerKey)            // a drag onto a layer pile → stage join / new layer
+            if let pulseFrame { drag.firePulse(at: pulseFrame) }
+        } else {
+            onDrop(wid, spec)                     // a drag → stage location (or nil = missed, just rebuild)
+            if spec != nil, let pulseFrame { drag.firePulse(at: pulseFrame) }
+        }
+    }
+
+    private func updateHoverLayer() {
+        let frames = drag.layerFrames[screenID] ?? [:]
+        let hit = frames.first { $0.value.width > 1 && $0.value.contains(drag.location) }?.key
+        if drag.hoverLayer != hit { drag.hoverLayer = hit }
+    }
+
+    private func updateHoverCell() {
+        guard let frame = drag.latticeFrames[screenID], frame.width > 1, frame.contains(drag.location) else {
+            if drag.hoverCell != nil { drag.hoverCell = nil }
+            return
+        }
+        let (cols, rows) = drag.res.dims
+        let cw = frame.width / CGFloat(cols)
+        let ch = frame.height / CGFloat(rows)
+        let c = min(cols - 1, max(0, Int((drag.location.x - frame.minX) / cw)))
+        let r = min(rows - 1, max(0, Int((drag.location.y - frame.minY) / ch)))
+        let cell = HoverCell(col: c, row: r)
+        if drag.hoverCell != cell { drag.hoverCell = cell }
+    }
+
     private func clusterBox(_ c: Cluster) -> some View {
         let cols = min(max(c.tiles.count, 1), colCap)
         let innerW = tile * CGFloat(cols) + 8 * CGFloat(cols - 1)
@@ -1958,14 +3915,58 @@ struct ExposeView: View {
         )
     }
 
+    // The right-click menu for a window: quick tile presets (stage immediately), a visual
+    // "Place…" that opens the life-size stage, layer joins, and pluck. Options, not actions —
+    // nothing real moves until ⏎/G, same as the rest of Hyperspace.
+    @ViewBuilder
+    private func tileMenu(_ t: Tile) -> some View {
+        Button { drag.beginPlacing(t.id, on: screenID) } label: {
+            Label("Place…", systemImage: "rectangle.dashed")
+        }
+        Divider()
+        Button("Left Half")   { stagePlacement(t.id, GridPlacement(columns: 2, rows: 1, column: 0, row: 0)) }
+        Button("Right Half")  { stagePlacement(t.id, GridPlacement(columns: 2, rows: 1, column: 1, row: 0)) }
+        Button("Top Half")    { stagePlacement(t.id, GridPlacement(columns: 1, rows: 2, column: 0, row: 0)) }
+        Button("Bottom Half") { stagePlacement(t.id, GridPlacement(columns: 1, rows: 2, column: 0, row: 1)) }
+        Menu("Quarter") {
+            Button("Top Left")     { stagePlacement(t.id, GridPlacement(columns: 2, rows: 2, column: 0, row: 0)) }
+            Button("Top Right")    { stagePlacement(t.id, GridPlacement(columns: 2, rows: 2, column: 1, row: 0)) }
+            Button("Bottom Left")  { stagePlacement(t.id, GridPlacement(columns: 2, rows: 2, column: 0, row: 1)) }
+            Button("Bottom Right") { stagePlacement(t.id, GridPlacement(columns: 2, rows: 2, column: 1, row: 1)) }
+        }
+        Button("Maximize") { stagePlacement(t.id, GridPlacement(columns: 1, rows: 1, column: 0, row: 0)) }
+        let joinable = layers.filter { !$0.isNew }
+        if !joinable.isEmpty {
+            Divider()
+            Menu("Add to Layer") {
+                ForEach(joinable) { p in
+                    Button(p.name) { onDropLayer(t.id, p.id) }
+                }
+            }
+        }
+        Divider()
+        Button(t.pickSlot != nil ? "Remove from group" : "Add to group") { onPick(t.id) }
+    }
+
+    private func stagePlacement(_ wid: UInt32, _ gp: GridPlacement?) {
+        onDrop(wid, gp.map(PlacementSpec.grid))
+    }
+
     private func tileView(_ t: Tile) -> some View {
         let w = tile
         let h = (tile * 0.62).rounded()
         let shape = RoundedRectangle(cornerRadius: 8, style: .continuous)
         let picked = t.pickSlot != nil
+        let staged = t.staged != nil || !t.layerTags.isEmpty
+        let beingDragged = drag.wid == t.id && drag.screenID == screenID
+        // Layer preview: when a pile is hovered, this layer's windows pop and the rest fade.
+        let inLayer = highlightWids?.contains(t.id)
+        let layerLit = inLayer == true
+        let layerDimmed = inLayer == false
         let lit = t.isAimed || picked                          // on the spotlight's stage
-        let strokeColor: Color = picked ? t.tint : (t.isAimed ? Color.white.opacity(0.9) : Color.white.opacity(0.1))
-        let strokeW: CGFloat = picked ? 2 : (t.isAimed ? 1.5 : 0.75)
+        let strokeColor: Color = staged ? Palette.running
+            : (picked ? t.tint : (t.isAimed ? Color.white.opacity(0.9) : Color.white.opacity(0.1)))
+        let strokeW: CGFloat = staged ? 2 : (picked ? 2 : (t.isAimed ? 1.5 : 0.75))
         let veil: Double = lit ? 0 : spotlight * 0.5
         let bloom: Color = t.isAimed ? lightColor.opacity(0.7 * spotlight) : .clear
         let bloomR: CGFloat = t.isAimed ? 8 + spotlight * 22 : 0
@@ -1974,12 +3975,57 @@ struct ExposeView: View {
             .overlay(shape.strokeBorder(strokeColor, lineWidth: strokeW))
             .overlay(alignment: .topTrailing) { hintChip(t) }
             .overlay(alignment: .topLeading) { if let s = t.pickSlot { slotBadge(s, t.tint) } }
-            .overlay(alignment: .bottomLeading) { titleLabel(t) }
+            .overlay(alignment: .bottomLeading) {
+                VStack(alignment: .leading, spacing: 3) {
+                    if !t.layerTags.isEmpty { layerTagRow(t.layerTags) }
+                    titleLabel(t)
+                }
+                .padding(5)
+            }
+            .overlay(alignment: .bottomTrailing) {
+                if let s = t.staged {
+                    stagedBadge(s).transition(.scale(scale: 0.5).combined(with: .opacity))
+                }
+            }
+            .animation(.spring(response: 0.3, dampingFraction: 0.62), value: t.staged)        // location badge pops
+            .animation(.spring(response: 0.3, dampingFraction: 0.62), value: t.layerTags)      // layer labels pop
+            // While previewing a layer, this tile's windows ring on-brand and the rest sink.
+            .overlay {
+                if layerLit { shape.strokeBorder(Palette.running, lineWidth: 2) }
+            }
+            // While this tile is the one being dragged, hollow it out so it keeps its
+            // slot (no reflow) but reads as "lifted" — the ghost is what moves.
+            .opacity(beingDragged ? 0.22 : (layerDimmed ? 0.26 : 1))
+            .overlay {
+                if beingDragged {
+                    shape.strokeBorder(style: StrokeStyle(lineWidth: 1.5, dash: [5, 4]))
+                        .foregroundColor(Palette.running.opacity(0.8))
+                }
+            }
             .background(frameReporter(t.id))
             .shadow(color: .black.opacity(picked ? 0.5 : 0.35), radius: picked ? 14 : 8, x: 0, y: 5)
-            .shadow(color: bloom, radius: bloomR)              // aimed tile catches the key light
+            .shadow(color: layerLit ? Palette.running.opacity(0.55) : bloom, radius: layerLit ? 14 : bloomR)  // layer-lit / aimed tile glows
             .contentShape(Rectangle())
-            .onTapGesture { onPick(t.id) }
+            // Right-click → a menu of options (not a surprise action). Quick tile presets stage
+            // immediately; "Place…" opens the life-size stage for a visual pick.
+            .contextMenu { tileMenu(t) }
+            // One gesture does both: a near-zero move is a tap (pluck); a real drag
+            // lifts a ghost and stages a location on drop.
+            .gesture(
+                DragGesture(minimumDistance: 0, coordinateSpace: .named(ExposeView.rootSpace))
+                    .onChanged { handleDragChange(t, $0) }
+                    .onEnded { handleDragEnd(t, $0) }
+            )
+    }
+
+    private func stagedBadge(_ text: String) -> some View {
+        Text(text)
+            .font(Typo.monoBold(9))
+            .foregroundColor(Palette.bg)
+            .padding(.horizontal, 5).padding(.vertical, 2)
+            .background(Capsule().fill(Palette.running))
+            .overlay(Capsule().strokeBorder(Color.white.opacity(0.4), lineWidth: 0.5))
+            .padding(5)
     }
 
     // The tile's image + app-tint accent, clipped to the rounded card.
@@ -2030,6 +4076,8 @@ struct ExposeView: View {
             .padding(5)
     }
 
+    // The window title — inset is provided by the enclosing bottom-leading VStack
+    // (which also carries any layer labels), so no outer padding here.
     private func titleLabel(_ t: Tile) -> some View {
         Text(t.title)
             .font(Typo.mono(8))
@@ -2037,7 +4085,25 @@ struct ExposeView: View {
             .lineLimit(1)
             .padding(.horizontal, 5).padding(.vertical, 2)
             .background(Capsule().fill(Color.black.opacity(0.5)))
-            .padding(5)
+    }
+
+    // Staged layer memberships as small on-brand pills along the tile's bottom — a
+    // label, since layer membership is non-exclusive and never moves the window.
+    private func layerTagRow(_ tags: [String]) -> some View {
+        HStack(spacing: 3) {
+            ForEach(Array(tags.prefix(3).enumerated()), id: \.offset) { _, tag in
+                Text(tag)
+                    .font(Typo.monoBold(8))
+                    .foregroundColor(Palette.bg)
+                    .lineLimit(1)
+                    .padding(.horizontal, 4).padding(.vertical, 1.5)
+                    .background(Capsule().fill(Palette.running))
+            }
+            if tags.count > 3 {
+                Text("+\(tags.count - 3)")
+                    .font(Typo.monoBold(8)).foregroundColor(Palette.running)
+            }
+        }
     }
 }
 
@@ -2051,6 +4117,7 @@ struct FlowLayout: Layout {
     var spacing: CGFloat = 12
     var lineSpacing: CGFloat = 12
     var alignment: HorizontalAlignment = .center   // row packing: centered (default) or left/right
+    var vAlign: VerticalAlignment = .center         // block placement within the bounds
 
     func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
         let maxWidth = proposal.width ?? .infinity
@@ -2063,7 +4130,14 @@ struct FlowLayout: Layout {
     func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
         let rows = computeRows(maxWidth: bounds.width, subviews: subviews)
         let totalH = rows.map(\.height).reduce(0, +) + lineSpacing * CGFloat(max(0, rows.count - 1))
-        var y = bounds.minY + max(0, (bounds.height - totalH) / 2)
+        var y: CGFloat
+        if vAlign == .top {
+            y = bounds.minY
+        } else if vAlign == .bottom {
+            y = bounds.maxY - totalH
+        } else {
+            y = bounds.minY + max(0, (bounds.height - totalH) / 2)
+        }
         for row in rows {
             var x: CGFloat
             if alignment == .leading {

--- a/design/hyperspace-drag-drop.md
+++ b/design/hyperspace-drag-drop.md
@@ -1,0 +1,294 @@
+# Hyperspace — Drag & Drop ("Intent Layer")
+
+Status: design agreed 2026-06-14. Implements & evolves
+`feedback_hyperspace_design_philosophy` (fake until commit, calm, WYSIWYG).
+
+## Concept
+
+Hyperspace gains a persistent **intent layer**: the top ~1/3 of the survey,
+split into three sections — **Layers · Lattice · Spaces**. The exposé
+window-grid fills the bottom ~2/3. You drag a window thumbnail *up* into the
+intent layer and drop it on a target. Drops **stage** intent; **nothing real
+moves until Enter**. **Esc** discards the plan and leaves the mode.
+
+```
+┌───────────────────────── INTENT  (top third) ─────────────────────────┐
+│  LAYERS (tag-map, piles)  │   LATTICE  ½ ⅓ ¼ ▦   │      SPACES          │
+│  [Dev] [Comms] [Docs] ＋  │   ┌──┬──┐ resolution  │   ▢1  ▢2  ▢3  ＋      │
+│                           │   ├──┼──┤ via mods     │   (drop = move)      │
+├────────────────────────────────────────────────────────────────────────┤
+│            EXPOSÉ — grouped window lattice  (bottom two-thirds)           │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+## Model: orthogonal axes (not one destination)
+
+A staged intent for a window has three **independent** axes:
+
+```
+struct StagedIntent {
+    var layers: Set<LayerID>     // MULTI — non-exclusive tag-map
+    var location: PlacementSpec? // single — where on this screen
+    var space: SpaceID?          // single — which macOS Space
+}
+stagedIntents: [wid: StagedIntent]
+```
+
+- **Layers are non-exclusive** — a window can be dropped into any number of
+  piles. Maps cleanly to `StudioLayer` (rule-backed: one window can match many
+  rules). Dropping into a pile adds membership; dropping again removes it.
+- **Location** and **Space** are single-valued (re-drop replaces).
+- A window with an empty intent stays exactly where it is (= un-picked today).
+- **Enter** commits every axis of every staged window at once. **Esc** discards.
+
+The existing keyboard pluck (`pickOrder` → balanced grid) is preserved as a
+fast path; it becomes one way of staging a location. Drag is additive, never a
+replacement for the keyboard model.
+
+## Sections
+
+### Layers (left) — piles
+Each layer is a **pile** of its members' thumbnails (screenshot-forward, on
+brand). Multi-membership reads for free: the same thumbnail appears in several
+piles; hovering a window glows every pile it belongs to. `＋` pile = new layer
+seeded from the dropped window. **Fallback:** collapse piles to compact labeled
+chips beyond ~6–8 layers. Commit via `StudioLayerStore` rule authoring (the
+existing ⌘L path).
+
+### Lattice (middle) — granularity by modifier
+A live grid preview mirroring screen proportions. Resolution while dragging:
+
+| modifier | grid |
+|----------|------|
+| (none)   | quarters 2×2 |
+| ⇧        | halves |
+| ⌥        | thirds |
+| ⌘        | fine grid (4×4 — the placement target) |
+
+Plus a segmented `½ ⅓ ¼ ▦` selector for mouse-only users. Drop on a cell →
+stage `location`. Commit via `WindowTiler.tileWindowById(wid:pid:fractions:on:)`
+animated by `RealWindowAnimator`.
+
+### Spaces (right)
+Strip of Spaces from `getDisplaySpaces()`. Drop → stage `space`. Commit via
+`WindowTiler.moveViaCGS` / `window.move {spaceId}`. **Known gremlin:** the
+private CGS APIs are flaky; treat as best-effort, build last.
+
+## Interaction
+
+1. **Grab** a tile → screenshot ghost follows the cursor; the source slot keeps
+   a **placeholder** (the lattice never reflows mid-drag — anti-destabilizing).
+2. **Drag up** into intent → the section under the cursor highlights; over the
+   lattice section the current-resolution grid appears.
+3. **Drop** → set the staged axis, dock a marker (pile card / grid marker /
+   space chip), badge the source tile (`▦ ¼`, `L:Dev`, `→ 2`).
+4. **Cluster drag** (bonus): grab a whole cluster box → stage all its windows to
+   one target at once.
+5. **Enter** commits the plan + exits. **Esc** discards + exits. Keyboard
+   pluck/gather still works alongside.
+
+## Phasing
+
+- **Phase 0 — staging model. ✅ DONE (2026-06-14).** `StagedIntent`
+  (orthogonal axes) + `stagedIntents` on `MotionPanel`; `commitStagedIntents(on:)`
+  wired into `gatherInPlace()` (location axis live, layer/space stubbed). Dormant
+  until the drag UI populates it; existing pluck/gather untouched. Build-verified.
+- **Phase 1 — drag → location. ✅ DONE (2026-06-14).** Persistent top-third intent
+  band (Layers stub · Lattice live · Spaces stub). One `DragGesture` per tile (min
+  0) does both: a near-zero move = pluck (tap), a real drag lifts a screenshot ghost
+  while the source tile hollows to a dashed placeholder (no reflow). Lattice section
+  = `½ ⅓ ¼ ▦` selector with live modifier override (⇧ halves · ⌥ thirds · ⌘ fine) and
+  a drop grid mirroring screen aspect; the hovered cell lights. Drop → stage
+  `location` (badge "¼ 1,0" on the tile); gather commits via `tileWindowById`.
+  Staged-location windows are excluded from the balanced gather grid. Drag state
+  lives on `MotionPanel` (survives rebuilds; rebuilds suppressed mid-drag) and is
+  screen-scoped. Build-verified.
+- **Phase 2 — drag → layer. ✅ v1 DONE (2026-06-14).** Layers stub replaced by live
+  drop piles from `StudioLayerStore` (member thumbnails + match count) plus a `＋`
+  pile. Dragging a tile onto a pile toggles a staged join (`StagedIntent.layers`,
+  multi-membership); onto `＋` stages a fresh layer (`StagedIntent.newLayer`). Piles
+  hit-test via `LayerFrameKey` (root space), light under the cursor, and stay tinted
+  while holding a staged join; the tile badges layer count ("L2") alongside any staged
+  location. Commit on gather: `addAppToLayer` appends an app clause to each staged
+  layer (rule-backed, coarse — like `saveFromPluck`); `＋` seeds one new layer from all
+  its windows. Esc-safe (nothing written until gather). Build-verified.
+  **Polish (2026-06-14):** drop "landing" beat (`DropPulse` token on the drag model
+  fires an expanding ring at the released cell/pile, survives the post-drop rebuild);
+  active-section highlight (the Lattice/Layers card lights while the cursor is over it
+  mid-drag, so you see which axis you're committing); a live resolution readout next
+  to `½ ⅓ ¼ ▦` ("⌘ fine", "quarters", …); and a plan-summary pill under the band
+  ("▦ N placed · ▢ M tagged · ⏎ commit · esc discard"). Build-verified.
+  **Fixes/evidence (2026-06-14):** (1) Enter-to-confirm sometimes fell on the floor —
+  a click/drag on a survey screen-panel (`canBecomeKey == false`) could leave the app
+  with *no* key window. Fixed with a `.leftMouseUp` monitor that re-claims key on the
+  next runloop turn. (2) Standing evidence of the plan now lives in the band itself:
+  staged locations draw as translucent app-tinted footprints in the Lattice preview at
+  their true fractional rects (resolution-agnostic), and layer piles carry a "＋N"
+  staged-join badge — not just the per-tile badges + transient pulse.
+  **Band reshape + hybrid piles (2026-06-14):** Spaces deferred (its behaviour wasn't
+  clear yet) → the band is now just Layers + Lattice, splitting the width evenly. Layer
+  piles became the **hybrid** design: a compact, tactile *deep stack* at rest (top window
+  crisp, two more peeking with depth/shadow; name + count + ＋N), and a floating **roster
+  card** (name · rule from `StudioLayer.summary` · live member thumbnails · count · ＋N)
+  that reveals on plain mouse-hover (`inspectLayer`/`inspectScreen`) or while it's the
+  drop target. The roster is rendered at body level (above the survey) anchored to the
+  pile's reported frame, so revealing it never reflows the row. Build-verified.
+  **Layer = screen-map (2026-06-14):** the deep-stack/roster-strip didn't show *what a
+  layer looks like*, so a layer is now rendered as a **mini screen-map** — its member
+  windows drawn as app-tinted rects at their real (screen-relative, top-origin) positions
+  (`LayerMember.frac` via `MotionPanel.axRect(of:)` + `frac(of:in:)`). Compact map at rest;
+  the floating card expands it to a big map (member thumbnails filled in). Busy layers (10+
+  windows) read fine — they're just small rects. **Cheap per-monitor scoping:** each screen's
+  band shows the layer's members *on that display* (`layerPiles(on:)` filters by `entry(_:isOn:)`);
+  same global layer can appear on both monitors showing its slice. Selector uses true mini-grid
+  icons (2×1/3×1/2×2/4×4) instead of the ambiguous ▦. Build-verified.
+  **Band = 3 slots: Layers · Preview · Grid (2026-06-14).** The big reorg. Instead of each axis
+  rendering its own preview (a projection over the survey, a window-in-cell), the band has a
+  dominant **middle Preview canvas** — one well-established screen-map that renders the current
+  intent: a hovered/selected *layer's* formation, else the *staged-location plan* + the live
+  placement of whatever you're dragging onto the **Grid** (right, now just drop-target cells +
+  the resolution selector). **Layers** (left) is the selectable pile list. Drops still land on
+  Layers/Grid; the Preview is display-only (`previewCanvas`/`zoneRect`). Removed the full-survey
+  projection and the in-cell/over-grid staged markers — all consolidated into the middle.
+  **→ Preview became an ephemeral PiP (2026-06-14).** A fixed middle slot is dead weight when
+  idle (disruptive). So the band is back to **two control slots — Layers · Grid** — and the
+  preview is an **ephemeral PiP** (`previewPiP`/`shouldShowPreview`): a small lit panel that
+  blooms top-centre under the band *only* while hovering/selecting a layer or dragging onto the
+  grid, and fades out otherwise.
+  **→ Settled: dedicated slot, never empty (2026-06-14).** The PiP didn't read as a PiP and
+  still felt wrong; the call was to **dedicate a slot in the top row** after all. The reason the
+  fixed slot felt disruptive before was the *empty* state — fixed by making it **never empty**:
+  the Preview's default content is the **current layout of this display** (every on-screen window
+  as a faint `baseline` zone via `currentLayout(on:)`), with **staged** moves drawn bright at
+  their targets, the **live** drop highlighted while dragging, and a hovered layer's formation
+  overriding it. So band = three slots again — Layers · Preview · Grid — but the Preview always
+  reads as useful (`previewCanvas` + `ZoneStyle` baseline/staged/live).
+  **→ Settle on land, highlight in the survey (2026-06-14).** Two refinements after testing:
+  (1) *Preview only updates on landed, not on hover-while-dragging* — the mid-drag live cell
+  felt disruptive (it chased the cursor). `rosterPileID` now returns nil whenever `drag.isActive`,
+  and `previewCanvas` dropped the `.live` drop cell; during a drag the Preview holds steady on
+  baseline + the staged plan, and only changes when a drop *lands*. (2) *Previewing a layer now
+  highlights it in the bottom survey* — idle-hovering a pile dims every survey tile except that
+  layer's windows (`highlightWids` from the hovered pile's members; in-layer tiles get an on-brand
+  ring + glow, the rest fade to 0.26). Also hardened confirm: a `.keyDown` local monitor catches
+  Enter/Esc even when a survey screen-panel (`canBecomeKey == false`) or nothing holds key, so
+  confirm/cancel can't fall on the floor (alongside the mouseUp key-reclaim).
+  **→ Mouse exit + desktop-layer projection (2026-06-14).** (1) A mouse-driven **✕ exit** button
+  (top-right, above the gear) — there was no trackpad way out before (only Enter/Esc). It just
+  *closes* the survey keeping what's on screen (`ExposeView.onExit` → the panel's `onExit`); Esc
+  stays the explicit discard/revert. (2) **Layer preview now projects onto the desktop layer
+  itself** (`layerProjection`): idle-hovering a pile projects that layer *life-size* into the
+  desktop area below the band — its windows as lit, app-tinted cards (image + title) at their real
+  screen-relative fracs on a screen-proportioned stage, the survey sunk behind a scrim, captioned
+  with the layer name + on-display count. The middle Preview still says "what's in here"; this says
+  "here's how it sits on your screen." Display-only (`allowsHitTesting(false)`), fades on hover via
+  the body's `rosterPileID` animation. Coexists with the in-survey dim/highlight underneath.
+  **→ Right-click a window → life-size placement stage (2026-06-14).** A mouse-only twin of
+  drag → Grid. Secondary-click any survey tile (`RightClickCatcher`, an `NSViewRepresentable`
+  that claims *only* right-clicks via the `NSApp.currentEvent`/`hitTest` trick so left taps/drags
+  still reach the tile's DragGesture) → `drag.beginPlacing(wid)`. A modal `placementStage` blooms
+  over the desktop area: the screen with its current windows faint for context, a clickable **grid
+  of the active resolution**, and the picked window drawn as a bright ghost that **previews into
+  each cell as you hover** (`placementGhost` at the hovered cell's frac). Click a cell →
+  `commitPlacement` → same `onDrop`/`handleDrop` staging path (badge + plan + pulse). A compact
+  res selector in the caption (binds `drag.baseRes`); click-away or Esc cancels (Esc closes the
+  stage before it exits the mode — handled in both `keyDown` and the key monitor). State lives on
+  `HyperspaceDrag` (`placeWid`/`placeScreen`/`placeCell`), screen-scoped.
+  **→ Correction: right-click = a menu, not an action (2026-06-14).** Firing the placement stage
+  straight off a right-click was surprising — right-click should *offer options*. Replaced the
+  `RightClickCatcher` with a native `.contextMenu` (`tileMenu`): quick tile presets (Left/Right/
+  Top/Bottom half, Quarter ▸, Maximize) that **stage** immediately via `stagePlacement` → `onDrop`,
+  an **Add to Layer ▸** submenu (`onDropLayer`), pluck/unpluck, and a single **"Place…"** item that
+  opens the life-size stage as a deliberate visual pick. The stage code (`placementStage` et al.) is
+  unchanged — just gated behind the menu now. `RightClickCatcher` removed.
+  **→ Simplify: the survey IS the preview (2026-06-14).** It had grown three preview systems
+  (middle Preview canvas, life-size desktop projection, Place stage) all answering "what will this
+  do?" — too much. Collapsed to one principle: Hyperspace is already a screenshot layer on top of
+  the desktop, so the survey itself is the preview, shown once. **Removed** the middle Preview slot
+  (`previewSection`/`previewCanvas`/`previewSubtitle`) → band is now **two slots: Layers · Grid**.
+  **Removed** the desktop projection (`layerProjection`/`projectionCard`/`projectionCaption`).
+  **Kept** the one in-context preview: hover a layer → its windows light in the survey, the rest dim
+  (`highlightWids`). **Kept** the right-click menu (`tileMenu`, full — presets + Quarter ▸ + Maximize
+  + Add to Layer ▸ + pluck + a "Place…" item) and **kept** the Place stage, but **resized** it: it
+  now reserves margins + caption height *before* fitting the screen-proportioned stage, so the
+  "screen" always sits fully inside the monitor with air (was overflowing/awkward). `zoneRect`/
+  `ZoneStyle`/`currentLayout` retained (the Place stage still uses them).
+  **→ Place = full-screen overlay (2026-06-14).** The windowed Place stage clipped at the bottom and
+  the preview felt too big. Reworked into a **full-screen overlay**: drop the `bandHeight` padding +
+  `.ignoresSafeArea()` so it covers the whole monitor; the stage is the screen at true proportions
+  (only an 18px inset for the rounded edge) so the grid maps 1:1 to real placement — big, can't-miss
+  targets you click wherever you want it. Backdrop bumped to **0.86 opacity** (near-opaque, lit
+  gradient). Grid cells got wider gaps + bigger radius. The window ghost (`placementGhost`) is now
+  restrained — subdued screenshot (~0.42 armed) + glowing app-tint border, not a dominating card.
+  Chrome (badge, gear/✕, plan pill) hides while `drag.isPlacing` so the stage owns the screen.
+  **→ Fix size mismatch: preview uses visibleFrame (2026-06-14).** Windows tile into
+  `screen.visibleFrame` (`WindowTiler.tileFrame`), but the preview built its aspect + grid from the
+  full `screen.frame` — so cells were taller/offset vs where windows actually land, and the faint
+  context windows left a menu-bar gap at the top. `MotionPanel.axRect(of:)` and both `screenAspect`
+  args now use `visibleFrame`, so the stage proportions, grid cells, baseline footprints, and layer
+  mini-maps are all 1:1 with real placement.
+  **→ Fix bottom row behind the Dock (2026-06-14).** The full-screen stage was centred in the full
+  `frame`, so the bottom grid row fell behind the Dock and the top under the menu bar ("bottom tile
+  ends outside the viewport"). Now the backdrop still fills the monitor, but the stage is placed
+  inside the **usable region** via `MotionPanel.usableInset(of:)` (frame→visibleFrame edges, passed
+  as `ExposeView.usableInset`) and `.position(usable.midX, usable.midY)` — every cell sits fully on
+  screen.
+  **→ Place = a framed miniature monitor showing the future (2026-06-14).** The full-screen stage was
+  the worst of both: faint transparency (not pretty), still leaked off-screen, and the immersive
+  takeover felt like a bug ("why am I here?"). Reworked per direction into a **miniature of this
+  monitor** — `monitorVessel`: a bezel (+chin, brand dot) framing a screen, centred at ~52%×56% of
+  the display, floating in a **heavy 0.9 scrim** that swallows the desktop. A contained, illustrated
+  control — can't leak, reads as deliberate. The screen shows the **projected future layout**, not
+  the live desktop: unchanged windows as faint footprints, **staged moves bright at their new spots**
+  (`stagedPlan` reused), and the window being placed tracking the hovered section (resting at its
+  staged target if any). Sections (`placementGrid`) clearly delineated; click commits. `usableInset`
+  now unused by Place (kept on `ExposeView` for now).
+  **→ Vessel polish: opacity + centering (2026-06-14).** Scrim 0.9→**0.96** (survey no longer ghosts
+  through), the monitor's **screen fill is now opaque** (was a translucent gradient that let the
+  desktop show through), and the caption moved from a VStack above the monitor to an `.overlay(.top)`
+  so the **monitor sits at true screen centre** (the caption was pushing it low).
+  **→ Ghost is section-sized, not window-sized (2026-06-14).** At rest the ghost was drawn at the
+  window's *current* frac, so a big window looked larger than every section ("why is it bigger than
+  the spots?"). Now `placementGhost` draws the bright preview *only while hovering a section*, exactly
+  section-sized (its real future size); at rest it's a quiet dashed outline at the window's current/
+  projected spot (identity + origin, clearly not a target).
+  **→ Fix screenshot aspect overflow (2026-06-14).** The window screenshot overflowed its zone
+  (width-led, height ran past) because `.clipShape` was applied to the `aspectRatio(.fill)` *image*,
+  which scales up to cover — so the clip happened on the already-overflowed image. Fixed in `zoneRect`
+  and `placementGhost` by clipping the *framed container* (ZStack → `.frame(zone)` → `.clipShape`),
+  the same pattern the survey tiles use — confining the fill to the zone in both dimensions.
+  **→ Create-new-layer flow ✅ (2026-06-14).** Tapping the ＋ pile opens `NewLayerPanel` (new file
+  `Core/Overlays/Motion/NewLayerPanel.swift`) — its *own* key NSPanel (level +2, full-screen scrim +
+  centred vessel) because the survey's screen-panels can't become key, so a hosted TextField wouldn't
+  take input. The form: an auto-focused **name** field (smart default from plucked apps), a **Defined
+  by** row of toggleable app chips (thumbnail + count; plucked apps preselected), a live "matches N
+  windows" readout, and Create/Cancel. Create → `StudioLayerStore.add(name:match:)` with the selected
+  apps as OR'd clauses, then `rebuildExposeView`. Wiring on `MotionPanel`: `presentNewLayer()` seeds
+  candidates from `surveyMembers`/`pickOrderByScreen`; `ignoreResign=true` while open (so making the
+  panel key doesn't exit Hyperspace); the `.keyDown` monitor stands down while `newLayerPanel != nil`;
+  `finishNewLayer()` reclaims key. Drag-onto-＋ quick auto-named path still works.
+  **Remaining (v2):** **drag-a-window-*out* of a layer to remove it** — deferred because
+  rule-backed layers can't drop one window without an *exclusion / explicit-membership*
+  model (staged joins already un-stage on re-drop; existing rule-matched members are the
+  hard case). Deeper per-monitor: give `StudioLayer` a real display affinity (own list per
+  monitor) vs today's cheap view-filter. Plus cluster-box drag, compact-chip fallback,
+  hover-a-window-glows-its-piles. **Create-new-layer flow:** the ＋ pile stages `newLayer`
+  and commits via `saveFromPluck` (auto-named), but a real authoring flow (name it, choose
+  what defines it) is still TODO. Optional flourish: hover could *move* real survey tiles
+  into the layer's formation (vs the middle-canvas preview). Also open: drop a window directly
+  onto the middle Preview at a freeform position; click-to-pin a layer in the Preview.
+- **Phase 3 — drag → space.** Spaces strip + CGS commit. Hairy; isolated last. The band
+  reserves room for it (currently a 2-way split); restore the `stubSection` when built.
+
+## Files
+
+- `apps/mac/Sources/Core/Overlays/Motion/WindowMotionMode.swift` — controller,
+  `ExposeView`, state, key handling, the new intent band.
+- `apps/mac/Sources/Core/Overlays/Motion/RealWindowAnimator.swift` — commit
+  animation.
+- `apps/mac/Sources/Core/Desktop/WindowTiler.swift` — location + space commit.
+- `StudioLayerStore` — layer commit.
+
+No overlap with the command-bar work (`Core/Overlays/CommandBar/`).
+```
+```


### PR DESCRIPTION
The Hyperspace **intent layer** — drag/right-click to arrange windows on a screenshot survey, *fake until commit*. Nothing real moves until ⏎/G; Esc/✕ backs out.

## What's in it
- **Band = Layers · Grid.** The survey itself is the preview — hover a layer and its windows light up while the rest dim. No separate preview canvas.
- **Drag → place / tag.** Drag a window onto a Grid section to stage a location, or onto a Layer pile to tag it. Tiles badge what's staged; a plan pill shows the whole plan.
- **Right-click → menu.** Quick tile presets (halves, quarters, maximize), Add to Layer, pluck — plus **Place…**.
- **Place… → a framed miniature of your monitor.** Click a section to place the window; it's shown life-size against the **projected future layout** (staged moves already applied), with the preview snapped to the section (never bigger than the spot).
- **New Layer flow.** Tap the ＋ pile → name it and pick the apps that define it → a rule-backed `StudioLayer` (`NewLayerPanel.swift`, its own key panel so the text field takes input).
- **Robustness.** Mouse-driven ✕ exit; Enter/Esc hardened against lost key focus; preview geometry aligned to the screen's usable (`visibleFrame`) area; screenshot fills clipped to their zones.

## Scope
Three files only — `WindowMotionMode.swift`, the new `NewLayerPanel.swift`, and the `design/hyperspace-drag-drop.md` design doc. Deliberately excludes the parallel command-bar / placement work and other unrelated tree changes.

Design notes: `design/hyperspace-drag-drop.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)