### PR TITLE
✨ Embed Hudson Voice runtime + settings refresh

### DIFF
--- a/apps/mac/Lattices.app/Contents/Info.plist
+++ b/apps/mac/Lattices.app/Contents/Info.plist
@@ -35,6 +35,8 @@
     <true/>
     <key>NSHighResolutionCapable</key>
     <true/>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Lattices uses the microphone for Hudson Voice dictation and voice commands.</string>
     <key>NSSupportsAutomaticTermination</key>
     <true/>
 </dict>

--- a/apps/mac/Lattices.entitlements
+++ b/apps/mac/Lattices.entitlements
@@ -11,5 +11,11 @@
     <true/>
     <key>com.apple.security.network.client</key>
     <true/>
+
+    <!-- Microphone: required under Hardened Runtime for the embedded Hudson Voice
+         dictation/voice-command capture. Without it, AVCaptureDevice.requestAccess
+         is denied instantly with no prompt. -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
 </dict>
 </plist>

--- a/apps/mac/Sources/AppShell/App.swift
+++ b/apps/mac/Sources/AppShell/App.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 @main
@@ -5,22 +6,78 @@ struct LatticesApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var delegate
 
     var body: some Scene {
+        // Lattices is an LSUIElement app whose real UI is AppKit-driven (the menu
+        // bar item plus the unified app window in `ScreenMapWindowController`).
+        // SwiftUI still requires a `Scene`, and macOS binds the standard Settings
+        // command (⌘,) and the app-menu "Settings…" item to a `Settings` scene.
+        //
+        // Previously this scene hosted `SettingsContentView` directly, so ⌘,/the
+        // menu opened a *detached* "Lattices Settings" window — just the settings
+        // sub-sidebar, with none of the primary app shell or navigation rail. We
+        // now do two things so Settings always renders inside the unified shell:
+        //
+        //   1. Replace the `.appSettings` command group so ⌘,/the menu route
+        //      through `SettingsWindowController` (→ the Settings *page* inside
+        //      `AppShellView`, primary rail intact).
+        //   2. Keep the scene content as a redirect that immediately closes its
+        //      throwaway window and routes — a safety net in case anything else
+        //      ever opens the scene (e.g. `SettingsLink`/`openSettings`).
         Settings {
-            SettingsContentView(
-                prefs: Preferences.shared,
-                scanner: ProjectScanner.shared
-            )
-            .frame(width: 900, height: 640)
+            SettingsSceneRedirect()
         }
-            .commands {
-                CommandGroup(after: .appInfo) {
-                    Button("Update Lattices…") {
-                        AppUpdater.shared.promptForUpdate()
-                    }
-                    .disabled(!AppUpdater.shared.canUpdate)
-
-                    Divider()
+        .commands {
+            CommandGroup(replacing: .appSettings) {
+                Button("Settings…") {
+                    SettingsWindowController.shared.show()
                 }
+                .keyboardShortcut(",", modifiers: .command)
             }
+
+            CommandGroup(after: .appInfo) {
+                Button("Update Lattices…") {
+                    AppUpdater.shared.promptForUpdate()
+                }
+                .disabled(!AppUpdater.shared.canUpdate)
+
+                Divider()
+            }
+        }
+    }
+}
+
+/// Zero-size bridge hosted by the SwiftUI `Settings` scene. If macOS ever opens
+/// the standard Settings window, this view grabs its host `NSWindow`, closes it
+/// before it can become a visible detached island, and routes Settings into the
+/// unified Lattices app shell (with the primary rail) instead.
+private struct SettingsSceneRedirect: View {
+    @State private var hostWindow: NSWindow?
+
+    var body: some View {
+        Color.clear
+            .frame(width: 0, height: 0)
+            .background(WindowGrabber { hostWindow = $0 })
+            .onAppear { redirect() }
+    }
+
+    private func redirect() {
+        DispatchQueue.main.async {
+            (hostWindow ?? NSApp.keyWindow)?.close()
+            SettingsWindowController.shared.show()
+        }
+    }
+}
+
+/// Resolves the `NSWindow` hosting a SwiftUI view so callers can act on it.
+private struct WindowGrabber: NSViewRepresentable {
+    let onResolve: (NSWindow?) -> Void
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async { onResolve(view.window) }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        DispatchQueue.main.async { onResolve(nsView.window) }
     }
 }

--- a/apps/mac/Sources/AppShell/AppDelegate.swift
+++ b/apps/mac/Sources/AppShell/AppDelegate.swift
@@ -5,6 +5,7 @@ extension Notification.Name {
     static let latticesPopoverWillShow = Notification.Name("latticesPopoverWillShow")
     static let latticesShowGeneralSettings = Notification.Name("latticesShowGeneralSettings")
     static let latticesShowAssistantSettings = Notification.Name("latticesShowAssistantSettings")
+    static let latticesShowSettingsSection = Notification.Name("latticesShowSettingsSection")
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate {
@@ -210,6 +211,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             handleCompanionDeepLink(action: action)
         case "daemon":
             handleDaemonDeepLink(action: action)
+        case "settings":
+            // lattices://settings/<section> jumps straight to a sidebar tab.
+            if let action, !action.isEmpty {
+                SettingsWindowController.shared.show(section: action)
+            } else {
+                SettingsWindowController.shared.show()
+            }
         default:
             SettingsWindowController.shared.show()
         }

--- a/apps/mac/Sources/AppShell/AppServicesBootstrap.swift
+++ b/apps/mac/Sources/AppShell/AppServicesBootstrap.swift
@@ -7,6 +7,7 @@ enum AppServicesBootstrap {
         OcrModel.shared.start()
         TmuxModel.shared.start()
         ProcessModel.shared.start()
+        LatticesVoiceRuntime.start()
         LatticesApi.setup()
         DaemonServer.shared.start()
         if Preferences.shared.companionBridgeEnabled {
@@ -18,6 +19,7 @@ enum AppServicesBootstrap {
     }
 
     static func stop() {
+        LatticesVoiceRuntime.stop()
         PiChatSession.shared.shutdown()
         LatticesCompanionBridgeServer.shared.stop()
         DaemonServer.shared.stop()

--- a/apps/mac/Sources/AppShell/MainView.swift
+++ b/apps/mac/Sources/AppShell/MainView.swift
@@ -384,15 +384,6 @@ struct MainView: View {
                 ScreenMapWindowController.shared.showPage(.desktopInventory)
             }
             ActionRow(
-                label: "Assistant",
-                detail: "Open the workspace assistant",
-                hotkeyTokens: [],
-                icon: "bubble.left.and.bubble.right",
-                accentColor: Palette.textDim
-            ) {
-                ScreenMapWindowController.shared.showPage(.pi)
-            }
-            ActionRow(
                 label: "Command Palette",
                 detail: "Launch, attach, and control projects",
                 hotkeyTokens: hotkeyTokens(.palette),

--- a/apps/mac/Sources/AppShell/PermissionsAssistantView.swift
+++ b/apps/mac/Sources/AppShell/PermissionsAssistantView.swift
@@ -248,6 +248,20 @@ struct PermissionsAssistantView: View {
 
     private func statusMessage(_ cap: Capability) -> String {
         if isGranted(cap) { return cap.whenGrantedDetail }
+        if cap == .voiceCapture {
+            switch permChecker.microphone {
+            case .notDetermined:
+                return "Microphone has not been requested yet."
+            case .denied:
+                return "macOS reports Microphone access is off for Lattices."
+            case .restricted:
+                return "This Mac or an administrator is blocking Microphone access."
+            case .authorized:
+                return cap.whenGrantedDetail
+            @unknown default:
+                return "Lattices could not read the current Microphone permission state."
+            }
+        }
         if permChecker.refreshInFlight { return "Checking macOS permission state..." }
         if let lastCheckedAt = permChecker.lastCheckedAt {
             return "Last checked \(Self.checkTimeFormatter.string(from: lastCheckedAt)); macOS still reports not enabled."
@@ -257,7 +271,7 @@ struct PermissionsAssistantView: View {
 
     @ViewBuilder
     private func permissionRepairCard(_ cap: Capability) -> some View {
-        if !isGranted(cap) {
+        if !isGranted(cap) && cap.usesDragRepair {
             PermissionAppDragCard(
                 title: "Refresh the \(cap.requirementLabel) entry",
                 permissionName: cap.requirementLabel,
@@ -273,6 +287,8 @@ struct PermissionsAssistantView: View {
             return "If macOS shows an older Lattices entry, remove it first. Then drag this current app into Accessibility and toggle it on."
         case .screenSearch:
             return "If macOS shows an older Lattices entry, remove it first. Then drag this current app into Screen Recording and toggle it on."
+        case .voiceCapture:
+            return "Microphone access uses the macOS prompt and Privacy & Security list; no drag step is needed."
         }
     }
 
@@ -350,7 +366,7 @@ struct PermissionsAssistantView: View {
                     }
                     .buttonStyle(.plain)
 
-                    if !isGranted(cap) {
+                    if !isGranted(cap) && cap.usesDragRepair {
                         Button {
                             PermissionChecker.shared.resetSavedApproval(for: cap)
                         } label: {
@@ -458,6 +474,7 @@ struct PermissionsAssistantView: View {
         switch cap {
         case .windowControl: return "Request Accessibility"
         case .screenSearch:  return "Enable OCR"
+        case .voiceCapture:  return "Request Microphone"
         }
     }
 
@@ -467,6 +484,8 @@ struct PermissionsAssistantView: View {
             return "macOS will add Lattices to its Accessibility list. You finish the toggle in System Settings."
         case .screenSearch:
             return "Enabling this turns on OCR and asks macOS for Screen Recording on this Mac. If permission looks stuck, remove stale Lattices entries and drag the current app in again."
+        case .voiceCapture:
+            return "macOS will show the Microphone prompt the first time. After that, manage Lattices in Privacy & Security > Microphone."
         }
     }
 
@@ -480,13 +499,21 @@ struct PermissionsAssistantView: View {
         case .screenSearch:
             // Turning on OCR is the moment we ask for Screen Recording.
             OcrModel.shared.setEnabled(true)
+        case .voiceCapture:
+            permChecker.requestMicrophone()
+            return
         }
 
         showDragAssistant(cap, openSettings: false)
     }
 
     private func openSystemSettings(_ cap: Capability) {
-        showDragAssistant(cap, openSettings: true)
+        if cap.usesDragRepair {
+            showDragAssistant(cap, openSettings: true)
+        } else {
+            PermissionChecker.shared.openSettings(for: cap)
+            PermissionChecker.shared.recheckNow(reason: "permissions assistant open settings", probeIfMissing: false)
+        }
     }
 
     private func showDragAssistant(_ cap: Capability, openSettings: Bool) {

--- a/apps/mac/Sources/AppShell/SettingsView.swift
+++ b/apps/mac/Sources/AppShell/SettingsView.swift
@@ -1,5 +1,10 @@
 import DeckKit
+import AVFoundation
 import SwiftUI
+import HudsonUI
+#if canImport(HudsonVoice)
+import HudsonVoice
+#endif
 
 /// Settings content with internal General / Shortcuts tabs.
 /// Can also render the Docs page when `page == .docs`.
@@ -35,7 +40,7 @@ struct SettingsContentView: View {
             case .shortcuts: return "command"
             case .mouse: return "computermouse"
             case .hyperspace: return "square.grid.3x3.fill"
-            case .voice: return "mic"
+            case .voice: return "waveform.badge.mic"
             case .ai: return "sparkles"
             case .search: return "text.viewfinder"
             case .companion: return "ipad.and.iphone"
@@ -66,7 +71,7 @@ struct SettingsContentView: View {
             case .hyperspace:
                 return "Per-display window surveys, lighting, zoom, and layout for Hyperspace."
             case .voice:
-                return "Vox capture, mic ownership, command shortcuts, and the provider-backed voice model."
+                return "Lattices hosts the embedded voice runtime, microphone access, command shortcuts, and the provider-backed voice model."
             case .ai:
                 return "Provider auth, chat readiness, and assistant runtime state."
             case .search:
@@ -115,7 +120,6 @@ struct SettingsContentView: View {
     var onBack: (() -> Void)? = nil
 
     @State private var selectedTab: SettingsSection = .general
-    @State private var voiceRefreshRevision = 0
     @FocusState private var assistantAuthFieldFocused: Bool
 
     // Hyperspace survey dials — same UserDefaults keys (and defaults) the in-survey
@@ -156,6 +160,12 @@ struct SettingsContentView: View {
         .onReceive(NotificationCenter.default.publisher(for: .latticesShowAssistantSettings)) { _ in
             selectedTab = .ai
         }
+        .onReceive(NotificationCenter.default.publisher(for: .latticesShowSettingsSection)) { note in
+            if let raw = note.userInfo?["section"] as? String,
+               let section = SettingsSection(rawValue: raw) {
+                selectedTab = section
+            }
+        }
     }
 
     // MARK: - Back Bar
@@ -191,7 +201,7 @@ struct SettingsContentView: View {
                         onBack()
                     } label: {
                         Image(systemName: "chevron.left")
-                            .font(.system(size: 10, weight: .semibold))
+                            .font(.system(size: HudTextSize.xs, weight: .semibold))
                             .foregroundColor(Palette.textMuted)
                     }
                     .buttonStyle(.plain)
@@ -207,7 +217,7 @@ struct SettingsContentView: View {
             .padding(.horizontal, 16)
             .padding(.vertical, 8)
 
-            Rectangle().fill(Palette.border).frame(height: 0.5)
+            HudDivider(color: HudHairline.standard)
         }
     }
 
@@ -216,127 +226,92 @@ struct SettingsContentView: View {
     private var settingsBody: some View {
         HStack(spacing: 0) {
             settingsSidebar
-                .frame(width: 190, alignment: .top)
+                .frame(width: 196, alignment: .top)
+                .background(Palette.bg)
 
-            Rectangle()
-                .fill(Palette.border)
-                .frame(width: 0.5)
+            HudDivider(color: HudHairline.standard, axis: .vertical)
                 .frame(maxHeight: .infinity)
 
             VStack(spacing: 0) {
                 settingsSectionHero(selectedTab)
 
-                Rectangle().fill(Palette.border).frame(height: 0.5)
+                HudDivider(color: HudHairline.standard)
 
                 selectedSectionContent
+                    .background(Palette.bg)
             }
         }
+        .background(Palette.bg)
     }
 
     private var settingsSidebar: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            VStack(alignment: .leading, spacing: 6) {
-                Text("SETTINGS")
-                    .font(Typo.pixel(14))
-                    .foregroundColor(Palette.textDim)
-                    .tracking(1)
-                Text("Tune how Lattices launches workspaces, listens for commands, and navigates the desktop.")
-                    .font(Typo.caption(11))
-                    .foregroundColor(Palette.textMuted)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
+        // Scrollable so the section list never imposes a tall minimum height. The
+        // unified window is user-resizable; without this, the non-scrolling list
+        // (~480pt) overflows short windows and pushes the shell's status bar off
+        // the bottom — every section pane already scrolls, so the rail must too.
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Settings")
+                        .font(Typo.monoBold(12))
+                        .foregroundColor(Palette.text)
 
-            VStack(alignment: .leading, spacing: 12) {
-                ForEach(SettingsSection.groupedCases, id: \.0) { group, sections in
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text(group.uppercased())
-                            .font(Typo.pixel(11))
-                            .foregroundColor(Palette.textDim.opacity(0.85))
-                            .tracking(1.2)
-                            .padding(.horizontal, 4)
+                    Text("Workspace, input, agents, capture.")
+                        .font(Typo.caption(10))
+                        .foregroundColor(Palette.textMuted)
+                        .lineLimit(2)
+                }
 
-                        VStack(spacing: 4) {
-                            ForEach(sections) { section in
-                                settingsTab(section)
+                HudDivider(color: HudHairline.subtle)
+
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(SettingsSection.groupedCases, id: \.0) { group, sections in
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(group.uppercased())
+                                .font(Typo.pixel(11))
+                                .foregroundColor(Palette.textDim.opacity(0.85))
+                                .tracking(1.2)
+                                .padding(.horizontal, 4)
+
+                            VStack(spacing: 4) {
+                                ForEach(sections) { section in
+                                    settingsTab(section)
+                                }
                             }
                         }
                     }
                 }
             }
-
-            Spacer(minLength: 0)
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(16)
     }
 
     private func settingsTab(_ section: SettingsSection) -> some View {
-        let active = selectedTab == section
-        return Button {
+        SettingsSidebarRow(
+            icon: section.icon,
+            title: section.title,
+            eyebrow: section.eyebrow,
+            isActive: selectedTab == section,
+            accent: Palette.running
+        ) {
             selectedTab = section
-        } label: {
-            HStack(alignment: .top, spacing: 10) {
-                Image(systemName: section.icon)
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundColor(active ? Palette.text : Palette.textMuted)
-                    .frame(width: 16, height: 18, alignment: .center)
-
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(section.title)
-                        .font(Typo.mono(11))
-                        .foregroundColor(active ? Palette.text : Palette.textMuted)
-
-                    Text(section.eyebrow)
-                        .font(Typo.caption(9))
-                        .foregroundColor(Palette.textMuted.opacity(active ? 0.85 : 0.62))
-                }
-
-                Spacer(minLength: 0)
-            }
-            .padding(.horizontal, 10)
-            .frame(height: 38)
-            .contentShape(RoundedRectangle(cornerRadius: 7))
-            .background(
-                ZStack {
-                    if active {
-                        RoundedRectangle(cornerRadius: 7)
-                            .fill(Color.white.opacity(0.055))
-                        RoundedRectangle(cornerRadius: 7)
-                            .strokeBorder(
-                                LinearGradient(
-                                    colors: [Color.white.opacity(0.12), Color.white.opacity(0.04)],
-                                    startPoint: .top,
-                                    endPoint: .bottom
-                                ),
-                                lineWidth: 0.5
-                            )
-                    }
-                }
-            )
-            .overlay(alignment: .leading) {
-                RoundedRectangle(cornerRadius: 1)
-                    .fill(active ? Palette.running : Color.clear)
-                    .frame(width: 2)
-                    .padding(.vertical, 8)
-            }
         }
-        .buttonStyle(.plain)
-        .help(section.title)
     }
 
     private func settingsSectionHero(_ section: SettingsSection) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(section.eyebrow.uppercased())
-                .font(Typo.pixel(14))
-                .foregroundColor(Palette.textDim)
-                .tracking(1)
+        VStack(alignment: .leading, spacing: 6) {
+            Text(section.eyebrow)
+                .font(Typo.monoBold(10))
+                .foregroundColor(Palette.textMuted)
 
             Text(section.title)
-                .font(Typo.heading(16))
+                .font(Typo.heading(18))
                 .foregroundColor(Palette.text)
 
             Text(section.summary)
-                .font(Typo.caption(11))
-                .foregroundColor(Palette.textMuted)
+                .font(Typo.mono(10.5))
+                .foregroundColor(Palette.textDim)
                 .fixedSize(horizontal: false, vertical: true)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -394,44 +369,26 @@ struct SettingsContentView: View {
         let missing = Capability.allCases.filter { !$0.isGranted }
         return settingsCard {
             VStack(alignment: .leading, spacing: 12) {
-                HStack(alignment: .center, spacing: 8) {
-                    RoundedRectangle(cornerRadius: 5)
-                        .fill((missing.isEmpty ? Palette.running : Palette.detach).opacity(0.13))
-                        .overlay(
-                            Image(systemName: missing.isEmpty ? "checkmark.shield.fill" : "exclamationmark.shield.fill")
-                                .font(.system(size: 12, weight: .semibold))
-                                .foregroundColor(missing.isEmpty ? Palette.running : Palette.detach)
-                        )
-                        .frame(width: 26, height: 26)
-
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Permissions")
-                            .font(Typo.mono(12))
+                            .font(Typo.monoBold(12))
                             .foregroundColor(Palette.text)
-                        Text(missing.isEmpty ? "Ready for window control, gestures, and OCR" : "\(missing.count) permission \(missing.count == 1 ? "needs" : "need") attention")
-                            .font(Typo.caption(9.5))
+                        Text(missing.isEmpty ? "Ready for window control, OCR, and voice" : "\(missing.count) permission \(missing.count == 1 ? "needs" : "need") attention")
+                            .font(Typo.mono(9.5))
                             .foregroundColor(Palette.textMuted)
                     }
 
                     Spacer()
 
-                    Text(missing.isEmpty ? "All on" : "\(missing.count) off")
-                        .font(Typo.monoBold(9.5))
-                        .foregroundColor(missing.isEmpty ? Palette.running : Palette.detach)
-                        .padding(.horizontal, 7)
-                        .padding(.vertical, 3)
-                        .background(
-                            Capsule()
-                                .fill((missing.isEmpty ? Palette.running : Palette.detach).opacity(0.10))
-                                .overlay(Capsule().strokeBorder((missing.isEmpty ? Palette.running : Palette.detach).opacity(0.18), lineWidth: 0.5))
-                        )
+                    statusToken(missing.isEmpty ? "All on" : "\(missing.count) off", color: missing.isEmpty ? Palette.running : Palette.detach)
                 }
 
-                Text("The assistant explains each macOS prompt before you grant it. Advanced privacy panes stay available for review when a synthetic shortcut or input capture needs macOS-level repair.")
+                Text("Lattices uses these macOS grants for window control, OCR, gestures, shortcuts, and local voice capture.")
                     .font(Typo.caption(10))
                     .foregroundColor(Palette.textMuted)
 
-                HStack(spacing: 8) {
+                HStack(spacing: 12) {
                     ForEach(Capability.allCases) { cap in
                         HStack(spacing: 4) {
                             Circle()
@@ -441,11 +398,6 @@ struct SettingsContentView: View {
                                 .font(Typo.mono(9))
                                 .foregroundColor(Palette.textMuted)
                         }
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(
-                            Capsule().fill(Palette.surface)
-                        )
                     }
                     Spacer(minLength: 0)
                 }
@@ -503,12 +455,13 @@ struct SettingsContentView: View {
     }
 
     private var permissionsDetailCard: some View {
-        settingsCard {
+        let allCapabilitiesGranted = Capability.allCases.allSatisfy(\.isGranted)
+        return settingsCard {
             VStack(alignment: .leading, spacing: 10) {
                 HStack(alignment: .center, spacing: 8) {
-                    Image(systemName: permChecker.allGranted ? "checkmark.shield.fill" : "exclamationmark.shield.fill")
+                    Image(systemName: allCapabilitiesGranted ? "checkmark.shield.fill" : "exclamationmark.shield.fill")
                         .font(.system(size: 11, weight: .medium))
-                        .foregroundColor(permChecker.allGranted ? Palette.running : Palette.detach)
+                        .foregroundColor(allCapabilitiesGranted ? Palette.running : Palette.detach)
                     Text("macOS permissions")
                         .font(Typo.mono(12))
                         .foregroundColor(Palette.text)
@@ -525,7 +478,7 @@ struct SettingsContentView: View {
                     .help("Refresh permission status")
                 }
 
-                Text("Window discovery, gestures, remaps, OCR, and synthetic shortcuts all depend on these macOS grants.")
+                Text("Window discovery, gestures, remaps, OCR, voice capture, and synthetic shortcuts all depend on these macOS grants.")
                     .font(Typo.caption(10))
                     .foregroundColor(Palette.textMuted)
 
@@ -544,6 +497,14 @@ struct SettingsContentView: View {
                         detail: "Required for reliable window titles, OCR, and Space-aware window discovery."
                     ) {
                         permChecker.requestScreenRecording()
+                    }
+
+                    permissionSettingsRow(
+                        "Microphone",
+                        granted: permChecker.microphoneGranted,
+                        detail: "Required for local dictation and voice commands hosted by Lattices."
+                    ) {
+                        permChecker.requestMicrophone()
                     }
 
                     permissionReviewRow(
@@ -567,20 +528,11 @@ struct SettingsContentView: View {
     private var appUpdateCard: some View {
         settingsCard {
             VStack(alignment: .leading, spacing: 10) {
-                HStack(alignment: .center, spacing: 10) {
-                    RoundedRectangle(cornerRadius: 6)
-                        .fill((LatticesRuntime.isDevBuild ? Palette.detach : Palette.running).opacity(0.13))
-                        .overlay(
-                            Image(systemName: LatticesRuntime.isDevBuild ? "hammer.fill" : "checkmark.seal.fill")
-                                .font(.system(size: 13, weight: .semibold))
-                                .foregroundColor(LatticesRuntime.isDevBuild ? Palette.detach : Palette.running)
-                        )
-                        .frame(width: 30, height: 30)
-
+                HStack(alignment: .firstTextBaseline, spacing: 10) {
                     VStack(alignment: .leading, spacing: 4) {
                         HStack(spacing: 8) {
                             Text("Lattices app")
-                                .font(Typo.mono(12))
+                                .font(Typo.monoBold(12))
                                 .foregroundColor(Palette.text)
                             buildChannelBadge
                         }
@@ -591,7 +543,7 @@ struct SettingsContentView: View {
                                 .foregroundColor(Palette.text)
                             Text(LatticesRuntime.buildStatusLabel)
                                 .font(Typo.monoBold(9.5))
-                                .foregroundColor(LatticesRuntime.isDevBuild ? Palette.detach : Palette.running)
+                                .foregroundColor(Palette.textMuted)
                         }
                     }
 
@@ -659,7 +611,7 @@ struct SettingsContentView: View {
         settingsCard {
             VStack(alignment: .leading, spacing: 12) {
                 Text("Session behavior")
-                    .font(Typo.mono(12))
+                    .font(Typo.monoBold(12))
                     .foregroundColor(Palette.text)
 
                 HStack {
@@ -681,6 +633,104 @@ struct SettingsContentView: View {
                     : "Detaches sessions quietly once Lattices has done the workspace handoff.")
                     .font(Typo.caption(9.5))
                     .foregroundColor(Palette.textMuted.opacity(0.75))
+            }
+        }
+    }
+
+    private var terminalSettingsCard: some View {
+        settingsCard {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Terminal")
+                    .font(Typo.monoBold(12))
+                    .foregroundColor(Palette.text)
+
+                Picker("", selection: $prefs.terminal) {
+                    ForEach(Terminal.installed) { t in
+                        Text(t.rawValue).tag(t)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+
+                Text("Used when Lattices attaches to tmux sessions.")
+                    .font(Typo.caption(9.5))
+                    .foregroundColor(Palette.textMuted.opacity(0.75))
+            }
+        }
+    }
+
+    private var projectDiscoveryCard: some View {
+        settingsCard {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Project discovery")
+                    .font(Typo.monoBold(12))
+                    .foregroundColor(Palette.text)
+
+                Text("Project scan root")
+                    .font(Typo.mono(10))
+                    .foregroundColor(Palette.textDim)
+
+                HStack(spacing: 6) {
+                    TextField("~/dev", text: $prefs.scanRoot)
+                        .textFieldStyle(.plain)
+                        .font(Typo.mono(11))
+                        .foregroundColor(Palette.text)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 5)
+                        .background(
+                            RoundedRectangle(cornerRadius: 5)
+                                .fill(HudSurface.control)
+                                .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(HudHairline.standard, lineWidth: 0.5))
+                        )
+
+                    Button {
+                        let panel = NSOpenPanel()
+                        panel.canChooseDirectories = true
+                        panel.canChooseFiles = false
+                        panel.allowsMultipleSelection = false
+                        if !prefs.scanRoot.isEmpty {
+                            panel.directoryURL = URL(fileURLWithPath: prefs.scanRoot)
+                        }
+                        if panel.runModal() == .OK, let url = panel.url {
+                            prefs.scanRoot = url.path
+                        }
+                    } label: {
+                        Image(systemName: "folder")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundColor(Palette.textDim)
+                            .frame(width: 26, height: 24)
+                            .background(
+                                RoundedRectangle(cornerRadius: 5)
+                                    .fill(HudSurface.control)
+                                    .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(HudHairline.standard, lineWidth: 0.5))
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .help("Choose scan root")
+                }
+
+                HStack {
+                    Text("Scans for .lattices.json project configs.")
+                        .font(Typo.caption(9))
+                        .foregroundColor(Palette.textMuted.opacity(0.7))
+                    Spacer()
+                    Button {
+                        scanner.updateRoot(prefs.scanRoot)
+                        scanner.scan()
+                    } label: {
+                        Text("Rescan")
+                            .font(Typo.monoBold(10))
+                            .foregroundColor(Palette.text)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 4)
+                            .background(
+                                RoundedRectangle(cornerRadius: 4)
+                                    .fill(Palette.surfaceHov)
+                                    .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.borderLit, lineWidth: 0.5))
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
             }
         }
     }
@@ -1008,100 +1058,19 @@ struct SettingsContentView: View {
 
                 permissionsAssistantCard
 
-                settingsCard {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Terminal")
-                            .font(Typo.mono(11))
-                            .foregroundColor(Palette.text)
+                ViewThatFits(in: .horizontal) {
+                    HStack(alignment: .top, spacing: 12) {
+                        terminalSettingsCard
+                        interactionBehaviorCard
+                    }
 
-                        Picker("", selection: $prefs.terminal) {
-                            ForEach(Terminal.installed) { t in
-                                Text(t.rawValue).tag(t)
-                            }
-                        }
-                        .pickerStyle(.segmented)
-                        .labelsHidden()
-
-                        Text("Used for attaching to sessions")
-                            .font(Typo.caption(10))
-                            .foregroundColor(Palette.textMuted)
+                    VStack(alignment: .leading, spacing: 12) {
+                        terminalSettingsCard
+                        interactionBehaviorCard
                     }
                 }
 
-                settingsCard {
-                    VStack(alignment: .leading, spacing: 10) {
-                        Text("Project discovery")
-                            .font(Typo.mono(11))
-                            .foregroundColor(Palette.text)
-
-                        Text("Project scan root")
-                            .font(Typo.mono(10))
-                            .foregroundColor(Palette.textDim)
-
-                        HStack(spacing: 6) {
-                            TextField("~/dev", text: $prefs.scanRoot)
-                                .textFieldStyle(.plain)
-                                .font(Typo.mono(11))
-                                .foregroundColor(Palette.text)
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 5)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 5)
-                                        .fill(Color.white.opacity(0.06))
-                                        .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(Color.white.opacity(0.08), lineWidth: 0.5))
-                                )
-
-                            Button {
-                                let panel = NSOpenPanel()
-                                panel.canChooseDirectories = true
-                                panel.canChooseFiles = false
-                                panel.allowsMultipleSelection = false
-                                if !prefs.scanRoot.isEmpty {
-                                    panel.directoryURL = URL(fileURLWithPath: prefs.scanRoot)
-                                }
-                                if panel.runModal() == .OK, let url = panel.url {
-                                    prefs.scanRoot = url.path
-                                }
-                            } label: {
-                                Image(systemName: "folder")
-                                    .font(.system(size: 11))
-                                    .foregroundColor(Palette.textDim)
-                                    .padding(6)
-                                    .background(
-                                        RoundedRectangle(cornerRadius: 5)
-                                            .fill(Color.white.opacity(0.06))
-                                            .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(Color.white.opacity(0.08), lineWidth: 0.5))
-                                    )
-                            }
-                            .buttonStyle(.plain)
-                        }
-
-                        HStack {
-                            Text("Scans for .lattices.json project configs")
-                                .font(Typo.caption(9))
-                                .foregroundColor(Palette.textMuted.opacity(0.7))
-                            Spacer()
-                            Button {
-                                scanner.updateRoot(prefs.scanRoot)
-                                scanner.scan()
-                            } label: {
-                                Text("Rescan")
-                                    .font(Typo.monoBold(10))
-                                    .foregroundColor(Palette.text)
-                                    .padding(.horizontal, 12)
-                                    .padding(.vertical, 4)
-                                    .background(
-                                        RoundedRectangle(cornerRadius: 4)
-                                            .fill(Palette.surfaceHov)
-                                            .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.borderLit, lineWidth: 0.5))
-                                    )
-                            }
-                            .buttonStyle(.plain)
-                        }
-                    }
-                }
-
-                interactionBehaviorCard
+                projectDiscoveryCard
             }
             .padding(16)
             .frame(maxWidth: 760, alignment: .leading)
@@ -1114,12 +1083,13 @@ struct SettingsContentView: View {
             VStack(alignment: .leading, spacing: 12) {
                 permissionsAssistantCard
 
+                let allCapabilitiesGranted = Capability.allCases.allSatisfy(\.isGranted)
                 settingsCard {
                     VStack(alignment: .leading, spacing: 10) {
                         HStack(alignment: .center, spacing: 8) {
-                            Image(systemName: permChecker.allGranted ? "checkmark.shield.fill" : "exclamationmark.shield.fill")
+                            Image(systemName: allCapabilitiesGranted ? "checkmark.shield.fill" : "exclamationmark.shield.fill")
                                 .font(.system(size: 11, weight: .medium))
-                                .foregroundColor(permChecker.allGranted ? Palette.running : Palette.detach)
+                                .foregroundColor(allCapabilitiesGranted ? Palette.running : Palette.detach)
                             Text("Permissions")
                                 .font(Typo.mono(12))
                                 .foregroundColor(Palette.text)
@@ -1136,7 +1106,7 @@ struct SettingsContentView: View {
                             .help("Refresh permission status")
                         }
 
-                        Text("Lattices uses macOS privacy permissions for window discovery, tiling, gestures, remaps, and synthetic shortcuts.")
+                        Text("Lattices uses macOS privacy permissions for window discovery, tiling, gestures, remaps, voice capture, and synthetic shortcuts.")
                             .font(Typo.caption(10))
                             .foregroundColor(Palette.textMuted)
 
@@ -1155,6 +1125,14 @@ struct SettingsContentView: View {
                                 detail: "Required for reliable window titles, OCR, and Space-aware window discovery."
                             ) {
                                 permChecker.requestScreenRecording()
+                            }
+
+                            permissionSettingsRow(
+                                "Microphone",
+                                granted: permChecker.microphoneGranted,
+                                detail: "Required for local dictation and voice commands hosted by Lattices."
+                            ) {
+                                permChecker.requestMicrophone()
                             }
 
                             permissionReviewRow(
@@ -2230,7 +2208,45 @@ struct SettingsContentView: View {
     private var voiceContent: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
-                voiceCaptureCard
+                voiceMicrophoneAccessCard
+
+                #if canImport(HudsonVoice)
+                HudsonVoiceSettingsView(
+                    showsMicrophonePermission: false,
+                    managesMicrophonePermission: false,
+                    appName: "Lattices"
+                )
+                #else
+                settingsCard {
+                    VStack(alignment: .leading, spacing: 10) {
+                        HStack(spacing: 10) {
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(Palette.surfaceHov)
+                                .overlay(
+                                    Image(systemName: "waveform.slash")
+                                        .font(.system(size: 12, weight: .semibold))
+                                        .foregroundColor(Palette.textMuted)
+                                )
+                                .frame(width: 30, height: 30)
+
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text("Voice runtime")
+                                    .font(Typo.mono(12))
+                                    .foregroundColor(Palette.text)
+                                Text("Lattices' embedded voice runtime isn't compiled into this build.")
+                                    .font(Typo.caption(9.5))
+                                    .foregroundColor(Palette.textMuted)
+                            }
+                        }
+
+                        Text("Build with HUDSONKIT_WITH_VOICE=1 to host the voice runtime and reveal its settings.")
+                            .font(Typo.caption(10))
+                            .foregroundColor(Palette.textMuted)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                #endif
+
                 voiceModelCard
                 voiceShortcutsCard
             }
@@ -2240,67 +2256,6 @@ struct SettingsContentView: View {
         }
         .onAppear {
             assistantSession.prepareForDisplay()
-        }
-    }
-
-    private var voiceCaptureCard: some View {
-        _ = voiceRefreshRevision
-        let info = VoxDaemon.info()
-        let isRunning = info != nil
-        let providerAvailable = audioLayer.provider?.isAvailable ?? false
-        let installed = voiceVoxAppURL() != nil || FileManager.default.fileExists(atPath: NSHomeDirectory() + "/.vox")
-
-        return settingsCard {
-            VStack(alignment: .leading, spacing: 12) {
-                HStack(alignment: .center, spacing: 10) {
-                    RoundedRectangle(cornerRadius: 6)
-                        .fill(voiceCaptureTint(isRunning: isRunning, installed: installed).opacity(0.13))
-                        .overlay(
-                            Image(systemName: isRunning ? "mic.fill" : (installed ? "mic.badge.plus" : "mic.slash"))
-                                .font(.system(size: 12, weight: .semibold))
-                                .foregroundColor(voiceCaptureTint(isRunning: isRunning, installed: installed))
-                        )
-                        .frame(width: 30, height: 30)
-
-                    VStack(alignment: .leading, spacing: 3) {
-                        Text("Voice capture")
-                            .font(Typo.mono(12))
-                            .foregroundColor(Palette.text)
-                        Text(voiceCaptureSummary(isRunning: isRunning, installed: installed, providerAvailable: providerAvailable))
-                            .font(Typo.caption(9.5))
-                            .foregroundColor(Palette.textMuted)
-                    }
-
-                    Spacer()
-
-                    aiStatusPill(isRunning ? "VOX LIVE" : (installed ? "VOX OFF" : "NO VOX"), tint: voiceCaptureTint(isRunning: isRunning, installed: installed))
-                }
-
-                Text("Lattices borrows Vox for microphone capture and transcription. Choose the physical microphone in Vox; Lattices receives final text and routes it through workspace intents.")
-                    .font(Typo.caption(10))
-                    .foregroundColor(Palette.textMuted)
-                    .fixedSize(horizontal: false, vertical: true)
-
-                VStack(alignment: .leading, spacing: 8) {
-                    voiceFactRow("Mic selection", value: "Vox audio input", detail: "Open Vox to change the actual device.")
-                    voiceFactRow("Capture daemon", value: isRunning ? "127.0.0.1:\(info?.port ?? VoxDaemon.fallbackPort)" : "not running", detail: info.map { "pid \($0.pid) · v\($0.version)" } ?? "Starts on demand when possible.")
-                    voiceFactRow("Provider", value: audioLayer.providerName, detail: providerAvailable ? "Ready for Lattices voice capture." : "Waiting for Vox availability.")
-                }
-                .padding(10)
-                .background(shortcutsInsetPanel)
-
-                HStack(spacing: 8) {
-                    aiActionButton(installed ? "Open Vox" : "Find Vox", tint: installed ? Palette.running : Palette.detach) {
-                        openVoxApp()
-                    }
-
-                    aiActionButton("Refresh", tint: Palette.textMuted) {
-                        voiceRefreshRevision += 1
-                    }
-
-                    Spacer()
-                }
-            }
         }
     }
 
@@ -2421,40 +2376,217 @@ struct SettingsContentView: View {
         }
     }
 
-    private func voiceCaptureTint(isRunning: Bool, installed: Bool) -> Color {
-        if isRunning { return Palette.running }
-        if installed { return Palette.detach }
-        return Palette.kill
-    }
+    private var voiceMicrophoneAccessCard: some View {
+        settingsCard {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Voice access")
+                            .font(Typo.monoBold(12))
+                            .foregroundColor(Palette.text)
+                        Text(voiceMicrophoneSummary)
+                            .font(Typo.mono(9.5))
+                            .foregroundColor(Palette.textMuted)
+                    }
 
-    private func voiceCaptureSummary(isRunning: Bool, installed: Bool, providerAvailable: Bool) -> String {
-        if isRunning && providerAvailable { return "Vox is reachable and ready for capture." }
-        if isRunning { return "Vox daemon is running; waiting for provider readiness." }
-        if installed { return "Vox is installed but not running." }
-        return "Install Vox to enable microphone capture."
-    }
+                    Spacer()
 
-    private func voiceVoxAppURL() -> URL? {
-        [
-            "/Applications/Vox.app",
-            NSHomeDirectory() + "/Applications/Vox.app",
-        ]
-        .first(where: { FileManager.default.fileExists(atPath: $0) })
-        .map { URL(fileURLWithPath: $0) }
-    }
+                    statusToken(voiceMicrophoneStatusLabel, color: voiceMicrophoneStatusColor)
+                }
 
-    private func openVoxApp() {
-        guard let url = voiceVoxAppURL() else {
-            NSWorkspace.shared.open(URL(fileURLWithPath: "/Applications"))
-            return
-        }
+                voiceMicrophonePermissionRow
 
-        let configuration = NSWorkspace.OpenConfiguration()
-        configuration.activates = true
-        NSWorkspace.shared.openApplication(at: url, configuration: configuration) { _, error in
-            if let error {
-                DiagnosticLog.shared.warn("Settings: failed to open Vox — \(error.localizedDescription)")
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text("Lattices hosts the embedded voice engine, so macOS Microphone access belongs to Lattices.")
+                        .font(Typo.caption(9.5))
+                        .foregroundColor(Palette.textMuted.opacity(0.8))
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Spacer(minLength: 0)
+
+                    Button {
+                        PermissionsAssistantWindowController.shared.show(focus: .voiceCapture)
+                    } label: {
+                        settingsActionLabel("Permissions", icon: "slider.horizontal.3")
+                    }
+                    .buttonStyle(.plain)
+
+                    if voiceMicrophoneShowsSettings {
+                        Button {
+                            permChecker.openMicrophoneSettings()
+                        } label: {
+                            settingsActionLabel("System Settings", icon: "arrow.up.forward.app")
+                        }
+                        .buttonStyle(.plain)
+                    }
+
+                    Button {
+                        permChecker.check()
+                    } label: {
+                        settingsActionLabel("Recheck", icon: "checkmark.shield")
+                    }
+                    .buttonStyle(.plain)
+
+                    Spacer(minLength: 0)
+                }
             }
+        }
+    }
+
+    @ViewBuilder
+    private var voiceMicrophonePermissionRow: some View {
+        HStack(alignment: .center, spacing: 10) {
+            RoundedRectangle(cornerRadius: 6)
+                .fill(voiceMicrophoneStatusColor.opacity(0.14))
+                .overlay(
+                    Image(systemName: voiceMicrophoneIcon)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(voiceMicrophoneStatusColor)
+                )
+                .frame(width: 30, height: 30)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Microphone")
+                    .font(Typo.monoBold(11))
+                    .foregroundColor(Palette.text)
+                Text(voiceMicrophoneDetail)
+                    .font(Typo.caption(9.5))
+                    .foregroundColor(Palette.textMuted.opacity(0.82))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 12)
+
+            voiceMicrophonePrimaryAction
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 9)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Palette.surfaceHov.opacity(0.32))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(voiceMicrophoneStatusColor.opacity(voiceMicrophoneNeedsAttention ? 0.24 : 0.12), lineWidth: 0.5)
+                )
+        )
+    }
+
+    @ViewBuilder
+    private var voiceMicrophonePrimaryAction: some View {
+        switch permChecker.microphone {
+        case .notDetermined:
+            Button {
+                permChecker.requestMicrophone()
+            } label: {
+                settingsActionLabel("Request Access", icon: "mic.badge.plus", emphasized: true)
+            }
+            .buttonStyle(.plain)
+        case .denied, .restricted:
+            Button {
+                permChecker.openMicrophoneSettings()
+            } label: {
+                settingsActionLabel("Open Settings", icon: "arrow.up.forward.app", emphasized: true)
+            }
+            .buttonStyle(.plain)
+        case .authorized:
+            HStack(spacing: 4) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 10, weight: .semibold))
+                Text("Ready")
+                    .font(Typo.monoBold(10))
+            }
+            .foregroundColor(Palette.running)
+        @unknown default:
+            EmptyView()
+        }
+    }
+
+    private var voiceMicrophoneSummary: String {
+        switch permChecker.microphone {
+        case .authorized:
+            return "Ready for dictation and voice commands"
+        case .notDetermined:
+            return "Not requested yet"
+        case .denied:
+            return "Needs macOS approval"
+        case .restricted:
+            return "Blocked by device policy"
+        @unknown default:
+            return "Microphone status is unknown"
+        }
+    }
+
+    private var voiceMicrophoneStatusLabel: String {
+        switch permChecker.microphone {
+        case .authorized:
+            return "ready"
+        case .notDetermined:
+            return "not requested"
+        case .denied:
+            return "blocked"
+        case .restricted:
+            return "restricted"
+        @unknown default:
+            return "unknown"
+        }
+    }
+
+    private var voiceMicrophoneStatusColor: Color {
+        switch permChecker.microphone {
+        case .authorized:
+            return Palette.running
+        case .notDetermined:
+            return Palette.textMuted
+        case .denied, .restricted:
+            return Palette.detach
+        @unknown default:
+            return Palette.textDim
+        }
+    }
+
+    private var voiceMicrophoneIcon: String {
+        switch permChecker.microphone {
+        case .authorized:
+            return "checkmark.circle.fill"
+        case .notDetermined:
+            return "mic"
+        case .denied, .restricted:
+            return "exclamationmark.circle.fill"
+        @unknown default:
+            return "questionmark.circle.fill"
+        }
+    }
+
+    private var voiceMicrophoneDetail: String {
+        switch permChecker.microphone {
+        case .authorized:
+            return "Lattices can listen when you start dictation or a voice command."
+        case .notDetermined:
+            return "Ask macOS once before using local dictation or voice commands."
+        case .denied:
+            return "Open Privacy & Security > Microphone and enable Lattices, then recheck."
+        case .restricted:
+            return "This Mac or an administrator is blocking microphone access."
+        @unknown default:
+            return "Lattices could not read the current microphone permission state."
+        }
+    }
+
+    private var voiceMicrophoneNeedsAttention: Bool {
+        switch permChecker.microphone {
+        case .authorized:
+            return false
+        default:
+            return true
+        }
+    }
+
+    private var voiceMicrophoneShowsSettings: Bool {
+        switch permChecker.microphone {
+        case .denied, .restricted:
+            return true
+        default:
+            return false
         }
     }
 
@@ -2749,17 +2881,26 @@ struct SettingsContentView: View {
     }
 
     private var buildChannelBadge: some View {
-        let tint = LatticesRuntime.isDevBuild ? Palette.detach : Palette.running
-
-        return Text(LatticesRuntime.buildChannelLabel)
+        Text(LatticesRuntime.buildChannelLabel)
             .font(Typo.monoBold(9))
-            .foregroundColor(tint)
+            .foregroundColor(Palette.textMuted)
             .padding(.horizontal, 6)
             .padding(.vertical, 3)
             .background(
                 Capsule()
-                    .fill(tint.opacity(0.12))
+                    .fill(Palette.surfaceHov.opacity(0.6))
             )
+    }
+
+    private func statusToken(_ label: String, color: Color) -> some View {
+        HStack(spacing: 5) {
+            Circle()
+                .fill(color)
+                .frame(width: 5, height: 5)
+            Text(label)
+                .font(Typo.monoBold(9.5))
+                .foregroundColor(Palette.textDim)
+        }
     }
 
     // MARK: - Search & OCR
@@ -3151,25 +3292,41 @@ struct SettingsContentView: View {
 
     // MARK: - Settings Card
 
-    private func settingsCard<Content: View>(@ViewBuilder content: () -> Content) -> some View {
-        content()
-            .padding(.horizontal, 14)
-            .padding(.vertical, 12)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .liquidGlass()
+    private func settingsCard<Content: View>(@ViewBuilder content: @escaping () -> Content) -> some View {
+        HudCard(
+            padding: 12,
+            radius: HudRadius.card,
+            fill: Palette.surface,
+            stroke: Palette.border
+        ) {
+            content()
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
     }
 
     private var cardDivider: some View {
-        Rectangle()
-            .fill(
-                LinearGradient(
-                    colors: [Color.white.opacity(0.03), Color.white.opacity(0.08), Color.white.opacity(0.03)],
-                    startPoint: .leading,
-                    endPoint: .trailing
-                )
-            )
-            .frame(height: 0.5)
+        HudDivider(color: HudHairline.subtle)
             .padding(.vertical, 3)
+    }
+
+    private func settingsActionLabel(_ title: String, icon: String, emphasized: Bool = false) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 9, weight: .semibold))
+            Text(title)
+                .font(Typo.monoBold(10))
+        }
+        .foregroundColor(emphasized ? Palette.text : Palette.textMuted)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 4)
+                .fill(emphasized ? Palette.surfaceHov : Palette.surface)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4)
+                        .strokeBorder(emphasized ? Palette.borderLit : Palette.border, lineWidth: 0.5)
+                )
+        )
     }
 
     private func permissionSettingsRow(
@@ -3716,7 +3873,7 @@ struct SettingsContentView: View {
         title: String,
         eyebrow: String,
         summary: String,
-        @ViewBuilder content: () -> Content
+        @ViewBuilder content: @escaping () -> Content
     ) -> some View {
         settingsCard {
             VStack(alignment: .leading, spacing: 12) {
@@ -4126,5 +4283,68 @@ struct SettingsContentView: View {
                             .strokeBorder(Palette.border, lineWidth: 0.5)
                     )
             )
+    }
+}
+
+private struct SettingsSidebarRow: View {
+    let icon: String
+    let title: String
+    let eyebrow: String
+    let isActive: Bool
+    let accent: Color
+    let action: () -> Void
+
+    @State private var isHovering = false
+
+    private var iconTint: Color {
+        if isActive || isHovering { return Palette.textDim }
+        return Palette.textMuted
+    }
+
+    private var titleTint: Color {
+        if isActive || isHovering { return Palette.text }
+        return Palette.textDim
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Capsule()
+                    .fill(isActive ? accent : Color.clear)
+                    .frame(width: 2, height: 22)
+
+                HStack(alignment: .center, spacing: 9) {
+                    Image(systemName: icon)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(iconTint)
+                        .frame(width: 16, height: 20, alignment: .center)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(title)
+                            .font(isActive ? Typo.monoBold(11) : Typo.mono(11))
+                            .foregroundColor(titleTint)
+
+                        Text(eyebrow)
+                            .font(Typo.mono(8.5))
+                            .foregroundColor(Palette.textMuted.opacity(isActive ? 0.82 : 0.62))
+                    }
+
+                    Spacer(minLength: 0)
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 7)
+            .contentShape(RoundedRectangle(cornerRadius: HudRadius.standard))
+            .background(
+                RoundedRectangle(cornerRadius: HudRadius.standard)
+                    .fill(isActive ? Palette.surface.opacity(0.95) : (isHovering ? Palette.surface.opacity(0.62) : Color.clear))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: HudRadius.standard)
+                    .stroke(isActive ? Palette.borderLit : Color.clear, lineWidth: 0.5)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovering = $0 }
     }
 }

--- a/apps/mac/Sources/AppShell/SettingsWindow.swift
+++ b/apps/mac/Sources/AppShell/SettingsWindow.swift
@@ -21,6 +21,19 @@ final class SettingsWindowController {
         ScreenMapWindowController.shared.showPage(.companionSettings)
     }
 
+    /// Open Settings and jump to a specific sidebar section by its raw value
+    /// (general, shortcuts, mouse, ai, voice, search, companion).
+    func show(section rawValue: String) {
+        ScreenMapWindowController.shared.showPage(.settings)
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(
+                name: .latticesShowSettingsSection,
+                object: nil,
+                userInfo: ["section": rawValue]
+            )
+        }
+    }
+
     func showAssistant() {
         ScreenMapWindowController.shared.showPage(.settings)
         DispatchQueue.main.async {

--- a/apps/mac/Sources/Core/Companion/LatticesDeckHost.swift
+++ b/apps/mac/Sources/Core/Companion/LatticesDeckHost.swift
@@ -607,7 +607,7 @@ private extension LatticesDeckHost {
             transcript: handsOff.lastTranscript ?? audio.lastTranscript,
             transcriptLines: buildTranscriptLines(handsOff: handsOff, audio: audio),
             responseSummary: handsOff.lastResponse ?? audio.executionResult,
-            provider: audio.providerName == "none" ? "vox" : audio.providerName
+            provider: audio.providerName == "none" ? "voice-runtime" : audio.providerName
         )
         let desktop = DeckDesktopSummary(
             activeLayerName: activeLayerName(),
@@ -694,7 +694,7 @@ private extension LatticesDeckHost {
                 text: transcript,
                 isFinal: currentVoicePhase() == .idle,
                 confidence: audio.matchConfidence > 0 ? audio.matchConfidence : nil,
-                source: audio.providerName == "none" ? "vox" : audio.providerName
+                source: audio.providerName == "none" ? "voice-runtime" : audio.providerName
             ))
         }
 

--- a/apps/mac/Sources/Core/Daemon/LatticesApi.swift
+++ b/apps/mac/Sources/Core/Daemon/LatticesApi.swift
@@ -2,6 +2,9 @@ import AppKit
 import ApplicationServices
 import DeckKit
 import Foundation
+#if canImport(HudsonVoice)
+import HudsonVoice
+#endif
 
 // MARK: - Registry Types
 
@@ -2024,7 +2027,7 @@ final class LatticesApi {
                 Param(name: "slots", type: "object", required: false, description: "Named parameters for the intent"),
                 Param(name: "rawText", type: "string", required: false, description: "Original transcription text"),
                 Param(name: "confidence", type: "double", required: false, description: "Transcription confidence (0-1)"),
-                Param(name: "source", type: "string", required: false, description: "Source of the intent (e.g. 'vox', 'siri', 'cli')"),
+                Param(name: "source", type: "string", required: false, description: "Source of the intent (e.g. 'hudson-voice', 'siri', 'cli')"),
             ],
             returns: .custom("Intent-specific result"),
             handler: { params in
@@ -2054,7 +2057,7 @@ final class LatticesApi {
 
         api.register(Endpoint(
             method: "voice.status",
-            description: "Check audio provider status (e.g. Vox availability)",
+            description: "Check voice runtime provider status",
             access: .read,
             params: [],
             returns: .custom("Provider status with name and listening state"),
@@ -2071,13 +2074,13 @@ final class LatticesApi {
 
         api.register(Endpoint(
             method: "voice.listen",
-            description: "Start voice capture via the audio provider (e.g. Vox)",
+            description: "Start voice capture via the audio provider",
             access: .mutate,
             params: [],
             returns: .ok,
             handler: { _ in
                 guard AudioLayer.shared.provider != nil else {
-                    throw RouterError.custom("No audio provider available. Is Vox running?")
+                    throw RouterError.custom("No audio provider available. Is the voice runtime available?")
                 }
                 DispatchQueue.main.async {
                     AudioLayer.shared.startVoiceCommand()
@@ -2205,19 +2208,58 @@ final class LatticesApi {
 
         api.register(Endpoint(
             method: "voice.reconnect",
-            description: "Re-probe the Vox daemon. HudsonVoice opens a fresh session per capture, so there is no persistent socket to reconnect — this reports daemon reachability from ~/.vox/runtime.json.",
+            description: "Re-probe the voice runtime. HudsonVoice opens a fresh session per capture, so there is no persistent socket to reconnect.",
             access: .mutate,
             params: [],
-            returns: .custom("Daemon reachability: { ok, daemonRunning, port, pid }"),
+            returns: .custom("Voice runtime reachability: { ok, runtimeAvailable, runtimeHost, service, transport, endpoint, port, pid, capabilityPath, standaloneVoxRunning }"),
             handler: { _ in
-                let info = VoxDaemon.info()
+                #if canImport(HudsonVoice)
+                let capability: HudsonVoiceRuntimeCapability?
+                let runtimeError: String?
+                do {
+                    capability = try HudsonVoiceRuntime.read()
+                    runtimeError = nil
+                } catch {
+                    capability = nil
+                    runtimeError = error.localizedDescription
+                }
+                let runtimePid = capability?.pid
+                let standaloneInfo = VoxDaemon.info()
                 return .object([
                     "ok": .bool(true),
-                    "daemonRunning": .bool(info != nil),
-                    "port": info.map { .int(Int($0.port)) } ?? .null,
-                    "pid": info.map { .int($0.pid) } ?? .null,
-                    "note": .string("HudsonVoice connects per-session; no persistent socket to reconnect."),
+                    "runtimeAvailable": .bool(capability != nil),
+                    "runtimeHost": .string("lattices"),
+                    "service": capability.map { .string($0.service) } ?? .null,
+                    "transport": capability.map { .string($0.transport) } ?? .null,
+                    "endpoint": capability.map { .string($0.endpoint.url.absoluteString) } ?? .null,
+                    "port": capability.map { .int(Int($0.port)) } ?? .null,
+                    "pid": runtimePid.map { .int(Int($0)) } ?? .null,
+                    "capabilityPath": .string(HudsonVoiceRuntime.runtimeURL().path),
+                    "runtimeError": runtimeError.map { .string($0) } ?? .null,
+                    "standaloneVoxRunning": .bool(standaloneInfo != nil),
+                    "standaloneVoxPort": standaloneInfo.map { .int(Int($0.port)) } ?? .null,
+                    "standaloneVoxPid": standaloneInfo.map { .int($0.pid) } ?? .null,
+                    "note": .string("Lattices hosts the embedded HudsonVoice runtime; standalone Vox is reported only as legacy diagnostic state."),
                 ])
+                #else
+                let standaloneInfo = VoxDaemon.info()
+                return .object([
+                    "ok": .bool(true),
+                    "runtimeAvailable": .bool(false),
+                    "runtimeHost": .string("none"),
+                    "service": .null,
+                    "transport": .null,
+                    "endpoint": .null,
+                    "port": .null,
+                    "pid": .null,
+                    "capabilityPath": .null,
+                    "runtimeError": .string("HudsonVoice is not compiled into this build."),
+                    "standaloneVoxRunning": .bool(standaloneInfo != nil),
+                    "standaloneVoxPort": standaloneInfo.map { .int(Int($0.port)) } ?? .null,
+                    "standaloneVoxPid": standaloneInfo.map { .int($0.pid) } ?? .null,
+                    "note": .string("HudsonVoice is not compiled into this build."),
+                ])
+                #endif
             }
         ))
 

--- a/apps/mac/Sources/Core/HudsonKit/HudsonKitBridge.swift
+++ b/apps/mac/Sources/Core/HudsonKit/HudsonKitBridge.swift
@@ -44,14 +44,30 @@ enum HudsonKitSwitch {
 
 #if canImport(HudsonVoice)
 /// The HudsonKit-backed voice surface. `HudVoicePanel` manages its own live
-/// session against the local voxd daemon. We hand it the endpoint discovered from
-/// `~/.vox/runtime.json` (via `VoxEndpointResolver`) rather than letting it trust
-/// the SDK default port (42138), which doesn't match the running voxd (42137).
+/// session against the embedded runtime hosted by Lattices.
 struct HudsonVoiceSurface: View {
     var onClose: () -> Void
 
     var body: some View {
-        HudVoicePanel(endpoint: VoxEndpointResolver.resolve())
+        if let runtime = HudsonVoiceRuntimeResolver.resolve(clientId: "lattices") {
+            HudVoicePanel(
+                endpoint: runtime.endpoint,
+                options: runtime.options
+            )
+        } else {
+            VStack(spacing: 8) {
+                Image(systemName: "waveform.badge.exclamationmark")
+                    .font(.system(size: 22, weight: .semibold))
+                    .foregroundColor(.secondary)
+                Text("Voice runtime unavailable")
+                    .font(.headline)
+                Text("Restart Lattices and try again.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(24)
+        }
     }
 }
 #endif

--- a/apps/mac/Sources/Core/Overlays/Voice/VoiceComponents.swift
+++ b/apps/mac/Sources/Core/Overlays/Voice/VoiceComponents.swift
@@ -70,27 +70,26 @@ final class VoiceCommandState: ObservableObject {
     private var cancelled = false
 
     func startListening() {
-        // Capture runs through AudioLayer (HudsonVoice opens its own session). Here we
-        // only gate on the daemon being discoverable so the overlay can show a
-        // "connecting" phase while voxd spins up.
-        if VoxDaemon.isRunning {
+        // Capture runs through AudioLayer; this gate only lets the overlay show a
+        // "connecting" phase while the embedded voice runtime becomes discoverable.
+        if AudioLayer.shared.provider?.isAvailable == true {
             beginListening()
         } else {
             phase = .connecting
-            waitForDaemon(attempts: 0)
+            waitForVoiceRuntime(attempts: 0)
         }
     }
 
-    private func waitForDaemon(attempts: Int) {
-        if VoxDaemon.isRunning {
+    private func waitForVoiceRuntime(attempts: Int) {
+        if AudioLayer.shared.provider?.isAvailable == true {
             beginListening()
         } else if attempts < 20 {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-                self?.waitForDaemon(attempts: attempts + 1)
+                self?.waitForVoiceRuntime(attempts: attempts + 1)
             }
         } else {
-            appendLog("Vox daemon not running")
-            executionResult = "Vox daemon not running — open Vox and try again."
+            appendLog("Voice runtime not running")
+            executionResult = "Voice runtime not running — try again after it starts."
             resultSummary = executionResult ?? ""
             syncLogs()
             phase = .result

--- a/apps/mac/Sources/Core/Pi/AgentTurnView.swift
+++ b/apps/mac/Sources/Core/Pi/AgentTurnView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 // Agent-session turn rendering — a self-contained Swift component for drawing a
@@ -56,6 +57,7 @@ struct AgentTurn: Identifiable, Equatable {
 struct AgentTurnView: View, Equatable {
     let turn: AgentTurn
     var style: PiChatStyle = .workspace
+    @State private var copied = false
 
     static func == (lhs: AgentTurnView, rhs: AgentTurnView) -> Bool {
         lhs.turn == rhs.turn && lhs.style == rhs.style
@@ -72,7 +74,7 @@ struct AgentTurnView: View, Equatable {
     // MARK: System
 
     private var systemRow: some View {
-        HStack {
+        HStack(spacing: 6) {
             Spacer(minLength: 0)
             Text(turn.text)
                 .font(Typo.caption(11))
@@ -89,6 +91,7 @@ struct AgentTurnView: View, Equatable {
                                 .strokeBorder(Palette.border, lineWidth: 0.5)
                         )
                 )
+            copyButton(size: 22, iconSize: 9)
             Spacer(minLength: 0)
         }
         .padding(.vertical, 2)
@@ -154,6 +157,8 @@ struct AgentTurnView: View, Equatable {
             Text(PiChatFormat.time(turn.timestamp))
                 .font(Typo.mono(9))
                 .foregroundColor(Palette.textMuted.opacity(isAssistant ? 0.75 : 0.8))
+
+            copyButton(size: 23, iconSize: 10)
         }
     }
 
@@ -189,5 +194,55 @@ struct AgentTurnView: View, Equatable {
                 RoundedRectangle(cornerRadius: 11, style: .continuous)
                     .strokeBorder(streaming ? Palette.running.opacity(0.22) : Palette.border, lineWidth: 0.5)
             )
+    }
+
+    private var copyableText: String {
+        turn.text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func copyButton(size: CGFloat, iconSize: CGFloat) -> some View {
+        Button {
+            copyTurnText()
+        } label: {
+            Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                .font(.system(size: iconSize, weight: .semibold))
+                .foregroundColor(copied ? Palette.running : Palette.textMuted)
+                .frame(width: size, height: size)
+                .background(
+                    Circle()
+                        .fill(Color.white.opacity(copied ? 0.055 : 0.025))
+                        .overlay(
+                            Circle()
+                                .strokeBorder(copied ? Palette.running.opacity(0.32) : Palette.border, lineWidth: 0.5)
+                        )
+                )
+        }
+        .buttonStyle(.plain)
+        .help(copied ? "Copied" : "Copy message")
+        .disabled(copyableText.isEmpty)
+        .opacity(copyableText.isEmpty ? 0.4 : 1)
+    }
+
+    private func copyTurnText() {
+        let text = copyableText
+        guard !text.isEmpty else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        DiagnosticLog.shared.success("PiChat: copied \(copyLabel.lowercased()) message to clipboard (\(text.count) chars)")
+        withAnimation(.easeOut(duration: 0.12)) { copied = true }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.1) {
+            withAnimation(.easeOut(duration: 0.16)) { copied = false }
+        }
+    }
+
+    private var copyLabel: String {
+        switch turn.role {
+        case .system:
+            return "System"
+        case .user:
+            return "User"
+        case .assistant:
+            return "Assistant"
+        }
     }
 }

--- a/apps/mac/Sources/Core/Pi/PiChatDock.swift
+++ b/apps/mac/Sources/Core/Pi/PiChatDock.swift
@@ -319,7 +319,13 @@ struct PiChatDock: View {
 
             Spacer()
 
-            footerIconButton(systemName: "gearshape") {
+            if session.hasConversationHistory {
+                footerIconButton(systemName: "doc.on.doc", help: "Copy chat") {
+                    session.copyConversationToClipboard()
+                }
+            }
+
+            footerIconButton(systemName: "gearshape", help: "Assistant settings") {
                 SettingsWindowController.shared.showAssistant()
             }
 
@@ -436,7 +442,7 @@ struct PiChatDock: View {
             .disabled(disabled)
     }
 
-    private func footerIconButton(systemName: String, tint: Color = Palette.textMuted, action: @escaping () -> Void) -> some View {
+    private func footerIconButton(systemName: String, tint: Color = Palette.textMuted, help: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Image(systemName: systemName)
                 .font(.system(size: 10, weight: .semibold))
@@ -449,6 +455,7 @@ struct PiChatDock: View {
                 )
         }
         .buttonStyle(.plain)
+        .help(help)
     }
 
     private func authCardBackground(tint: Color) -> some View {

--- a/apps/mac/Sources/Core/Pi/PiChatSession.swift
+++ b/apps/mac/Sources/Core/Pi/PiChatSession.swift
@@ -39,6 +39,7 @@ struct PiProvider: Identifiable, Equatable {
 
     let id: String
     let name: String
+    let modelID: String
     let authMode: AuthMode
     let tokenLabel: String
     let tokenPlaceholder: String
@@ -48,6 +49,7 @@ struct PiProvider: Identifiable, Equatable {
         PiProvider(
             id: "github-copilot",
             name: "GitHub Copilot",
+            modelID: "gpt-5.4",
             authMode: .oauth,
             tokenLabel: "OAuth",
             tokenPlaceholder: "",
@@ -56,6 +58,7 @@ struct PiProvider: Identifiable, Equatable {
         PiProvider(
             id: "openai-codex",
             name: "OpenAI Codex",
+            modelID: "gpt-5.5",
             authMode: .oauth,
             tokenLabel: "OAuth",
             tokenPlaceholder: "",
@@ -64,6 +67,7 @@ struct PiProvider: Identifiable, Equatable {
         PiProvider(
             id: "openai",
             name: "OpenAI",
+            modelID: "gpt-5.4",
             authMode: .apiKey,
             tokenLabel: "API key",
             tokenPlaceholder: "sk-...",
@@ -72,6 +76,7 @@ struct PiProvider: Identifiable, Equatable {
         PiProvider(
             id: "anthropic",
             name: "Anthropic",
+            modelID: "claude-opus-4-7",
             authMode: .apiKey,
             tokenLabel: "API key",
             tokenPlaceholder: "sk-ant-...",
@@ -80,6 +85,7 @@ struct PiProvider: Identifiable, Equatable {
         PiProvider(
             id: "google",
             name: "Google Gemini",
+            modelID: "gemini-3.1-pro-preview",
             authMode: .apiKey,
             tokenLabel: "API key",
             tokenPlaceholder: "AIza...",
@@ -88,6 +94,7 @@ struct PiProvider: Identifiable, Equatable {
         PiProvider(
             id: "openrouter",
             name: "OpenRouter",
+            modelID: "moonshotai/kimi-k2.6",
             authMode: .apiKey,
             tokenLabel: "API key",
             tokenPlaceholder: "sk-or-...",
@@ -96,6 +103,7 @@ struct PiProvider: Identifiable, Equatable {
         PiProvider(
             id: "groq",
             name: "Groq",
+            modelID: "openai/gpt-oss-120b",
             authMode: .apiKey,
             tokenLabel: "API key",
             tokenPlaceholder: "gsk_...",
@@ -104,6 +112,7 @@ struct PiProvider: Identifiable, Equatable {
         PiProvider(
             id: "xai",
             name: "xAI",
+            modelID: "grok-4.20-0309-reasoning",
             authMode: .apiKey,
             tokenLabel: "API key",
             tokenPlaceholder: "xai-...",
@@ -112,6 +121,7 @@ struct PiProvider: Identifiable, Equatable {
         PiProvider(
             id: "mistral",
             name: "Mistral",
+            modelID: "devstral-medium-latest",
             authMode: .apiKey,
             tokenLabel: "API key",
             tokenPlaceholder: "",
@@ -120,6 +130,7 @@ struct PiProvider: Identifiable, Equatable {
         PiProvider(
             id: "minimax",
             name: "MiniMax",
+            modelID: "MiniMax-M2.7",
             authMode: .apiKey,
             tokenLabel: "API key",
             tokenPlaceholder: "",
@@ -319,7 +330,9 @@ final class PiChatSession: ObservableObject {
                 let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !trimmed.isEmpty else { return }
                 self.draft = WorkspaceDictationBuffer.appending(trimmed, to: self.draft)
-                WorkspaceVoiceInput.shared.consumeFinalText()
+                Task { @MainActor in
+                    WorkspaceVoiceInput.shared.consumeFinalText()
+                }
             }
         #endif
     }
@@ -355,6 +368,17 @@ final class PiChatSession: ObservableObject {
 
     var hasConversationHistory: Bool {
         messages.contains { $0.role != .system }
+    }
+
+    var copyableConversationText: String {
+        messages
+            .filter { $0.role != .system }
+            .compactMap { message -> String? in
+                let text = message.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !text.isEmpty else { return nil }
+                return "\(Self.copyLabel(for: message.role)):\n\(text)"
+            }
+            .joined(separator: "\n\n")
     }
 
     var selectedCredentialSummary: String {
@@ -532,6 +556,14 @@ final class PiChatSession: ObservableObject {
         appendSystemMessage("Copied the provider runtime install command to the clipboard.")
     }
 
+    func copyConversationToClipboard() {
+        let text = copyableConversationText
+        guard !text.isEmpty else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        DiagnosticLog.shared.success("PiChat: copied conversation to clipboard (\(text.count) chars)")
+    }
+
     func installPiInTerminal() {
         Preferences.shared.terminal.launch(command: piInstallCommand, in: NSHomeDirectory())
         appendSystemMessage("Opened \(Preferences.shared.terminal.rawValue) and started the provider runtime install.")
@@ -609,7 +641,7 @@ final class PiChatSession: ObservableObject {
                 prompt: prompt,
                 runtime: runtime,
                 providerName: provider.name,
-                modelID: provider.id,
+                modelID: provider.modelID,
                 messageID: messageID,
                 generation: turnGen,
                 inferenceTimer: inferenceTimer
@@ -1129,6 +1161,7 @@ final class PiChatSession: ObservableObject {
             piPath: piPath,
             sessionDir: chatSessionDirURL,
             providerID: provider.id,
+            modelID: provider.modelID,
             environment: buildProcessEnvironment(for: provider),
             appendSystemPrompt: Self.chatAppendSystemPrompt
         )
@@ -1161,6 +1194,7 @@ final class PiChatSession: ObservableObject {
             piPath: piPath,
             sessionDir: sessionDir,
             providerID: provider.id,
+            modelID: provider.modelID,
             environment: buildProcessEnvironment(for: provider),
             appendSystemPrompt: Self.voiceAppendSystemPrompt,
             disableBuiltInTools: true,
@@ -1530,6 +1564,17 @@ final class PiChatSession: ObservableObject {
         authProcessIdentifier = nil
         authenticatingProviderID = nil
         clearRecordedAuthHelperProcess()
+    }
+
+    private static func copyLabel(for role: PiChatMessage.Role) -> String {
+        switch role {
+        case .system:
+            return "System"
+        case .user:
+            return "You"
+        case .assistant:
+            return "Assistant"
+        }
     }
 
     private func appendSystemMessage(_ text: String) {

--- a/apps/mac/Sources/Core/Pi/PiRpcRuntime.swift
+++ b/apps/mac/Sources/Core/Pi/PiRpcRuntime.swift
@@ -36,6 +36,7 @@ final class PiRpcRuntime {
     private let piPath: String
     private let sessionDir: URL
     private let providerID: String
+    private let modelID: String
     private let environment: [String: String]
     private let appendSystemPrompt: String
     private let disableBuiltInTools: Bool
@@ -56,6 +57,7 @@ final class PiRpcRuntime {
         piPath: String,
         sessionDir: URL,
         providerID: String,
+        modelID: String,
         environment: [String: String],
         appendSystemPrompt: String,
         disableBuiltInTools: Bool = false,
@@ -64,6 +66,7 @@ final class PiRpcRuntime {
         self.piPath = piPath
         self.sessionDir = sessionDir
         self.providerID = providerID
+        self.modelID = modelID
         self.environment = environment
         self.appendSystemPrompt = appendSystemPrompt
         self.disableBuiltInTools = disableBuiltInTools
@@ -249,6 +252,7 @@ final class PiRpcRuntime {
             "--mode", "rpc",
             "--session-dir", sessionDir.path,
             "--provider", providerID,
+            "--model", modelID,
             "--no-extensions",
             "--no-skills",
             "--no-prompt-templates",

--- a/apps/mac/Sources/Core/Pi/PiWorkspaceView.swift
+++ b/apps/mac/Sources/Core/Pi/PiWorkspaceView.swift
@@ -63,7 +63,13 @@ struct PiWorkspaceView: View {
             HStack(spacing: 8) {
                 PiChatModelChip(session: session)
 
-                headerIconButton(symbol: "gearshape") {
+                if session.hasConversationHistory {
+                    headerIconButton(symbol: "doc.on.doc", help: "Copy chat") {
+                        session.copyConversationToClipboard()
+                    }
+                }
+
+                headerIconButton(symbol: "gearshape", help: "Assistant settings") {
                     SettingsWindowController.shared.showAssistant()
                 }
 
@@ -165,7 +171,7 @@ struct PiWorkspaceView: View {
         .background(Palette.surface.opacity(0.22))
     }
 
-    private func headerIconButton(symbol: String, action: @escaping () -> Void) -> some View {
+    private func headerIconButton(symbol: String, help: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Image(systemName: symbol)
                 .font(.system(size: 12, weight: .semibold))
@@ -178,6 +184,7 @@ struct PiWorkspaceView: View {
                 )
         }
         .buttonStyle(.plain)
+        .help(help)
     }
 
     private func headerTextButton(_ title: String, tint: Color = Palette.textMuted, action: @escaping () -> Void) -> some View {

--- a/apps/mac/Sources/Core/Pi/WorkspaceVoiceInput.swift
+++ b/apps/mac/Sources/Core/Pi/WorkspaceVoiceInput.swift
@@ -6,15 +6,13 @@ import HudsonVoice
 
 // Voice-enabled message input for the Workspace Assistant — powered by HudsonVoice.
 //
-// Modeled on OpenScout's HUD dictation (ScoutVoxService + HUDDockState + MicButton):
+// Modeled on OpenScout's HUD dictation (HUDDockState + MicButton):
 // tap-to-start, live `session.partial` preview, `session.final` spliced once into
 // the composer draft. The difference is the transport: instead of OpenScout's
-// hand-rolled HTTP/NDJSON wrapper, this drives HudsonKit's native HudVoxLiveSession,
-// whose default endpoint (127.0.0.1:42137) is exactly the voxd daemon Lattices
-// already runs — so it lights up with no extra wiring.
+// hand-rolled HTTP/NDJSON wrapper, this drives HudsonKit's native HudVoxLiveSession
+// through the Lattices-hosted HudsonVoice runtime capability.
 //
-// Mic capture lives entirely in the Vox daemon process, so the Lattices app needs
-// no NSMicrophoneUsageDescription — the OS prompt belongs to Vox.
+// Mic capture is owned by Lattices because Lattices embeds the HudsonVoice runtime.
 
 enum WorkspaceVoiceState: Equatable {
     case idle
@@ -62,11 +60,15 @@ final class WorkspaceVoiceInput: ObservableObject {
 
     private var session: HudVoxLiveSession?
     private var pumpTask: Task<Void, Never>?
+    private var stopTimeoutTask: Task<Void, Never>?
+    private var activeCaptureID: String?
     private var finalDelivered = false
+    private static let stopTimeoutNanoseconds: UInt64 = 10_000_000_000
 
     private init() {}
 
     /// Mic-tap action: idle/unavailable → start, hot → stop, processing → ignore.
+    @MainActor
     func toggle() {
         switch state {
         case .idle, .unavailable:
@@ -78,17 +80,29 @@ final class WorkspaceVoiceInput: ObservableObject {
         }
     }
 
+    @MainActor
     func start() {
-        guard session == nil else { return }
+        guard session == nil else {
+            DiagnosticLog.shared.warn("WorkspaceVoiceInput: start ignored; existing capture \(activeCaptureID ?? "unknown") is still \(stateLabel)")
+            return
+        }
         partial = ""
         finalDelivered = false
+        let captureID = UUID().uuidString.prefix(8).lowercased()
+        activeCaptureID = String(captureID)
         state = .starting
 
-        let endpoint = VoxEndpointResolver.resolve()
-        DiagnosticLog.shared.info("WorkspaceVoiceInput: starting Vox session at \(endpoint.url.absoluteString)")
+        guard let runtime = HudsonVoiceRuntimeResolver.resolve(clientId: "lattices") else {
+            DiagnosticLog.shared.warn("WorkspaceVoiceInput[\(captureID)]: HudsonVoice runtime unavailable")
+            activeCaptureID = nil
+            state = .unavailable(reason: "Hudson Voice runtime is unavailable.")
+            return
+        }
+        let endpoint = runtime.endpoint
+        DiagnosticLog.shared.info("WorkspaceVoiceInput[\(captureID)]: starting voice session at \(endpoint.url.absoluteString)")
         let session = HudVoxLiveSession(
             endpoint: endpoint,
-            options: HudVoxLiveSessionOptions(clientId: "lattices", mode: .pushToTalk)
+            options: runtime.options
         )
         self.session = session
 
@@ -96,34 +110,54 @@ final class WorkspaceVoiceInput: ObservableObject {
             do {
                 let stream = try await session.start()
                 for try await event in stream {
-                    await MainActor.run { [weak self] in self?.handle(event) }
+                    await MainActor.run { [weak self] in self?.handle(event, captureID: String(captureID)) }
                 }
-                await MainActor.run { [weak self] in self?.streamEnded(error: nil) }
+                await MainActor.run { [weak self] in self?.streamEnded(error: nil, captureID: String(captureID)) }
             } catch {
-                await MainActor.run { [weak self] in self?.streamEnded(error: error) }
+                await MainActor.run { [weak self] in self?.streamEnded(error: error, captureID: String(captureID)) }
             }
         }
     }
 
+    @MainActor
     func stop() {
-        guard state.isCaptureActive else { return }
+        guard state.isCaptureActive else {
+            DiagnosticLog.shared.warn("WorkspaceVoiceInput: stop ignored while \(stateLabel)")
+            return
+        }
+        let captureID = activeCaptureID ?? "unknown"
+        DiagnosticLog.shared.info("WorkspaceVoiceInput[\(captureID)]: stopping voice session")
         state = .processing
         let session = self.session
-        Task { try? await session?.stop() }
+        stopTimeoutTask?.cancel()
+        stopTimeoutTask = Task { [weak self, captureID] in
+            try? await Task.sleep(nanoseconds: Self.stopTimeoutNanoseconds)
+            guard !Task.isCancelled else { return }
+            await MainActor.run { self?.stopTimedOut(captureID: captureID) }
+        }
+        Task { [weak self, captureID] in
+            do {
+                try await session?.stop()
+            } catch {
+                await MainActor.run { self?.stopFailed(error, captureID: captureID) }
+            }
+        }
     }
 
+    @MainActor
     func cancel() {
+        let captureID = activeCaptureID ?? "unknown"
+        DiagnosticLog.shared.info("WorkspaceVoiceInput[\(captureID)]: cancelling voice session")
         let session = self.session
         finalDelivered = true   // suppress any trailing final
         partial = ""
         if !state.isUnavailable { state = .idle }
-        self.session = nil
-        pumpTask?.cancel()
-        pumpTask = nil
+        clearCapture(closeSession: false)
         Task { try? await session?.cancel() }
     }
 
     /// Drain the one-shot final signal after the consumer has appended it.
+    @MainActor
     func consumeFinalText() {
         lastFinalText = ""
     }
@@ -131,54 +165,121 @@ final class WorkspaceVoiceInput: ObservableObject {
     // MARK: - Event handling (main actor)
 
     @MainActor
-    private func handle(_ event: HudVoiceEvent) {
+    private func handle(_ event: HudVoiceEvent, captureID: String) {
+        guard isCurrentCapture(captureID) else { return }
         switch event {
         case .state(let s):
+            DiagnosticLog.shared.info("WorkspaceVoiceInput[\(captureID)]: session -> \(s.state)")
             switch s.state {
             case .recording:
                 state = .recording
             case .processing:
                 state = .processing
             case .error:
-                DiagnosticLog.shared.warn("WorkspaceVoiceInput: Vox reported a session error state")
-                state = .unavailable(reason: "Vox reported a session error.")
+                DiagnosticLog.shared.warn("WorkspaceVoiceInput[\(captureID)]: voice runtime reported a session error state")
+                state = .unavailable(reason: "Voice runtime reported a session error.")
+                clearCapture(closeSession: true)
             case .cancelled:
                 if !state.isUnavailable { state = .idle }
+                clearCapture(closeSession: true)
             case .starting:
                 if state != .recording { state = .starting }
             case .done:
-                break
+                if !finalDelivered {
+                    DiagnosticLog.shared.warn("WorkspaceVoiceInput[\(captureID)]: session ended without a final transcript")
+                    state = .unavailable(reason: "No speech detected. Try again.")
+                }
+                clearCapture(closeSession: true)
             }
         case .partial(let p):
             partial = p.text
         case .final(let f):
-            deliverFinal(f.text)
+            deliverFinal(f, captureID: captureID)
         case .raw:
             break
         }
     }
 
     @MainActor
-    private func deliverFinal(_ text: String) {
+    private func deliverFinal(_ final: HudVoiceFinalEvent, captureID: String) {
+        guard isCurrentCapture(captureID) else { return }
         guard !finalDelivered else { return }
         finalDelivered = true
         partial = ""
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmed.isEmpty { lastFinalText = text }
-        state = .idle
-        session?.close()
+        let trimmed = final.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        DiagnosticLog.shared.info("WorkspaceVoiceInput[\(captureID)]: final transcript length=\(trimmed.count) elapsed=\(final.elapsedMs)ms")
+        if trimmed.isEmpty {
+            DiagnosticLog.shared.warn("WorkspaceVoiceInput[\(captureID)]: empty transcript from voice runtime")
+            state = .unavailable(reason: "No speech detected. Try again.")
+        } else {
+            lastFinalText = trimmed
+            state = .idle
+        }
+        clearCapture(closeSession: true)
     }
 
     @MainActor
-    private func streamEnded(error: Error?) {
+    private func streamEnded(error: Error?, captureID: String) {
+        guard isCurrentCapture(captureID) else { return }
         if let error, !finalDelivered {
-            DiagnosticLog.shared.warn("WorkspaceVoiceInput: session stream ended with error — \(error.localizedDescription)")
+            DiagnosticLog.shared.warn("WorkspaceVoiceInput[\(captureID)]: session stream ended with error — \(error.localizedDescription)")
             state = .unavailable(reason: error.localizedDescription)
         } else if !finalDelivered, !state.isUnavailable {
+            DiagnosticLog.shared.warn("WorkspaceVoiceInput[\(captureID)]: stream ended without final transcript")
             state = .idle
         }
+        clearCapture(closeSession: false)
+    }
+
+    @MainActor
+    private func stopTimedOut(captureID: String) {
+        guard isCurrentCapture(captureID), state.isProcessing else { return }
+        DiagnosticLog.shared.warn("WorkspaceVoiceInput[\(captureID)]: stop timed out waiting for final transcript")
+        state = .unavailable(reason: "Transcription timed out. Try again.")
+        let session = self.session
+        clearCapture(closeSession: false)
+        Task { try? await session?.cancel() }
+    }
+
+    @MainActor
+    private func stopFailed(_ error: Error, captureID: String) {
+        guard isCurrentCapture(captureID) else { return }
+        DiagnosticLog.shared.warn("WorkspaceVoiceInput[\(captureID)]: stop failed — \(error.localizedDescription)")
+        state = .unavailable(reason: error.localizedDescription)
+        clearCapture(closeSession: true)
+    }
+
+    @MainActor
+    private func clearCapture(closeSession: Bool) {
+        let currentSession = session
         session = nil
+        stopTimeoutTask?.cancel()
+        stopTimeoutTask = nil
+        pumpTask?.cancel()
         pumpTask = nil
+        activeCaptureID = nil
+        if closeSession {
+            currentSession?.close()
+        }
+    }
+
+    private func isCurrentCapture(_ captureID: String) -> Bool {
+        activeCaptureID == captureID
+    }
+
+    private var stateLabel: String {
+        switch state {
+        case .idle:
+            return "idle"
+        case .starting:
+            return "starting"
+        case .recording:
+            return "recording"
+        case .processing:
+            return "processing"
+        case .unavailable(let reason):
+            return "unavailable(\(reason))"
+        }
     }
 }
 

--- a/apps/mac/Sources/Core/System/Capability.swift
+++ b/apps/mac/Sources/Core/System/Capability.swift
@@ -8,6 +8,7 @@ import Foundation
 enum Capability: String, CaseIterable, Identifiable {
     case windowControl   // macOS Accessibility — tiling, focus, snap
     case screenSearch    // macOS Screen Recording — OCR / on-screen text search
+    case voiceCapture    // macOS Microphone — dictation / voice commands
 
     var id: String { rawValue }
 
@@ -15,6 +16,7 @@ enum Capability: String, CaseIterable, Identifiable {
         switch self {
         case .windowControl: return "Tiling & focus"
         case .screenSearch:  return "Screen text search"
+        case .voiceCapture:  return "Voice capture"
         }
     }
 
@@ -22,6 +24,7 @@ enum Capability: String, CaseIterable, Identifiable {
         switch self {
         case .windowControl: return "rectangle.3.group"
         case .screenSearch:  return "text.viewfinder"
+        case .voiceCapture:  return "waveform"
         }
     }
 
@@ -29,6 +32,7 @@ enum Capability: String, CaseIterable, Identifiable {
         switch self {
         case .windowControl: return "Accessibility"
         case .screenSearch:  return "Screen & System Audio Recording"
+        case .voiceCapture:  return "Microphone"
         }
     }
 
@@ -38,6 +42,8 @@ enum Capability: String, CaseIterable, Identifiable {
             return "Move, resize, snap, and arrange windows from the menu bar, command palette, and gestures."
         case .screenSearch:
             return "Index on-screen text with OCR so the omni search can jump to any window by what it shows."
+        case .voiceCapture:
+            return "Use local dictation and voice commands through the embedded voice engine hosted by Lattices."
         }
     }
 
@@ -47,6 +53,8 @@ enum Capability: String, CaseIterable, Identifiable {
             return "macOS Accessibility lets Lattices read window titles and move or resize windows. No keystrokes are recorded."
         case .screenSearch:
             return "Screen Recording lets Lattices read pixels to OCR what is on-screen. Captures stay on this Mac."
+        case .voiceCapture:
+            return "macOS Microphone access lets Lattices capture audio only when you start dictation or a voice command."
         }
     }
 
@@ -55,6 +63,7 @@ enum Capability: String, CaseIterable, Identifiable {
         switch self {
         case .windowControl: return "Lattices can move and tile windows."
         case .screenSearch:  return "OCR can index visible windows for omni search."
+        case .voiceCapture:  return "Lattices can listen when you start dictation or a voice command."
         }
     }
 
@@ -63,6 +72,16 @@ enum Capability: String, CaseIterable, Identifiable {
         switch self {
         case .windowControl: return PermissionChecker.shared.accessibility
         case .screenSearch:  return PermissionChecker.shared.screenRecording
+        case .voiceCapture:  return PermissionChecker.shared.microphoneGranted
+        }
+    }
+
+    var usesDragRepair: Bool {
+        switch self {
+        case .windowControl, .screenSearch:
+            return true
+        case .voiceCapture:
+            return false
         }
     }
 

--- a/apps/mac/Sources/Core/System/PermissionChecker.swift
+++ b/apps/mac/Sources/Core/System/PermissionChecker.swift
@@ -1,4 +1,5 @@
 import AppKit
+import AVFoundation
 import SwiftUI
 import Combine
 import ScreenCaptureKit
@@ -8,6 +9,7 @@ final class PermissionChecker: ObservableObject {
 
     @Published var accessibility: Bool = false
     @Published var screenRecording: Bool = false
+    @Published var microphone: AVAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .audio)
     @Published private(set) var refreshInFlight: Bool = false
     @Published private(set) var lastCheckedAt: Date?
 
@@ -20,7 +22,8 @@ final class PermissionChecker: ObservableObject {
     private static let deniedScreenProbeCooldown: TimeInterval = 20
     private static let successfulScreenProbeTTL: TimeInterval = 8
 
-    var allGranted: Bool { accessibility && screenRecording }
+    var allGranted: Bool { accessibility && screenRecording && microphoneGranted }
+    var microphoneGranted: Bool { microphone == .authorized }
 
     var isSimulatingMissingPermissions: Bool {
         CommandLine.arguments.contains("--simulate-missing-permissions")
@@ -35,8 +38,10 @@ final class PermissionChecker: ObservableObject {
 
         let realAX = AXIsProcessTrusted()
         let realSR = CGPreflightScreenCaptureAccess()
+        let realMic = AVCaptureDevice.authorizationStatus(for: .audio)
         let simulating = isSimulatingMissingPermissions
         let ax = simulating ? false : realAX
+        let mic: AVAuthorizationStatus = simulating ? .denied : realMic
         if realSR {
             screenRecordingProbeGrantedUntil = nil
             screenProbeCooldownUntil = nil
@@ -63,16 +68,17 @@ final class PermissionChecker: ObservableObject {
         }
 
         // Log on state changes
-        if ax != accessibility || sr != screenRecording {
-            diag.info("Permissions: Accessibility \(ax ? "✓" : "✗"), Screen Recording \(sr ? "✓" : "✗")")
+        if ax != accessibility || sr != screenRecording || mic != microphone {
+            diag.info("Permissions: Accessibility \(ax ? "✓" : "✗"), Screen Recording \(sr ? "✓" : "✗"), Microphone \(Self.describe(mic))")
         }
 
         accessibility = ax
         screenRecording = sr
+        microphone = mic
 
         // Only poll after an intentional permission request. A passive launch-time
         // check should not keep nudging macOS privacy state in the background.
-        if allGranted {
+        if ax && sr && mic == .authorized {
             stopPolling()
         } else if pollIfMissing {
             startPolling()
@@ -89,6 +95,48 @@ final class PermissionChecker: ObservableObject {
             return accessibility
         case .screenSearch:
             return screenRecording
+        case .voiceCapture:
+            return microphoneGranted
+        }
+    }
+
+    func requestMicrophone() {
+        let diag = DiagnosticLog.shared
+        if isSimulatingMissingPermissions {
+            diag.warn("requestMicrophone: skipped because missing-permission simulation is enabled")
+            microphone = .denied
+            return
+        }
+
+        let before = AVCaptureDevice.authorizationStatus(for: .audio)
+        diag.info("requestMicrophone: before=\(Self.describe(before))")
+
+        switch before {
+        case .authorized:
+            microphone = before
+            return
+        case .denied, .restricted:
+            microphone = before
+            openMicrophoneSettings()
+            startPolling()
+            schedulePermissionRefresh()
+            return
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .audio) { [weak self] granted in
+                DispatchQueue.main.async {
+                    guard let self else { return }
+                    let after = AVCaptureDevice.authorizationStatus(for: .audio)
+                    diag.info("AVCaptureDevice.requestAccess(audio) → \(granted), after=\(Self.describe(after))")
+                    self.microphone = after
+                    if after != .authorized {
+                        self.openMicrophoneSettings()
+                        self.startPolling()
+                        self.schedulePermissionRefresh()
+                    }
+                }
+            }
+        @unknown default:
+            microphone = before
         }
     }
 
@@ -185,8 +233,18 @@ final class PermissionChecker: ObservableObject {
             openAccessibilitySettings()
         case .screenSearch:
             openScreenRecordingSettings()
+        case .voiceCapture:
+            openMicrophoneSettings()
         }
         passiveRecheck(reason: "open \(capability.requirementLabel)")
+    }
+
+    /// Opens System Settings → Privacy & Security → Microphone.
+    func openMicrophoneSettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone") {
+            NSWorkspace.shared.open(url)
+        }
+        passiveRecheck(reason: "open Microphone")
     }
 
     /// Opens System Settings → Privacy & Security → Accessibility
@@ -256,6 +314,16 @@ final class PermissionChecker: ObservableObject {
         return "\(nsError.domain)#\(nsError.code) \(nsError.localizedDescription)"
     }
 
+    private static func describe(_ status: AVAuthorizationStatus) -> String {
+        switch status {
+        case .notDetermined: return "notDetermined"
+        case .restricted: return "restricted"
+        case .denied: return "denied"
+        case .authorized: return "authorized"
+        @unknown default: return "unknown"
+        }
+    }
+
     // MARK: - Polling
 
     /// Poll every second to detect permission changes made in System Settings.
@@ -301,6 +369,8 @@ final class PermissionChecker: ObservableObject {
         case .screenSearch:
             screenRecording = false
             screenRecordingProbeGrantedUntil = nil
+        case .voiceCapture:
+            microphone = .notDetermined
         }
 
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
@@ -321,9 +391,7 @@ final class PermissionChecker: ObservableObject {
                 }
 
                 switch capability {
-                case .windowControl:
-                    self.promptForCurrentAppRegistration(capability)
-                case .screenSearch:
+                case .windowControl, .screenSearch, .voiceCapture:
                     self.promptForCurrentAppRegistration(capability)
                 }
 
@@ -389,6 +457,8 @@ final class PermissionChecker: ObservableObject {
             return ["Accessibility"]
         case .screenSearch:
             return ["ScreenCapture"]
+        case .voiceCapture:
+            return ["Microphone"]
         }
     }
 
@@ -417,6 +487,9 @@ final class PermissionChecker: ObservableObject {
             if !result {
                 openScreenRecordingSettings()
             }
+
+        case .voiceCapture:
+            requestMicrophone()
         }
     }
 

--- a/apps/mac/Sources/Core/Voice/AudioProvider.swift
+++ b/apps/mac/Sources/Core/Voice/AudioProvider.swift
@@ -6,8 +6,8 @@ import HudsonVoice
 // MARK: - Audio Provider Protocol
 
 /// A provider that can capture audio and return transcriptions.
-/// Lattices doesn't do transcription itself — it delegates to an external
-/// service (Vox, Whisper, etc.) and maps the result to intents.
+/// Lattices doesn't do transcription itself. It delegates capture to Hudson
+/// Voice and maps the transcript to intents.
 protocol AudioProvider: AnyObject {
     var isAvailable: Bool { get }
     var isListening: Bool { get }
@@ -25,7 +25,7 @@ protocol AudioProvider: AnyObject {
 struct Transcription {
     let text: String
     let confidence: Double
-    let source: String           // "vox", "whisper", etc.
+    let source: String           // "hudson-voice", "voice-runtime", etc.
     let isPartial: Bool          // true for streaming partial results
     let durationMs: Int?
 }
@@ -53,7 +53,7 @@ final class AudioLayer: ObservableObject {
     private init() {
         #if canImport(HudsonVoice)
         provider = HudVoxAudioProvider()
-        providerName = "vox"
+        providerName = "hudson-voice"
         #else
         provider = nil
         providerName = "none"
@@ -79,7 +79,7 @@ final class AudioLayer: ObservableObject {
         DiagnosticLog.shared.info("AudioLayer: voice capture starting")
 
         guard let provider = provider else {
-            setFinalResult("No voice provider — install Vox", warning: true)
+            setFinalResult("No voice provider available", warning: true)
             return
         }
 
@@ -91,9 +91,8 @@ final class AudioLayer: ObservableObject {
     private func startVoiceCommandWhenReady(provider: any AudioProvider, attempt: Int) {
         guard pendingVoiceStart, !isListening else { return }
 
-        // `isAvailable` reflects whether voxd is discoverable. HudsonVoice opens its
-        // own socket on capture start, so there's nothing to pre-connect — we just
-        // wait (and nudge Vox.app open once) until the daemon shows up.
+        // `isAvailable` reflects whether Lattices' embedded HudsonVoice runtime
+        // is discoverable. Do not fall back to Vox.app here; Lattices is the host.
         if provider.isAvailable {
             pendingVoiceStart = false
             DiagnosticLog.shared.info("AudioLayer: voice provider ready")
@@ -102,14 +101,13 @@ final class AudioLayer: ObservableObject {
         }
 
         if attempt == 0 {
-            let launched = launchVoxIfNeeded()
-            executionResult = launched ? "Starting Vox..." : "Connecting to Vox..."
+            executionResult = "Connecting to voice runtime..."
         }
 
         guard attempt < 40 else {
             pendingVoiceStart = false
-            DiagnosticLog.shared.warn("AudioLayer: Vox daemon not reachable before voice start")
-            setFinalResult("Vox unavailable — open Vox and try again", warning: true)
+            DiagnosticLog.shared.warn("AudioLayer: voice runtime not reachable before voice start")
+            setFinalResult("Voice runtime unavailable", warning: true)
             return
         }
 
@@ -151,31 +149,6 @@ final class AudioLayer: ObservableObject {
                 self.executeVoiceIntent(transcription)
             }
         }
-    }
-
-    private func launchVoxIfNeeded() -> Bool {
-        guard !VoxDaemon.isRunning else { return false }
-
-        let candidates = [
-            "/Applications/Vox.app",
-            NSHomeDirectory() + "/Applications/Vox.app",
-        ]
-
-        guard let path = candidates.first(where: { FileManager.default.fileExists(atPath: $0) }) else {
-            DiagnosticLog.shared.warn("AudioLayer: Vox daemon unavailable and Vox.app was not found")
-            return false
-        }
-
-        let configuration = NSWorkspace.OpenConfiguration()
-        configuration.activates = false
-        NSWorkspace.shared.openApplication(at: URL(fileURLWithPath: path), configuration: configuration) { _, error in
-            if let error {
-                DiagnosticLog.shared.warn("AudioLayer: failed to open Vox — \(error.localizedDescription)")
-            } else {
-                DiagnosticLog.shared.info("AudioLayer: opened Vox for voice command")
-            }
-        }
-        return true
     }
 
     /// Track whether we already executed for this recording session.
@@ -473,15 +446,13 @@ final class AudioLayer: ObservableObject {
 
 // MARK: - HudVox Audio Provider (HudsonVoice live session)
 //
-// Delegates recording and transcription entirely to the Vox daemon (voxd) via
-// HudsonKit's `HudVoxLiveSession`. Lattices never touches the mic — Vox owns the
-// mic, recording, and transcription. We open a live session (which dials the port
-// discovered from ~/.vox/runtime.json), stream `.partial` previews into the draft,
-// and deliver the final transcript on `.final`.
+// Delegates recording and transcription through HudsonKit's `HudVoxLiveSession`.
+// Lattices hosts the embedded HudsonVoice runtime in-process and exposes the
+// private tokened capability file HudsonKit uses to connect.
 //
 // This replaces the legacy `VoxAudioProvider` (which drove the now-retired
-// `VoxClient` WebSocket). Availability is "is voxd discoverable" (`VoxDaemon`),
-// since HudsonVoice opens its own socket per capture rather than holding one open.
+// `VoxClient` WebSocket). HudsonVoice opens its own socket per capture rather
+// than holding one open.
 
 #if canImport(HudsonVoice)
 final class HudVoxAudioProvider: AudioProvider {
@@ -492,13 +463,20 @@ final class HudVoxAudioProvider: AudioProvider {
     private var _isListening = false
     private var finalDelivered = false
 
-    var isAvailable: Bool { VoxDaemon.isRunning }
+    var isAvailable: Bool { HudsonVoiceRuntime.isAvailable() }
     var isListening: Bool { _isListening }
 
     func checkHealth(completion: @escaping (Bool) -> Void) {
-        let endpoint = VoxEndpointResolver.resolve()
+        guard let runtime = HudsonVoiceRuntimeResolver.resolve(clientId: "lattices") else {
+            completion(false)
+            return
+        }
         Task {
-            let ok = (try? await HudVoxProbe.health(endpoint: endpoint, clientId: "lattices")) != nil
+            let ok = (try? await HudVoxProbe.health(
+                endpoint: runtime.endpoint,
+                clientId: runtime.options.clientId,
+                authToken: runtime.options.authToken
+            )) != nil
             await MainActor.run { completion(ok) }
         }
     }
@@ -509,11 +487,17 @@ final class HudVoxAudioProvider: AudioProvider {
         _isListening = true
         finalDelivered = false
 
-        let endpoint = VoxEndpointResolver.resolve()
+        guard let runtime = HudsonVoiceRuntimeResolver.resolve(clientId: "lattices") else {
+            DiagnosticLog.shared.warn("HudVoxAudioProvider: cannot start because HudsonVoice runtime is unavailable")
+            _isListening = false
+            self.onTranscript = nil
+            return
+        }
+        let endpoint = runtime.endpoint
         DiagnosticLog.shared.info("HudVoxAudioProvider: starting session at \(endpoint.url.absoluteString)")
         let session = HudVoxLiveSession(
             endpoint: endpoint,
-            options: HudVoxLiveSessionOptions(clientId: "lattices", mode: .pushToTalk)
+            options: runtime.options
         )
         self.session = session
 
@@ -549,7 +533,7 @@ final class HudVoxAudioProvider: AudioProvider {
             DiagnosticLog.shared.info("HudVoxAudioProvider: session → \(s.state)")
         case .partial(let p):
             // Live preview — non-final, just updates the draft echo.
-            onTranscript?(Transcription(text: p.text, confidence: 0.5, source: "vox", isPartial: true, durationMs: nil))
+            onTranscript?(Transcription(text: p.text, confidence: 0.5, source: "hudson-voice", isPartial: true, durationMs: nil))
         case .final(let f):
             deliverFinal(text: f.text, elapsedMs: f.elapsedMs)
         case .raw:
@@ -562,7 +546,7 @@ final class HudVoxAudioProvider: AudioProvider {
         guard !finalDelivered else { return }
         finalDelivered = true
         _isListening = false
-        let t = Transcription(text: text, confidence: 0.95, source: "vox", isPartial: false, durationMs: elapsedMs)
+        let t = Transcription(text: text, confidence: 0.95, source: "hudson-voice", isPartial: false, durationMs: elapsedMs)
         DiagnosticLog.shared.info("HudVoxAudioProvider: transcribed → '\(text)' (\(elapsedMs)ms)")
         // onTranscript drives the streaming-execute path; stopCompletion the stop path.
         // AudioLayer guards against double-execution, so firing both is safe.
@@ -580,7 +564,7 @@ final class HudVoxAudioProvider: AudioProvider {
             if let error {
                 DiagnosticLog.shared.warn("HudVoxAudioProvider: session error — \(error.localizedDescription)")
                 AudioLayer.shared.setFinalResult("Transcription failed", warning: true)
-                onTranscript?(Transcription(text: "", confidence: 0, source: "vox", isPartial: false, durationMs: nil))
+                onTranscript?(Transcription(text: "", confidence: 0, source: "hudson-voice", isPartial: false, durationMs: nil))
             }
             stopCompletion?(nil)
             stopCompletion = nil

--- a/apps/mac/Sources/Core/Voice/HandsOffSession.swift
+++ b/apps/mac/Sources/Core/Voice/HandsOffSession.swift
@@ -6,7 +6,7 @@ import HudsonVoice
 /// Hands-off voice mode: hotkey → listen → worker handles everything.
 ///
 /// Architecture:
-///   - Swift owns: hotkey, Vox dictation, action execution
+///   - Swift owns: hotkey, Hudson Voice dictation, action execution
 ///   - Worker owns: inference (Groq), TTS (streaming OpenAI), fast path matching, audio caching
 ///   - Worker is a long-running bun process, started once, communicates via JSON lines over stdio
 ///
@@ -411,11 +411,11 @@ final class HandsOffSession: ObservableObject {
         playSound("Funk")
     }
 
-    /// Cancel any active Vox recording session without transcribing.
+    /// Cancel any active voice recording session without transcribing.
     private func cancelVoxSession() {
         #if canImport(HudsonVoice)
         guard let session = voxSession else { return }
-        DiagnosticLog.shared.info("HandsOff: cancelling Vox session")
+        DiagnosticLog.shared.info("HandsOff: cancelling voice session")
         voxSession = nil
         voxPump?.cancel()
         voxPump = nil
@@ -433,10 +433,9 @@ final class HandsOffSession: ObservableObject {
 
     private func beginListening() {
         #if canImport(HudsonVoice)
-        // HudsonVoice dials voxd on capture start — there's no socket to pre-connect,
-        // so we just confirm the daemon is discoverable (retrying briefly if it's
-        // still spinning up) and then open the live session.
-        if VoxDaemon.isRunning {
+        // HudsonVoice opens a fresh capture on start. We only gate on whether the
+        // runtime is discoverable so the UI can show a brief connecting phase.
+        if HudsonVoiceRuntime.isAvailable() {
             startDictation()
         } else {
             state = .connecting
@@ -453,7 +452,7 @@ final class HandsOffSession: ObservableObject {
 
     private func retryListenIfReady(attempts: Int) {
         #if canImport(HudsonVoice)
-        if VoxDaemon.isRunning {
+        if HudsonVoiceRuntime.isAvailable() {
             startDictation()
         } else if attempts > 0 {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
@@ -461,7 +460,7 @@ final class HandsOffSession: ObservableObject {
             }
         } else {
             state = .idle
-            DiagnosticLog.shared.warn("HandsOff: Vox not available")
+            DiagnosticLog.shared.warn("HandsOff: voice runtime not available")
             playSound("Basso")
         }
         #endif
@@ -479,12 +478,18 @@ final class HandsOffSession: ObservableObject {
 
         DiagnosticLog.shared.info("HandsOff: listening...")
 
-        // HudVoxLiveSession opens the mic in voxd; events stream back on start().
+        // HudVoxLiveSession opens the mic through the resolved voice runtime.
         // `.partial` updates the live transcript, `.final` delivers the turn.
-        let endpoint = VoxEndpointResolver.resolve()
+        guard let runtime = HudsonVoiceRuntimeResolver.resolve(clientId: "lattices") else {
+            state = .idle
+            DiagnosticLog.shared.warn("HandsOff: HudsonVoice runtime unavailable")
+            playSound("Basso")
+            return
+        }
+        let endpoint = runtime.endpoint
         let session = HudVoxLiveSession(
             endpoint: endpoint,
-            options: HudVoxLiveSessionOptions(clientId: "lattices", mode: .pushToTalk)
+            options: runtime.options
         )
         voxSession = session
         voxPump = Task { [weak self] in
@@ -616,7 +621,7 @@ final class HandsOffSession: ObservableObject {
         switch event {
         case .state(let s):
             DiagnosticLog.shared.info("HandsOff: session → \(s.state)")
-            // voxd cancelled the session (e.g. recording timeout)
+            // The voice runtime cancelled the session, e.g. recording timeout.
             if case .cancelled = s.state, state == .listening {
                 state = .idle
                 playSound("Basso")

--- a/apps/mac/Sources/Core/Voice/LatticesVoiceRuntime.swift
+++ b/apps/mac/Sources/Core/Voice/LatticesVoiceRuntime.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+#if canImport(HudsonVoice)
+import HudsonVoice
+#endif
+
+enum LatticesVoiceRuntime {
+    static func start() {
+        #if canImport(HudsonVoice)
+        do {
+            try HudsonVoiceRuntimeHost.shared.start()
+            DiagnosticLog.shared.info("HudsonVoice: embedded runtime host started at \(HudsonVoiceRuntimeHost.shared.capabilityURL.path)")
+        } catch {
+            DiagnosticLog.shared.warn("HudsonVoice: embedded runtime host failed to start - \(error.localizedDescription)")
+        }
+        #else
+        DiagnosticLog.shared.info("HudsonVoice: runtime host skipped because HudsonVoice is not compiled into this build")
+        #endif
+    }
+
+    static func stop() {
+        #if canImport(HudsonVoice)
+        HudsonVoiceRuntimeHost.shared.stop()
+        DiagnosticLog.shared.info("HudsonVoice: embedded runtime host stopped")
+        #endif
+    }
+}

--- a/apps/mac/Sources/Core/Voice/VoxDaemon.swift
+++ b/apps/mac/Sources/Core/Voice/VoxDaemon.swift
@@ -1,17 +1,16 @@
 import Foundation
 
-/// File-based discovery of the local voxd transcription daemon.
+/// File-based discovery of the standalone Vox compatibility daemon.
 ///
-/// voxd writes its live port + pid to `~/.vox/runtime.json`. This is the single
-/// source of truth for "is Vox reachable, and on what port" — it replaces the
-/// connection-state bookkeeping the old `VoxClient` singleton kept.
+/// The intended path is the Lattices-hosted HudsonVoice runtime discovered
+/// through `HudsonVoiceRuntime`. Standalone Vox writes its live port + pid to
+/// `~/.vox/runtime.json`; that path remains for legacy/non-HudsonVoice builds.
 ///
 /// Pure Foundation, intentionally **not** gated on `canImport(HudsonVoice)`, so the
-/// availability/launch paths (AudioLayer, HandsOffSession, the voice overlay, the
-/// daemon API) still compile in a build without the voice product. The HudsonVoice
-/// surfaces turn this into a `HudVoxEndpoint` via `VoxEndpointResolver`.
+/// availability/launch fallback paths still compile in a build without the voice
+/// product.
 enum VoxDaemon {
-    /// voxd's long-standing default port — used when runtime.json is absent.
+    /// Standalone voxd's long-standing default port when runtime.json is absent.
     static let fallbackPort: UInt16 = 42137
     private static let runtimePath = NSHomeDirectory() + "/.vox/runtime.json"
 
@@ -21,8 +20,8 @@ enum VoxDaemon {
         let version: String
     }
 
-    /// Parsed `~/.vox/runtime.json` with a verified-alive pid, or nil if the file
-    /// is missing, malformed, or names a process that is no longer running.
+    /// Parsed standalone `~/.vox/runtime.json` with a verified-alive pid, or nil
+    /// if the file is missing, malformed, or names a process that is no longer running.
     static func info() -> Info? {
         guard let data = FileManager.default.contents(atPath: runtimePath),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -30,7 +29,7 @@ enum VoxDaemon {
               let pid = json["pid"] as? Int else {
             return nil
         }
-        // A runtime.json can outlive its daemon — verify the pid is actually alive.
+        // A runtime.json can outlive its daemon; verify the pid is actually alive.
         guard kill(Int32(pid), 0) == 0 else {
             DiagnosticLog.shared.warn("VoxDaemon: stale runtime.json — pid \(pid) not running")
             return nil
@@ -39,9 +38,9 @@ enum VoxDaemon {
         return Info(port: UInt16(port), pid: pid, version: version)
     }
 
-    /// voxd's live port, falling back to the long-standing default when unknown.
+    /// Standalone voxd's live port, falling back to the default when unknown.
     static var port: UInt16 { info()?.port ?? fallbackPort }
 
-    /// Whether voxd is discoverable and its process is alive right now.
+    /// Whether standalone voxd is discoverable and alive right now.
     static var isRunning: Bool { info() != nil }
 }

--- a/apps/mac/Sources/Core/Voice/VoxEndpointResolver.swift
+++ b/apps/mac/Sources/Core/Voice/VoxEndpointResolver.swift
@@ -2,19 +2,26 @@
 import Foundation
 import HudsonVoice
 
-/// Builds the live voxd endpoint for HudsonVoice sessions.
+/// Resolves the voice runtime Lattices should use.
 ///
-/// HudsonVoice's built-in default (`HudVoxEndpoint.defaultPort`) can lag the
-/// installed daemon — e.g. the SDK defaults to 42138 while the running voxd is on
-/// 42137 — so a session that trusts the SDK default silently dials a dead port and
-/// the mic flashes red and fails. We always discover the real port from
-/// `~/.vox/runtime.json` via `VoxDaemon` instead.
-///
-/// This replaces `VoxClient.discoverDaemon()` for the HudsonVoice surfaces.
-enum VoxEndpointResolver {
-    /// The endpoint to hand `HudVoxLiveSession` / `HudVoicePanel`.
-    static func resolve(host: String = "127.0.0.1") -> HudVoxEndpoint {
-        HudVoxEndpoint(host: host, port: VoxDaemon.port)
+/// Lattices is the HudsonKit host app here: it starts the embedded Vox runtime
+/// and writes the private, tokened capability file during app boot.
+enum HudsonVoiceRuntimeResolver {
+    static func resolve(
+        clientId: String = "lattices",
+        mode: HudVoiceMode? = nil
+    ) -> (endpoint: HudVoxEndpoint, options: HudVoxLiveSessionOptions)? {
+        do {
+            let connection = try HudsonVoiceRuntime.resolveConnection(
+                clientId: clientId,
+                mode: mode,
+                metadata: ["hostApp": "lattices"]
+            )
+            return (connection.endpoint, connection.options)
+        } catch {
+            DiagnosticLog.shared.warn("HudsonVoice: embedded runtime unavailable - \(error.localizedDescription)")
+            return nil
+        }
     }
 }
 #endif

--- a/bin/lattices-app.ts
+++ b/bin/lattices-app.ts
@@ -314,6 +314,8 @@ ${buildMetadata}    <key>LSMinimumSystemVersion</key>
     <true/>
     <key>NSHighResolutionCapable</key>
     <true/>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Lattices uses the microphone for Hudson Voice dictation and voice commands.</string>
     <key>NSSupportsAutomaticTermination</key>
     <true/>
 </dict>


### PR DESCRIPTION
## Summary

- Host **HudsonVoice in-process** (client → host): `LatticesVoiceRuntime` starts the embedded runtime at boot, writes a tokened capability file, and all voice surfaces resolve through it instead of an external `voxd` daemon.
- **Mic permission**: add `com.apple.security.device.audio-input` entitlement (required under Hardened Runtime) + `NSMicrophoneUsageDescription`.
- **Settings**: render as a page inside the unified shell (⌘, routes through `SettingsWindowController`), scrollable section rail so the status bar never crops on resize.
- **Pi chat**: stop/steer/queue + live mic on the `HudAIClient` path.
- Remove the now-unused "Assistant" action row from the main view.

## Scope

27 files changed (~1245 insertions / 527 deletions). Touches voice runtime, settings, permissions, and Pi chat surfaces.