### PR TITLE
[codex] Adopt HUD composer workspace controls

### DIFF
--- a/apps/mac/Sources/AppShell/AppShellView.swift
+++ b/apps/mac/Sources/AppShell/AppShellView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import HudsonShell
 import HudsonUI
@@ -50,7 +51,9 @@ struct AppShellView: View {
     @ObservedObject var controller: ScreenMapController
     @ObservedObject var windowController = ScreenMapWindowController.shared
     @ObservedObject private var scanner = ProjectScanner.shared
+    @ObservedObject private var ocr = OcrModel.shared
     @StateObject private var commandState = CommandModeState()
+    @State private var selectedStudioLayerId: String?
 
     /// Sidebar starts minimized (icon-only rail); tapping the logo expands it.
     @State private var sidebarCompact = true
@@ -140,18 +143,110 @@ struct AppShellView: View {
     // MARK: - Status Bar
 
     private var statusBar: some View {
-        let running = scanner.projects.filter(\.isRunning).count
-        return HStack(spacing: 14) {
-            statusItem(icon: "circle.fill", text: "\(running) running", tint: Palette.running)
-            statusItem(icon: "folder", text: "\(scanner.projects.count) projects", tint: Palette.textMuted)
+        HStack(spacing: 14) {
+            statusBarItems
             Spacer()
-            Text(windowController.activePage.label)
+            Text(statusContextLabel)
                 .font(Typo.geistMonoBold(9))
                 .foregroundColor(Palette.textDim)
+                .lineLimit(1)
         }
         .padding(.horizontal, 14)
         .frame(height: 26)
         .background(Palette.bg)
+    }
+
+    @ViewBuilder
+    private var statusBarItems: some View {
+        switch windowController.activePage {
+        case .desktopInventory:
+            desktopInventoryStatusItems
+        case .screenMap:
+            screenMapStatusItems
+        default:
+            workspaceStatusItems
+        }
+    }
+
+    private var workspaceStatusItems: some View {
+        let running = scanner.projects.filter(\.isRunning).count
+        return Group {
+            statusItem(icon: "circle.fill", text: "\(running) running", tint: Palette.running)
+            statusItem(icon: "folder", text: "\(scanner.projects.count) projects", tint: Palette.textMuted)
+        }
+    }
+
+    private var desktopInventoryStatusItems: some View {
+        let snapshot = commandState.desktopSnapshot
+        let windowCount = snapshot?.allWindows.count ?? 0
+        let displayCount = snapshot?.displays.count ?? NSScreen.screens.count
+        let spaceCount = snapshot?.displays.reduce(0) { $0 + $1.spaceCount } ?? 0
+        let selectedCount = commandState.selectedWindowIds.count
+
+        return Group {
+            statusItem(icon: "macwindow", text: "\(windowCount) windows tracked", tint: Palette.running)
+            statusItem(icon: "display.2", text: "\(displayCount) monitors", tint: Palette.textMuted)
+            statusItem(icon: "rectangle.3.group", text: "\(spaceCount) spaces", tint: Palette.textMuted)
+            if selectedCount > 0 {
+                statusItem(icon: "checkmark.circle.fill", text: "\(selectedCount) selected", tint: Palette.running)
+            }
+            statusItem(icon: "text.viewfinder", text: ocrStatusText, tint: ocrStatusTint)
+        }
+    }
+
+    private var screenMapStatusItems: some View {
+        let windowCount = controller.editor?.windows.count ?? 0
+        let displayCount = controller.editor?.displays.count ?? NSScreen.screens.count
+        let pendingEdits = controller.editor?.pendingEditCount ?? 0
+
+        return Group {
+            statusItem(icon: "macwindow", text: "\(windowCount) windows mapped", tint: Palette.running)
+            statusItem(icon: "display.2", text: "\(displayCount) monitors", tint: Palette.textMuted)
+            if pendingEdits > 0 {
+                statusItem(icon: "pencil.and.outline", text: "\(pendingEdits) pending", tint: Palette.detach)
+            }
+        }
+    }
+
+    private var statusContextLabel: String {
+        switch windowController.activePage {
+        case .desktopInventory:
+            let filter = commandState.activePreset?.rawValue
+            let mode: String? = {
+                switch commandState.desktopMode {
+                case .browsing: return nil
+                case .tiling: return "Grid Region"
+                case .gridPreview: return "Grid Preview"
+                case .screenMap: return "Screen Map"
+                }
+            }()
+            return [windowController.activePage.label, filter, mode]
+                .compactMap { $0 }
+                .joined(separator: " · ")
+        default:
+            return windowController.activePage.label
+        }
+    }
+
+    private var ocrStatusText: String {
+        if ocr.isScanning { return "OCR scanning" }
+        guard ocr.enabled else { return "OCR off" }
+
+        var parts = ["OCR armed"]
+        if ocr.lastReviewedWindowCount > 0 {
+            parts.append("\(ocr.lastReviewedWindowCount) reviewed")
+        } else if !ocr.results.isEmpty {
+            parts.append("\(ocr.results.count) cached")
+        }
+        if let lastReviewedAt = ocr.lastReviewedAt ?? ocr.results.values.map(\.timestamp).max() {
+            parts.append("\(relativeStatusTime(lastReviewedAt)) review")
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    private var ocrStatusTint: Color {
+        if ocr.isScanning { return Palette.detach }
+        return ocr.enabled ? Palette.running : Palette.textMuted
     }
 
     private func statusItem(icon: String, text: String, tint: Color) -> some View {
@@ -162,7 +257,19 @@ struct AppShellView: View {
             Text(text)
                 .font(Typo.mono(10))
                 .foregroundColor(Palette.textMuted)
+                .lineLimit(1)
         }
+    }
+
+    private func relativeStatusTime(_ date: Date) -> String {
+        let seconds = max(0, Int(-date.timeIntervalSinceNow))
+        if seconds < 10 { return "now" }
+        if seconds < 60 { return "\(seconds)s ago" }
+        let minutes = seconds / 60
+        if minutes < 60 { return "\(minutes)m ago" }
+        let hours = minutes / 60
+        if hours < 24 { return "\(hours)h ago" }
+        return "\(hours / 24)d ago"
     }
 
     /// Entering a feature page clears its capability snooze — the user is
@@ -192,11 +299,13 @@ struct AppShellView: View {
             })
         case .screenMap:
             HStack(spacing: 0) {
+                StudioLayersView(selectedLayerId: $selectedStudioLayerId)
+                    .frame(width: 320)
                 ScreenMapView(controller: controller, onNavigate: { page in
                     windowController.activePage = page
+                }, studioLayerScopeId: selectedStudioLayerId, onClearStudioLayerScope: {
+                    selectedStudioLayerId = nil
                 })
-                StudioLayersView()
-                    .frame(width: 260)
             }
         case .desktopInventory:
             CommandModeView(state: commandState, presentation: .embedded)

--- a/apps/mac/Sources/AppShell/KeyRecorderView.swift
+++ b/apps/mac/Sources/AppShell/KeyRecorderView.swift
@@ -18,78 +18,69 @@ struct KeyRecorderView: View {
     }
 
     var body: some View {
-        HStack(spacing: 8) {
-            // Action label
-            Text(action.label)
-                .font(Typo.caption(11))
-                .foregroundColor(Palette.textDim)
-                .frame(minWidth: 60, idealWidth: 90, alignment: .trailing)
-                .lineLimit(1)
+        GeometryReader { geo in
+            let compact = geo.size.width < 360
+            let labelWidth: CGFloat = compact ? 110 : 136
+            let controlsWidth: CGFloat = binding == nil && !isModified ? 28 : 78
+            let shortcutWidth = max(84, geo.size.width - labelWidth - controlsWidth - 24)
 
-            // Key badges or capture prompt
-            if isCapturing {
-                Text("Press shortcut...")
-                    .font(Typo.mono(11))
-                    .foregroundColor(Palette.running)
-                    .frame(minWidth: 80, alignment: .leading)
-            } else if let binding = binding {
+            HStack(spacing: 8) {
+                Text(action.label)
+                    .font(Typo.caption(11))
+                    .foregroundColor(Palette.textDim)
+                    .frame(width: labelWidth, alignment: .leading)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                shortcutDisplay
+                    .frame(width: shortcutWidth, alignment: .leading)
+
+                Spacer(minLength: 0)
+
                 HStack(spacing: 4) {
-                    ForEach(binding.compactDisplayParts, id: \.self) { part in
-                        keyBadge(part)
+                    recorderControlButton(
+                        systemName: isCapturing ? "xmark" : "pencil",
+                        help: isCapturing ? "Cancel capture" : "Edit shortcut",
+                        color: isCapturing ? Palette.kill : Palette.textDim
+                    ) {
+                        isCapturing.toggle()
+                    }
+
+                    if binding != nil {
+                        recorderControlButton(
+                            systemName: "minus.circle",
+                            help: "Clear shortcut",
+                            color: Palette.textDim
+                        ) {
+                            store.clearBinding(for: action)
+                            isCapturing = false
+                        }
+                    }
+
+                    if isModified {
+                        recorderControlButton(
+                            systemName: "arrow.counterclockwise",
+                            help: "Reset to default",
+                            color: Palette.detach
+                        ) {
+                            store.resetBinding(for: action)
+                            isCapturing = false
+                        }
                     }
                 }
-                .frame(minWidth: 80, alignment: .leading)
-            }
-
-            Spacer()
-
-            // Edit button
-            Button {
-                if isCapturing {
-                    isCapturing = false
-                } else {
-                    isCapturing = true
-                }
-            } label: {
-                Text(isCapturing ? "Cancel" : "Edit")
-                    .font(Typo.caption(10))
-                    .foregroundColor(isCapturing ? Palette.kill : Palette.textDim)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 3)
-                    .background(
-                        RoundedRectangle(cornerRadius: 3)
-                            .fill(Palette.surface)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 3)
-                                    .strokeBorder(Palette.border, lineWidth: 0.5)
-                            )
-                    )
-            }
-            .buttonStyle(.plain)
-
-            // Reset link (only when modified)
-            if isModified {
-                Button {
-                    store.resetBinding(for: action)
-                } label: {
-                    Text("Reset")
-                        .font(Typo.caption(10))
-                        .foregroundColor(Palette.detach)
-                }
-                .buttonStyle(.plain)
+                .frame(width: controlsWidth, alignment: .trailing)
             }
         }
-        .padding(.vertical, 2)
-        .background(
-            isCapturing
-                ? KeyCaptureOverlay(onCapture: handleCapture, onCancel: { isCapturing = false })
-                : nil
-        )
+        .frame(height: 24)
+        .background {
+            if isCapturing {
+                KeyCaptureOverlay(onCapture: handleCapture, onCancel: { isCapturing = false })
+            }
+        }
         .alert("Shortcut Conflict", isPresented: $showConflict) {
             Button("Replace") {
                 if let pending = pendingBinding, let conflict = conflictAction {
-                    // Remove conflicting binding by resetting it
-                    store.resetBinding(for: conflict)
+                    store.clearBinding(for: conflict)
                     store.updateBinding(for: action, to: pending)
                 }
                 pendingBinding = nil
@@ -107,6 +98,30 @@ struct KeyRecorderView: View {
         }
     }
 
+    @ViewBuilder
+    private var shortcutDisplay: some View {
+        if isCapturing {
+            Text("Press shortcut...")
+                .font(Typo.mono(11))
+                .foregroundColor(Palette.running)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+        } else if let binding = binding {
+            HStack(spacing: 4) {
+                ForEach(binding.compactDisplayParts, id: \.self) { part in
+                    keyBadge(part)
+                }
+            }
+            .lineLimit(1)
+        } else {
+            Text("Not set")
+                .font(Typo.mono(10.5))
+                .foregroundColor(Palette.textMuted)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+        }
+    }
+
     private func handleCapture(_ binding: KeyBinding) {
         if let conflict = store.conflicts(for: action, with: binding) {
             pendingBinding = binding
@@ -118,10 +133,36 @@ struct KeyRecorderView: View {
         }
     }
 
+    private func recorderControlButton(
+        systemName: String,
+        help: String,
+        color: Color,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(color)
+                .frame(width: 20, height: 20)
+                .background(
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(Palette.surface)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 3)
+                                .strokeBorder(Palette.border, lineWidth: 0.5)
+                        )
+                )
+        }
+        .buttonStyle(.plain)
+        .help(help)
+    }
+
     private func keyBadge(_ key: String) -> some View {
         Text(key)
             .font(Typo.geistMonoBold(10))
             .foregroundColor(Palette.text)
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
             .padding(.horizontal, 6)
             .padding(.vertical, 3)
             .background(

--- a/apps/mac/Sources/AppShell/SettingsView.swift
+++ b/apps/mac/Sources/AppShell/SettingsView.swift
@@ -3334,7 +3334,6 @@ struct SettingsContentView: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 0) {
                         VStack(alignment: .leading, spacing: 16) {
-                            shortcutsOverviewCard
                             inputControlsCard
 
                             LazyVGrid(columns: sectionColumns, alignment: .leading, spacing: 16) {
@@ -3523,36 +3522,6 @@ struct SettingsContentView: View {
                     .font(Typo.caption(10.5))
                     .foregroundColor(Palette.textDim)
                 }
-            }
-        }
-    }
-
-    private var shortcutsOverviewCard: some View {
-        shortcutSectionCard(
-            title: "Shortcut Map",
-            eyebrow: "Quick Reference",
-            summary: "Global hotkeys are editable here. tmux shortcuts stay as a built-in reference so you can keep your workspace flow in one place."
-        ) {
-            LazyVGrid(
-                columns: [GridItem(.adaptive(minimum: 180, maximum: 240), spacing: 10, alignment: .top)],
-                alignment: .leading,
-                spacing: 10
-            ) {
-                shortcutFactCard(
-                    icon: "command",
-                    title: "Global Hotkeys",
-                    detail: "Edit palette, search, voice, and workspace actions without leaving settings."
-                )
-                shortcutFactCard(
-                    icon: "rectangle.split.3x3",
-                    title: "Spatial Tiling",
-                    detail: "The layout grid mirrors the screen positions used by the menu bar app."
-                )
-                shortcutFactCard(
-                    icon: "terminal",
-                    title: "Pane Muscle Memory",
-                    detail: "Keep the core pane controls visible here while you tune the app-level shortcuts."
-                )
             }
         }
     }
@@ -3790,7 +3759,7 @@ struct SettingsContentView: View {
 
     private func tileCell(action: HotkeyAction, label: String) -> some View {
         let binding = hotkeyStore.bindings[action]
-        let badgeText = binding?.displayParts.last ?? ""
+        let badgeText = binding?.displayParts.last ?? "Unset"
 
         return Button {
             // Open inline key recorder for this action

--- a/apps/mac/Sources/Core/Actions/HotkeyManager.swift
+++ b/apps/mac/Sources/Core/Actions/HotkeyManager.swift
@@ -183,6 +183,16 @@ class HotkeyManager {
         }
     }
 
+    /// Unregister one global hotkey and clear its active callback.
+    func unregisterSingle(id: UInt32) {
+        if let existing = hotKeyRefs[id] {
+            UnregisterEventHotKey(existing)
+            hotKeyRefs.removeValue(forKey: id)
+        }
+        hotkeyCallbacks.removeValue(forKey: id)
+        DiagnosticLog.shared.info("HotkeyManager: unregistered id=\(id)")
+    }
+
     /// Unregister all global hotkeys and clear callbacks
     func unregisterAll() {
         for (id, ref) in hotKeyRefs {

--- a/apps/mac/Sources/Core/Actions/HotkeyStore.swift
+++ b/apps/mac/Sources/Core/Actions/HotkeyStore.swift
@@ -224,6 +224,20 @@ struct KeyBinding: Codable, Equatable {
     }
 }
 
+private enum HotkeyFileOverride: Decodable {
+    case binding(KeyBinding)
+    case disabled
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .disabled
+        } else {
+            self = .binding(try container.decode(KeyBinding.self))
+        }
+    }
+}
+
 // MARK: - HotkeyStore
 
 class HotkeyStore: ObservableObject {
@@ -263,14 +277,11 @@ class HotkeyStore: ObservableObject {
         bind(.bezel,     19, hyper)      // Hyper+2
         bind(.hud,       20, hyper)      // Hyper+3 (HUD overlay)
         bind(.desktopInventory, 5, hyper) // Hyper+G
-        bind(.voiceCommand, 2, hyper)    // Hyper+D
         let cmdCtrl = UInt32(cmdKey | controlKey)
         bind(.handsOff, 46, cmdCtrl)          // Ctrl+Cmd+M
-        bind(.omniSearch, 23, hyper)       // Hyper+5
         bind(.activityLog, 37, cmdShift)   // Cmd+Shift+L
         bind(.cheatSheet, 22, hyper)       // Hyper+6
         bind(.mouseFinder, 26, hyper)      // Hyper+7
-        bind(.overlayActors, 11, hyper)    // Hyper+B
         bind(.gridPlacement, 5, ctrlOpt)   // Ctrl+Opt+G (4x4 placement target)
         bind(.commandBar, 49, ctrlOpt)     // Ctrl+Opt+Space (precise placement command bar)
 
@@ -307,6 +318,14 @@ class HotkeyStore: ObservableObject {
         return d
     }()
 
+    private static func storageKey(for action: HotkeyAction) -> String {
+        "hotkey.\(action.rawValue)"
+    }
+
+    private static func disabledKey(for action: HotkeyAction) -> String {
+        "hotkey.\(action.rawValue).disabled"
+    }
+
     private init() {
         // Start with defaults
         var merged = Self.defaultBindings
@@ -314,7 +333,12 @@ class HotkeyStore: ObservableObject {
         // Layer 2: UserDefaults overrides
         let ud = UserDefaults.standard
         for action in HotkeyAction.allCases {
-            let key = "hotkey.\(action.rawValue)"
+            if ud.bool(forKey: Self.disabledKey(for: action)) {
+                merged.removeValue(forKey: action)
+                continue
+            }
+
+            let key = Self.storageKey(for: action)
             if let data = ud.data(forKey: key),
                let binding = try? JSONDecoder().decode(KeyBinding.self, from: data) {
                 merged[action] = binding
@@ -324,10 +348,15 @@ class HotkeyStore: ObservableObject {
         // Layer 3: ~/.lattices/hotkeys.json overrides
         let jsonPath = NSHomeDirectory() + "/.lattices/hotkeys.json"
         if let data = FileManager.default.contents(atPath: jsonPath),
-           let overrides = try? JSONDecoder().decode([String: KeyBinding].self, from: data) {
-            for (rawValue, binding) in overrides {
+           let overrides = try? JSONDecoder().decode([String: HotkeyFileOverride].self, from: data) {
+            for (rawValue, override) in overrides {
                 if let action = HotkeyAction(rawValue: rawValue) {
-                    merged[action] = binding
+                    switch override {
+                    case .binding(let binding):
+                        merged[action] = binding
+                    case .disabled:
+                        merged.removeValue(forKey: action)
+                    }
                 }
             }
         }
@@ -339,7 +368,10 @@ class HotkeyStore: ObservableObject {
 
     func register(action: HotkeyAction, callback: @escaping () -> Void) {
         callbacks[action] = callback
-        guard let binding = bindings[action] else { return }
+        guard let binding = bindings[action] else {
+            HotkeyManager.shared.unregisterSingle(id: action.carbonID)
+            return
+        }
         HotkeyManager.shared.registerSingle(
             id: action.carbonID,
             keyCode: binding.keyCode,
@@ -355,8 +387,9 @@ class HotkeyStore: ObservableObject {
 
         // Persist to UserDefaults
         if let data = try? JSONEncoder().encode(binding) {
-            UserDefaults.standard.set(data, forKey: "hotkey.\(action.rawValue)")
+            UserDefaults.standard.set(data, forKey: Self.storageKey(for: action))
         }
+        UserDefaults.standard.removeObject(forKey: Self.disabledKey(for: action))
 
         // Re-register if we have a callback
         if let callback = callbacks[action] {
@@ -369,13 +402,26 @@ class HotkeyStore: ObservableObject {
         }
     }
 
+    func clearBinding(for action: HotkeyAction) {
+        bindings.removeValue(forKey: action)
+        UserDefaults.standard.removeObject(forKey: Self.storageKey(for: action))
+        UserDefaults.standard.set(true, forKey: Self.disabledKey(for: action))
+        HotkeyManager.shared.unregisterSingle(id: action.carbonID)
+    }
+
     // MARK: - Reset
 
     func resetBinding(for action: HotkeyAction) {
-        guard let defaultBinding = Self.defaultBindings[action] else { return }
-        UserDefaults.standard.removeObject(forKey: "hotkey.\(action.rawValue)")
-        bindings[action] = defaultBinding
+        UserDefaults.standard.removeObject(forKey: Self.storageKey(for: action))
+        UserDefaults.standard.removeObject(forKey: Self.disabledKey(for: action))
 
+        guard let defaultBinding = Self.defaultBindings[action] else {
+            bindings.removeValue(forKey: action)
+            HotkeyManager.shared.unregisterSingle(id: action.carbonID)
+            return
+        }
+
+        bindings[action] = defaultBinding
         if let callback = callbacks[action] {
             HotkeyManager.shared.registerSingle(
                 id: action.carbonID,
@@ -388,13 +434,17 @@ class HotkeyStore: ObservableObject {
 
     func resetAll() {
         for action in HotkeyAction.allCases {
-            UserDefaults.standard.removeObject(forKey: "hotkey.\(action.rawValue)")
+            UserDefaults.standard.removeObject(forKey: Self.storageKey(for: action))
+            UserDefaults.standard.removeObject(forKey: Self.disabledKey(for: action))
         }
         bindings = Self.defaultBindings
 
         // Re-register all with stored callbacks
         for (action, callback) in callbacks {
-            guard let binding = bindings[action] else { continue }
+            guard let binding = bindings[action] else {
+                HotkeyManager.shared.unregisterSingle(id: action.carbonID)
+                continue
+            }
             HotkeyManager.shared.registerSingle(
                 id: action.carbonID,
                 keyCode: binding.keyCode,

--- a/apps/mac/Sources/Core/Desktop/OcrModel.swift
+++ b/apps/mac/Sources/Core/Desktop/OcrModel.swift
@@ -33,6 +33,8 @@ final class OcrModel: ObservableObject {
 
     @Published private(set) var results: [UInt32: OcrWindowResult] = [:]
     @Published private(set) var isScanning: Bool = false
+    @Published private(set) var lastReviewedAt: Date?
+    @Published private(set) var lastReviewedWindowCount: Int = 0
     @Published var interval: TimeInterval = 60
     @Published var enabled: Bool = true
 
@@ -180,6 +182,8 @@ final class OcrModel: ObservableObject {
 
             DispatchQueue.main.async {
                 self.results = fresh
+                self.lastReviewedAt = Date()
+                self.lastReviewedWindowCount = windows.count
                 self.isScanning = false
             }
 
@@ -302,6 +306,8 @@ final class OcrModel: ObservableObject {
 
             DispatchQueue.main.async {
                 self.results = fresh
+                self.lastReviewedAt = Date()
+                self.lastReviewedWindowCount = windows.count
                 self.isScanning = false
             }
 

--- a/apps/mac/Sources/Core/Overlays/CommandMode/CommandModeView.swift
+++ b/apps/mac/Sources/Core/Overlays/CommandMode/CommandModeView.swift
@@ -64,7 +64,7 @@ struct CommandModeView: View {
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                 }
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: isEmbedded ? .topLeading : .top)
         }
         .onAppear { installKeyHandler(); installMouseMonitors() }
         .onDisappear { removeKeyHandler(); removeMouseMonitors() }
@@ -137,7 +137,7 @@ struct CommandModeView: View {
             .frame(maxHeight: .infinity)
             .padding(.horizontal, 12)
             .padding(.vertical, 10)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
     // MARK: - Header
@@ -1905,12 +1905,28 @@ struct CommandModeView: View {
     private func installKeyHandler() {
         eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             guard state.phase == .inventory || state.phase == .desktopInventory else { return event }
-            // Only handle keys when our panel is the key window
-            guard let panel = CommandModeWindow.shared.panelWindow,
-                  panel.isKeyWindow else { return event }
+            guard shouldHandleKeyEvent(event) else { return event }
             let consumed = state.handleKey(event.keyCode, modifiers: event.modifierFlags)
             return consumed ? nil : event
         }
+    }
+
+    private func shouldHandleKeyEvent(_ event: NSEvent) -> Bool {
+        if isEmbedded {
+            guard let window = ScreenMapWindowController.shared.nsWindow,
+                  window.isKeyWindow else { return false }
+            if let eventWindow = event.window {
+                return eventWindow === window
+            }
+            return NSApp.keyWindow === window
+        }
+
+        guard let panel = CommandModeWindow.shared.panelWindow,
+              panel.isKeyWindow else { return false }
+        if let eventWindow = event.window {
+            return eventWindow === panel
+        }
+        return NSApp.keyWindow === panel
     }
 
     // MARK: - Mouse Monitors (marquee drag + screen map drag)

--- a/apps/mac/Sources/Core/Overlays/HUD/HUDController.swift
+++ b/apps/mac/Sources/Core/Overlays/HUD/HUDController.swift
@@ -34,6 +34,8 @@ final class HUDController {
     private var rightPanel: NSPanel?
     private var previewPanel: NSPanel?
     private var minimapPanels: [NSPanel] = []
+    private let hintBezels = HUDWindowHintBezels()
+    private var windowHintObserver: AnyCancellable?
     private var keyMonitor: Any?
     private var clickMonitor: Any?
     private var mouseMovedMonitor: Any?
@@ -194,6 +196,7 @@ final class HUDController {
 
         installMonitors()
         applyExperienceToAllPanels()
+        refreshHintBezels()
 
         let xp = HUDExperienceStore.shared
         if xp.has(.mouseSpecular) || xp.has(.meshLight) {
@@ -212,6 +215,7 @@ final class HUDController {
         guard isVisible else { return }
         removeMonitors()
         removeMouseMovedMonitor()
+        hintBezels.setRevealed(false)
 
         // Restore untiled windows only if user actually tiled something
         if !state.tiledWindows.isEmpty {
@@ -305,6 +309,7 @@ final class HUDController {
         }
         positionMinimapPanels()
         positionedScreen = screen
+        refreshHintBezels()
     }
 
     private func buildMinimapPanels(dismiss: @escaping () -> Void) {
@@ -454,6 +459,12 @@ final class HUDController {
                     self?.updatePreviewPanelVisibility(animated: true)
                 }
             }
+
+        // Rebuild on-window jump badges whenever the hint assignment changes
+        windowHintObserver = state.$windowHints
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.refreshHintBezels() }
 
         // Re-apply experience settings when preset changes
         experienceObserver = HUDExperienceStore.shared.$presetIndex
@@ -646,6 +657,18 @@ final class HUDController {
                 return nil
             }
             dismiss()
+            return nil
+        }
+
+        // ⌥+letter: jump straight to the window wearing that badge (any focus).
+        // `v`/`x` are reserved out of the hint alphabet, so ⌥V / ⌥X still fall
+        // through to voice / experience below.
+        if event.modifierFlags.contains(.option),
+           let ch = event.charactersIgnoringModifiers?.lowercased(),
+           ch.count == 1,
+           let wid = state.hintWid(for: ch),
+           let win = DesktopModel.shared.windows[wid] {
+            activateItem(.window(win))
             return nil
         }
 
@@ -1289,6 +1312,22 @@ final class HUDController {
     private func removeMonitors() {
         if let m = keyMonitor   { NSEvent.removeMonitor(m); keyMonitor = nil }
         if let m = clickMonitor { NSEvent.removeMonitor(m); clickMonitor = nil }
+    }
+
+    // MARK: - Window jump badges
+
+    /// Reposition + reveal the ⌥+letter badges over each on-screen window.
+    private func refreshHintBezels() {
+        guard isVisible else { hintBezels.setRevealed(false); return }
+        var obscured: [NSRect] = []
+        if let leftPanel { obscured.append(leftPanel.frame) }
+        if let rightPanel, rightPanel.alphaValue > 0.5 { obscured.append(rightPanel.frame) }
+        hintBezels.update(
+            hints: state.windowHints,
+            windows: DesktopModel.shared.windows,
+            obscuredBy: obscured
+        )
+        hintBezels.setRevealed(true)
     }
 
     private func mouseScreen() -> NSScreen {

--- a/apps/mac/Sources/Core/Overlays/HUD/HUDLeftBar.swift
+++ b/apps/mac/Sources/Core/Overlays/HUD/HUDLeftBar.swift
@@ -25,6 +25,23 @@ struct HUDLeftBar: View {
         let items: [HUDItem]
     }
 
+    private struct FooterHint: Identifiable {
+        let key: String
+        let label: String
+        var id: String { "\(key)-\(label)" }
+    }
+
+    private var footerHints: [FooterHint] {
+        [
+            FooterHint(key: "⇧↕", label: "Range"),
+            FooterHint(key: "⌘", label: "Multi"),
+            FooterHint(key: "⇥", label: "Focus"),
+            FooterHint(key: "↵", label: "Go"),
+            FooterHint(key: "⌥A", label: "Jump"),
+            FooterHint(key: "[ ]", label: "Layer"),
+        ]
+    }
+
     private var sections: [SectionDef] {
         [
             SectionDef(key: 1, title: "Projects", icon: "folder.fill", items: filteredProjects.map { .project($0) }),
@@ -199,6 +216,14 @@ struct HUDLeftBar: View {
         state.flatItems = flat
         state.sectionOffsets = offsets
         state.reconcileSelection(with: flat)
+
+        // Assign ⌥+letter jump hints over the full filtered window list (independent
+        // of section expansion) so the on-window badges work even when collapsed.
+        let windowWids = filteredWindows.map(\.wid)
+        let hints = HUDWindowHintAssigner.assign(orderedWids: windowWids)
+        if state.windowHints != hints {
+            state.windowHints = hints
+        }
     }
 
     private var resizeHandle: some View {
@@ -398,6 +423,10 @@ struct HUDLeftBar: View {
                 }
 
                 Spacer()
+
+                if case .window(let w) = item, let hint = state.windowHints[w.wid] {
+                    windowHintBadge(hint)
+                }
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 8)
@@ -769,11 +798,7 @@ struct HUDLeftBar: View {
                     keyBadge("D", label: "Distrib")
                 }
             }
-            keyBadge("⇧↕", label: "Range")
-            keyBadge("⌘", label: "Multi")
-            keyBadge("⇥", label: "Focus")
-            keyBadge("↵", label: "Go")
-            keyBadge("[ ]", label: "Layer")
+            footerNavigationHints(selectionActive: selectionCount > 1)
 
             // Experience badge (visible when no top bar)
             if !xp.showChrome && xp.presetIndex > 0 {
@@ -834,11 +859,38 @@ struct HUDLeftBar: View {
         .padding(.vertical, 7)
     }
 
-    private func keyBadge(_ key: String, label: String) -> some View {
-        HStack(spacing: 3) {
+    @ViewBuilder
+    private func footerNavigationHints(selectionActive: Bool) -> some View {
+        let minimapDockButtonVisible = state.minimapMode != .docked
+
+        if selectionActive || minimapDockButtonVisible || state.leftSidebarWidth < 300 {
+            footerHintRow(footerHints, labeled: false, spacing: 6)
+        } else if state.leftSidebarWidth < 390 {
+            VStack(alignment: .leading, spacing: 4) {
+                footerHintRow(Array(footerHints.prefix(3)), labeled: true, spacing: 8)
+                footerHintRow(Array(footerHints.suffix(3)), labeled: true, spacing: 8)
+            }
+        } else {
+            footerHintRow(footerHints, labeled: true, spacing: 8)
+        }
+    }
+
+    private func footerHintRow(_ hints: [FooterHint], labeled: Bool, spacing: CGFloat) -> some View {
+        HStack(spacing: spacing) {
+            ForEach(hints) { hint in
+                keyBadge(hint.key, label: labeled ? hint.label : nil)
+            }
+        }
+        .fixedSize(horizontal: true, vertical: false)
+    }
+
+    private func keyBadge(_ key: String, label: String? = nil) -> some View {
+        HStack(spacing: label == nil ? 0 : 3) {
             Text(key)
                 .font(.system(size: 9, weight: .semibold, design: .monospaced))
                 .foregroundColor(Palette.text)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
                 .padding(.horizontal, 4)
                 .padding(.vertical, 2)
                 .background(
@@ -849,10 +901,33 @@ struct HUDLeftBar: View {
                                 .strokeBorder(Color.white.opacity(0.12), lineWidth: 0.5)
                         )
                 )
-            Text(label)
-                .font(.system(size: 10, weight: .medium))
-                .foregroundColor(Palette.textMuted)
+            if let label {
+                Text(label)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(Palette.textMuted)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
         }
+        .fixedSize(horizontal: true, vertical: false)
+        .help(label.map { "\($0) (\(key))" } ?? key)
+    }
+
+    /// ⌥-jump letter shown on the trailing edge of a window row, echoing the
+    /// badge drawn over the window itself.
+    private func windowHintBadge(_ letter: String) -> some View {
+        Text(letter.uppercased())
+            .font(.system(size: 11, weight: .bold, design: .monospaced))
+            .foregroundColor(HUDChrome.cyan)
+            .frame(width: 19, height: 19)
+            .background(
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(HUDChrome.cyan.opacity(0.12))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 5)
+                            .strokeBorder(HUDChrome.cyan.opacity(0.35), lineWidth: 0.5)
+                    )
+            )
     }
 
     private func shortcutBadge(_ key: String) -> some View {

--- a/apps/mac/Sources/Core/Overlays/HUD/HUDState.swift
+++ b/apps/mac/Sources/Core/Overlays/HUD/HUDState.swift
@@ -92,6 +92,16 @@ final class HUDState: ObservableObject {
     /// Snapshot of the flat item list — set by HUDLeftBar so key handler can index into it
     var flatItems: [HUDItem] = []
 
+    /// wid → jump letter for the Windows list. Set by HUDLeftBar; consumed by the
+    /// sidebar rows, the on-window badge overlays, and the ⌥+letter key handler.
+    @Published var windowHints: [UInt32: String] = [:]
+
+    /// Reverse lookup for the ⌥+letter jump.
+    func hintWid(for letter: String) -> UInt32? {
+        let key = letter.lowercased()
+        return windowHints.first(where: { $0.value == key })?.key
+    }
+
     var hoverPreviewAnchorScreenY: CGFloat?
     var previewInteractionActive: Bool = false
 

--- a/apps/mac/Sources/Core/Overlays/HUD/HUDWindowHints.swift
+++ b/apps/mac/Sources/Core/Overlays/HUD/HUDWindowHints.swift
@@ -1,0 +1,202 @@
+import AppKit
+import SwiftUI
+
+// MARK: - Hint assignment (pure / testable)
+
+/// Assigns a single keyboard-jump letter to each window in the HUD window list.
+///
+/// The HUD captures all keys while it's up, so window jumps are gated behind a
+/// modifier (⌥). Letters are dealt in home-row-first order so the most recently
+/// used windows (which sort to the top of the list) get the fastest keys.
+/// `v` and `x` are omitted because the HUD already binds ⌥V (voice) and ⌥X
+/// (experience).
+enum HUDWindowHintAssigner {
+    /// Home row → top row → bottom row, minus the reserved `v` / `x`.
+    static let alphabet: [String] = "asdfghjklqwertyuiopzcbnm".map(String.init)
+
+    /// `orderedWids` should be the window list in display order (front-to-back).
+    static func assign(orderedWids: [UInt32]) -> [UInt32: String] {
+        var map: [UInt32: String] = [:]
+        for (index, wid) in orderedWids.enumerated() where index < alphabet.count {
+            map[wid] = alphabet[index]
+        }
+        return map
+    }
+}
+
+// MARK: - Badge view
+
+/// A small HUD tile worn at a window's top-right corner: dark `baseTop/baseBottom`
+/// gradient, a cyan signal rim + glow, and the jump letter in mono — the same
+/// language as the rest of the HUD chrome.
+struct HUDWindowHintBadge: View {
+    let letter: String
+
+    /// Transparent margin so the cyan glow / drop shadow aren't clipped by the
+    /// tight panel bounds. Folded into the corner inset when positioning.
+    static let glowMargin: CGFloat = 7
+
+    var body: some View {
+        HStack(spacing: 3) {
+            Text("⌥")
+                .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                .foregroundColor(HUDChrome.cyan.opacity(0.62))
+            Text(letter.uppercased())
+                .font(.system(size: 13, weight: .bold, design: .monospaced))
+                .foregroundColor(HUDChrome.cyan)
+        }
+        .padding(.horizontal, 7)
+        .padding(.vertical, 4)
+        .background(
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [HUDChrome.baseTop, HUDChrome.baseBottom],
+                        startPoint: .top, endPoint: .bottom
+                    )
+                )
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .strokeBorder(HUDChrome.cyan.opacity(0.55), lineWidth: 1)
+        )
+        .shadow(color: HUDChrome.cyan.opacity(0.30), radius: 6, y: 1)
+        .shadow(color: Color.black.opacity(0.45), radius: 5, y: 2)
+        .padding(Self.glowMargin)
+        .fixedSize()
+    }
+}
+
+// MARK: - Overlay manager
+
+/// Manages one borderless, click-through panel per on-screen, unoccluded hinted
+/// window, positioned at that window's top-right corner. Owned by `HUDController`.
+final class HUDWindowHintBezels {
+    private struct Bezel {
+        let panel: NSPanel
+        let hosting: NSHostingView<HUDWindowHintBadge>
+    }
+
+    /// Gap between the window's top-right corner and the badge tile (the badge's
+    /// own `glowMargin` sits inside this, so the visible inset is a touch more).
+    private static let cornerGap: CGFloat = 3
+
+    private var bezels: [UInt32: Bezel] = [:]
+    private var hiddenWids: Set<UInt32> = []
+    private(set) var revealed = false
+
+    /// Recompute badge positions + visibility for the current window set.
+    /// - Parameters:
+    ///   - hints: wid → letter mapping (from `HUDWindowHintAssigner`).
+    ///   - windows: current desktop window table (`DesktopModel.shared.windows`).
+    ///   - obscured: chrome panel frames (e.g. the sidebar) — badges landing
+    ///     inside any of these are suppressed.
+    func update(hints: [UInt32: String], windows: [UInt32: WindowEntry], obscuredBy obscured: [NSRect]) {
+        let primaryHeight = NSScreen.screens.first?.frame.height ?? 900
+        let screenFrames = NSScreen.screens.map(\.frame)
+        let allWindows = Array(windows.values)
+
+        // Retire bezels for windows that dropped out of the hint set.
+        for wid in Array(bezels.keys) where hints[wid] == nil { drop(wid) }
+
+        var nextHidden: Set<UInt32> = []
+
+        for (wid, letter) in hints {
+            guard let window = windows[wid], window.isOnScreen else { drop(wid); continue }
+            let frame = Self.appKitRect(for: window.frame, primaryHeight: primaryHeight)
+            guard screenFrames.contains(where: { $0.intersects(frame) }) else { drop(wid); continue }
+
+            let bezel = bezels[wid] ?? makeBezel()
+            bezel.hosting.rootView = HUDWindowHintBadge(letter: letter)
+            let size = bezel.hosting.fittingSize
+            bezel.panel.setContentSize(size)
+
+            // Top-right corner of the window.
+            let originX = frame.maxX - Self.cornerGap - size.width
+            let originY = frame.maxY - Self.cornerGap - size.height
+            bezel.panel.setFrameOrigin(NSPoint(x: originX, y: originY))
+            bezels[wid] = bezel
+
+            // Badge centre (where the tile visually sits) for hit tests.
+            let centerAppKit = NSPoint(x: originX + size.width / 2, y: originY + size.height / 2)
+            let centerCG = CGPoint(x: centerAppKit.x, y: primaryHeight - centerAppKit.y)
+
+            // Occluded: a window in front (smaller zIndex) covers the badge spot.
+            let occluded = allWindows.contains { other in
+                other.wid != wid && other.isOnScreen && other.zIndex < window.zIndex &&
+                Self.cgRect(other.frame).contains(centerCG)
+            }
+            let underChrome = obscured.contains { $0.contains(centerAppKit) }
+            if occluded || underChrome { nextHidden.insert(wid) }
+        }
+
+        hiddenWids = nextHidden
+        applyVisibility()
+    }
+
+    func setRevealed(_ on: Bool) {
+        revealed = on
+        applyVisibility()
+    }
+
+    /// Tear down every panel (called when the HUD is fully dismissed).
+    func clear() {
+        revealed = false
+        for bezel in bezels.values { bezel.panel.orderOut(nil) }
+        bezels.removeAll()
+        hiddenWids.removeAll()
+    }
+
+    // MARK: - Internals
+
+    private func applyVisibility() {
+        for (wid, bezel) in bezels {
+            let shouldShow = revealed && !hiddenWids.contains(wid)
+            bezel.panel.alphaValue = shouldShow ? 1 : 0
+            if shouldShow { bezel.panel.orderFrontRegardless() }
+        }
+    }
+
+    private func drop(_ wid: UInt32) {
+        bezels[wid]?.panel.orderOut(nil)
+        bezels[wid] = nil
+    }
+
+    private func makeBezel() -> Bezel {
+        let hosting = NSHostingView(rootView: HUDWindowHintBadge(letter: ""))
+        hosting.sizingOptions = []
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 48, height: 32),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.level = .floating
+        panel.hasShadow = false
+        panel.hidesOnDeactivate = false
+        panel.isReleasedWhenClosed = false
+        panel.ignoresMouseEvents = true   // click through to the window beneath
+        panel.alphaValue = 0
+        panel.sharingType = .readOnly
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+        panel.contentView = hosting
+        return Bezel(panel: panel, hosting: hosting)
+    }
+
+    private static func cgRect(_ frame: WindowFrame) -> CGRect {
+        CGRect(x: frame.x, y: frame.y, width: frame.w, height: frame.h)
+    }
+
+    /// Convert a CoreGraphics window frame (top-left origin, y-down, global) into
+    /// an AppKit panel frame (bottom-left origin, y-up, global).
+    private static func appKitRect(for frame: WindowFrame, primaryHeight: CGFloat) -> NSRect {
+        NSRect(
+            x: frame.x,
+            y: primaryHeight - frame.y - frame.h,
+            width: frame.w,
+            height: frame.h
+        )
+    }
+}

--- a/apps/mac/Sources/Core/Overlays/Motion/HyperspaceCommandBar.swift
+++ b/apps/mac/Sources/Core/Overlays/Motion/HyperspaceCommandBar.swift
@@ -1,0 +1,443 @@
+import AppKit
+import SwiftUI
+
+// MARK: - HyperspaceCommandBar
+//
+// The `/` command bar for Hyperspace — a slim palette pinned to the bottom of the
+// survey monitor. Curated to the survey's own verbs: search the windows on this
+// screen, target a group or layer (⏎ adds them to the selection), and /tile to
+// stage a placement. Monitor-scoped — it only ever sees the windows / clusters /
+// layers on the screen you opened it on. Wears the same chrome as the main command
+// bar (HUDChrome carbon texture + cyan accent) so the two read as one family. Like
+// NewLayerPanel it must be its own key panel, because the survey's screen-panels
+// can't become key. Nothing real moves here: selections build the set, /tile
+// stages a location, and gather (⏎/G) is still the one real move.
+
+final class HyperspaceCommandModel: ObservableObject {
+    struct WindowItem: Identifiable { let wid: UInt32; let title: String; let app: String; var id: UInt32 { wid } }
+    struct GroupItem: Identifiable { let cid: Int; let name: String; let hint: String; let members: [UInt32]; var id: Int { cid } }
+    struct LayerItem: Identifiable { let lid: String; let name: String; let members: [UInt32]; var id: String { lid } }
+
+    enum Row: Identifiable {
+        case window(WindowItem)
+        case group(GroupItem)
+        case layer(LayerItem)
+        case tile(name: String, placement: GridPlacement)
+        case saveLayer
+        case command(label: String, detail: String, fill: String)
+
+        var id: String {
+            switch self {
+            case .window(let w):        return "w\(w.wid)"
+            case .group(let g):         return "g\(g.cid)"
+            case .layer(let l):         return "l\(l.lid)"
+            case .tile(let n, _):       return "t\(n)"
+            case .saveLayer:            return "savelayer"
+            case .command(let l, _, _): return "c\(l)"
+            }
+        }
+    }
+
+    /// What a commit does to the bar: dismiss it, or stay up (selection toggles the
+    /// selection and a verb hint pre-fills the field — either way you keep going).
+    enum Commit { case close, stay }
+
+    @Published var query: String = "" { didSet { if selected != 0 { selected = 0 } } }
+    @Published var selected: Int = 0
+    /// The picked set on this screen, in pick order — refreshed after every selection so
+    /// rows can show their slot / count. Mirrors the survey's own selection.
+    @Published var pluckedOrder: [UInt32] = []
+
+    let windows: [WindowItem]
+    let groups: [GroupItem]
+    let layers: [LayerItem]
+
+    var onPluckWindow: (UInt32) -> Void = { _ in }
+    var onPluckGroup:  (Int) -> Void = { _ in }
+    var onRecallLayer: (String) -> Void = { _ in }
+    var onTile:        (GridPlacement) -> Void = { _ in }
+    var onSaveLayer:   () -> Void = { }
+    var pluckedProvider: () -> [UInt32] = { [] }
+
+    init(windows: [WindowItem], groups: [GroupItem], layers: [LayerItem]) {
+        self.windows = windows
+        self.groups = groups
+        self.layers = layers
+    }
+
+    func refreshPluck() { pluckedOrder = pluckedProvider() }
+
+    /// 1-based slot of a window in the pick order (the badge number), or nil.
+    func slot(of wid: UInt32) -> Int? { pluckedOrder.firstIndex(of: wid).map { $0 + 1 } }
+    /// How many of a group's / layer's windows are currently plucked.
+    func pluckedCount(_ members: [UInt32]) -> Int {
+        let set = Set(pluckedOrder); return members.reduce(0) { $0 + (set.contains($1) ? 1 : 0) }
+    }
+
+    // Named half / quadrant / maximize positions → a GridPlacement the survey stages,
+    // mirroring the right-click tile menu so /tile and the menu speak the same grid.
+    static let tilePositions: [(String, GridPlacement)] = [
+        ("Left Half",    GridPlacement(columns: 2, rows: 1, column: 0, row: 0)!),
+        ("Right Half",   GridPlacement(columns: 2, rows: 1, column: 1, row: 0)!),
+        ("Top Half",     GridPlacement(columns: 1, rows: 2, column: 0, row: 0)!),
+        ("Bottom Half",  GridPlacement(columns: 1, rows: 2, column: 0, row: 1)!),
+        ("Maximize",     GridPlacement(columns: 1, rows: 1, column: 0, row: 0)!),
+        ("Top Left",     GridPlacement(columns: 2, rows: 2, column: 0, row: 0)!),
+        ("Top Right",    GridPlacement(columns: 2, rows: 2, column: 1, row: 0)!),
+        ("Bottom Left",  GridPlacement(columns: 2, rows: 2, column: 0, row: 1)!),
+        ("Bottom Right", GridPlacement(columns: 2, rows: 2, column: 1, row: 1)!),
+    ]
+
+    var rows: [Row] {
+        let q = query.trimmingCharacters(in: .whitespaces).lowercased()
+
+        if q.hasPrefix("/tile") || q.hasPrefix("/place") {
+            let rest = arg(q, ["/tile", "/place"])
+            return Self.tilePositions
+                .filter { rest.isEmpty || $0.0.lowercased().contains(rest) }
+                .map { Row.tile(name: $0.0, placement: $0.1) }
+        }
+        if q.hasPrefix("/group") {
+            let rest = arg(q, ["/group"])
+            return groups
+                .filter { rest.isEmpty || $0.hint.lowercased() == rest || score($0.name, rest) != nil }
+                .map(Row.group)
+        }
+        if q.hasPrefix("/layer") {
+            let rest = arg(q, ["/layer"])
+            if rest.hasPrefix("new") { return [.saveLayer] }
+            return layers
+                .filter { rest.isEmpty || score($0.name, rest) != nil }
+                .map(Row.layer)
+        }
+        // A bare "/" (or an unrecognised command) → the verb menu.
+        if q.hasPrefix("/") {
+            let rest = String(q.dropFirst())
+            let menu: [Row] = [
+                .command(label: "/tile",  detail: "stage a placement for the selection",      fill: "/tile "),
+                .command(label: "/group", detail: "target a cluster by name or ⇧-letter",      fill: "/group "),
+                .command(label: "/layer", detail: "recall a layer · /layer new saves the pick", fill: "/layer "),
+            ]
+            return menu.filter { rest.isEmpty || labelOf($0).lowercased().contains(rest) }
+        }
+        // Empty query → the things you usually target: groups, then layers.
+        if q.isEmpty {
+            return groups.map(Row.group) + layers.map(Row.layer)
+        }
+        // Plain search across windows + groups + layers, scored; groups/layers edge
+        // out a same-score window so a typed cluster name leads.
+        var scored: [(Int, Row)] = []
+        for w in windows { if let s = best([w.title, w.app], q) { scored.append((s, .window(w))) } }
+        for g in groups  { if let s = score(g.name, q)         { scored.append((s + 2, .group(g))) } }
+        for l in layers  { if let s = score(l.name, q)         { scored.append((s + 1, .layer(l))) } }
+        return scored.sorted { $0.0 > $1.0 }.prefix(9).map { $0.1 }
+    }
+
+    func move(_ d: Int) {
+        let n = rows.count
+        guard n > 0 else { return }
+        selected = (selected + d + n) % n
+    }
+
+    func commitSelected() -> Commit {
+        let r = rows
+        guard selected >= 0, selected < r.count else { return .stay }
+        switch r[selected] {
+        case .window(let w):           onPluckWindow(w.wid); return .stay
+        case .group(let g):            onPluckGroup(g.cid);  return .stay
+        case .layer(let l):            onRecallLayer(l.lid); return .stay
+        case .tile(_, let p):          onTile(p);            return .close
+        case .saveLayer:               onSaveLayer();        return .close
+        case .command(_, _, let fill): query = fill;         return .stay
+        }
+    }
+
+    // MARK: scoring
+    private func arg(_ q: String, _ tokens: [String]) -> String {
+        for t in tokens where q.hasPrefix(t) {
+            return String(q.dropFirst(t.count)).trimmingCharacters(in: .whitespaces)
+        }
+        return ""
+    }
+    private func score(_ hay: String, _ q: String) -> Int? {
+        let h = hay.lowercased()
+        if q.isEmpty { return 0 }
+        if h == q { return 100 }
+        if h.hasPrefix(q) { return 60 }
+        if h.contains(q) { return 30 }
+        return nil
+    }
+    private func best(_ fields: [String], _ q: String) -> Int? { fields.compactMap { score($0, q) }.max() }
+    private func labelOf(_ row: Row) -> String { if case .command(let l, _, _) = row { return l }; return "" }
+}
+
+// MARK: - HyperspaceCommandView
+
+struct HyperspaceCommandView: View {
+    @ObservedObject var model: HyperspaceCommandModel
+    var onActivate: (Int) -> Void
+    var onDismiss: () -> Void
+    @FocusState private var focused: Bool
+
+    private let radius: CGFloat = 14
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            Color.clear
+                .contentShape(Rectangle())
+                .onTapGesture { onDismiss() }           // click-away closes; survey stays visible
+            card.frame(width: 580).padding(.bottom, 90)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onAppear { focused = true }
+        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { _ in
+            focused = true                               // assert focus only once the panel is key
+        }
+    }
+
+    // Results sit ABOVE the input (the bar lives at the bottom of the screen); same
+    // carbon card / cyan rim as the main command bar so they read as one surface.
+    private var card: some View {
+        let rows = model.rows
+        return VStack(spacing: 0) {
+            if !rows.isEmpty {
+                VStack(spacing: 1) {
+                    ForEach(Array(rows.enumerated()), id: \.element.id) { i, row in
+                        rowView(row, selected: i == model.selected)
+                            .contentShape(Rectangle())
+                            .onTapGesture { onActivate(i) }
+                    }
+                }
+                .padding(.vertical, 5)
+                Rectangle().fill(Palette.border).frame(height: 0.5)
+            }
+            inputRow
+        }
+        .background(cardTexture)
+        .clipShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: radius, style: .continuous).strokeBorder(borderGradient, lineWidth: 0.75))
+        .overlay(alignment: .top) { topRim }
+        .shadow(color: Color.black.opacity(0.5), radius: 22, y: 10)
+    }
+
+    private var inputRow: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 13, weight: .medium)).foregroundColor(Palette.textMuted).frame(width: 20)
+            TextField("Search windows, groups, layers   ·   /tile  /group  /layer", text: $model.query)
+                .textFieldStyle(.plain)
+                .font(Typo.mono(14)).foregroundColor(Palette.text)
+                .focused($focused)
+                .onExitCommand(perform: onDismiss)
+            if !model.pluckedOrder.isEmpty {
+                Text("\(model.pluckedOrder.count) selected")
+                    .font(Typo.mono(9)).foregroundColor(HUDChrome.cyan.opacity(0.9))
+            }
+            Text("esc").font(Typo.mono(9)).foregroundColor(Palette.textMuted)
+        }
+        .padding(.horizontal, 14).frame(height: 46)
+        .background(LinearGradient(colors: [Color.white.opacity(0.05), Color.white.opacity(0.012)],
+                                   startPoint: .top, endPoint: .bottom))
+    }
+
+    private func rowView(_ row: HyperspaceCommandModel.Row, selected: Bool) -> some View {
+        let plucked = isPlucked(row)
+        let lit = selected || plucked
+        let accent: Color = selected ? HUDChrome.cyan : (plucked ? HUDChrome.cyan.opacity(0.85) : tint(row))
+        return HStack(spacing: 11) {
+            Image(systemName: icon(row))
+                .font(.system(size: 11, weight: .medium)).foregroundColor(accent).frame(width: 16)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title(row)).font(Typo.mono(12))
+                    .foregroundColor(lit ? Palette.text : Palette.textDim).lineLimit(1)
+                if let m = meta(row) {
+                    Text(m).font(Typo.mono(10)).foregroundColor(Palette.textMuted).lineLimit(1)
+                }
+            }
+            Spacer(minLength: 8)
+            trailing(row, selected: selected)
+        }
+        .padding(.horizontal, 14).padding(.vertical, 7)
+        .background(rowBackground(selected: selected, plucked: plucked))
+    }
+
+    // Cursor row → bright cyan wash + solid leading bar; a selected-but-not-cursor row
+    // → a quieter persistent cyan tint + dim bar, so the selected set stays legible
+    // at a glance (the layer-preview pop, not a green glow).
+    @ViewBuilder private func rowBackground(selected: Bool, plucked: Bool) -> some View {
+        ZStack(alignment: .leading) {
+            if selected { HUDChrome.cyan.opacity(0.14) }
+            else if plucked { HUDChrome.cyan.opacity(0.06) }
+            else { Color.clear }
+            if selected { Rectangle().fill(HUDChrome.cyan).frame(width: 2) }
+            else if plucked { Rectangle().fill(HUDChrome.cyan.opacity(0.45)).frame(width: 2) }
+        }
+    }
+
+    @ViewBuilder private func trailing(_ row: HyperspaceCommandModel.Row, selected: Bool) -> some View {
+        switch row {
+        case .window(let w):
+            if let s = model.slot(of: w.wid) { slotBadge("\(s)") } else { keyHint("⏎ select", selected) }
+        case .group(let g): countOrHint(model.pluckedCount(g.members), g.members.count, selected)
+        case .layer(let l): countOrHint(model.pluckedCount(l.members), l.members.count, selected)
+        case .tile:       keyHint("⏎ stage", selected)
+        case .saveLayer:  keyHint("⏎ save", selected)
+        case .command:    keyHint("⏎", selected)
+        }
+    }
+
+    @ViewBuilder private func countOrHint(_ picked: Int, _ total: Int, _ selected: Bool) -> some View {
+        if picked > 0 { slotBadge("\(picked)/\(total)", full: picked >= total && total > 0) }
+        else { keyHint("⏎ select", selected) }
+    }
+
+    private func slotBadge(_ text: String, full: Bool = true) -> some View {
+        Text(text)
+            .font(Typo.monoBold(9)).foregroundColor(full ? HUDChrome.onSignal : HUDChrome.cyan)
+            .padding(.horizontal, 5).padding(.vertical, 1.5)
+            .background(Capsule().fill(full ? HUDChrome.cyan : HUDChrome.cyan.opacity(0.16)))
+    }
+
+    private func keyHint(_ text: String, _ selected: Bool) -> some View {
+        Text(text).font(Typo.mono(9)).foregroundColor(selected ? HUDChrome.cyan.opacity(0.8) : Palette.textMuted)
+    }
+
+    private func isPlucked(_ row: HyperspaceCommandModel.Row) -> Bool {
+        switch row {
+        case .window(let w): return model.slot(of: w.wid) != nil
+        case .group(let g):  return model.pluckedCount(g.members) > 0
+        case .layer(let l):  return model.pluckedCount(l.members) > 0
+        default:             return false
+        }
+    }
+
+    // MARK: chrome (ported from the main command bar so the two match)
+    private var cardTexture: some View {
+        ZStack {
+            LinearGradient(colors: [HUDChrome.baseTop, HUDChrome.baseBottom], startPoint: .top, endPoint: .bottom)
+            LinearGradient(colors: [HUDChrome.cyan.opacity(0.06), .clear, HUDChrome.rose.opacity(0.035)],
+                           startPoint: .topLeading, endPoint: .bottomTrailing)
+            LinearGradient(colors: [Color.white.opacity(0.06), .clear], startPoint: .top, endPoint: .center)
+        }
+    }
+    private var borderGradient: LinearGradient {
+        LinearGradient(colors: [Color.white.opacity(0.18), Color.white.opacity(0.05)], startPoint: .top, endPoint: .bottom)
+    }
+    private var topRim: some View {
+        LinearGradient(stops: [
+            .init(color: .clear, location: 0.0),
+            .init(color: Color.white.opacity(0.5), location: 0.28),
+            .init(color: HUDChrome.cyan.opacity(0.38), location: 0.5),
+            .init(color: Color.white.opacity(0.5), location: 0.72),
+            .init(color: .clear, location: 1.0),
+        ], startPoint: .leading, endPoint: .trailing)
+        .frame(height: 1).blur(radius: 0.4)
+    }
+
+    // MARK: row presentation
+    private func icon(_ r: HyperspaceCommandModel.Row) -> String {
+        switch r {
+        case .window:    return "macwindow"
+        case .group:     return "square.grid.2x2"
+        case .layer:     return "square.stack.3d.up"
+        case .tile:      return "rectangle.righthalf.inset.filled"
+        case .saveLayer: return "plus.square.on.square"
+        case .command:   return "slash.circle"
+        }
+    }
+    private func tint(_ r: HyperspaceCommandModel.Row) -> Color {
+        switch r {
+        case .group, .layer, .saveLayer: return HUDChrome.cyan.opacity(0.7)
+        default:                          return Palette.textDim
+        }
+    }
+    private func title(_ r: HyperspaceCommandModel.Row) -> String {
+        switch r {
+        case .window(let w):        return w.title
+        case .group(let g):         return g.name
+        case .layer(let l):         return l.name
+        case .tile(let n, _):       return n
+        case .saveLayer:            return "Save the selection as a layer"
+        case .command(let l, _, _): return l
+        }
+    }
+    private func meta(_ r: HyperspaceCommandModel.Row) -> String? {
+        switch r {
+        case .window(let w): return w.app
+        case .group(let g):  return g.hint.isEmpty ? "\(g.members.count)" : "⇧\(g.hint) · \(g.members.count)"
+        case .layer(let l):  return "\(l.members.count) here"
+        case .tile:          return nil
+        case .saveLayer:     return nil
+        case .command(_, let d, _): return d
+        }
+    }
+}
+
+// MARK: - HyperspaceCommandPanel
+
+final class HyperspaceCommandPanel: NSPanel {
+    private let model: HyperspaceCommandModel
+    private let onClose: () -> Void
+    private var monitor: Any?
+
+    init(model: HyperspaceCommandModel, onClose: @escaping () -> Void) {
+        self.model = model
+        self.onClose = onClose
+        super.init(contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+                   styleMask: [.borderless, .nonactivatingPanel], backing: .buffered, defer: false)
+        isFloatingPanel = true
+        level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()) + 2)   // above the survey panels
+        backgroundColor = .clear
+        isOpaque = false
+        hasShadow = false
+        let view = HyperspaceCommandView(
+            model: model,
+            onActivate: { [weak self] i in self?.activate(i) },
+            onDismiss:  { [weak self] in self?.onClose() })
+        let host = NSHostingView(rootView: view)
+        host.frame = NSRect(origin: .zero, size: frame.size)
+        host.autoresizingMask = [.width, .height]
+        contentView = host
+    }
+
+    @available(*, unavailable) required init?(coder: NSCoder) { fatalError() }
+    override var canBecomeKey: Bool { true }
+
+    func present(on screen: NSScreen) {
+        setFrame(screen.frame, display: true)
+        model.refreshPluck()                 // reflect anything already selected
+        installMonitor()
+        NSApp.activate(ignoringOtherApps: true)
+        makeKeyAndOrderFront(nil)
+    }
+
+    override func close() {
+        if let monitor { NSEvent.removeMonitor(monitor) }
+        monitor = nil
+        super.close()
+    }
+
+    /// Run the highlighted row's action and decide whether the bar stays up.
+    private func activate(_ index: Int) {
+        model.selected = index
+        switch model.commitSelected() {
+        case .close: onClose()
+        case .stay:  model.refreshPluck()    // show the new slot / count immediately
+        }
+    }
+
+    // Local monitor so ↑↓/⏎/Esc drive the list before the focused TextField sees
+    // them (typing still falls through). Mirrors the survey's own monitor pattern.
+    private func installMonitor() {
+        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] e in
+            guard let self, self.isKeyWindow else { return e }
+            switch e.keyCode {
+            case 53:     self.onClose(); return nil                       // Esc
+            case 126:    self.model.move(-1); return nil                  // ↑
+            case 125:    self.model.move(1); return nil                   // ↓
+            case 36, 76: self.activate(self.model.selected); return nil   // ⏎ / keypad Enter
+            default:     return e
+            }
+        }
+    }
+}

--- a/apps/mac/Sources/Core/Overlays/Motion/LayerRulePanel.swift
+++ b/apps/mac/Sources/Core/Overlays/Motion/LayerRulePanel.swift
@@ -1,0 +1,293 @@
+import AppKit
+import SwiftUI
+
+// MARK: - LayerRulePanel
+
+final class LayerRulePanel: NSPanel {
+    private let onSave: (StudioLayerClause) -> Void
+    private let onCancel: () -> Void
+
+    init(
+        layerName: String,
+        clauseIndex: Int?,
+        clause: StudioLayerClause,
+        onSave: @escaping (StudioLayerClause) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        self.onSave = onSave
+        self.onCancel = onCancel
+        super.init(contentRect: NSRect(x: 0, y: 0, width: 720, height: 360),
+                   styleMask: [.borderless], backing: .buffered, defer: false)
+        isFloatingPanel = true
+        level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()) + 3)
+        backgroundColor = .clear
+        isOpaque = false
+        hasShadow = false
+
+        let form = LayerRuleForm(
+            layerName: layerName,
+            clauseIndex: clauseIndex,
+            clause: clause,
+            onSave: { [weak self] saved in self?.onSave(saved); self?.close() },
+            onCancel: { [weak self] in self?.onCancel(); self?.close() }
+        )
+        let host = NSHostingView(rootView: form)
+        host.frame = NSRect(origin: .zero, size: frame.size)
+        host.autoresizingMask = [.width, .height]
+        contentView = host
+    }
+
+    @available(*, unavailable) required init?(coder: NSCoder) { fatalError() }
+    override var canBecomeKey: Bool { true }
+
+    func present(on screen: NSScreen) {
+        setFrame(screen.frame, display: true)
+        NSApp.activate(ignoringOtherApps: true)
+        makeKeyAndOrderFront(nil)
+    }
+}
+
+// MARK: - LayerRuleForm
+
+private struct LayerRuleForm: View {
+    private struct Draft {
+        enum NameMatchMode: String, CaseIterable, Identifiable {
+            case direct = "Text"
+            case regex = "Regex"
+
+            var id: String { rawValue }
+        }
+
+        var app = ""
+        var name = ""
+        var nameMode: NameMatchMode = .direct
+
+        init(_ clause: StudioLayerClause) {
+            app = clause.appEquals ?? clause.app ?? clause.appRegex ?? ""
+            if let titleRegex = clause.titleRegex {
+                name = titleRegex
+                nameMode = .regex
+            } else {
+                name = clause.titleContains ?? clause.titleEquals ?? ""
+                nameMode = .direct
+            }
+        }
+
+        var clause: StudioLayerClause {
+            switch nameMode {
+            case .direct:
+                StudioLayerClause(appEquals: clean(app), titleContains: clean(name))
+            case .regex:
+                StudioLayerClause(appEquals: clean(app), titleRegex: clean(name))
+            }
+        }
+
+        var canSave: Bool {
+            (clean(app) != nil || clean(name) != nil) && nameIsValid
+        }
+
+        var nameIsValid: Bool {
+            guard nameMode == .regex, let value = clean(name) else { return true }
+            return (try? NSRegularExpression(pattern: value, options: [.caseInsensitive])) != nil
+        }
+
+        var statusText: String {
+            if !nameIsValid { return "invalid regex" }
+            if !canSave { return "add app or name" }
+            return "ready"
+        }
+
+        private func clean(_ value: String) -> String? {
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+    }
+
+    let layerName: String
+    let clauseIndex: Int?
+    let onSave: (StudioLayerClause) -> Void
+    let onCancel: () -> Void
+
+    @State private var draft: Draft
+    @FocusState private var appFocused: Bool
+
+    init(
+        layerName: String,
+        clauseIndex: Int?,
+        clause: StudioLayerClause,
+        onSave: @escaping (StudioLayerClause) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        self.layerName = layerName
+        self.clauseIndex = clauseIndex
+        self.onSave = onSave
+        self.onCancel = onCancel
+        _draft = State(initialValue: Draft(clause))
+    }
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.66)
+                .ignoresSafeArea()
+                .contentShape(Rectangle())
+                .onTapGesture { onCancel() }
+            vessel
+        }
+    }
+
+    private var vessel: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            header
+            fields
+            preview
+            footer
+        }
+        .padding(22)
+        .frame(width: 480)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(Color(red: 0.06, green: 0.07, blue: 0.09))
+                .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .strokeBorder(.white.opacity(0.12), lineWidth: 1))
+                .shadow(color: .black.opacity(0.62), radius: 44, y: 20)
+        )
+        .onAppear { appFocused = true }
+        .onSubmit { saveIfReady() }
+        .onExitCommand(perform: onCancel)
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "line.3.horizontal.decrease.circle.fill")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(Palette.running)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(clauseIndex == nil ? "New Rule" : "Edit Rule")
+                    .font(Typo.monoBold(14))
+                    .foregroundColor(.white)
+                Text(layerName)
+                    .font(Typo.mono(9))
+                    .foregroundColor(.white.opacity(0.42))
+                    .lineLimit(1)
+            }
+            Spacer()
+            Text("esc").font(Typo.mono(9)).foregroundColor(.white.opacity(0.4))
+        }
+    }
+
+    private var fields: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            field("App", text: $draft.app, placeholder: "Google Chrome", focused: true)
+            nameField
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.white.opacity(0.05))
+                .overlay(RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .strokeBorder(Palette.border, lineWidth: 0.5))
+        )
+    }
+
+    private var nameField: some View {
+        HStack(spacing: 10) {
+            Text("Name")
+                .font(Typo.mono(10))
+                .foregroundColor(.white.opacity(0.46))
+                .frame(width: 82, alignment: .leading)
+            textInput($draft.name, placeholder: draft.nameMode == .regex ? "GitHub|Pull Request" : "Pull Request")
+            Picker("", selection: $draft.nameMode) {
+                ForEach(Draft.NameMatchMode.allCases) { mode in
+                    Text(mode.rawValue).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .frame(width: 132)
+        }
+    }
+
+    @ViewBuilder
+    private func field(_ label: String, text: Binding<String>, placeholder: String, focused: Bool = false) -> some View {
+        HStack(spacing: 10) {
+            Text(label)
+                .font(Typo.mono(10))
+                .foregroundColor(.white.opacity(0.46))
+                .frame(width: 82, alignment: .leading)
+            if focused {
+                textInput(text, placeholder: placeholder)
+                    .focused($appFocused)
+            } else {
+                textInput(text, placeholder: placeholder)
+            }
+        }
+    }
+
+    private func textInput(_ text: Binding<String>, placeholder: String) -> some View {
+        TextField(placeholder, text: text)
+            .textFieldStyle(.plain)
+            .font(Typo.mono(11))
+            .foregroundColor(.white)
+            .padding(.horizontal, 9)
+            .padding(.vertical, 7)
+            .background(
+                RoundedRectangle(cornerRadius: 7, style: .continuous)
+                    .fill(Color.white.opacity(0.06))
+                    .overlay(RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .strokeBorder(Palette.border, lineWidth: 0.5))
+            )
+    }
+
+    private var preview: some View {
+        HStack(spacing: 8) {
+            Text("RULE")
+                .font(Typo.monoBold(8.5))
+                .foregroundColor(.white.opacity(0.4))
+            Text(draft.nameIsValid ? (draft.canSave ? draft.clause.summary : "no rule") : "invalid regex")
+                .font(Typo.mono(10))
+                .foregroundColor(draft.canSave ? .white.opacity(0.78) : Palette.detach.opacity(0.8))
+                .lineLimit(1)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.black.opacity(0.18))
+                .overlay(RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .strokeBorder(Palette.border, lineWidth: 0.5))
+        )
+    }
+
+    private var footer: some View {
+        HStack(spacing: 12) {
+            Text(draft.statusText)
+                .font(Typo.mono(9))
+                .foregroundColor(draft.canSave ? .white.opacity(0.42) : Palette.detach.opacity(0.75))
+            Spacer(minLength: 0)
+            Button(action: onCancel) {
+                Text("Cancel")
+                    .font(Typo.monoBold(11))
+                    .foregroundColor(.white.opacity(0.72))
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 7)
+            }
+            .buttonStyle(.plain)
+            Button(action: saveIfReady) {
+                Text("Save")
+                    .font(Typo.monoBold(11))
+                    .foregroundColor(draft.canSave ? Palette.bg : .white.opacity(0.4))
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 7)
+                    .background(Capsule().fill(draft.canSave ? Palette.running : Color.white.opacity(0.08)))
+            }
+            .buttonStyle(.plain)
+            .disabled(!draft.canSave)
+        }
+    }
+
+    private func saveIfReady() {
+        guard draft.canSave else { return }
+        onSave(draft.clause)
+    }
+}

--- a/apps/mac/Sources/Core/Overlays/Motion/WindowMotionMode.swift
+++ b/apps/mac/Sources/Core/Overlays/Motion/WindowMotionMode.swift
@@ -12,15 +12,26 @@ import SwiftUI
 final class WindowMotionMode {
     static let shared = WindowMotionMode()
     private var panel: MotionPanel?
+    private var lastToggle: CFTimeInterval = 0
 
     var isActive: Bool { panel != nil }
 
     func toggle() {
+        // Debounce machine-gun re-fire. The Hyper trigger rides the Caps Lock
+        // transport remap, which can flicker active/inactive and fire the hotkey
+        // several times in a few ms — racing activate against deactivate. A human
+        // toggle is never this fast, so swallow anything inside the window.
+        let now = CACurrentMediaTime()
+        if now - lastToggle < 0.18 { return }
+        lastToggle = now
         if isActive { deactivate() } else { activate() }
     }
 
     func activate() {
         guard panel == nil else { return }
+        // Defensive: clear any overlay panels orphaned by a prior race before we
+        // open a fresh one, so we never stack a new survey on top of a stuck one.
+        MotionPanel.teardownStrayPanels()
         let t0 = CACurrentMediaTime()
         DesktopModel.shared.forcePoll()
         let tPoll = CACurrentMediaTime()
@@ -53,6 +64,10 @@ final class WindowMotionMode {
     func deactivate() {
         panel?.dismiss()
         panel = nil
+        // Belt-and-suspenders: sweep up any Hyperspace overlay panel still on screen
+        // even if we lost the reference to it. Guarantees the toggle hotkey always
+        // clears the spread — the recovery path for the "stuck on top" trap.
+        MotionPanel.teardownStrayPanels()
     }
 }
 
@@ -186,6 +201,7 @@ final class HyperspaceDrag: ObservableObject {
     @Published var hoverLayer: String?       // layer pile under the cursor (layer id, or newLayerKey)
     @Published var inspectLayer: String?     // pile under a plain mouse hover (no drag) — reveals its roster
     @Published var inspectScreen: String?    // which screen that hovered pile is on
+    @Published var selectedLayer: String?    // layer pile clicked open → the inspector modal (layer id)
     @Published var screenID: String = ""     // which screen owns the in-flight drag
 
     // Right-click "place me" mode: a tile was secondary-clicked, opening a life-size
@@ -248,6 +264,7 @@ private final class MotionPanel: NSPanel {
     private var borderLayers: [CALayer] = []
     private var originalFrames: [UInt32: CGRect] = [:]   // for Esc-undo
     private var exposed = false                          // Exposé spread is laid out
+    private var dismissed = false                        // torn down — any late async work must no-op
 
     private var lastSide: MotionSide?
     private var cycleStep = 0
@@ -270,6 +287,8 @@ private final class MotionPanel: NSPanel {
     private var mouseUpMonitor: Any?    // re-claims key focus after a survey click/drag
     private var keyMonitor: Any?        // catches Enter/Esc even when a survey panel holds key
     private var newLayerPanel: NewLayerPanel?   // the "create a new layer" authoring flow, when open
+    private var rulePanel: LayerRulePanel?       // the "add/edit layer rule" flow, when open
+    private var commandPanel: HyperspaceCommandPanel?   // the `/` command bar, when open
 
     // Selection order — `group` is membership, `pickOrder` is the order picks were
     // made, which is what the slot numbers (and the gather grid) follow.
@@ -448,7 +467,7 @@ private final class MotionPanel: NSPanel {
                 return event
             }
             DispatchQueue.main.async { [weak self] in
-                guard let self, self.exposed, !self.isKeyWindow else { return }
+                guard let self, self.exposed, !self.isKeyWindow, self.commandPanel == nil else { return }
                 self.makeKey()
             }
             return event   // don't swallow — the click/drag still needs to process
@@ -458,8 +477,10 @@ private final class MotionPanel: NSPanel {
         // keyDown never fires. Catch Enter/Esc here and route them so they never fall on the
         // floor. When the MotionPanel *is* key, defer to its keyDown (don't double-handle).
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            // Stand down while the New Layer panel is up — it owns the keyboard (text field).
-            guard let self, self.exposed, !self.isKeyWindow, self.newLayerPanel == nil else { return event }
+            // Stand down while the New Layer panel, rule panel, or command bar is up — they own
+            // the keyboard (text field).
+            guard let self, self.exposed, !self.isKeyWindow,
+                  self.newLayerPanel == nil, self.rulePanel == nil, self.commandPanel == nil else { return event }
             switch event.keyCode {
             case 53:
                 if self.dragModel.isPlacing { self.dragModel.endPlacing() } else { self.undoAndExit() }
@@ -477,6 +498,17 @@ private final class MotionPanel: NSPanel {
     }
 
     func dismiss() {
+        // Mark dead FIRST. A rapid hotkey re-fire can land a deactivate while the
+        // async survey capture / first-paint from the *previous* activate is still
+        // in flight. Those callbacks check `exposed` and self-heal via
+        // rebuildExposeView() → installExposeHosts() — which, after teardown, would
+        // resurrect the survey panels on a controller we no longer track (no key
+        // monitor, no resign observer). That's the "Hyperspace stuck on top, esc /
+        // quit / hotkey do nothing" trap. Clearing `exposed` + `dismissed` makes
+        // every late callback a no-op so nothing can come back.
+        dismissed = true
+        exposed = false
+        ignoresMouseEvents = false
         if let keyObserver { NotificationCenter.default.removeObserver(keyObserver) }
         keyObserver = nil
         if let scrollMonitor { NSEvent.removeMonitor(scrollMonitor) }
@@ -487,9 +519,24 @@ private final class MotionPanel: NSPanel {
         keyMonitor = nil
         newLayerPanel?.close()
         newLayerPanel = nil
+        rulePanel?.close()
+        rulePanel = nil
+        commandPanel?.close()
+        commandPanel = nil
         animators.values.forEach { $0.cancel() }
         removeExposeHost()
         orderOut(nil)
+    }
+
+    /// Force every Hyperspace overlay panel off screen — even ones no live
+    /// controller still tracks. Used as the recovery sweep so the toggle hotkey
+    /// can always clear a survey that a prior race left orphaned (no key monitor,
+    /// no resign observer) and stuck on top. Cheap; runs only on activate/deactivate.
+    static func teardownStrayPanels() {
+        for window in NSApp.windows where window is HyperspaceScreenPanel || window is MotionPanel {
+            window.orderOut(nil)
+            window.close()
+        }
     }
 
     override func mouseDown(with event: NSEvent) {
@@ -592,7 +639,8 @@ private final class MotionPanel: NSPanel {
 
     override func keyDown(with event: NSEvent) {
         let code = event.keyCode
-        if code == 53 {                                     // Esc — close the placement stage first, else leave
+        if code == 53 {                                     // Esc — close inspector / placement stage first, else leave
+            if dragModel.selectedLayer != nil { dragModel.selectedLayer = nil; return }
             if dragModel.isPlacing { dragModel.endPlacing(); return }
             undoAndExit(); return
         }
@@ -652,6 +700,9 @@ private final class MotionPanel: NSPanel {
             case 27: zoomCanvasStep(-0.2); return                           // −      — zoom out
             case 29:
                 if let eventScreen { canvasForScreen(eventScreen).reset() }  // 0      — reset to fit
+                return
+            case 44:                                                         // / — curated command bar
+                if let eventScreen { presentCommandBar(on: eventScreen) }
                 return
             default:
                 let ch = event.charactersIgnoringModifiers?.lowercased()
@@ -773,7 +824,7 @@ private final class MotionPanel: NSPanel {
         let picked = orderedGroup()
         guard !picked.isEmpty else { NSSound.beep(); return }
         let layer = StudioLayerStore.shared.saveFromPluck(picked)
-        DiagnosticLog.shared.info("Motion — saved \(picked.count) plucked windows as layer '\(layer.name)' [\(layer.summary)]")
+        DiagnosticLog.shared.info("Motion — saved \(picked.count) selected windows as layer '\(layer.name)' [\(layer.summary)]")
         LayerBezel.shared.show(label: "Saved · \(layer.name)", index: 0, total: 1, allLabels: ["Saved · \(layer.name)"])
     }
 
@@ -1068,6 +1119,72 @@ private final class MotionPanel: NSPanel {
         rebuildExposeView()
     }
 
+    /// Edit mode: drop one rule clause from a layer (the ✕ on a pile's rule chip).
+    /// Writes straight through to StudioLayerStore — these are committed rules, not
+    /// staged intents. A layer whose last rule is removed is deleted (a ruleless
+    /// layer matches nothing). The band rebuilds so the pile preview re-resolves.
+    private func removeLayerClause(_ layerId: String, _ clauseIndex: Int) {
+        let store = StudioLayerStore.shared
+        guard var layer = store.layers.first(where: { $0.id == layerId }),
+              layer.match.indices.contains(clauseIndex) else { return }
+        layer.match.remove(at: clauseIndex)
+        if layer.match.isEmpty {
+            store.delete(id: layerId)
+        } else {
+            store.update(layer)
+        }
+        DiagnosticLog.shared.info("Hyperspace edit — layer \(layer.name) dropped clause \(clauseIndex)")
+        rebuildExposeView()
+    }
+
+    /// Edit mode: write a new or edited rule clause from the Hyperspace inspector.
+    private func saveLayerClause(_ layerId: String, _ clauseIndex: Int?, _ clause: StudioLayerClause) {
+        let store = StudioLayerStore.shared
+        guard var layer = store.layers.first(where: { $0.id == layerId }) else { return }
+        if let clauseIndex, layer.match.indices.contains(clauseIndex) {
+            layer.match[clauseIndex] = clause
+            DiagnosticLog.shared.info("Hyperspace edit — layer \(layer.name) updated clause \(clauseIndex)")
+        } else {
+            layer.match.append(clause)
+            DiagnosticLog.shared.info("Hyperspace edit — layer \(layer.name) added clause [\(clause.summary)]")
+        }
+        store.update(layer)
+        rebuildExposeView()
+    }
+
+    private func presentLayerRuleEditor(_ layerId: String, _ clauseIndex: Int?, _ clause: StudioLayerClause, on screen: NSScreen) {
+        guard exposed, rulePanel == nil,
+              let layer = StudioLayerStore.shared.layers.first(where: { $0.id == layerId }) else { return }
+        ignoreResign = true
+        let panel = LayerRulePanel(
+            layerName: layer.name,
+            clauseIndex: clauseIndex,
+            clause: clause,
+            onSave: { [weak self] saved in
+                guard let self else { return }
+                self.saveLayerClause(layerId, clauseIndex, saved)
+                self.finishLayerRuleEditor()
+            },
+            onCancel: { [weak self] in self?.finishLayerRuleEditor() }
+        )
+        rulePanel = panel
+        panel.present(on: screen)
+    }
+
+    private func finishLayerRuleEditor() {
+        rulePanel = nil
+        ignoreResign = false
+        makeKey()
+    }
+
+    /// Edit mode: delete a whole layer (the "Delete layer" item in a pile's right-click menu).
+    private func deleteLayer(_ layerId: String) {
+        let name = StudioLayerStore.shared.layers.first(where: { $0.id == layerId })?.name ?? layerId
+        StudioLayerStore.shared.delete(id: layerId)
+        DiagnosticLog.shared.info("Hyperspace edit — deleted layer \(name)")
+        rebuildExposeView()
+    }
+
     /// The ＋ pile's authoring flow: open the New Layer panel seeded with the apps on the active
     /// display (the plucked apps preselected, if any), let the user name it and pick which apps
     /// define it, then write a rule-backed StudioLayer. A real flow vs the drag-onto-＋ quick path.
@@ -1096,7 +1213,7 @@ private final class MotionPanel: NSPanel {
             candidates: candidates, preselected: pluckedApps, defaultName: defaultName,
             onCreate: { [weak self] name, apps in
                 guard let self else { return }
-                let clauses = apps.map { StudioLayerClause(app: $0, titleContains: nil) }
+                let clauses = apps.map { StudioLayerClause(appEquals: $0) }
                 let layer = StudioLayerStore.shared.add(
                     name: name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "Layer" : name,
                     match: clauses.isEmpty ? [StudioLayerClause()] : clauses)
@@ -1144,8 +1261,8 @@ private final class MotionPanel: NSPanel {
             }
             let stagedCount = stagedIntents.values.filter { $0.layers.contains(layer.id) }.count
             return ExposeView.LayerPile(id: layer.id, name: layer.name, count: onScreen.count,
-                                        members: members, rule: layer.summary, isNew: false,
-                                        staged: stagedCount > 0, stagedCount: stagedCount)
+                                        members: members, rule: layer.summary, clauses: layer.match,
+                                        isNew: false, staged: stagedCount > 0, stagedCount: stagedCount)
         }
         let newCount = stagedIntents.values.filter { $0.newLayer }.count
         piles.append(ExposeView.LayerPile(id: HyperspaceDrag.newLayerKey, name: "new", count: 0,
@@ -1211,15 +1328,28 @@ private final class MotionPanel: NSPanel {
         }
     }
 
-    /// Add an app clause to a layer's rule so it (and future windows of that app)
-    /// join the layer. Rule-backed membership — coarse by design, like saveFromPluck.
+    /// Add an exact app clause to a layer's rule so it (and future windows of that
+    /// app) join the layer.
     /// No-op if the layer already matches the app.
     private func addAppToLayer(_ app: String, layerID: String) {
         let store = StudioLayerStore.shared
         guard var layer = store.layers.first(where: { $0.id == layerID }) else { return }
-        let already = layer.match.contains { $0.titleContains == nil && $0.app?.localizedCaseInsensitiveCompare(app) == .orderedSame }
+        let already = layer.match.contains { clause in
+            let appOnly = clause.titleContains == nil
+                && clause.titleEquals == nil
+                && clause.titleRegex == nil
+                && clause.session == nil
+                && clause.sessionContains == nil
+                && clause.isOnScreen == nil
+                && clause.spaceId == nil
+                && (clause.not?.isEmpty ?? true)
+            let sameExactApp = clause.appEquals?.localizedCaseInsensitiveCompare(app) == .orderedSame
+            let sameLegacyApp = clause.app?.localizedCaseInsensitiveCompare(app) == .orderedSame
+                && clause.appRegex == nil
+            return appOnly && (sameExactApp || sameLegacyApp)
+        }
         guard !already else { return }
-        layer.match.append(StudioLayerClause(app: app, titleContains: nil))
+        layer.match.append(StudioLayerClause(appEquals: app))
         store.update(layer)
         DiagnosticLog.shared.info("Hyperspace commit — layer '\(layer.name)' += app '\(app)'")
     }
@@ -1517,6 +1647,7 @@ private final class MotionPanel: NSPanel {
     // MARK: - Survey overlay (SwiftUI spread)
 
     private func installExposeHosts() {
+        guard !dismissed else { return }   // never re-create panels after teardown (orphan guard)
         removeExposeHost()
         for screen in surveyScreens() {
             let id = MotionPanel.screenID(screen)
@@ -1612,6 +1743,10 @@ private final class MotionPanel: NSPanel {
                 },
                 onExit: { [weak self] in self?.onExit?() },   // ✕ — leave, keep what's on screen
                 onNewLayer: { [weak self] in self?.presentNewLayer() },
+                onRecallLayer: { [weak self] id in self?.pluckLayer(id, on: screen) },
+                onEditClause: { [weak self] id, idx, clause in self?.presentLayerRuleEditor(id, idx, clause, on: screen) },
+                onRemoveClause: { [weak self] id, idx in self?.removeLayerClause(id, idx) },
+                onDeleteLayer: { [weak self] id in self?.deleteLayer(id) },
                 loadSummary: loadSummaryText())
         }
     }
@@ -1748,6 +1883,78 @@ private final class MotionPanel: NSPanel {
         rebuildExposeView()
         updateLegend()
         updateStack()
+    }
+
+    // MARK: - Command bar (/)
+
+    /// Open the curated `/` palette for one monitor: search its windows, target a
+    /// group/layer (⏎ plucks), or /tile to stage a placement. Snapshots this screen's
+    /// windows/clusters/layers and wires each verb to the survey's own selection path.
+    private func presentCommandBar(on screen: NSScreen) {
+        guard commandPanel == nil else { return }
+        let id = MotionPanel.screenID(screen)
+        let windows = surveyMembers(on: screen).map {
+            HyperspaceCommandModel.WindowItem(wid: $0.wid, title: $0.title.isEmpty ? $0.app : $0.title, app: $0.app)
+        }
+        let hintFor = clusterHintForByScreen[id] ?? [:]
+        let groups = (exposeClustersByScreen[id] ?? []).map { cluster in
+            HyperspaceCommandModel.GroupItem(cid: cluster.id, name: cluster.name,
+                                             hint: hintFor[cluster.id] ?? "", members: cluster.members.map(\.wid))
+        }
+        let store = StudioLayerStore.shared
+        let layers = store.layers.map { layer in
+            HyperspaceCommandModel.LayerItem(lid: layer.id, name: layer.name,
+                                             members: store.resolve(layer).filter { self.entry($0, isOn: screen) }.map(\.wid))
+        }
+        let model = HyperspaceCommandModel(windows: windows, groups: groups, layers: layers)
+        model.onPluckWindow = { [weak self] wid in self?.exposeToggle(wid, on: screen) }
+        model.onPluckGroup  = { [weak self] cid in self?.exposeToggleCluster(cid, on: screen) }
+        model.onRecallLayer = { [weak self] lid in self?.pluckLayer(lid, on: screen) }
+        model.onTile        = { [weak self] gp  in self?.stageTileForSelection(gp, on: screen) }
+        model.onSaveLayer   = { [weak self] in self?.saveGroupAsLayer() }
+        model.pluckedProvider = { [weak self] in self?.pickOrderByScreen[id] ?? [] }
+        let panel = HyperspaceCommandPanel(model: model, onClose: { [weak self] in self?.dismissCommandBar() })
+        commandPanel = panel
+        ignoreResign = true                 // the bar takes key → our key-resign must NOT exit the survey
+        panel.present(on: screen)
+    }
+
+    private func dismissCommandBar() {
+        commandPanel?.close()
+        commandPanel = nil
+        ignoreResign = false
+        makeKey()                           // reclaim key so the survey keeps responding
+    }
+
+    /// Select every on-screen window a layer's rule resolves to — the survey-native
+    /// read of "recall this layer": it builds the selection (nothing raises), and
+    /// gather (⏎/G) is still the only real move.
+    private func pluckLayer(_ layerID: String, on screen: NSScreen) {
+        let store = StudioLayerStore.shared
+        guard let layer = store.layers.first(where: { $0.id == layerID }) else { NSSound.beep(); return }
+        let members = store.resolve(layer).filter { entry($0, isOn: screen) }
+        guard !members.isEmpty else { NSSound.beep(); return }
+        let id = MotionPanel.screenID(screen)
+        var order = pickOrderByScreen[id] ?? []
+        for w in members where !order.contains(w.wid) {
+            order.append(w.wid)
+            if let e = eligible.first(where: { $0.wid == w.wid }) { _ = ax(for: e) }
+        }
+        pickOrderByScreen[id] = order
+        if activeSurveyScreen.map(MotionPanel.screenID) != id { setActiveSurveyScreen(screen) }
+        else { restorePickState(for: screen) }
+        rebuildExposeView(); updateLegend(); updateStack()
+    }
+
+    /// Stage a named placement for the plucked set on this screen — the same staging
+    /// a drag onto the Grid does. Nothing moves until gather (⏎/G).
+    private func stageTileForSelection(_ gp: GridPlacement, on screen: NSScreen) {
+        let id = MotionPanel.screenID(screen)
+        let picked = pickOrderByScreen[id] ?? []
+        guard !picked.isEmpty else { NSSound.beep(); return }
+        let spec = PlacementSpec.grid(gp)
+        for wid in picked { handleDrop(wid, spec) }
+        rebuildExposeView()
     }
 
     // MARK: - Display-scoped survey
@@ -2265,7 +2472,7 @@ private struct MotionLegend: View {
             Rectangle().fill(Palette.border).frame(width: 1, height: 13)
 
             if exposed {
-                keyHint("a–z", "pluck")
+                keyHint("a–z", "select")
                 keyHint("⇧a–z", "group")
                 keyHint("Tab", "aim")
                 keyHint("⌘scroll", "zoom")
@@ -2275,7 +2482,7 @@ private struct MotionLegend: View {
                 keyHint("esc", "cancel")
             } else {
                 keyHint("Tab", "aim")
-                keyHint("Space", "pluck")
+                keyHint("Space", "select")
                 keyHint("E", "expose")
                 keyHint("G", "grid")
                 if groupCount > 0 { keyHint("⌘L", "save layer") }
@@ -2663,6 +2870,7 @@ struct ExposeView: View {
         let count: Int                       // members on the active screen
         var members: [LayerMember] = []      // for the screen-map preview
         var rule: String = ""                // human-readable match rule, e.g. "Chrome · ~dev"
+        var clauses: [StudioLayerClause] = []// structured rules, for edit-mode removal
         var isNew: Bool = false
         var staged: Bool = false
         var stagedCount: Int = 0             // how many windows are staged to join this pile
@@ -2698,6 +2906,10 @@ struct ExposeView: View {
     var onHandKeys: (Bool) -> Void = { _ in }
     var onExit: () -> Void = { }              // mouse-driven leave (the ✕ button)
     var onNewLayer: () -> Void = { }          // tap the ＋ pile → open the New Layer authoring flow
+    var onRecallLayer: (String) -> Void = { _ in } // add every live match to the survey selection
+    var onEditClause: (String, Int?, StudioLayerClause) -> Void = { _, _, _ in }
+    var onRemoveClause: (String, Int) -> Void = { _, _ in }  // edit mode: drop a rule clause (layerId, clauseIndex)
+    var onDeleteLayer: (String) -> Void = { _ in }           // edit mode: delete a whole layer (layerId)
     var loadSummary: String = ""
 
     private let ink = Color(red: 0.02, green: 0.03, blue: 0.05)
@@ -2775,6 +2987,12 @@ struct ExposeView: View {
                 planSummaryBar.padding(.top, bandHeight + 4)   // sits just under the intent band
             }
         }
+        .overlay {
+            if let id = drag.selectedLayer, let pile = layers.first(where: { $0.id == id }) {
+                layerInspector(pile).transition(.opacity)
+            }
+        }
+        .animation(.easeOut(duration: 0.16), value: drag.selectedLayer)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
@@ -3362,22 +3580,27 @@ struct ExposeView: View {
     private var intentBand: some View {
         // Two slots: Layers (pick/tag) · Grid (drop a position). No preview canvas — the survey
         // *is* the preview: a staged move badges its tile, and hovering a layer lights its windows
-        // in place. Centred. design/hyperspace-drag-drop.md
-        HStack(alignment: .top, spacing: 14) {
-            layersSection.frame(width: layersWidth)
-            gridSection.frame(width: gridWidth)
+        // in place. Each panel is a predictable 20% of the display width, the pair centred with a
+        // proportional gap. design/hyperspace-drag-drop.md
+        GeometryReader { geo in
+            let panelW = (geo.size.width * 0.20).rounded()
+            let gap    = (geo.size.width * 0.03).rounded()
+            HStack(alignment: .top, spacing: gap) {
+                layersSection.frame(width: panelW)
+                gridSection.frame(width: panelW)
+            }
+            .frame(maxWidth: .infinity)        // centre the cluster (not full-bleed)
+            .padding(.top, 16)
+            .padding(.bottom, 8)
         }
-        .frame(maxWidth: .infinity)        // centre the cluster (not full-bleed)
-        .padding(.top, 16)
-        .padding(.bottom, 8)
     }
 
-    // The Layers list hugs its pile count; Grid is a fixed, comfortable drop target.
-    private var layersWidth: CGFloat {
-        let pileSlot: CGFloat = 90
-        return min(max(CGFloat(min(max(layers.count, 1), 3)) * pileSlot + 24, 220), 340)
+    // Layer piles chunked into rows of two for the 2×N band grid (＋ pile trails last).
+    private var layerRows: [[LayerPile]] {
+        stride(from: 0, to: layers.count, by: 2).map {
+            Array(layers[$0 ..< min($0 + 2, layers.count)])
+        }
     }
-    private var gridWidth: CGFloat { 320 }
 
     // A not-yet-live section — visible so the three-axis model reads, dimmed so it's
     // clearly inert. Replaced by real piles / a Spaces strip in later phases.
@@ -3411,14 +3634,31 @@ struct ExposeView: View {
                     Text("\(max(0, layers.count - 1)) \(layers.count - 1 == 1 ? "layer" : "layers")")
                         .font(Typo.mono(9)).foregroundColor(.white.opacity(0.55))
                     Spacer(minLength: 6)
-                    Text("hover → preview · drop to tag")
-                        .font(Typo.mono(8.5)).foregroundColor(.white.opacity(0.35))
+                    Button(action: onNewLayer) {
+                        Image(systemName: "plus")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundColor(Palette.bg)
+                            .frame(width: 22, height: 22)
+                            .background(RoundedRectangle(cornerRadius: 6, style: .continuous).fill(Palette.running))
+                    }
+                    .buttonStyle(.plain)
+                    .help("New layer")
                 }
-                FlowLayout(spacing: 10, lineSpacing: 10, alignment: .leading) {
-                    ForEach(layers) { layerPileView($0) }
+                // Fixed 2-wide grid: layers fill row-major and the ＋ pile trails as the
+                // next free cell ([L1][＋] → [L1][L2]/[＋] → …). Eager VStack/HStack — not a
+                // lazy grid — so every pile reports its LayerFrameKey for drag hit-testing.
+                GeometryReader { geo in
+                    let pileW = max(104, min(220, ((geo.size.width - 10) / 2).rounded()))
+                    VStack(alignment: .leading, spacing: 10) {
+                        ForEach(layerRows.indices, id: \.self) { r in
+                            HStack(alignment: .top, spacing: 10) {
+                                ForEach(layerRows[r]) { layerPileView($0, mapW: pileW) }
+                            }
+                        }
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .onPreferenceChange(LayerFrameKey.self) { drag.layerFrames[screenID] = $0 }
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                .onPreferenceChange(LayerFrameKey.self) { drag.layerFrames[screenID] = $0 }
             }
         }
     }
@@ -3436,17 +3676,16 @@ struct ExposeView: View {
     // you read what the layer looks like at a glance (design/hyperspace-drag-drop.md). The
     // full-size formation renders in the middle Preview on hover / drop. Lights as a drop
     // target and stays tinted while it holds a staged join. ＋ = a new-layer drop slot.
-    private func layerPileView(_ pile: LayerPile) -> some View {
+    private func layerPileView(_ pile: LayerPile, mapW: CGFloat = 104) -> some View {
         let lit = dragOnThisScreen && drag.hoverLayer == pile.id
         let on = lit || pile.staged
-        let mapW: CGFloat = 104
         let mapH = layerMapHeight(for: mapW)
         return VStack(spacing: 4) {
             Group {
                 if pile.isNew {
                     ZStack {
                         RoundedRectangle(cornerRadius: 7, style: .continuous)
-                            .fill(on ? Palette.running.opacity(0.9) : Color.white.opacity(0.05))
+                            .fill(on ? HUDChrome.cyan.opacity(0.9) : Color.white.opacity(0.05))
                         Image(systemName: "plus")
                             .font(.system(size: 18, weight: .semibold))
                             .foregroundColor(on ? Palette.bg : .white.opacity(0.6))
@@ -3458,7 +3697,7 @@ struct ExposeView: View {
             }
             .overlay(                                       // the "monitor" bezel
                 RoundedRectangle(cornerRadius: 7, style: .continuous)
-                    .strokeBorder(on ? Palette.running : Palette.border, lineWidth: on ? 1.5 : 0.5)
+                    .strokeBorder(on ? HUDChrome.cyan : Palette.border, lineWidth: on ? 1.5 : 0.5)
             )
             .overlay(alignment: .topTrailing) {
                 if !pile.isNew && pile.count > 0 {
@@ -3482,17 +3721,304 @@ struct ExposeView: View {
             Text(pile.isNew ? "new" : pile.name)
                 .font(Typo.mono(9)).foregroundColor(.white.opacity(on ? 0.9 : 0.65))
                 .lineLimit(1).frame(maxWidth: mapW)
+            layerPileMeta(pile, active: on, width: mapW)
         }
         .animation(.spring(response: 0.3, dampingFraction: 0.7), value: pile.stagedCount)
         .scaleEffect(lit ? 1.06 : 1)
-        .shadow(color: lit ? Palette.running.opacity(0.5) : .clear, radius: lit ? 8 : 0)
+        .shadow(color: lit ? HUDChrome.cyan.opacity(0.5) : .clear, radius: lit ? 8 : 0)
         .animation(.spring(response: 0.24, dampingFraction: 0.72), value: lit)
         .background(layerFrameReporter(pile.id))     // hit-test = the compact footprint
         .onHover { hovering in
             if hovering { drag.inspectLayer = pile.id; drag.inspectScreen = screenID }
             else if drag.inspectLayer == pile.id { drag.inspectLayer = nil; drag.inspectScreen = nil }
         }
-        .onTapGesture { if pile.isNew { onNewLayer() } }   // ＋ → author a new layer (name it, pick apps)
+        .onTapGesture {                                    // ＋ → author a new layer; else open the inspector
+            if pile.isNew { onNewLayer() } else { drag.selectedLayer = pile.id }
+        }
+        .contextMenu { layerPileMenu(pile) }               // right-click → inspect / remove rules, delete layer
+    }
+
+    // Right-click menu for a layer pile: see each rule, what it currently matches, and
+    // remove it — plus delete the whole layer. The rules are the committed StudioLayer
+    // clauses (the same ones the Studio panel and, later, the agent edit). Empty for the
+    // ＋ pile (it has no layer yet).
+    @ViewBuilder
+    private func layerPileMenu(_ pile: LayerPile) -> some View {
+        if !pile.isNew {
+            Text(pile.name)
+            Divider()
+            Button("Select matching windows") {
+                onRecallLayer(pile.id)
+            }
+            Divider()
+            if pile.clauses.isEmpty {
+                Text("No rules")
+            } else {
+                ForEach(Array(pile.clauses.enumerated()), id: \.offset) { idx, clause in
+                    let matches = DesktopModel.shared.allWindows().filter { clause.matches($0) }
+                    Menu("\(clauseTitle(clause))  ·  \(matches.count)") {
+                        if matches.isEmpty {
+                            Text("No live windows match")
+                        } else {
+                            ForEach(matches.prefix(12), id: \.wid) { w in
+                                Text(w.title.isEmpty ? w.app : "\(w.app) — \(w.title)")
+                            }
+                            if matches.count > 12 { Text("+\(matches.count - 12) more") }
+                        }
+                        Divider()
+                        Button("Remove this rule", role: .destructive) { onRemoveClause(pile.id, idx) }
+                    }
+                }
+            }
+            Divider()
+            Button("Delete layer “\(pile.name)”", role: .destructive) { onDeleteLayer(pile.id) }
+        }
+    }
+
+    // A rule clause as a readable menu label.
+    private func clauseTitle(_ clause: StudioLayerClause) -> String {
+        clause.summary
+    }
+
+    private func layerPileMeta(_ pile: LayerPile, active: Bool, width: CGFloat) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: pile.isNew ? "plus.square" : "line.3.horizontal.decrease.circle")
+                .font(.system(size: 7.5, weight: .semibold))
+            if pile.isNew {
+                Text("create")
+            } else {
+                Text("\(pile.clauses.count) rule\(pile.clauses.count == 1 ? "" : "s")")
+                if pile.count == 0 {
+                    Text("empty")
+                        .foregroundColor(Palette.detach.opacity(active ? 0.9 : 0.65))
+                }
+            }
+        }
+        .font(Typo.mono(7.5))
+        .foregroundColor(active ? Palette.running : .white.opacity(0.38))
+        .lineLimit(1)
+        .frame(maxWidth: width)
+    }
+
+    // MARK: - Layer inspector (click a pile to open)
+    //
+    // A top-area modal: the layer's match rules on the left, the windows they currently
+    // resolve to on the right (a table). Backdrop tap / ✕ / esc closes it. Rules are the
+    // committed StudioLayer clauses — editable in place (remove), the live source of truth.
+    @ViewBuilder
+    private func layerInspector(_ pile: LayerPile) -> some View {
+        let allWindows = DesktopModel.shared.allWindows()
+        let windows = allWindows.filter { w in pile.clauses.contains { $0.matches(w) } }
+        GeometryReader { geo in
+            let panelW = min(760, max(440, geo.size.width * 0.55))
+            let panelH = min(440, max(260, geo.size.height * 0.52))
+            ZStack(alignment: .top) {
+                Color.black.opacity(0.5)
+                    .ignoresSafeArea()
+                    .contentShape(Rectangle())
+                    .onTapGesture { drag.selectedLayer = nil }
+                inspectorPanel(pile, windows: windows, allWindows: allWindows)
+                    .frame(width: panelW, height: panelH)
+                    .padding(.top, max(24, geo.size.height * 0.12))
+            }
+            .frame(width: geo.size.width, height: geo.size.height)
+        }
+    }
+
+    private func inspectorPanel(_ pile: LayerPile, windows: [WindowEntry], allWindows: [WindowEntry]) -> some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 8) {
+                Image(systemName: "square.stack.3d.up")
+                    .font(.system(size: 12, weight: .semibold)).foregroundColor(HUDChrome.cyan)
+                Text(pile.name).font(Typo.monoBold(14)).foregroundColor(.white)
+                Text("\(windows.count) window\(windows.count == 1 ? "" : "s")")
+                    .font(Typo.mono(10)).foregroundColor(.white.opacity(0.5))
+                Spacer()
+                Button {
+                    onRecallLayer(pile.id)
+                    drag.selectedLayer = nil
+                } label: {
+                    HStack(spacing: 5) {
+                        Image(systemName: "scope")
+                            .font(.system(size: 10, weight: .semibold))
+                        Text("Select")
+                            .font(Typo.monoBold(10))
+                    }
+                    .foregroundColor(Palette.bg)
+                    .padding(.horizontal, 9)
+                    .padding(.vertical, 5)
+                    .background(Capsule().fill(Palette.running))
+                }
+                .buttonStyle(.plain)
+                .disabled(windows.isEmpty)
+                .opacity(windows.isEmpty ? 0.4 : 1)
+                .help("Select matching windows")
+                Button { drag.selectedLayer = nil } label: {
+                    Image(systemName: "xmark").font(.system(size: 11, weight: .bold))
+                        .foregroundColor(.white.opacity(0.6)).contentShape(Rectangle())
+                }.buttonStyle(.plain)
+            }
+            .padding(.horizontal, 16).padding(.vertical, 12)
+            Rectangle().fill(Palette.border).frame(height: 0.5)
+            inspectorSummary(pile, windows: windows)
+            Rectangle().fill(Palette.border).frame(height: 0.5)
+            HStack(alignment: .top, spacing: 0) {
+                inspectorRules(pile, allWindows: allWindows).frame(width: 240)
+                Rectangle().fill(Palette.border).frame(width: 0.5)
+                inspectorWindows(windows).frame(maxWidth: .infinity)
+            }
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(.ultraThinMaterial)
+                .overlay(RoundedRectangle(cornerRadius: 16, style: .continuous).fill(Color.black.opacity(0.35)))
+        )
+        .overlay(RoundedRectangle(cornerRadius: 16, style: .continuous).strokeBorder(Palette.borderLit, lineWidth: 1))
+        .shadow(color: .black.opacity(0.5), radius: 24, y: 10)
+    }
+
+    private func inspectorSummary(_ pile: LayerPile, windows: [WindowEntry]) -> some View {
+        HStack(spacing: 8) {
+            inspectorMetric("rules", "\(pile.clauses.count)")
+            inspectorMetric("live", "\(windows.count)")
+            inspectorMetric("screen", "\(pile.count)")
+            Text(pile.rule.isEmpty ? "no rule" : pile.rule)
+                .font(Typo.mono(9))
+                .foregroundColor(.white.opacity(0.5))
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .background(Color.black.opacity(0.14))
+    }
+
+    private func inspectorMetric(_ label: String, _ value: String) -> some View {
+        HStack(spacing: 4) {
+            Text(label).foregroundColor(.white.opacity(0.38))
+            Text(value).foregroundColor(.white.opacity(0.82))
+        }
+        .font(Typo.monoBold(9))
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .background(
+            RoundedRectangle(cornerRadius: 5, style: .continuous)
+                .fill(Color.white.opacity(0.05))
+                .overlay(RoundedRectangle(cornerRadius: 5, style: .continuous).strokeBorder(Palette.border, lineWidth: 0.5))
+        )
+    }
+
+    // Left column: the layer's match rules, each removable.
+    private func inspectorRules(_ pile: LayerPile, allWindows: [WindowEntry]) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 8) {
+                Text("RULES").font(Typo.monoBold(9)).foregroundColor(.white.opacity(0.4)).tracking(0.5)
+                Spacer()
+                Button {
+                    onEditClause(pile.id, nil, StudioLayerClause())
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundColor(Palette.bg)
+                        .frame(width: 18, height: 18)
+                        .background(RoundedRectangle(cornerRadius: 5, style: .continuous).fill(Palette.running))
+                }
+                .buttonStyle(.plain)
+                .help("Add rule")
+            }
+            .padding(.horizontal, 14).padding(.vertical, 8)
+            Rectangle().fill(Palette.border).frame(height: 0.5)
+            if pile.clauses.isEmpty {
+                Text("No rules — matches nothing")
+                    .font(Typo.mono(11)).foregroundColor(.white.opacity(0.4)).padding(14)
+            } else {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(Array(pile.clauses.enumerated()), id: \.offset) { idx, clause in
+                        inspectorRuleRow(clause, count: allWindows.filter { clause.matches($0) }.count) {
+                            onEditClause(pile.id, idx, clause)
+                        } remove: {
+                            onRemoveClause(pile.id, idx)
+                        }
+                    }
+                }
+                .padding(12)
+            }
+            Spacer(minLength: 0)
+        }
+        .frame(maxHeight: .infinity, alignment: .top)
+    }
+
+    private func inspectorRuleRow(
+        _ clause: StudioLayerClause,
+        count: Int,
+        edit: @escaping () -> Void,
+        remove: @escaping () -> Void
+    ) -> some View {
+        return HStack(alignment: .top, spacing: 6) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(clause.summary)
+                    .font(Typo.mono(10))
+                    .foregroundColor(clause.not?.isEmpty == false ? Palette.detach : .white.opacity(0.85))
+                    .lineLimit(2)
+                Text("\(count) live match\(count == 1 ? "" : "es")")
+                    .font(Typo.mono(8))
+                    .foregroundColor(count == 0 ? Palette.detach.opacity(0.72) : .white.opacity(0.38))
+            }
+            Spacer(minLength: 4)
+            Button(action: edit) {
+                Image(systemName: "pencil").font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(.white.opacity(0.45)).contentShape(Rectangle())
+            }.buttonStyle(.plain).help("Edit rule")
+            Button(action: remove) {
+                Image(systemName: "xmark.circle.fill").font(.system(size: 11))
+                    .foregroundColor(.white.opacity(0.35)).contentShape(Rectangle())
+            }.buttonStyle(.plain).help("Remove this rule")
+        }
+        .padding(.horizontal, 10).padding(.vertical, 7)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Color.white.opacity(0.05))
+                .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(Palette.border, lineWidth: 0.5))
+        )
+    }
+
+    // Right column: the windows the rules currently resolve to — a simple app/title table.
+    private func inspectorWindows(_ windows: [WindowEntry]) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 8) {
+                Text("APP").frame(width: 84, alignment: .leading)
+                Text("WINDOW").frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .font(Typo.monoBold(9)).foregroundColor(.white.opacity(0.4)).tracking(0.5)
+            .padding(.horizontal, 14).padding(.vertical, 8)
+            Rectangle().fill(Palette.border).frame(height: 0.5)
+            if windows.isEmpty {
+                Text("No live windows match")
+                    .font(Typo.mono(11)).foregroundColor(.white.opacity(0.4)).padding(14)
+                Spacer(minLength: 0)
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(windows, id: \.wid) { w in
+                            HStack(spacing: 8) {
+                                HStack(spacing: 6) {
+                                    Circle().fill(Color(nsColor: MotionPanel.tint(for: w.app)))
+                                        .frame(width: 6, height: 6)
+                                    Text(w.app).font(Typo.mono(10)).foregroundColor(.white.opacity(0.7)).lineLimit(1)
+                                }
+                                .frame(width: 84, alignment: .leading)
+                                Text(w.title.isEmpty ? "—" : w.title)
+                                    .font(Typo.mono(10)).foregroundColor(.white.opacity(0.85))
+                                    .frame(maxWidth: .infinity, alignment: .leading).lineLimit(1)
+                            }
+                            .padding(.horizontal, 14).padding(.vertical, 6)
+                            Rectangle().fill(Palette.border.opacity(0.5)).frame(height: 0.5)
+                        }
+                    }
+                }
+            }
+        }
+        .frame(maxHeight: .infinity, alignment: .top)
     }
 
     // Map height for a given width — the active screen's aspect, clamped so a very wide
@@ -3747,11 +4273,11 @@ struct ExposeView: View {
             HStack(spacing: 6) {
                 Image(systemName: icon)
                     .font(.system(size: 11, weight: .semibold))
-                    .foregroundColor(live ? Palette.running : .white.opacity(0.5))
+                    .foregroundColor(.white.opacity(live ? 0.85 : 0.5))
                 Text(title)
                     .font(Typo.monoBold(11)).foregroundColor(.white).tracking(0.3)
                 Text(sub)
-                    .font(Typo.mono(8.5)).foregroundColor(armed ? Palette.running : Palette.textMuted)
+                    .font(Typo.mono(8.5)).foregroundColor(armed ? HUDChrome.cyan : Palette.textMuted)
                 Spacer(minLength: 0)
             }
             content()
@@ -3760,14 +4286,15 @@ struct ExposeView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(armed ? Palette.running.opacity(0.14) : (live ? Palette.running.opacity(0.05) : Color.white.opacity(0.02)))
+                .fill(.ultraThinMaterial)                                  // frosted glass — opacity + blur, no colour wash
+                .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(armed ? HUDChrome.cyan.opacity(0.10) : Color.white.opacity(0.02)))
         )
         .overlay(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .strokeBorder(armed ? Palette.running.opacity(0.75) : (live ? Palette.running.opacity(0.30) : Palette.border),
-                              lineWidth: armed ? 1.5 : 1)
+                .strokeBorder(armed ? HUDChrome.cyan.opacity(0.5) : Palette.borderLit, lineWidth: armed ? 1.5 : 1)
         )
-        .shadow(color: armed ? Palette.running.opacity(0.35) : .clear, radius: armed ? 12 : 0)
+        .shadow(color: armed ? HUDChrome.cyan.opacity(0.22) : Color.black.opacity(0.3), radius: armed ? 12 : 14, y: 6)
         .animation(.easeOut(duration: 0.16), value: armed)
     }
 
@@ -3893,7 +4420,7 @@ struct ExposeView: View {
                                 .fill(c.userDefined ? Palette.running.opacity(0.8) : Color.white.opacity(0.16))
                                 .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Color.white.opacity(0.28), lineWidth: 0.5))
                         )
-                        .help("Pluck the whole \(c.name) group")
+                        .help("Select the whole \(c.name) group")
                 }
                 Text(c.name)
                     .font(Typo.monoBold(11)).foregroundColor(.white).tracking(0.3)
@@ -3919,11 +4446,11 @@ struct ExposeView: View {
         .padding(.horizontal, 11).padding(.top, 9).padding(.bottom, 11)
         .background(
             RoundedRectangle(cornerRadius: 13, style: .continuous)
-                .fill(c.userDefined ? Palette.running.opacity(0.04) : Color.white.opacity(0.018))
+                .fill(Color.white.opacity(c.userDefined ? 0.03 : 0.018))
         )
         .overlay(
             RoundedRectangle(cornerRadius: 13, style: .continuous)
-                .strokeBorder(c.userDefined ? Palette.running.opacity(0.32) : Palette.border, lineWidth: 1)
+                .strokeBorder(c.userDefined ? Palette.borderLit : Palette.border, lineWidth: 1)
         )
     }
 
@@ -3976,8 +4503,8 @@ struct ExposeView: View {
         let layerLit = inLayer == true
         let layerDimmed = inLayer == false
         let lit = t.isAimed || picked                          // on the spotlight's stage
-        let strokeColor: Color = staged ? Palette.running
-            : (picked ? t.tint : (t.isAimed ? Color.white.opacity(0.9) : Color.white.opacity(0.1)))
+        let strokeColor: Color = staged ? HUDChrome.cyan
+            : (picked ? HUDChrome.cyan : (t.isAimed ? Color.white.opacity(0.9) : Color.white.opacity(0.1)))
         let strokeW: CGFloat = staged ? 2 : (picked ? 2 : (t.isAimed ? 1.5 : 0.75))
         let veil: Double = lit ? 0 : spotlight * 0.5
         let bloom: Color = t.isAimed ? lightColor.opacity(0.7 * spotlight) : .clear
@@ -3986,7 +4513,7 @@ struct ExposeView: View {
             .overlay(shape.fill(Color.black.opacity(veil)))    // spotlight: off-stage tiles sink to shadow
             .overlay(shape.strokeBorder(strokeColor, lineWidth: strokeW))
             .overlay(alignment: .topTrailing) { hintChip(t) }
-            .overlay(alignment: .topLeading) { if let s = t.pickSlot { slotBadge(s, t.tint) } }
+            .overlay(alignment: .topLeading) { if let s = t.pickSlot { slotBadge(s, HUDChrome.cyan) } }
             .overlay(alignment: .bottomLeading) {
                 VStack(alignment: .leading, spacing: 3) {
                     if !t.layerTags.isEmpty { layerTagRow(t.layerTags) }
@@ -4003,7 +4530,7 @@ struct ExposeView: View {
             .animation(.spring(response: 0.3, dampingFraction: 0.62), value: t.layerTags)      // layer labels pop
             // While previewing a layer, this tile's windows ring on-brand and the rest sink.
             .overlay {
-                if layerLit { shape.strokeBorder(Palette.running, lineWidth: 2) }
+                if layerLit { shape.strokeBorder(HUDChrome.cyan, lineWidth: 2) }
             }
             // While this tile is the one being dragged, hollow it out so it keeps its
             // slot (no reflow) but reads as "lifted" — the ghost is what moves.
@@ -4011,12 +4538,12 @@ struct ExposeView: View {
             .overlay {
                 if beingDragged {
                     shape.strokeBorder(style: StrokeStyle(lineWidth: 1.5, dash: [5, 4]))
-                        .foregroundColor(Palette.running.opacity(0.8))
+                        .foregroundColor(HUDChrome.cyan.opacity(0.8))
                 }
             }
             .background(frameReporter(t.id))
             .shadow(color: .black.opacity(picked ? 0.5 : 0.35), radius: picked ? 14 : 8, x: 0, y: 5)
-            .shadow(color: layerLit ? Palette.running.opacity(0.55) : bloom, radius: layerLit ? 14 : bloomR)  // layer-lit / aimed tile glows
+            .shadow(color: layerLit ? HUDChrome.cyan.opacity(0.55) : bloom, radius: layerLit ? 14 : bloomR)  // layer-lit / aimed tile glows
             .contentShape(Rectangle())
             // Right-click → a menu of options (not a surprise action). Quick tile presets stage
             // immediately; "Place…" opens the life-size stage for a visual pick.
@@ -4033,9 +4560,9 @@ struct ExposeView: View {
     private func stagedBadge(_ text: String) -> some View {
         Text(text)
             .font(Typo.monoBold(9))
-            .foregroundColor(Palette.bg)
+            .foregroundColor(HUDChrome.onSignal)
             .padding(.horizontal, 5).padding(.vertical, 2)
-            .background(Capsule().fill(Palette.running))
+            .background(Capsule().fill(HUDChrome.cyan))
             .overlay(Capsule().strokeBorder(Color.white.opacity(0.4), lineWidth: 0.5))
             .padding(5)
     }
@@ -4044,7 +4571,7 @@ struct ExposeView: View {
     private func tileBody(_ t: Tile, w: CGFloat, h: CGFloat, shape: RoundedRectangle) -> some View {
         ZStack(alignment: .topLeading) {
             ZStack {
-                t.tint.opacity(0.16)
+                Color.white.opacity(0.04)
                 if let img = t.image {
                     Image(nsImage: img).resizable().aspectRatio(contentMode: .fill)
                 }
@@ -4052,8 +4579,8 @@ struct ExposeView: View {
             .frame(width: w, height: h)
             .clipShape(shape)
 
-            VStack(spacing: 0) {                                   // app-tint top accent
-                Rectangle().fill(t.tint).frame(height: 2)
+            VStack(spacing: 0) {                                   // a light top edge, not an app colour
+                Rectangle().fill(Color.white.opacity(0.12)).frame(height: 1)
                 Spacer(minLength: 0)
             }
         }
@@ -4106,14 +4633,14 @@ struct ExposeView: View {
             ForEach(Array(tags.prefix(3).enumerated()), id: \.offset) { _, tag in
                 Text(tag)
                     .font(Typo.monoBold(8))
-                    .foregroundColor(Palette.bg)
+                    .foregroundColor(HUDChrome.onSignal)
                     .lineLimit(1)
                     .padding(.horizontal, 4).padding(.vertical, 1.5)
-                    .background(Capsule().fill(Palette.running))
+                    .background(Capsule().fill(HUDChrome.cyan))
             }
             if tags.count > 3 {
                 Text("+\(tags.count - 3)")
-                    .font(Typo.monoBold(8)).foregroundColor(Palette.running)
+                    .font(Typo.monoBold(8)).foregroundColor(HUDChrome.cyan)
             }
         }
     }

--- a/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapView.swift
+++ b/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapView.swift
@@ -148,9 +148,12 @@ struct ScreenMapView: View {
 
     @ObservedObject var controller: ScreenMapController
     var onNavigate: ((AppPage) -> Void)? = nil
+    var studioLayerScopeId: String? = nil
+    var onClearStudioLayerScope: (() -> Void)? = nil
     @ObservedObject private var daemon = DaemonServer.shared
     @ObservedObject private var handsOff = HandsOffSession.shared
     @ObservedObject private var diagnosticLog = DiagnosticLog.shared
+    @ObservedObject private var studioLayers = StudioLayerStore.shared
     @StateObject private var piChat = PiChatSession.shared
     @State private var eventMonitor: Any?
     @State private var mouseDownMonitor: Any?
@@ -243,6 +246,48 @@ struct ScreenMapView: View {
         .onChange(of: controller.editor?.isPreviewing) { isPreviewing in
             handlePreviewChange(isPreviewing: isPreviewing ?? false)
         }
+        .onChange(of: studioLayerScopeId) { _ in
+            controller.clearSelection()
+        }
+    }
+
+    // MARK: - Studio Layer Scope
+
+    private var activeStudioLayer: StudioLayer? {
+        guard let studioLayerScopeId else { return nil }
+        return studioLayers.layers.first { $0.id == studioLayerScopeId }
+    }
+
+    private func scopedWindows(_ windows: [ScreenMapWindowEntry]) -> [ScreenMapWindowEntry] {
+        guard let layer = activeStudioLayer else { return windows }
+        return windows.filter { screenMapWindow($0, matches: layer) }
+    }
+
+    private func screenMapWindow(_ win: ScreenMapWindowEntry, matches layer: StudioLayer) -> Bool {
+        if let entry = DesktopModel.shared.windows[win.id] {
+            return layer.contains(entry)
+        }
+        let entry = WindowEntry(
+            wid: win.id,
+            app: win.app,
+            pid: win.pid,
+            title: win.title,
+            frame: WindowFrame(
+                x: Double(win.editedFrame.origin.x),
+                y: Double(win.editedFrame.origin.y),
+                w: Double(win.editedFrame.width),
+                h: Double(win.editedFrame.height)
+            ),
+            spaceIds: [],
+            isOnScreen: win.isOnScreen,
+            latticesSession: win.latticesSession,
+            zIndex: win.zIndex
+        )
+        return layer.contains(entry)
+    }
+
+    private func visibleWindowCount(in editor: ScreenMapEditorState) -> Int {
+        scopedWindows(editor.focusedVisibleWindows).count
     }
 
     // MARK: - Display Toolbar (floating in canvas)
@@ -338,7 +383,14 @@ struct ScreenMapView: View {
     private var canvasHeaderBezel: some View {
         HStack(spacing: 6) {
             if let editor = controller.editor {
-                if let focused = editor.focusedDisplay {
+                if let layer = activeStudioLayer {
+                    Circle().fill(Palette.running.opacity(0.55)).frame(width: 6, height: 6)
+                    Text("Layer").font(Typo.monoBold(9)).foregroundColor(Palette.textMuted)
+                    Text(layer.name).font(Typo.monoBold(9)).foregroundColor(Palette.running).lineLimit(1)
+                    if let focused = editor.focusedDisplay {
+                        Text("· \(focused.label)").font(Typo.mono(8)).foregroundColor(Palette.textMuted).lineLimit(1)
+                    }
+                } else if let focused = editor.focusedDisplay {
                     Circle().fill(Palette.running.opacity(0.4)).frame(width: 6, height: 6)
                     Text(focused.label).font(Typo.monoBold(9)).foregroundColor(Palette.textDim).lineLimit(1)
                     Text("\(Int(focused.cgRect.width))×\(Int(focused.cgRect.height))").font(Typo.mono(8)).foregroundColor(Palette.textMuted)
@@ -347,7 +399,7 @@ struct ScreenMapView: View {
                     Text("\(editor.displays.count) monitors").font(Typo.mono(8)).foregroundColor(Palette.textMuted)
                 }
                 Spacer()
-                Text("\(editor.focusedVisibleWindows.count) windows").font(Typo.mono(8)).foregroundColor(Palette.textMuted)
+                Text("\(visibleWindowCount(in: editor)) windows").font(Typo.mono(8)).foregroundColor(Palette.textMuted)
             } else { Text("Canvas"); Spacer() }
         }
         .padding(.horizontal, 10).padding(.vertical, 5)
@@ -424,13 +476,20 @@ struct ScreenMapView: View {
         let viewport = editor.viewportWorldRect
         let world = editor.canvasWorldBounds
         let scope = editor.focusedDisplay.map { "\(editor.spatialNumber(for: $0.index)). \($0.label)" } ?? "All Displays"
+        let studioLayer = activeStudioLayer
 
         return VStack(alignment: .leading, spacing: 4) {
             inspectorRow(label: "Scope", value: scope)
-            inspectorRow(label: "Mode", value: "Desktop")
+            inspectorRow(label: "Mode", value: studioLayer == nil ? "Desktop" : "Layer")
+            if let studioLayer {
+                inspectorRow(label: "Layer", value: "\(studioLayer.name) · \(visibleWindowCount(in: editor)) windows")
+                inspectorRow(label: "Rules", value: studioLayer.summary)
+            }
             inspectorRow(label: "View", value: "\(Int(viewport.midX)), \(Int(viewport.midY)) · \(Int(viewport.width))×\(Int(viewport.height))")
             inspectorRow(label: "World", value: "\(Int(world.width))×\(Int(world.height))")
-            inspectorRow(label: "Set", value: controller.activeWindowSet?.name ?? "None")
+            if studioLayer == nil {
+                inspectorRow(label: "Set", value: controller.activeWindowSet?.name ?? "None")
+            }
             inspectorRow(label: "Select", value: "\(selectedCount) window\(selectedCount == 1 ? "" : "s")")
         }
         .padding(8)
@@ -1355,22 +1414,23 @@ struct ScreenMapView: View {
     private var canvasContextBadge: some View {
         HStack(spacing: 6) {
             if let editor = controller.editor {
-                let layerColor = editor.activeLayer != nil
-                    ? Self.layerColor(for: editor.activeLayer!)
-                    : Palette.running
+                let studioLayer = activeStudioLayer
+                let layerColor = studioLayer != nil
+                    ? Palette.running
+                    : (editor.activeLayer != nil ? Self.layerColor(for: editor.activeLayer!) : Palette.running)
 
                 Circle()
                     .fill(layerColor)
                     .frame(width: 6, height: 6)
 
-                Text(editor.layerLabel)
+                Text(studioLayer.map { "LAYER · \($0.name)" } ?? editor.layerLabel)
                     .font(Typo.monoBold(9))
                     .foregroundColor(layerColor)
 
                 Text("·")
                     .foregroundColor(Palette.textMuted)
 
-                Text("\(editor.focusedVisibleWindows.count) windows")
+                Text("\(visibleWindowCount(in: editor)) windows")
                     .font(Typo.mono(9))
                     .foregroundColor(Palette.textDim)
 
@@ -1429,12 +1489,17 @@ struct ScreenMapView: View {
 
     private func layerSidebar(editor: ScreenMapEditorState) -> some View {
         return VStack(spacing: 0) {
-            // Header
             HStack {
-                Text("VIEW")
+                Text(activeStudioLayer == nil ? "VIEW" : "LAYER VIEW")
                     .font(Typo.monoBold(9))
                     .foregroundColor(Palette.textMuted)
                 Spacer()
+                if let layer = activeStudioLayer {
+                    Text(layer.name)
+                        .font(Typo.monoBold(8))
+                        .foregroundColor(Palette.running)
+                        .lineLimit(1)
+                }
                 if editor.effectiveLayerCount > 1 && !editor.isShowingAll {
                     Button(action: { controller.consolidateLayers() }) {
                         Image(systemName: "arrow.triangle.merge")
@@ -1449,23 +1514,39 @@ struct ScreenMapView: View {
 
             // Layer list
             ScrollView(.vertical, showsIndicators: false) {
-                let visibleWindows = editor.renderedCanvasWindows.sorted { $0.zIndex < $1.zIndex }
+                let visibleWindows = scopedWindows(editor.renderedCanvasWindows).sorted { $0.zIndex < $1.zIndex }
+                let visibleRowSlots = visibleWindows.isEmpty && activeStudioLayer != nil ? 2 : visibleWindows.count + 1
                 let rowWidth = max(sidebarWidth - 16, 1)
 
                 ZStack(alignment: .topLeading) {
                     VStack(spacing: 2) {
                         layerTreeHeader(
-                            label: "Desktop",
+                            label: activeStudioLayer.map { "Layer: \($0.name)" } ?? "Desktop",
                             count: visibleWindows.count,
-                            isActive: editor.isShowingAll,
+                            isActive: editor.isShowingAll || activeStudioLayer != nil,
                             color: Palette.running
                         ) {
-                            editor.selectLayer(nil)
+                            if activeStudioLayer != nil {
+                                onClearStudioLayerScope?()
+                            } else {
+                                editor.selectLayer(nil)
+                            }
                         }
                         .frame(width: rowWidth, height: Self.sidebarWindowRowHeight, alignment: .leading)
 
                         ForEach(visibleWindows) { win in
                             visibleWindowRow(win: win)
+                        }
+
+                        if visibleWindows.isEmpty, let layer = activeStudioLayer {
+                            Text("No visible windows match \(layer.name).")
+                                .font(Typo.mono(8))
+                                .foregroundColor(Palette.textMuted)
+                                .lineLimit(2)
+                                .padding(.leading, 20)
+                                .padding(.trailing, 8)
+                                .padding(.vertical, 8)
+                                .frame(width: rowWidth, alignment: .leading)
                         }
 
                         /*
@@ -1528,7 +1609,7 @@ struct ScreenMapView: View {
                 }
                 .frame(
                     width: rowWidth,
-                    height: CGFloat(visibleWindows.count + 1) * Self.sidebarWindowRowStride,
+                    height: CGFloat(visibleRowSlots) * Self.sidebarWindowRowStride,
                     alignment: .topLeading
                 )
             }
@@ -1897,7 +1978,7 @@ struct ScreenMapView: View {
 
     private func screenMapCanvas(editor: ScreenMapEditorState?) -> some View {
         let isFocused = editor?.focusedDisplayIndex != nil
-        let canvasWindows = editor?.renderedCanvasWindows ?? []
+        let canvasWindows = editor.map { scopedWindows($0.renderedCanvasWindows) } ?? []
         let displays = editor?.displays ?? []
         let zoomLevel = editor?.zoomLevel ?? 1.0
         let panOffset = editor?.panOffset ?? .zero
@@ -3061,8 +3142,8 @@ struct ScreenMapView: View {
                                y: primaryHeight - (union.origin.y + union.height))
         }
 
-        let visible = editor.focusedVisibleWindows
-        let label = editor.layerLabel
+        let visible = scopedWindows(editor.focusedVisibleWindows)
+        let label = activeStudioLayer.map { "Layer · \($0.name)" } ?? editor.layerLabel
         let captures = controller.previewCaptures
 
         let overlay = ScreenMapPreviewOverlay(

--- a/apps/mac/Sources/Core/Overlays/Studio/StudioLayersView.swift
+++ b/apps/mac/Sources/Core/Overlays/Studio/StudioLayersView.swift
@@ -1,19 +1,26 @@
+import AppKit
 import SwiftUI
 
 // MARK: - StudioLayersView
 //
 // The Studio panel for rule-backed layers. Each layer shows its name, the rule
 // it resolves by, and how many live windows currently match. Clicking a row
-// recalls the layer (raises the matching windows + shows the bezel). Layers are
-// authored by plucking in Hyperspace; here you browse, rename, and recall them.
+// inspects that layer; the explicit focus action recalls matching windows.
+// Layers are authored by plucking in Hyperspace; here you browse, rename,
+// inspect, discuss, and recall them.
 
 struct StudioLayersView: View {
     @ObservedObject private var store = StudioLayerStore.shared
     // Observed so match counts re-compute as windows open/close/retitle.
     @ObservedObject private var desktop = DesktopModel.shared
+    @Binding private var selectedLayerId: String?
 
     @State private var editingId: String?
     @State private var draftName: String = ""
+
+    init(selectedLayerId: Binding<String?> = .constant(nil)) {
+        self._selectedLayerId = selectedLayerId
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -25,17 +32,26 @@ struct StudioLayersView: View {
             } else {
                 ScrollView {
                     LazyVStack(spacing: 6) {
+                        allDesktopRow
                         ForEach(store.layers) { layer in
+                            let matches = store.resolve(layer, in: desktop)
                             StudioLayerRow(
                                 layer: layer,
-                                matchCount: store.matchCount(layer, in: desktop),
+                                matches: matches,
+                                isSelected: selectedLayerId == layer.id,
                                 isEditing: editingId == layer.id,
                                 draftName: $draftName,
-                                onRecall:      { store.recall(layer) },
+                                onSelect:      { selectedLayerId = layer.id },
+                                onRecall:      { selectedLayerId = layer.id; store.recall(layer) },
                                 onBeginRename: { draftName = layer.name; editingId = layer.id },
                                 onCommitRename:{ store.rename(id: layer.id, to: draftName); editingId = nil },
                                 onCancelRename:{ editingId = nil },
-                                onDelete:      { store.delete(id: layer.id) }
+                                onCopySpec:    { copyLayerSpec(layer, matches: matches) },
+                                onAskAssistant:{ askAssistantAboutLayer(layer, matches: matches) },
+                                onDelete:      {
+                                    if selectedLayerId == layer.id { selectedLayerId = nil }
+                                    store.delete(id: layer.id)
+                                }
                             )
                         }
                     }
@@ -46,7 +62,7 @@ struct StudioLayersView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .background(Palette.bg)
-        .overlay(alignment: .leading) {
+        .overlay(alignment: .trailing) {
             Rectangle().fill(Palette.border).frame(width: 0.5)
         }
     }
@@ -76,7 +92,7 @@ struct StudioLayersView: View {
             Text("No layers yet")
                 .font(Typo.heading(12))
                 .foregroundColor(Palette.textDim)
-            Text("Pluck windows in Hyperspace, then save them as a layer.")
+            Text("Select windows in Hyperspace, then save them as a layer.")
                 .font(Typo.body(11))
                 .foregroundColor(Palette.textMuted)
                 .multilineTextAlignment(.center)
@@ -85,65 +101,153 @@ struct StudioLayersView: View {
         .padding(24)
         .frame(maxWidth: .infinity)
     }
+
+    private var allDesktopRow: some View {
+        let count = desktop.allWindows().filter(\.isOnScreen).count
+        let isSelected = selectedLayerId == nil
+        return HStack(spacing: 8) {
+            Image(systemName: "display")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(isSelected ? Palette.running : Palette.textMuted)
+                .frame(width: 16)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("All Desktop")
+                    .font(Typo.heading(12))
+                    .foregroundColor(isSelected ? Palette.text : Palette.textDim)
+                Text("whole visible desktop")
+                    .font(Typo.mono(9))
+                    .foregroundColor(Palette.textMuted)
+            }
+            Spacer()
+            Text("\(count)")
+                .font(Typo.monoBold(9))
+                .foregroundColor(isSelected ? Palette.bg : Palette.textMuted)
+                .frame(minWidth: 16)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 2)
+                .background(Capsule().fill(isSelected ? Palette.running : Palette.surfaceHov))
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 7)
+                .fill(isSelected ? Palette.running.opacity(0.12) : Palette.surface.opacity(0.65))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 7)
+                        .strokeBorder(isSelected ? Palette.running.opacity(0.45) : Palette.border, lineWidth: 0.75)
+                )
+        )
+        .contentShape(Rectangle())
+        .onTapGesture { selectedLayerId = nil }
+        .help("Show the whole desktop")
+    }
+
+    private func copyLayerSpec(_ layer: StudioLayer, matches: [WindowEntry]) {
+        let text = store.layerContextJSON(layer, matches: matches)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        DiagnosticLog.shared.success("Copied layer spec for '\(layer.name)' (\(text.count) chars)")
+    }
+
+    private func askAssistantAboutLayer(_ layer: StudioLayer, matches: [WindowEntry]) {
+        let spec = store.layerContextJSON(layer, matches: matches)
+        let prompt = """
+        Help me reason about this Lattices Studio layer. Explain what the rules mean, what live windows currently match, and suggest a cleaner rule if the layer is too broad or too narrow.
+
+        \(spec)
+        """
+        ScreenMapWindowController.shared.showAssistant()
+        PiChatSession.shared.draft = prompt
+        PiChatSession.shared.sendDraft()
+    }
 }
 
 // MARK: - StudioLayerRow
 
 private struct StudioLayerRow: View {
     let layer: StudioLayer
-    let matchCount: Int
+    let matches: [WindowEntry]
+    let isSelected: Bool
     let isEditing: Bool
     @Binding var draftName: String
+    let onSelect: () -> Void
     let onRecall: () -> Void
     let onBeginRename: () -> Void
     let onCommitRename: () -> Void
     let onCancelRename: () -> Void
+    let onCopySpec: () -> Void
+    let onAskAssistant: () -> Void
     let onDelete: () -> Void
 
     @State private var hovering = false
     @FocusState private var nameFocused: Bool
 
     var body: some View {
-        HStack(alignment: .top, spacing: 8) {
-            // Leading content — the recall target.
-            VStack(alignment: .leading, spacing: 4) {
-                if isEditing {
-                    TextField("Name", text: $draftName)
-                        .textFieldStyle(.plain)
-                        .font(Typo.heading(12))
-                        .foregroundColor(Palette.text)
-                        .focused($nameFocused)
-                        .onSubmit(onCommitRename)
-                        .onExitCommand(perform: onCancelRename)
-                        .onAppear { nameFocused = true }
-                } else {
-                    Text(layer.name)
-                        .font(Typo.heading(12))
-                        .foregroundColor(Palette.text)
-                        .lineLimit(1)
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 8) {
+                VStack(alignment: .leading, spacing: 4) {
+                    if isEditing {
+                        TextField("Name", text: $draftName)
+                            .textFieldStyle(.plain)
+                            .font(Typo.heading(12))
+                            .foregroundColor(Palette.text)
+                            .focused($nameFocused)
+                            .onSubmit(onCommitRename)
+                            .onExitCommand(perform: onCancelRename)
+                            .onAppear { nameFocused = true }
+                    } else {
+                        HStack(spacing: 6) {
+                            Text(layer.name)
+                                .font(Typo.heading(12))
+                                .foregroundColor(isSelected ? Palette.text : Palette.textDim)
+                                .lineLimit(1)
+                            if isSelected {
+                                Text("viewing")
+                                    .font(Typo.monoBold(7))
+                                    .foregroundColor(Palette.running)
+                                    .padding(.horizontal, 4)
+                                    .padding(.vertical, 1)
+                                    .background(RoundedRectangle(cornerRadius: 3).fill(Palette.running.opacity(0.12)))
+                            }
+                        }
+                    }
+                    ruleChips
                 }
-                ruleChips
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .contentShape(Rectangle())
-            .onTapGesture { if !isEditing { onRecall() } }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+                .onTapGesture { if !isEditing { onSelect() } }
 
-            // Trailing controls — never recall.
-            VStack(alignment: .trailing, spacing: 6) {
-                matchBadge
-                if hovering && !isEditing {
-                    HStack(spacing: 8) {
-                        iconButton("pencil", onBeginRename)
-                        iconButton("trash", onDelete)
+                VStack(alignment: .trailing, spacing: 6) {
+                    matchBadge
+                    if (hovering || isSelected) && !isEditing {
+                        HStack(spacing: 8) {
+                            iconButton("arrow.up.forward.square", onRecall, help: "Focus matching windows")
+                            iconButton("pencil", onBeginRename, help: "Rename layer")
+                            iconButton("doc.on.doc", onCopySpec, help: "Copy layer spec")
+                            iconButton("sparkles", onAskAssistant, help: "Ask assistant about this layer")
+                            iconButton("trash", onDelete, help: "Delete layer")
+                        }
                     }
                 }
+            }
+
+            if isSelected && !isEditing {
+                selectedDetails
             }
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
-        .glassCard(hovered: hovering)
+        .background(
+            RoundedRectangle(cornerRadius: 7)
+                .fill(isSelected ? Palette.running.opacity(0.10) : (hovering ? Palette.surfaceHov : Palette.surface.opacity(0.65)))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 7)
+                        .strokeBorder(isSelected ? Palette.running.opacity(0.45) : Palette.border, lineWidth: isSelected ? 0.9 : 0.5)
+                )
+        )
         .onHover { hovering = $0 }
         .animation(.easeOut(duration: 0.1), value: hovering)
+        .animation(.easeOut(duration: 0.12), value: isSelected)
     }
 
     /// The rule, shown as one chip per clause. Clauses are OR'd, so each chip is
@@ -164,27 +268,13 @@ private struct StudioLayerRow: View {
     }
 
     private func clauseChip(_ clause: StudioLayerClause) -> some View {
-        let app = clause.app?.isEmpty == false ? clause.app : nil
-        let title = clause.titleContains?.isEmpty == false ? clause.titleContains : nil
         return HStack(spacing: 4) {
-            if let app {
-                Image(systemName: "macwindow")
-                    .font(.system(size: 8))
-                    .foregroundColor(Palette.textMuted)
-                Text(app)
-                    .font(Typo.mono(10))
-                    .foregroundColor(Palette.textDim)
-            }
-            if let title {
-                Text("~\(title)")
-                    .font(Typo.mono(10))
-                    .foregroundColor(Palette.detach)   // amber: a title match reads distinct from an app
-            }
-            if app == nil && title == nil {
-                Text("any")
-                    .font(Typo.mono(10))
-                    .foregroundColor(Palette.textMuted)
-            }
+            Image(systemName: clause.not?.isEmpty == false ? "line.3.horizontal.decrease.circle" : "scope")
+                .font(.system(size: 8))
+                .foregroundColor(Palette.textMuted)
+            Text(clause.summary)
+                .font(Typo.mono(10))
+                .foregroundColor(clause.not?.isEmpty == false ? Palette.detach : Palette.textDim)
         }
         .lineLimit(1)
         .padding(.horizontal, 6)
@@ -197,18 +287,109 @@ private struct StudioLayerRow: View {
     }
 
     private var matchBadge: some View {
-        let live = matchCount > 0
-        return Text("\(matchCount)")
+        let live = !matches.isEmpty
+        return Text("\(matches.count)")
             .font(Typo.monoBold(9))
             .foregroundColor(live ? Palette.bg : Palette.textMuted)
             .frame(minWidth: 16)
             .padding(.horizontal, 5)
             .padding(.vertical, 2)
             .background(Capsule().fill(live ? Palette.running : Palette.surfaceHov))
-            .help(live ? "\(matchCount) live window\(matchCount == 1 ? "" : "s") match" : "No live windows match")
+            .help(live ? "\(matches.count) live window\(matches.count == 1 ? "" : "s") match" : "No live windows match")
     }
 
-    private func iconButton(_ name: String, _ action: @escaping () -> Void) -> some View {
+    private var selectedDetails: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            specPanel
+
+            HStack(spacing: 6) {
+                Text("WINDOWS")
+                    .font(Typo.monoBold(8))
+                    .foregroundColor(Palette.textMuted)
+                Text("\(matches.count)")
+                    .font(Typo.mono(8))
+                    .foregroundColor(Palette.textMuted)
+                Spacer()
+            }
+            if matches.isEmpty {
+                Text("No live windows match these rules.")
+                    .font(Typo.mono(9))
+                    .foregroundColor(Palette.textMuted)
+            } else {
+                VStack(spacing: 3) {
+                    ForEach(matches.prefix(8), id: \.wid) { win in
+                        HStack(spacing: 5) {
+                            Circle()
+                                .fill(Palette.running.opacity(0.7))
+                                .frame(width: 4, height: 4)
+                            Text(win.app)
+                                .font(Typo.monoBold(8))
+                                .foregroundColor(Palette.textDim)
+                                .lineLimit(1)
+                                .frame(width: 58, alignment: .leading)
+                            Text(win.title.isEmpty ? "—" : win.title)
+                                .font(Typo.mono(8))
+                                .foregroundColor(Palette.textMuted)
+                                .lineLimit(1)
+                        }
+                    }
+                    if matches.count > 8 {
+                        Text("+\(matches.count - 8) more")
+                            .font(Typo.mono(8))
+                            .foregroundColor(Palette.textMuted)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+            }
+        }
+        .padding(8)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Color.black.opacity(0.18))
+                .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(Palette.border, lineWidth: 0.5))
+        )
+    }
+
+    private var specPanel: some View {
+        let spec = StudioLayerStore.shared.layerContextJSON(layer, matches: matches)
+        return VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Text("SPEC")
+                    .font(Typo.monoBold(8))
+                    .foregroundColor(Palette.textMuted)
+                Text("lattices.studio-layer.v1")
+                    .font(Typo.mono(8))
+                    .foregroundColor(Palette.textMuted)
+                    .lineLimit(1)
+                Spacer()
+                compactAction("doc.on.doc", onCopySpec, help: "Copy layer spec")
+                compactAction("sparkles", onAskAssistant, help: "Ask assistant about this layer")
+            }
+
+            ScrollView([.vertical, .horizontal]) {
+                Text(spec)
+                    .font(Typo.mono(8))
+                    .foregroundColor(Palette.textDim)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: true, vertical: true)
+                    .padding(7)
+            }
+            .frame(maxHeight: 150)
+            .background(
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(Color.black.opacity(0.22))
+                    .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(Palette.border, lineWidth: 0.5))
+            )
+        }
+        .padding(8)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Color.black.opacity(0.14))
+                .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(Palette.border, lineWidth: 0.5))
+        )
+    }
+
+    private func iconButton(_ name: String, _ action: @escaping () -> Void, help: String) -> some View {
         Button(action: action) {
             Image(systemName: name)
                 .font(.system(size: 10))
@@ -216,5 +397,22 @@ private struct StudioLayerRow: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .help(help)
+    }
+
+    private func compactAction(_ name: String, _ action: @escaping () -> Void, help: String) -> some View {
+        Button(action: action) {
+            Image(systemName: name)
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(Palette.textMuted)
+                .frame(width: 18, height: 18)
+                .background(
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color.white.opacity(0.04))
+                        .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.border, lineWidth: 0.5))
+                )
+        }
+        .buttonStyle(.plain)
+        .help(help)
     }
 }

--- a/apps/mac/Sources/Core/Overlays/UnifiedCommandBar/UnifiedCommandBarView.swift
+++ b/apps/mac/Sources/Core/Overlays/UnifiedCommandBar/UnifiedCommandBarView.swift
@@ -18,6 +18,7 @@ struct UnifiedCommandBarView: View {
     var onCommit: () -> Void
     var onMic: () -> Void
     var onSettings: () -> Void
+    var onDismiss: () -> Void
 
     @FocusState private var focused: Bool
 
@@ -58,7 +59,7 @@ struct UnifiedCommandBarView: View {
                 .strokeBorder(borderGradient, lineWidth: 0.75)
         )
         .overlay(alignment: .top) { topRim }
-        .shadow(color: Color.black.opacity(0.5), radius: 22, y: 10)
+        .shadow(color: Color.black.opacity(0.38), radius: 14, y: 6)
         .animation(.easeOut(duration: 0.16), value: state.detail)
     }
 
@@ -128,6 +129,7 @@ struct UnifiedCommandBarView: View {
             // Right action cluster — mic flush against send.
             micButton
             sendButton
+            dismissButton
         }
         .frame(height: 46)
         // Bar reads as a raised surface over the darker expansion.
@@ -203,7 +205,13 @@ struct UnifiedCommandBarView: View {
     /// Send reflects routing: solid cyan when there's something to act on, a
     /// softer cyan "ask" tint (sparkle) when the text reads as a question.
     @ViewBuilder private var sendButton: some View {
-        if state.wantsAssistant {
+        if state.voice.phase == .listening || state.voice.phase == .connecting {
+            actionButton(system: "stop.fill", primary: true, action: onCommit)
+                .help("Stop recording · ↵")
+        } else if state.voice.phase == .transcribing {
+            actionButton(system: "hourglass", primary: false, action: {})
+                .help("Transcribing")
+        } else if state.wantsAssistant {
             Button(action: onCommit) {
                 Image(systemName: "sparkles")
                     .font(.system(size: 12, weight: .medium))
@@ -223,13 +231,27 @@ struct UnifiedCommandBarView: View {
     private var micButton: some View {
         let listening = state.voice.phase == .listening
         return Button(action: onMic) {
-            Image(systemName: listening ? "mic.fill" : "mic")
+            Image(systemName: listening ? "stop.circle.fill" : "mic")
                 .font(.system(size: 13, weight: .medium))
-                .foregroundColor(listening ? HUDChrome.cyan : Palette.textMuted)
+                .foregroundColor(listening ? HUDChrome.onSignal : Palette.textMuted)
                 .frame(width: 44, height: 46)
+                .background(listening ? HUDChrome.cyan.opacity(0.95) : Color.clear)
                 .overlay(HUDHairline(axis: .vertical), alignment: .leading)
         }
         .buttonStyle(.plain)
+        .help(listening ? "Stop recording" : "Start recording")
+    }
+
+    private var dismissButton: some View {
+        Button(action: onDismiss) {
+            Image(systemName: "xmark")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(Palette.textMuted)
+                .frame(width: 34, height: 46)
+                .overlay(HUDHairline(axis: .vertical), alignment: .leading)
+        }
+        .buttonStyle(.plain)
+        .help("Dismiss · Esc")
     }
 
     private func actionButton(system: String, primary: Bool, action: @escaping () -> Void) -> some View {

--- a/apps/mac/Sources/Core/Overlays/UnifiedCommandBar/UnifiedCommandBarWindow.swift
+++ b/apps/mac/Sources/Core/Overlays/UnifiedCommandBar/UnifiedCommandBarWindow.swift
@@ -62,7 +62,8 @@ final class UnifiedCommandBarWindow {
             state: st,
             onCommit: { [weak self] in self?.commit() },
             onMic: { [weak self] in self?.onMic() },
-            onSettings: { [weak self] in self?.dismiss(); SettingsWindowController.shared.show() }
+            onSettings: { [weak self] in self?.dismiss(); SettingsWindowController.shared.show() },
+            onDismiss: { [weak self] in self?.dismiss() }
         )
         .preferredColorScheme(.dark)
 
@@ -71,13 +72,8 @@ final class UnifiedCommandBarWindow {
 
         let p = OverlayPanelShell.makePanel(
             config: .init(
-                // `.utilityWindow` at `.floating` mirrors OmniSearch's proven recipe:
-                // a plain titled panel at `.popUpMenu` level never reliably becomes
-                // key for a background (accessory) app, so typing fell through.
                 size: NSSize(width: panelWidth, height: panelHeight),
-                styleMask: [.titled, .utilityWindow, .nonactivatingPanel],
-                titleVisible: .hidden,
-                titlebarAppearsTransparent: true,
+                styleMask: [.borderless, .nonactivatingPanel],
                 background: .clear,          // SwiftUI draws the opaque card + shadow
                 level: .floating,
                 hasShadow: false,            // the card draws its own shadow
@@ -179,7 +175,7 @@ final class UnifiedCommandBarWindow {
         flagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
             guard let self, self.panel?.isKeyWindow == true, let voice = self.state?.voice else { return event }
             if event.modifierFlags.contains(.option) {
-                if voice.armed, voice.phase == .idle || voice.phase == .result {
+                if voice.armed && (voice.phase == .idle || voice.phase == .result) {
                     voice.startListening()
                 }
             } else if voice.phase == .listening {
@@ -193,8 +189,10 @@ final class UnifiedCommandBarWindow {
 
     private func commit() {
         guard let st = state else { return }
-        // Voice commits by releasing ⌥ / stopping; routing lands in Phase C.
-        if st.voiceActive { return }
+        if st.voiceActive {
+            commitVoice(st.voice)
+            return
+        }
         if st.commandMode {
             // Enter on an empty / unmatched command is a no-op, not a dismiss.
             guard let s = st.search.command.selected else { return }
@@ -228,6 +226,19 @@ final class UnifiedCommandBarWindow {
             guard st.search.selectedIndex >= 0, st.search.selectedIndex < ordered.count else { return }
             ordered[st.search.selectedIndex].action()
             dismiss()
+        }
+    }
+
+    private func commitVoice(_ voice: VoiceCommandState) {
+        switch voice.phase {
+        case .connecting:
+            voice.cancelProcessing()
+        case .listening:
+            voice.stopListening()
+        case .result:
+            dismiss()
+        case .idle, .transcribing:
+            break
         }
     }
 
@@ -341,7 +352,17 @@ final class UnifiedCommandBarWindow {
 
     /// Tapping the mic toggles listening (start/stop); ⌥-hold is the power gesture.
     private func onMic() {
-        state?.voice.toggleListening()
+        guard let voice = state?.voice else { return }
+        switch voice.phase {
+        case .connecting:
+            voice.cancelProcessing()
+        case .listening:
+            voice.stopListening()
+        case .idle, .result:
+            voice.startListening()
+        case .transcribing:
+            break
+        }
     }
 
     // MARK: - Glide (grab → accelerate → snap)

--- a/apps/mac/Sources/Core/Overlays/Voice/VoiceComponents.swift
+++ b/apps/mac/Sources/Core/Overlays/Voice/VoiceComponents.swift
@@ -341,10 +341,10 @@ final class VoiceCommandState: ObservableObject {
                     self.resultSummary = "\(items.count) result\(items.count == 1 ? "" : "s")"
                 case .object(let obj):
                     self.resultItems = []
-                    self.resultSummary = obj.map { "\($0.key): \($0.value)" }.joined(separator: ", ")
+                    self.resultSummary = self.friendlyObjectSummary(obj, fallback: result)
                 default:
                     self.resultItems = []
-                    self.resultSummary = "\(data)"
+                    self.resultSummary = self.friendlyScalarSummary(data, fallback: result)
                 }
             } else {
                 self.resultItems = []
@@ -366,6 +366,63 @@ final class VoiceCommandState: ObservableObject {
         // Sync immediately (no delay for transcript), then start polling
         syncState()
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { poll() }
+    }
+
+    private func friendlyObjectSummary(_ obj: [String: JSON], fallback: String?) -> String {
+        if let summary = obj["summary"]?.stringValue, !summary.isEmpty {
+            return summary
+        }
+        if let message = obj["message"]?.stringValue, !message.isEmpty {
+            return message
+        }
+        if obj["ok"]?.boolValue == false {
+            return obj["reason"]?.stringValue ?? fallbackSummary(fallback, defaultValue: "Voice command did not complete")
+        }
+
+        switch intentName ?? "" {
+        case "focus":
+            if let target = obj["focused"]?.stringValue ?? obj["app"]?.stringValue {
+                return "Focused \(target)"
+            }
+        case "tile_window":
+            if let position = obj["position"]?.stringValue {
+                return "Moved window to \(position)"
+            }
+        case "move_to_display":
+            if let display = obj["display"]?.intValue {
+                return "Moved window to display \(display + 1)"
+            }
+        case "launch":
+            if let launched = obj["launched"]?.stringValue {
+                return "Opened \(launched)"
+            }
+        case "kill":
+            if let killed = obj["killed"]?.stringValue ?? obj["session"]?.stringValue {
+                return "Closed \(killed)"
+            }
+        default:
+            break
+        }
+
+        return fallbackSummary(fallback, defaultValue: obj["ok"]?.boolValue == true ? "Done" : "Result ready")
+    }
+
+    private func friendlyScalarSummary(_ data: JSON, fallback: String?) -> String {
+        if let text = data.stringValue, !text.isEmpty {
+            return text
+        }
+        if let ok = data.boolValue {
+            return ok ? "Done" : "Voice command did not complete"
+        }
+        return fallbackSummary(fallback, defaultValue: "Result ready")
+    }
+
+    private func fallbackSummary(_ fallback: String?, defaultValue: String) -> String {
+        let text = fallback?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !text.isEmpty && text != "ok" {
+            return text
+        }
+        return defaultValue
     }
 }
 

--- a/apps/mac/Sources/Core/Pi/PiChatSession.swift
+++ b/apps/mac/Sources/Core/Pi/PiChatSession.swift
@@ -5,6 +5,13 @@ import Foundation
 import HudsonAI
 #endif
 
+/// A prompt the user queued mid-turn. Carries a stable id so the composer's chips
+/// diff cleanly and remove/edit resolve by identity (not a shifting index).
+struct QueuedPrompt: Identifiable, Equatable {
+    let id = UUID()
+    var text: String
+}
+
 struct PiChatMessage: Identifiable, Equatable {
     enum Role {
         case system
@@ -149,7 +156,7 @@ final class PiChatSession: ObservableObject {
     @Published private(set) var statusText: String = "idle"
     /// Prompts submitted while a turn was streaming. They render as pending chips
     /// and fire FIFO once the current turn finishes (the "queue" primitive).
-    @Published private(set) var queuedPrompts: [String] = []
+    @Published private(set) var queuedPrompts: [QueuedPrompt] = []
     @Published var dockHeight: CGFloat = 230 {
         didSet {
             dockHeight = Self.clampDockHeight(dockHeight)
@@ -542,7 +549,7 @@ final class PiChatSession: ObservableObject {
         guard !text.isEmpty else { return }
         draft = ""
         if isSending {
-            queuedPrompts.append(text)   // queue while a turn is in flight
+            queuedPrompts.append(QueuedPrompt(text: text))   // queue while a turn is in flight
             return
         }
         send(text)
@@ -1017,35 +1024,52 @@ final class PiChatSession: ObservableObject {
     private func drainQueuedPrompt() {
         guard !isSending, !queuedPrompts.isEmpty else { return }
         let next = queuedPrompts.removeFirst()
-        send(next)
+        send(next.text)
     }
 
-    /// Stop button. Halts the in-flight turn (cancelling generation on the
-    /// HudAIClient path; the generation guard neutralizes the native path's stale
-    /// callbacks), settles the partial answer, then — if the composer has text —
-    /// sends it immediately as a redirect (steer). Empty draft = plain stop, and
-    /// any queued prompts still continue.
-    func interruptAndSteer() {
-        guard isSending else { return }
-        let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+    /// Halt the in-flight turn (cancelling generation on the HudAIClient path; the
+    /// generation guard neutralizes the native path's stale callbacks) and settle
+    /// the partial answer. `drainQueue` fires the next queued prompt afterward —
+    /// true for a plain stop, false when the caller is about to send a steer.
+    private func stop(drainQueue: Bool) {
         turnGeneration &+= 1
         streamingTask?.cancel()
         streamingTask = nil
         isSending = false
         statusText = "idle"
         settleActiveStreamingMessage(interrupted: true)
-        if text.isEmpty {
-            drainQueuedPrompt()
-        } else {
-            draft = ""
-            send(text)
-        }
+        if drainQueue { drainQueuedPrompt() }
     }
 
-    /// Remove a still-pending queued prompt (tapping its chip before it fires).
-    func removeQueuedPrompt(at index: Int) {
-        guard queuedPrompts.indices.contains(index) else { return }
-        queuedPrompts.remove(at: index)
+    /// Stop button. Halts the in-flight turn without sending anything; any queued
+    /// prompts still continue.
+    func stop() {
+        guard isSending else { return }
+        stop(drainQueue: true)
+    }
+
+    /// Stop the in-flight turn and, if the composer has text, send it immediately
+    /// as a redirect (steer). Empty draft falls back to a plain stop.
+    func interruptAndSteer() {
+        guard isSending else { return }
+        let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        stop(drainQueue: text.isEmpty)   // don't drain when we're about to steer
+        guard !text.isEmpty else { return }
+        draft = ""
+        send(text)
+    }
+
+    /// Remove a still-pending queued prompt (tapping its chip's ✕ before it fires).
+    func removeQueuedPrompt(id: UUID) {
+        queuedPrompts.removeAll { $0.id == id }
+    }
+
+    /// Pull a queued prompt back into the composer to edit it: splice its text into
+    /// the draft and drop it from the queue.
+    func editQueuedPrompt(id: UUID) {
+        guard let index = queuedPrompts.firstIndex(where: { $0.id == id }) else { return }
+        let removed = queuedPrompts.remove(at: index)
+        draft = WorkspaceDictationBuffer.appending(removed.text, to: draft)
     }
 
     private func removeMessageIfEmpty(id: UUID) {

--- a/apps/mac/Sources/Core/Pi/PiChatSession.swift
+++ b/apps/mac/Sources/Core/Pi/PiChatSession.swift
@@ -1975,6 +1975,7 @@ final class PiChatSession: ObservableObject {
                     "deepScanBudget": prefs.ocrDeepBudget,
                 ],
                 "mouseShortcuts": mouseShortcutContextPayload(),
+                "studioLayers": StudioLayerStore.shared.assistantContextPayload(),
             ],
             "settingsCatalog": [
                 [
@@ -2019,6 +2020,7 @@ final class PiChatSession: ObservableObject {
             ],
             "settingsFiles": [
                 "workspace": "\(NSHomeDirectory())/.lattices/workspace.json",
+                "studioLayers": StudioLayerStore.shared.configFilePath,
                 "mouseShortcuts": MouseShortcutStore.shared.configURL.path,
                 "mouseShortcutsHistory": MouseShortcutStore.shared.historyDirectoryURL.path,
                 "snapZones": "\(NSHomeDirectory())/.lattices/snap-zones.json",

--- a/apps/mac/Sources/Core/Pi/PiChatUI.swift
+++ b/apps/mac/Sources/Core/Pi/PiChatUI.swift
@@ -730,6 +730,7 @@ struct PiChatCodeBlock: View {
         HudCodeBlock(language: language, source: source)
     }
 }
+
 // MARK: - Composer
 
 struct PiChatComposer: View {

--- a/apps/mac/Sources/Core/Pi/PiChatUI.swift
+++ b/apps/mac/Sources/Core/Pi/PiChatUI.swift
@@ -744,53 +744,73 @@ struct PiChatComposer: View {
 
     var body: some View {
         VStack(spacing: 7) {
-            if !session.queuedPrompts.isEmpty {
-                queuedChips
-            }
-
             #if canImport(HudsonVoice)
             if voice.state.isCaptureActive || voice.state.isProcessing {
                 dictationStrip
             }
             #endif
 
-            HStack(alignment: .center, spacing: 10) {
-                #if canImport(HudsonVoice)
-                micButton
-                #endif
-
-                TextField(
-                    style.placeholder,
-                    text: $session.draft,
-                    axis: .vertical
-                )
-                .textFieldStyle(.plain)
-                .font(Typo.body(style.composerSize))
-                .foregroundColor(Palette.text)
-                .lineLimit(1...style.composerLineLimit)
-                .focused(focus)
-                .onSubmit {
-                    if canSend {
-                        session.sendDraft()
-                    }
-                }
-
-                if session.isSending {
-                    stopButton
-                }
-                sendButton
-            }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 10)
-            .background(composerFieldBackground)
-
-            #if canImport(HudsonVoice)
-            statusLine
-            #endif
+            // Turn lifecycle + layout live in HudsonKit's HudComposer (.stacked):
+            // the field spans the top; a control row sits beneath with a `+`
+            // attach affordance on the left and model · effort + the bespoke mic
+            // grouped with the morphing send/stop on the right. Queued messages
+            // stack as full-width rows above the field.
+            HudComposer(
+                text: $session.draft,
+                phase: session.isSending ? .streaming : .idle,
+                queued: queuedItems,
+                style: hudStyle,
+                layout: .stacked,
+                focus: focus,
+                trailingAccessory: { micAccessory },
+                onAction: handle(_:),
+                onRemoveQueued: { session.removeQueuedPrompt(id: $0.id) },
+                onEditQueued: { session.editQueuedPrompt(id: $0.id) },
+                model: HudComposerModelInfo(model: session.currentProvider.name.lowercased(), effort: "auto"),
+                onAddAttachment: { /* attachments not wired in Lattices yet — placeholder affordance */ }
+            )
         }
         .padding(.horizontal, style.horizontalPadding)
         .padding(.vertical, style.verticalPadding)
         .background(composerChrome)
+        .environment(\.hudTheme, .lattices)
+    }
+
+    private var queuedItems: [HudComposerQueuedItem] {
+        session.queuedPrompts.map { HudComposerQueuedItem(id: $0.id, text: $0.text) }
+    }
+
+    private var hudStyle: HudComposerStyle {
+        HudComposerStyle(
+            placeholder: style.placeholder,
+            fontSize: style.composerSize,
+            lineLimit: 1...style.composerLineLimit
+        )
+    }
+
+    /// `sendDraft()` already submits-or-queues based on `isSending`, so both map to
+    /// it; steer/stop hit the dedicated session primitives.
+    private func handle(_ action: HudComposerAction) {
+        switch action {
+        case .submit, .queue: session.sendDraft()
+        case .steer:          session.interruptAndSteer()
+        case .stop:           session.stop()
+        }
+    }
+
+    // MARK: Control-row accessories
+
+    /// The `+` attach affordance and the model · effort label are now first-class
+    /// in HudComposer (passed via `onAddAttachment` / `model`), so Lattices only
+    /// supplies the bespoke mic here. Effort is a placeholder until a real setting
+    /// exists; attachments aren't wired on the chat path yet.
+    @ViewBuilder
+    private var micAccessory: some View {
+        #if canImport(HudsonVoice)
+        micButton
+        #else
+        EmptyView()
+        #endif
     }
 
     #if canImport(HudsonVoice)
@@ -851,21 +871,6 @@ struct PiChatComposer: View {
         .transition(.opacity)
     }
 
-    /// One quiet mono line under the field: dictation state while the mic is hot,
-    /// a faint affordance hint when idle.
-    private var statusLine: some View {
-        HStack(spacing: 0) {
-            Text(statusText)
-                .font(Typo.mono(9.5))
-                .tracking(0.3)
-                .foregroundColor(statusTint)
-                .lineLimit(1)
-                .truncationMode(.tail)
-            Spacer(minLength: 0)
-        }
-        .padding(.horizontal, 16)
-        .animation(.easeInOut(duration: 0.18), value: voice.state)
-    }
 
     private var micSymbol: String {
         switch voice.state {
@@ -922,121 +927,7 @@ struct PiChatComposer: View {
         }
     }
 
-    private var statusText: String {
-        switch voice.state {
-        case .idle: return "Tap mic to dictate · ↵ to send"
-        case .starting: return "Starting…"
-        case .recording: return "Listening — tap mic to commit"
-        case .processing: return "Transcribing…"
-        case .unavailable(let reason): return reason
-        }
-    }
-
-    private var statusTint: Color {
-        switch voice.state {
-        case .recording, .starting: return Palette.kill.opacity(0.85)
-        case .processing, .unavailable: return Palette.detach.opacity(0.85)
-        case .idle: return Palette.textMuted.opacity(0.7)
-        }
-    }
     #endif
-
-    /// Calm filled-circle send (after OpenScout's ScoutSendButton): a solid accent
-    /// disc with an up-arrow when there's something to send, a quiet hollow ring
-    /// otherwise. No glow, no keycap clutter.
-    private var sendButton: some View {
-        Button {
-            session.sendDraft()
-        } label: {
-            Image(systemName: sendIcon)
-                .font(.system(size: 12.5, weight: .bold))
-                .foregroundColor(canSend ? Palette.bg : Palette.textMuted.opacity(0.7))
-                .frame(width: 30, height: 30)
-                .background(
-                    Circle()
-                        .fill(canSend ? Palette.running : Color.white.opacity(0.05))
-                        .overlay(
-                            Circle().strokeBorder(canSend ? Color.clear : Palette.border, lineWidth: 0.5)
-                        )
-                )
-                .contentShape(Circle())
-        }
-        .buttonStyle(.plain)
-        .disabled(!canSend)
-        .help(sendHelp)
-        .animation(.easeInOut(duration: 0.15), value: canSend)
-    }
-
-    /// While a turn streams, the send action queues; while idle it sends. The icon
-    /// falls back to a quiet ellipsis when streaming with nothing to queue.
-    private var sendIcon: String {
-        if session.isSending && !canSend { return "ellipsis" }
-        return "arrow.up"
-    }
-
-    private var sendHelp: String {
-        guard canSend else { return "" }
-        return session.isSending ? "Queue (↵)" : "Send (↵)"
-    }
-
-    /// Stop the in-flight turn. With text in the composer it halts and sends that
-    /// text immediately (steer); empty, it's a plain stop.
-    private var stopButton: some View {
-        Button {
-            session.interruptAndSteer()
-        } label: {
-            Image(systemName: "stop.fill")
-                .font(.system(size: 11, weight: .bold))
-                .foregroundColor(.white)
-                .frame(width: 30, height: 30)
-                .background(Circle().fill(Color.red.opacity(0.85)))
-                .contentShape(Circle())
-        }
-        .buttonStyle(.plain)
-        .help(session.draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "Stop" : "Stop & send")
-    }
-
-    /// Pending messages submitted mid-turn. Each chip can be tapped to drop it
-    /// before it fires.
-    private var queuedChips: some View {
-        HStack(spacing: 6) {
-            ForEach(Array(session.queuedPrompts.enumerated()), id: \.offset) { index, text in
-                Button {
-                    session.removeQueuedPrompt(at: index)
-                } label: {
-                    HStack(spacing: 4) {
-                        Image(systemName: "clock").font(.system(size: 8.5))
-                        Text(text).lineLimit(1).truncationMode(.tail)
-                        Image(systemName: "xmark").font(.system(size: 8, weight: .bold))
-                    }
-                    .font(Typo.caption(10))
-                    .foregroundColor(Palette.textDim)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 3)
-                    .background(Capsule().fill(Color.white.opacity(0.06)))
-                }
-                .buttonStyle(.plain)
-                .help("Queued — tap to remove")
-            }
-            Spacer(minLength: 0)
-        }
-        .padding(.horizontal, 14)
-    }
-
-    // Flat composer field — hairline border, no focus glow, no running-tinted
-    // halo. The "glowy" look the operator flagged is gone; affordance comes
-    // from a single 0.5pt border that brightens slightly on focus.
-    private var composerFieldBackground: some View {
-        RoundedRectangle(cornerRadius: 12, style: .continuous)
-            .fill(Color.white.opacity(0.025))
-            .overlay(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .strokeBorder(
-                        focus.wrappedValue ? Palette.borderLit : Palette.border,
-                        lineWidth: 0.5
-                    )
-            )
-    }
 
     private var composerChrome: some View {
         ZStack {
@@ -1046,12 +937,6 @@ struct PiChatComposer: View {
             Palette.surface.opacity(0.18)
         }
             .overlay(Rectangle().fill(Palette.border).frame(height: 0.5), alignment: .top)
-    }
-
-    /// True whenever the composer has text. While a turn is in flight the action
-    /// queues instead of sending, so the button stays live (the "queue" primitive).
-    private var canSend: Bool {
-        !session.draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 }
 

--- a/apps/mac/Sources/Core/Workspace/StudioLayer.swift
+++ b/apps/mac/Sources/Core/Workspace/StudioLayer.swift
@@ -2,34 +2,123 @@ import AppKit
 
 // MARK: - StudioLayerClause
 
-/// One match clause. A window satisfies a clause when it meets every present
-/// criterion (app AND titleContains) — the same semantics as a `ClusterRule`.
-/// A `StudioLayer` ORs its clauses together, so a heterogeneous plucked set
+/// One match clause. The Hyperspace editor intentionally keeps authoring simple:
+/// pick an app name and, optionally, a direct or regex match against the window
+/// name/title.
+/// The extra fields remain Codable so older layers.json files keep working.
+/// A `StudioLayer` ORs its clauses together, so a heterogeneous selection
 /// (a Chrome window + a terminal) becomes "app Chrome OR app iTerm".
 struct StudioLayerClause: Codable, Equatable {
-    var app: String?            // app name contains (case-insensitive)
-    var titleContains: String?  // window title contains (case-insensitive)
+    var app: String? = nil              // app name contains (case-insensitive)
+    var appEquals: String? = nil        // app name exactly equals (case-insensitive)
+    var appRegex: String? = nil         // app name matches regex (case-insensitive)
+    var titleContains: String? = nil    // window title contains (case-insensitive)
+    var titleEquals: String? = nil      // window title exactly equals (case-insensitive)
+    var titleRegex: String? = nil       // window title matches regex (case-insensitive)
+    var session: String? = nil          // lattices session exactly equals (case-insensitive)
+    var sessionContains: String? = nil  // lattices session contains (case-insensitive)
+    var isOnScreen: Bool? = nil         // visible on current Space
+    var spaceId: Int? = nil             // member of a specific macOS Space id
+    var not: [StudioLayerClause]? = nil // no exclusion clause may match
 
     func matches(_ e: WindowEntry) -> Bool {
-        var matched = false
-        if let app {
-            if !e.app.localizedCaseInsensitiveContains(app) { return false }
-            matched = true
+        guard positiveCriteriaMatch(e) else { return false }
+        if let not, not.contains(where: { $0.matches(e) }) {
+            return false
         }
-        if let titleContains {
-            if !e.title.localizedCaseInsensitiveContains(titleContains) { return false }
-            matched = true
-        }
-        return matched
+        return true
     }
 
     var summary: String {
-        switch (app, titleContains) {
-        case let (a?, t?):  return "\(a)·~\(t)"
-        case let (a?, nil): return a
-        case let (nil, t?): return "~\(t)"
-        default:            return "any"
+        let positives = positiveSummaryParts
+        guard !positives.isEmpty else { return "no rule" }
+        let exclusions = (not ?? []).map { "not(\($0.summary))" }
+        return (positives + exclusions).joined(separator: " · ")
+    }
+
+    var positiveSummaryParts: [String] {
+        var parts: [String] = []
+        appendNonEmpty(app, prefix: "App contains ", to: &parts)
+        appendNonEmpty(appEquals, prefix: "App: ", to: &parts)
+        appendNonEmpty(appRegex, prefix: "App matches /", suffix: "/", to: &parts)
+        appendNonEmpty(titleContains, prefix: "Name: ", to: &parts)
+        appendNonEmpty(titleEquals, prefix: "Name: ", to: &parts)
+        appendNonEmpty(titleRegex, prefix: "Name matches /", suffix: "/", to: &parts)
+        appendNonEmpty(session, prefix: "Session: ", to: &parts)
+        appendNonEmpty(sessionContains, prefix: "Session contains ", to: &parts)
+        if let isOnScreen {
+            parts.append(isOnScreen ? "Visible" : "Offscreen")
         }
+        if let spaceId {
+            parts.append("Space \(spaceId)")
+        }
+        return parts
+    }
+
+    private func positiveCriteriaMatch(_ e: WindowEntry) -> Bool {
+        var matched = false
+
+        if let app = trimmed(app) {
+            guard e.app.localizedCaseInsensitiveContains(app) else { return false }
+            matched = true
+        }
+        if let appEquals = trimmed(appEquals) {
+            guard e.app.localizedCaseInsensitiveCompare(appEquals) == .orderedSame else { return false }
+            matched = true
+        }
+        if let appRegex = trimmed(appRegex) {
+            guard Self.regex(appRegex, matches: e.app) else { return false }
+            matched = true
+        }
+        if let titleContains = trimmed(titleContains) {
+            guard e.title.localizedCaseInsensitiveContains(titleContains) else { return false }
+            matched = true
+        }
+        if let titleEquals = trimmed(titleEquals) {
+            guard e.title.localizedCaseInsensitiveCompare(titleEquals) == .orderedSame else { return false }
+            matched = true
+        }
+        if let titleRegex = trimmed(titleRegex) {
+            guard Self.regex(titleRegex, matches: e.title) else { return false }
+            matched = true
+        }
+        if let session = trimmed(session) {
+            guard e.latticesSession?.localizedCaseInsensitiveCompare(session) == .orderedSame else { return false }
+            matched = true
+        }
+        if let sessionContains = trimmed(sessionContains) {
+            guard e.latticesSession?.localizedCaseInsensitiveContains(sessionContains) == true else { return false }
+            matched = true
+        }
+        if let isOnScreen {
+            guard e.isOnScreen == isOnScreen else { return false }
+            matched = true
+        }
+        if let spaceId {
+            guard e.spaceIds.contains(spaceId) else { return false }
+            matched = true
+        }
+
+        return matched
+    }
+
+    private static func regex(_ pattern: String, matches value: String) -> Bool {
+        guard let expression = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+            return false
+        }
+        let range = NSRange(value.startIndex..<value.endIndex, in: value)
+        return expression.firstMatch(in: value, range: range) != nil
+    }
+
+    private func trimmed(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func appendNonEmpty(_ value: String?, prefix: String?, suffix: String = "", to parts: inout [String]) {
+        guard let value = trimmed(value) else { return }
+        parts.append("\(prefix ?? "")\(value)\(suffix)")
     }
 }
 
@@ -37,9 +126,9 @@ struct StudioLayerClause: Codable, Equatable {
 
 /// A named, rule-backed layer. Membership is *computed* by evaluating the rule
 /// against live windows — it is not a frozen list of window IDs — so a layer
-/// survives restarts and auto-includes any new window that matches. Authored by
-/// plucking in Hyperspace (or edited by hand), recalled from the Studio panel
-/// or ⌘L. This is the unified successor to clusters and session layers.
+/// survives restarts and auto-includes any new window that matches. Authored in
+/// Hyperspace (or edited by hand), recalled from the Studio panel or ⌘L. This
+/// is the unified successor to clusters and session layers.
 struct StudioLayer: Identifiable, Codable, Equatable {
     let id: String
     var name: String
@@ -56,9 +145,9 @@ struct StudioLayer: Identifiable, Codable, Equatable {
         match.contains { $0.matches(e) }
     }
 
-    /// Human-readable rule, e.g. "Chrome · iTerm2 · ~localhost".
+    /// Human-readable rule, e.g. "App: Google Chrome · Name: GitHub".
     var summary: String {
         guard !match.isEmpty else { return "no rule" }
-        return match.map(\.summary).joined(separator: " · ")
+        return match.map(\.summary).joined(separator: " OR ")
     }
 }

--- a/apps/mac/Sources/Core/Workspace/StudioLayerStore.swift
+++ b/apps/mac/Sources/Core/Workspace/StudioLayerStore.swift
@@ -14,6 +14,8 @@ final class StudioLayerStore: ObservableObject {
     private let fileURL: URL = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent(".lattices/layers.json")
 
+    var configFilePath: String { fileURL.path }
+
     private init() {
         load()
     }
@@ -28,6 +30,129 @@ final class StudioLayerStore: ObservableObject {
     /// How many live windows the rule matches right now.
     func matchCount(_ layer: StudioLayer, in desktop: DesktopModel = .shared) -> Int {
         desktop.windows.values.reduce(0) { $0 + (layer.contains($1) ? 1 : 0) }
+    }
+
+    // MARK: - Assistant Context
+
+    func assistantContextPayload(in desktop: DesktopModel = .shared) -> [String: Any] {
+        [
+            "kind": "lattices.studio-layers.v1",
+            "configFile": configFilePath,
+            "semantics": Self.ruleSemantics,
+            "count": layers.count,
+            "layers": layers.map { layer in
+                layerContextPayload(layer, matches: resolve(layer, in: desktop), includeSemantics: false)
+            },
+        ]
+    }
+
+    func layerContextPayload(_ layer: StudioLayer, matches providedMatches: [WindowEntry]? = nil, includeSemantics: Bool = true) -> [String: Any] {
+        let matches = providedMatches ?? resolve(layer)
+        var payload: [String: Any] = [
+            "kind": "lattices.studio-layer.v1",
+            "configFile": configFilePath,
+            "layer": layerPayload(layer),
+            "liveMatchCount": matches.count,
+            "liveMatches": matches.map(windowPayload),
+        ]
+        if includeSemantics {
+            payload["semantics"] = Self.ruleSemantics
+        }
+        return payload
+    }
+
+    func layerContextJSON(_ layer: StudioLayer, matches: [WindowEntry]? = nil) -> String {
+        Self.prettyJSONString(layerContextPayload(layer, matches: matches))
+    }
+
+    private static let ruleSemantics: [String: String] = [
+        "membership": "Layer membership is computed from live desktop windows; window ids are not persisted as members.",
+        "layerMatch": "A window belongs to a layer when it matches any clause in layer.match.",
+        "clauseMatch": "Within one clause, every present positive field must match and no clause in not may match.",
+        "authoringDefault": "The Hyperspace rule editor writes simple clauses: appEquals plus optional titleContains (Text) or titleRegex (Regex).",
+        "app": "Legacy case-insensitive substring match against the owning app name.",
+        "appEquals": "Case-insensitive exact match against the owning app name. This is the App field in Hyperspace.",
+        "appRegex": "Case-insensitive regular expression match against the owning app name.",
+        "titleContains": "Case-insensitive plain-text substring match against the window name/title. This is the Name Text mode in Hyperspace.",
+        "titleEquals": "Case-insensitive exact match against the window name/title.",
+        "titleRegex": "Case-insensitive regular expression match against the window name/title. This is the Name Regex mode in Hyperspace.",
+        "session": "Case-insensitive exact match against the parsed lattices tmux session tag.",
+        "sessionContains": "Case-insensitive substring match against the parsed lattices tmux session tag.",
+        "isOnScreen": "Boolean match against whether the window is visible on the current Space.",
+        "spaceId": "Matches when the window belongs to the given macOS Space id.",
+        "not": "Array of exclusion clauses; if any exclusion clause matches, this clause fails.",
+        "emptyClause": "A clause with no positive fields matches no windows, even when not is present.",
+    ]
+
+    private func layerPayload(_ layer: StudioLayer) -> [String: Any] {
+        [
+            "id": layer.id,
+            "name": layer.name,
+            "match": layer.match.map(clausePayload),
+            "summary": layer.summary,
+        ]
+    }
+
+    private func clausePayload(_ clause: StudioLayerClause) -> [String: Any] {
+        var payload: [String: Any] = [
+            "app": jsonNullable(clause.app),
+            "titleContains": jsonNullable(clause.titleContains),
+            "summary": clause.summary,
+        ]
+        addOptional(clause.appEquals, key: "appEquals", to: &payload)
+        addOptional(clause.appRegex, key: "appRegex", to: &payload)
+        addOptional(clause.titleEquals, key: "titleEquals", to: &payload)
+        addOptional(clause.titleRegex, key: "titleRegex", to: &payload)
+        addOptional(clause.session, key: "session", to: &payload)
+        addOptional(clause.sessionContains, key: "sessionContains", to: &payload)
+        if let isOnScreen = clause.isOnScreen {
+            payload["isOnScreen"] = isOnScreen
+        }
+        if let spaceId = clause.spaceId {
+            payload["spaceId"] = spaceId
+        }
+        if let not = clause.not, !not.isEmpty {
+            payload["not"] = not.map(clausePayload)
+        }
+        return payload
+    }
+
+    private func windowPayload(_ window: WindowEntry) -> [String: Any] {
+        [
+            "wid": Int(window.wid),
+            "pid": Int(window.pid),
+            "app": window.app,
+            "title": window.title,
+            "isOnScreen": window.isOnScreen,
+            "spaceIds": window.spaceIds,
+            "latticesSession": jsonNullable(window.latticesSession),
+            "zIndex": window.zIndex,
+            "frame": [
+                "x": window.frame.x,
+                "y": window.frame.y,
+                "w": window.frame.w,
+                "h": window.frame.h,
+            ],
+        ]
+    }
+
+    private func jsonNullable(_ value: String?) -> Any {
+        if let value { return value }
+        return NSNull()
+    }
+
+    private func addOptional(_ value: String?, key: String, to payload: inout [String: Any]) {
+        guard let value else { return }
+        payload[key] = value
+    }
+
+    private static func prettyJSONString(_ payload: [String: Any]) -> String {
+        guard JSONSerialization.isValidJSONObject(payload),
+              let data = try? JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys]),
+              let text = String(data: data, encoding: .utf8) else {
+            return #"{"error":"layer context unavailable"}"#
+        }
+        return text
     }
 
     // MARK: - Recall
@@ -77,13 +202,13 @@ final class StudioLayerStore: ObservableObject {
 
     // MARK: - Authoring from a pluck
 
-    /// Infer a rule from a plucked set of live windows: group by app and OR the
-    /// apps together. Coarse on purpose — a rule-backed layer is meant to
-    /// auto-include future windows of the same apps. Refine it later in Studio.
+    /// Infer a rule from a plucked set of live windows: group by exact app name
+    /// and OR the apps together. This still auto-includes future windows from
+    /// those apps, but avoids accidental substring matches.
     @discardableResult
     func saveFromPluck(_ entries: [WindowEntry], name: String? = nil) -> StudioLayer {
         let apps = orderedUniqueApps(entries)
-        let clauses = apps.map { StudioLayerClause(app: $0, titleContains: nil) }
+        let clauses = apps.map { StudioLayerClause(appEquals: $0) }
         let layerName = name ?? defaultName(forApps: apps)
         return add(name: layerName, match: clauses.isEmpty ? [StudioLayerClause()] : clauses)
     }

--- a/apps/mac/Sources/UI/HudThemeBridge.swift
+++ b/apps/mac/Sources/UI/HudThemeBridge.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import HudsonUI
+
+extension HudTheme {
+    /// Lattices' `Palette` mapped onto Hudson's runtime theme so HudsonUI
+    /// primitives (starting with `HudComposer`) render in the app's dark
+    /// aesthetic. Inject with `.environment(\.hudTheme, .lattices)`.
+    ///
+    /// `statusError → kill` makes the composer's morphing Stop button the exact
+    /// Lattices red; `accent → running` gives the Send disc its green.
+    static let lattices = HudTheme(
+        palette: HudThemePalette(
+            bg:          Palette.bg,
+            surface:     Palette.surface,
+            chrome:      Palette.bgSidebar,
+            ink:         Palette.text,
+            muted:       Palette.textDim,
+            dim:         Palette.textMuted,
+            border:      Palette.border,
+            accent:      Palette.running,
+            accentSoft:  Palette.running.opacity(0.12),
+            statusOk:    Palette.running,
+            statusWarn:  Palette.detach,
+            statusError: Palette.kill,
+            statusInfo:  Palette.launch
+        ),
+        hairline: HudThemeHairline(subtle: Palette.border, standard: Palette.borderLit),
+        radius:   .default,
+        focus:    HudThemeFocus(ring: Palette.borderLit, ringWidth: 1)
+    )
+}

--- a/docs/assistant-knowledge.md
+++ b/docs/assistant-knowledge.md
@@ -41,8 +41,10 @@ bar. → [Tiling reference](/docs/tiling-reference), positions in [Configuration
 
 ### Workspace layers & tab groups
 Group projects into named **layers** you can switch between, and tab-group related
-windows. Layers are rule-backed and persisted (`~/.lattices/layers.json`); switch
-via the palette or `lattices layer [name|index]`. → [Layers](/docs/layers).
+windows. `workspace.json` layers launch/focus/tile projects. Studio layers are
+rule-backed live window sets persisted in `~/.lattices/layers.json`; their clauses
+support app/title/session exact, substring, regex, Space, visibility, and exclusion
+matches. → [Layers](/docs/layers).
 
 ### Command palette & menu bar app
 The palette (**Cmd+Shift+M**) is the app's primary surface: launch projects, tile,

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -315,6 +315,59 @@ event is broadcast to all connected clients.
 
 More methods in the [Agent API reference](/docs/api).
 
+## Rule-backed Studio layers
+
+Studio layers are live window rules stored in `~/.lattices/layers.json`.
+They are separate from `workspace.json` launch-and-tile layers: Studio
+layers do not launch projects. They resolve matching desktop windows,
+then recall or scope those windows in Studio and Screen Map.
+
+Each layer has a `match` array. A window joins the layer when it matches
+any clause in that array. Inside one clause, every present positive field
+must match, and every clause in `not` must fail.
+
+```json
+[
+  {
+    "id": "review",
+    "name": "Review",
+    "match": [
+      {
+        "appEquals": "Google Chrome",
+        "titleRegex": "(GitHub|Pull Request)",
+        "not": [
+          { "titleContains": "Actions" }
+        ]
+      },
+      {
+        "sessionContains": "lattices",
+        "isOnScreen": true
+      }
+    ]
+  }
+]
+```
+
+Supported clause fields:
+
+| Field | Match |
+|-------|-------|
+| `app` | App name contains this string |
+| `appEquals` | App name exactly equals this string |
+| `appRegex` | App name matches this regular expression |
+| `titleContains` | Window title contains this string |
+| `titleEquals` | Window title exactly equals this string |
+| `titleRegex` | Window title matches this regular expression |
+| `session` | Parsed lattices tmux session exactly equals this string |
+| `sessionContains` | Parsed lattices tmux session contains this string |
+| `isOnScreen` | Window is, or is not, visible on the current Space |
+| `spaceId` | Window belongs to this macOS Space id |
+| `not` | Exclusion clauses; any match rejects the window |
+
+`app` and `titleContains` are the original substring fields, so older
+`layers.json` files continue to work. New layers created from plucked
+windows use `appEquals` by default to avoid accidental substring matches.
+
 ### Layer bar
 
 When a workspace config is loaded, a layer bar appears between the

--- a/docs/terminal-kit.md
+++ b/docs/terminal-kit.md
@@ -1,0 +1,87 @@
+# LatticesTerminalKit
+
+`LatticesTerminalKit` is the reusable Swift terminal-inventory slice of
+lattices. It is designed for native hosts such as Scout that should embed the
+same macOS probes directly instead of talking to the lattices daemon or CLI.
+
+## V1 Scope
+
+The first slice inventories:
+
+- Apple Terminal
+- iTerm2
+- Ghostty
+
+It intentionally stays read-oriented. Focus and placement actions can build on
+the returned handles later, but the v1 contract is an observed terminal
+projection, not a canonical session or message store.
+
+## Import
+
+The product lives in the repo's reusable Swift package:
+
+```swift
+import LatticesTerminalKit
+
+let snapshot = TerminalInventory.snapshot()
+```
+
+For bounded tmux pane context:
+
+```swift
+let snapshot = TerminalInventory.snapshot(options: .init(
+    includePaneContent: true,
+    paneContentLineLimit: 120
+))
+```
+
+## Snapshot Shape
+
+`TerminalInventorySnapshot` contains:
+
+- `snapshotId`
+- `observedAt`
+- `terminals`
+- `tmuxSessions`
+- `terminalTabs`
+- `terminalWindows`
+
+Each `TerminalInstance` includes:
+
+- identity: `stableKey`, `tty`, app name, bundle id, app pid
+- terminal UI: window id/title, tab index/title, terminal session id
+- process context: interesting process rows, shell pid, cwd, cwd source
+- tmux context: session and pane id
+- harness detection: `detectedHarnesses` for Claude and Codex signals
+- action preparation: `focusHandle`, `placementHandle`, `capabilities`
+- trust metadata: `provenance` with confidence for tty/cwd/window/tmux/harness
+- optional inspection: bounded `paneCapture`
+
+## Join Strategy
+
+The kit joins by TTY first.
+
+Inputs:
+
+- process table from `ps`
+- cwd lookup from batched `lsof`
+- tmux sessions and panes
+- AppleScript tab probes for Terminal and iTerm2
+- CG window inventory for Terminal, iTerm2, and Ghostty
+
+Window resolution order:
+
+1. lattices title tag: `[lattices:<session>]`
+2. app window index from Terminal/iTerm2 tab probes
+3. CG owner process tree TTY, used especially for Ghostty
+
+Ghostty is expected to be window-level in v1. The kit does not synthesize stable
+tab ids from titles or z-order.
+
+## Notes For Scout
+
+CG window IDs are useful but volatile. Consumers should pair them with
+`stableKey`, app pid, bundle id, tty, and tmux pane identity where available.
+
+Pane capture is opt-in and ephemeral. It should be treated as drill-down context,
+not as durable chat or terminal history.

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -8,13 +8,19 @@ let package = Package(
         .iOS(.v17)
     ],
     products: [
-        .library(name: "DeckKit", targets: ["DeckKit"])
+        .library(name: "DeckKit", targets: ["DeckKit"]),
+        .library(name: "LatticesTerminalKit", targets: ["LatticesTerminalKit"])
     ],
     targets: [
         .target(name: "DeckKit"),
+        .target(name: "LatticesTerminalKit"),
         .testTarget(
             name: "DeckKitTests",
             dependencies: ["DeckKit"]
+        ),
+        .testTarget(
+            name: "LatticesTerminalKitTests",
+            dependencies: ["LatticesTerminalKit"]
         )
     ]
 )

--- a/swift/Sources/LatticesTerminalKit/ProcessQuery.swift
+++ b/swift/Sources/LatticesTerminalKit/ProcessQuery.swift
@@ -1,0 +1,176 @@
+import Darwin
+import Foundation
+
+public enum ProcessQuery {
+    public static let defaultInterestingCommands: Set<String> = [
+        "claude", "node", "bun", "deno", "python", "python3",
+        "ruby", "go", "cargo", "nvim", "vim", "npm", "npx",
+        "pnpm", "swift", "make", "git"
+    ]
+
+    private static let shellCommands: Set<String> = [
+        "bash", "zsh", "fish", "sh", "dash", "tcsh", "csh"
+    ]
+
+    public static func snapshot() -> [Int: ProcessEntry] {
+        let raw = shell([
+            "/bin/ps", "-eo", "pid,ppid,pgid,tty,comm,args"
+        ])
+        guard !raw.isEmpty else { return [:] }
+
+        var table: [Int: ProcessEntry] = [:]
+        let lines = raw.split(separator: "\n", omittingEmptySubsequences: true)
+
+        for line in lines.dropFirst() {
+            let trimmed = String(line).trimmingCharacters(in: .whitespaces)
+            let parts = trimmed.split(separator: " ", maxSplits: 5, omittingEmptySubsequences: true)
+            guard parts.count >= 6 else { continue }
+
+            guard let pid = Int(parts[0]),
+                  let ppid = Int(parts[1]),
+                  let pgid = Int(parts[2])
+            else { continue }
+
+            let commFull = String(parts[4])
+            let comm = (commFull as NSString).lastPathComponent
+
+            table[pid] = ProcessEntry(
+                pid: pid,
+                ppid: ppid,
+                pgid: pgid,
+                tty: String(parts[3]),
+                comm: comm,
+                args: String(parts[5])
+            )
+        }
+
+        return table
+    }
+
+    public static func batchCWD(pids: [Int]) -> [Int: String] {
+        guard !pids.isEmpty else { return [:] }
+
+        let pidList = pids.map(String.init).joined(separator: ",")
+        let raw = shell([
+            "/usr/sbin/lsof", "-a", "-d", "cwd", "-p", pidList, "-Fn"
+        ])
+        guard !raw.isEmpty else { return [:] }
+
+        var result: [Int: String] = [:]
+        var currentPid: Int?
+
+        for line in raw.split(separator: "\n", omittingEmptySubsequences: true) {
+            let s = String(line)
+            if s.hasPrefix("p") {
+                currentPid = Int(s.dropFirst())
+            } else if s.hasPrefix("n"), let pid = currentPid {
+                result[pid] = String(s.dropFirst())
+            }
+        }
+
+        return result
+    }
+
+    public static func filterInteresting(
+        _ table: [Int: ProcessEntry],
+        commands: Set<String> = defaultInterestingCommands
+    ) -> [ProcessEntry] {
+        table.values
+            .filter { commands.contains($0.comm) }
+            .sorted { $0.pid < $1.pid }
+    }
+
+    public static func snapshotWithCWDs(commands: Set<String> = defaultInterestingCommands) -> (
+        table: [Int: ProcessEntry],
+        interesting: [ProcessEntry]
+    ) {
+        var table = snapshot()
+        let interestingEntries = filterInteresting(table, commands: commands)
+        let cwdPids = Set(interestingEntries.map(\.pid) + table.values
+            .filter { shellCommands.contains($0.comm) && TerminalQuery.normalizeTTY($0.tty).hasPrefix("ttys") }
+            .map(\.pid))
+        let cwds = batchCWD(pids: Array(cwdPids))
+
+        for (pid, cwd) in cwds {
+            table[pid]?.cwd = cwd
+        }
+
+        let interesting = interestingEntries.compactMap { table[$0.pid] }
+        return (table, interesting)
+    }
+
+    public static func childrenMap(from table: [Int: ProcessEntry]) -> [Int: [Int]] {
+        var children: [Int: [Int]] = [:]
+        for (pid, entry) in table {
+            children[entry.ppid, default: []].append(pid)
+        }
+        for parent in children.keys {
+            children[parent]?.sort()
+        }
+        return children
+    }
+
+    public static func descendants(of pid: Int, in table: [Int: ProcessEntry]) -> [ProcessEntry] {
+        let children = childrenMap(from: table)
+        var result: [ProcessEntry] = []
+        var queue = children[pid] ?? []
+        var visited: Set<Int> = [pid]
+
+        while !queue.isEmpty {
+            let childPid = queue.removeFirst()
+            guard !visited.contains(childPid) else { continue }
+            visited.insert(childPid)
+
+            if let entry = table[childPid] {
+                result.append(entry)
+            }
+            queue.append(contentsOf: children[childPid] ?? [])
+        }
+
+        return result
+    }
+
+    public static func shell(_ args: [String]) -> String {
+        var pipeFds: [Int32] = [0, 0]
+        guard pipe(&pipeFds) == 0 else { return "" }
+
+        var fileActions: posix_spawn_file_actions_t?
+        posix_spawn_file_actions_init(&fileActions)
+        posix_spawn_file_actions_adddup2(&fileActions, pipeFds[1], STDOUT_FILENO)
+        posix_spawn_file_actions_addopen(&fileActions, STDERR_FILENO, "/dev/null", O_WRONLY, 0)
+        posix_spawn_file_actions_addclose(&fileActions, pipeFds[0])
+        posix_spawn_file_actions_addclose(&fileActions, pipeFds[1])
+
+        let cArgs = args.map { strdup($0) } + [nil]
+        defer { cArgs.compactMap { $0 }.forEach { free($0) } }
+
+        var pid: pid_t = 0
+        let spawnResult = args[0].withCString { path in
+            posix_spawn(&pid, path, &fileActions, nil, cArgs, environ)
+        }
+        posix_spawn_file_actions_destroy(&fileActions)
+
+        close(pipeFds[1])
+
+        guard spawnResult == 0 else {
+            close(pipeFds[0])
+            return ""
+        }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 65_536)
+        while true {
+            let count = read(pipeFds[0], &buffer, buffer.count)
+            if count <= 0 { break }
+            data.append(buffer, count: count)
+        }
+        close(pipeFds[0])
+
+        var status: Int32 = 0
+        waitpid(pid, &status, 0)
+
+        guard status == 0 else { return "" }
+        return String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+}

--- a/swift/Sources/LatticesTerminalKit/TerminalInventory.swift
+++ b/swift/Sources/LatticesTerminalKit/TerminalInventory.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+public enum TerminalInventory {
+    public static func snapshot(options: TerminalInventoryOptions = TerminalInventoryOptions()) -> TerminalInventorySnapshot {
+        let observedAt = Date()
+        let processSnapshot = ProcessQuery.snapshotWithCWDs(commands: options.interestingCommands)
+        let tmuxSessions = TmuxQuery.listSessions()
+        let terminalTabs = TerminalQuery.queryAll(apps: options.apps)
+        let terminalWindows = TerminalWindowQuery.listTerminalWindows(
+            apps: options.apps,
+            additionalAppNames: options.additionalTerminalAppNames
+        )
+
+        let capturedContent = options.includePaneContent
+            ? capturePaneContent(tmuxSessions: tmuxSessions, lineLimit: options.paneContentLineLimit)
+            : [:]
+
+        let terminals = TerminalSynthesizer.synthesize(
+            processTable: processSnapshot.table,
+            interesting: processSnapshot.interesting,
+            tmuxSessions: tmuxSessions,
+            terminalTabs: terminalTabs,
+            terminalWindows: terminalWindows,
+            paneCaptureByPaneId: capturedContent,
+            observedAt: observedAt
+        )
+
+        return TerminalInventorySnapshot(
+            snapshotId: UUID().uuidString,
+            observedAt: observedAt,
+            timestamp: observedAt,
+            terminals: terminals,
+            tmuxSessions: tmuxSessions,
+            terminalTabs: terminalTabs,
+            terminalWindows: terminalWindows
+        )
+    }
+
+    private static func capturePaneContent(tmuxSessions: [TmuxSession], lineLimit: Int) -> [String: TerminalPaneCapture] {
+        var result: [String: TerminalPaneCapture] = [:]
+        let observedAt = Date()
+        let clampedLimit = max(1, min(lineLimit, 2_000))
+        for pane in tmuxSessions.flatMap(\.panes) {
+            if let content = TmuxQuery.capturePane(paneId: pane.id, lineLimit: clampedLimit) {
+                let lineCount = content.split(separator: "\n", omittingEmptySubsequences: false).count
+                result[pane.id] = TerminalPaneCapture(
+                    text: content,
+                    observedAt: observedAt,
+                    lineLimit: clampedLimit,
+                    lineCount: lineCount,
+                    truncated: lineCount >= clampedLimit
+                )
+            }
+        }
+        return result
+    }
+}

--- a/swift/Sources/LatticesTerminalKit/TerminalModels.swift
+++ b/swift/Sources/LatticesTerminalKit/TerminalModels.swift
@@ -1,0 +1,453 @@
+import Foundation
+
+public enum TerminalApp: String, CaseIterable, Codable, Identifiable, Sendable {
+    case terminal = "Terminal"
+    case iterm2 = "iTerm2"
+    case ghostty = "Ghostty"
+
+    public var id: String { rawValue }
+
+    public var bundleIdentifier: String {
+        switch self {
+        case .terminal:
+            return "com.apple.Terminal"
+        case .iterm2:
+            return "com.googlecode.iterm2"
+        case .ghostty:
+            return "com.mitchellh.ghostty"
+        }
+    }
+
+    public static func named(_ appName: String) -> TerminalApp? {
+        allCases.first { $0.rawValue == appName }
+    }
+}
+
+public struct TerminalFrame: Codable, Equatable, Sendable {
+    public let x: Double
+    public let y: Double
+    public let w: Double
+    public let h: Double
+
+    public init(x: Double, y: Double, w: Double, h: Double) {
+        self.x = x
+        self.y = y
+        self.w = w
+        self.h = h
+    }
+}
+
+public struct TerminalWindow: Codable, Equatable, Identifiable, Sendable {
+    public let wid: UInt32
+    public let app: String
+    public let bundleIdentifier: String?
+    public let pid: Int32
+    public let title: String
+    public let frame: TerminalFrame
+    public let isOnScreen: Bool
+    public let latticesSession: String?
+    public var axVerified: Bool
+    public var zIndex: Int
+
+    public var id: UInt32 { wid }
+
+    public init(
+        wid: UInt32,
+        app: String,
+        bundleIdentifier: String? = nil,
+        pid: Int32,
+        title: String,
+        frame: TerminalFrame,
+        isOnScreen: Bool,
+        latticesSession: String? = nil,
+        axVerified: Bool = true,
+        zIndex: Int = 0
+    ) {
+        self.wid = wid
+        self.app = app
+        self.bundleIdentifier = bundleIdentifier
+        self.pid = pid
+        self.title = title
+        self.frame = frame
+        self.isOnScreen = isOnScreen
+        self.latticesSession = latticesSession
+        self.axVerified = axVerified
+        self.zIndex = zIndex
+    }
+}
+
+public struct ProcessEntry: Codable, Equatable, Identifiable, Sendable {
+    public let pid: Int
+    public let ppid: Int
+    public let pgid: Int
+    public let tty: String
+    public let comm: String
+    public let args: String
+    public var cwd: String?
+
+    public var id: Int { pid }
+
+    public init(pid: Int, ppid: Int, pgid: Int, tty: String, comm: String, args: String, cwd: String? = nil) {
+        self.pid = pid
+        self.ppid = ppid
+        self.pgid = pgid
+        self.tty = tty
+        self.comm = comm
+        self.args = args
+        self.cwd = cwd
+    }
+}
+
+public struct TmuxSession: Codable, Equatable, Identifiable, Sendable {
+    public let id: String
+    public let name: String
+    public let windowCount: Int
+    public let attached: Bool
+    public let panes: [TmuxPane]
+
+    public init(name: String, windowCount: Int, attached: Bool, panes: [TmuxPane]) {
+        self.id = name
+        self.name = name
+        self.windowCount = windowCount
+        self.attached = attached
+        self.panes = panes
+    }
+}
+
+public struct TmuxPane: Codable, Equatable, Identifiable, Sendable {
+    public let id: String
+    public let windowIndex: Int
+    public let windowName: String
+    public let title: String
+    public let currentCommand: String
+    public let pid: Int
+    public let isActive: Bool
+
+    public init(
+        id: String,
+        windowIndex: Int,
+        windowName: String,
+        title: String,
+        currentCommand: String,
+        pid: Int,
+        isActive: Bool
+    ) {
+        self.id = id
+        self.windowIndex = windowIndex
+        self.windowName = windowName
+        self.title = title
+        self.currentCommand = currentCommand
+        self.pid = pid
+        self.isActive = isActive
+    }
+}
+
+public struct TerminalTab: Codable, Equatable, Sendable {
+    public let app: TerminalApp
+    public let windowIndex: Int
+    public let tabIndex: Int
+    public let tty: String
+    public let isActiveTab: Bool
+    public let title: String
+    public let sessionId: String?
+
+    public init(
+        app: TerminalApp,
+        windowIndex: Int,
+        tabIndex: Int,
+        tty: String,
+        isActiveTab: Bool,
+        title: String,
+        sessionId: String? = nil
+    ) {
+        self.app = app
+        self.windowIndex = windowIndex
+        self.tabIndex = tabIndex
+        self.tty = tty
+        self.isActiveTab = isActiveTab
+        self.title = title
+        self.sessionId = sessionId
+    }
+}
+
+public enum TerminalWindowResolution: String, Codable, Sendable {
+    case latticesTag
+    case appWindowIndex
+    case processTreeTTY
+}
+
+public enum TerminalConfidence: String, Codable, Sendable {
+    case high
+    case medium
+    case low
+}
+
+public enum TerminalCWDSource: String, Codable, Sendable {
+    case interestingProcess
+    case shell
+}
+
+public enum TerminalHarnessKind: String, Codable, Sendable {
+    case claude
+    case codex
+}
+
+public struct DetectedHarness: Codable, Equatable, Identifiable, Sendable {
+    public let kind: TerminalHarnessKind
+    public let pid: Int
+    public let command: String
+    public let args: String
+    public let evidence: String
+
+    public var id: String { "\(kind.rawValue):\(pid)" }
+
+    public init(kind: TerminalHarnessKind, pid: Int, command: String, args: String, evidence: String) {
+        self.kind = kind
+        self.pid = pid
+        self.command = command
+        self.args = args
+        self.evidence = evidence
+    }
+}
+
+public enum TerminalFocusGranularity: String, Codable, Sendable {
+    case window
+    case tab
+    case pane
+    case none
+}
+
+public struct TerminalCapabilities: Codable, Equatable, Sendable {
+    public let canFocus: Bool
+    public let canPlace: Bool
+    public let canCapturePane: Bool
+    public let canResolveCwd: Bool
+    public let focusGranularity: TerminalFocusGranularity
+    public let requiresAutomation: Bool
+
+    public init(
+        canFocus: Bool,
+        canPlace: Bool,
+        canCapturePane: Bool,
+        canResolveCwd: Bool,
+        focusGranularity: TerminalFocusGranularity,
+        requiresAutomation: Bool
+    ) {
+        self.canFocus = canFocus
+        self.canPlace = canPlace
+        self.canCapturePane = canCapturePane
+        self.canResolveCwd = canResolveCwd
+        self.focusGranularity = focusGranularity
+        self.requiresAutomation = requiresAutomation
+    }
+}
+
+public struct TerminalJoinProvenance: Codable, Equatable, Sendable {
+    public let tty: TerminalConfidence
+    public let cwd: TerminalConfidence?
+    public let window: TerminalConfidence?
+    public let tmux: TerminalConfidence?
+    public let harness: TerminalConfidence?
+    public let notes: [String]
+
+    public init(
+        tty: TerminalConfidence,
+        cwd: TerminalConfidence?,
+        window: TerminalConfidence?,
+        tmux: TerminalConfidence?,
+        harness: TerminalConfidence?,
+        notes: [String] = []
+    ) {
+        self.tty = tty
+        self.cwd = cwd
+        self.window = window
+        self.tmux = tmux
+        self.harness = harness
+        self.notes = notes
+    }
+}
+
+public struct TerminalPaneCapture: Codable, Equatable, Sendable {
+    public let text: String
+    public let observedAt: Date
+    public let lineLimit: Int
+    public let lineCount: Int
+    public let truncated: Bool
+
+    public init(text: String, observedAt: Date, lineLimit: Int, lineCount: Int, truncated: Bool) {
+        self.text = text
+        self.observedAt = observedAt
+        self.lineLimit = lineLimit
+        self.lineCount = lineCount
+        self.truncated = truncated
+    }
+}
+
+public struct TerminalInstance: Codable, Equatable, Identifiable, Sendable {
+    public let observedAt: Date
+    public let stableKey: String
+    public let tty: String
+    public let app: TerminalApp?
+    public let appName: String?
+    public let appBundleIdentifier: String?
+    public let appPid: Int32?
+    public let windowIndex: Int?
+    public let tabIndex: Int?
+    public let isActiveTab: Bool
+    public let tabTitle: String?
+    public let terminalSessionId: String?
+    public let processes: [ProcessEntry]
+    public let detectedHarnesses: [DetectedHarness]
+    public let shellPid: Int?
+    public let cwd: String?
+    public let cwdSource: TerminalCWDSource?
+    public let tmuxSession: String?
+    public let tmuxPaneId: String?
+    public let windowId: UInt32?
+    public let windowTitle: String?
+    public let windowResolution: TerminalWindowResolution?
+    public let focusHandle: String?
+    public let placementHandle: String?
+    public let capabilities: TerminalCapabilities
+    public let provenance: TerminalJoinProvenance
+    public let paneCapture: TerminalPaneCapture?
+
+    public var id: String { tty }
+
+    public var hasClaude: Bool {
+        detectedHarnesses.contains { $0.kind == .claude }
+    }
+
+    public var hasCodex: Bool {
+        detectedHarnesses.contains { $0.kind == .codex }
+    }
+
+    public var displayName: String {
+        if let session = tmuxSession { return session }
+        if let title = tabTitle, !title.isEmpty { return title }
+        if let title = windowTitle, !title.isEmpty { return title }
+        return tty
+    }
+
+    public init(
+        observedAt: Date,
+        stableKey: String,
+        tty: String,
+        app: TerminalApp?,
+        appName: String?,
+        appBundleIdentifier: String?,
+        appPid: Int32?,
+        windowIndex: Int?,
+        tabIndex: Int?,
+        isActiveTab: Bool,
+        tabTitle: String?,
+        terminalSessionId: String?,
+        processes: [ProcessEntry],
+        detectedHarnesses: [DetectedHarness],
+        shellPid: Int?,
+        cwd: String?,
+        cwdSource: TerminalCWDSource?,
+        tmuxSession: String?,
+        tmuxPaneId: String?,
+        windowId: UInt32?,
+        windowTitle: String?,
+        windowResolution: TerminalWindowResolution?,
+        focusHandle: String?,
+        placementHandle: String?,
+        capabilities: TerminalCapabilities,
+        provenance: TerminalJoinProvenance,
+        paneCapture: TerminalPaneCapture? = nil
+    ) {
+        self.observedAt = observedAt
+        self.stableKey = stableKey
+        self.tty = tty
+        self.app = app
+        self.appName = appName
+        self.appBundleIdentifier = appBundleIdentifier
+        self.appPid = appPid
+        self.windowIndex = windowIndex
+        self.tabIndex = tabIndex
+        self.isActiveTab = isActiveTab
+        self.tabTitle = tabTitle
+        self.terminalSessionId = terminalSessionId
+        self.processes = processes
+        self.detectedHarnesses = detectedHarnesses
+        self.shellPid = shellPid
+        self.cwd = cwd
+        self.cwdSource = cwdSource
+        self.tmuxSession = tmuxSession
+        self.tmuxPaneId = tmuxPaneId
+        self.windowId = windowId
+        self.windowTitle = windowTitle
+        self.windowResolution = windowResolution
+        self.focusHandle = focusHandle
+        self.placementHandle = placementHandle
+        self.capabilities = capabilities
+        self.provenance = provenance
+        self.paneCapture = paneCapture
+    }
+}
+
+public struct TerminalInventorySnapshot: Codable, Equatable, Sendable {
+    public let snapshotId: String
+    public let observedAt: Date
+    public let timestamp: Date
+    public let terminals: [TerminalInstance]
+    public let tmuxSessions: [TmuxSession]
+    public let terminalTabs: [TerminalTab]
+    public let terminalWindows: [TerminalWindow]
+
+    public init(
+        snapshotId: String,
+        observedAt: Date,
+        timestamp: Date,
+        terminals: [TerminalInstance],
+        tmuxSessions: [TmuxSession],
+        terminalTabs: [TerminalTab],
+        terminalWindows: [TerminalWindow]
+    ) {
+        self.snapshotId = snapshotId
+        self.observedAt = observedAt
+        self.timestamp = timestamp
+        self.terminals = terminals
+        self.tmuxSessions = tmuxSessions
+        self.terminalTabs = terminalTabs
+        self.terminalWindows = terminalWindows
+    }
+}
+
+public struct TerminalInventoryOptions: Sendable {
+    public var apps: [TerminalApp]
+    public var additionalTerminalAppNames: [String]
+    public var interestingCommands: Set<String>
+    public var includePaneContent: Bool
+    public var paneContentLineLimit: Int
+
+    public init(
+        apps: [TerminalApp] = TerminalApp.allCases,
+        additionalTerminalAppNames: [String] = [],
+        interestingCommands: Set<String> = ProcessQuery.defaultInterestingCommands,
+        includePaneContent: Bool = false,
+        paneContentLineLimit: Int = 120
+    ) {
+        self.apps = apps
+        self.additionalTerminalAppNames = additionalTerminalAppNames
+        self.interestingCommands = interestingCommands
+        self.includePaneContent = includePaneContent
+        self.paneContentLineLimit = paneContentLineLimit
+    }
+}
+
+public enum LatticesTerminalTag {
+    public static func windowTag(for session: String) -> String {
+        "[lattices:\(session)]"
+    }
+
+    public static func extractSessionName(from title: String) -> String? {
+        guard let range = title.range(of: #"\[lattices:([^\]]+)\]"#, options: .regularExpression) else {
+            return nil
+        }
+        let match = String(title[range])
+        return String(match.dropFirst(10).dropLast(1))
+    }
+}

--- a/swift/Sources/LatticesTerminalKit/TerminalQuery.swift
+++ b/swift/Sources/LatticesTerminalKit/TerminalQuery.swift
@@ -1,0 +1,126 @@
+import AppKit
+import Foundation
+
+public enum TerminalQuery {
+    public static func normalizeTTY(_ raw: String) -> String {
+        if raw.hasPrefix("/dev/") {
+            return String(raw.dropFirst(5))
+        }
+        return raw
+    }
+
+    public static func queryAll(apps: [TerminalApp] = TerminalApp.allCases) -> [TerminalTab] {
+        var results: [TerminalTab] = []
+        for app in apps where isAppRunning(app.rawValue) {
+            switch app {
+            case .iterm2:
+                results.append(contentsOf: queryITerm2())
+            case .terminal:
+                results.append(contentsOf: queryTerminalApp())
+            case .ghostty:
+                break
+            }
+        }
+        return results
+    }
+
+    public static func queryITerm2() -> [TerminalTab] {
+        let script = """
+        tell application "iTerm2"
+            set output to ""
+            set winIdx to 0
+            repeat with w in windows
+                set tabIdx to 0
+                repeat with t in tabs of w
+                    repeat with s in sessions of t
+                        set output to output & winIdx & "\t" & tabIdx & "\t" & (tty of s) & "\t" & (name of s) & "\t" & (unique ID of s) & linefeed
+                    end repeat
+                    set tabIdx to tabIdx + 1
+                end repeat
+                set winIdx to winIdx + 1
+            end repeat
+            return output
+        end tell
+        """
+
+        let raw = osascript(script)
+        guard !raw.isEmpty else { return [] }
+
+        var tabs: [TerminalTab] = []
+        for line in raw.split(separator: "\n", omittingEmptySubsequences: true) {
+            let cols = line.split(separator: "\t", maxSplits: 4, omittingEmptySubsequences: false)
+            guard cols.count >= 5,
+                  let windowIndex = Int(cols[0]),
+                  let tabIndex = Int(cols[1])
+            else { continue }
+
+            let tty = normalizeTTY(String(cols[2]))
+            guard tty.hasPrefix("ttys") else { continue }
+
+            tabs.append(TerminalTab(
+                app: .iterm2,
+                windowIndex: windowIndex,
+                tabIndex: tabIndex,
+                tty: tty,
+                isActiveTab: false,
+                title: String(cols[3]),
+                sessionId: String(cols[4])
+            ))
+        }
+        return tabs
+    }
+
+    public static func queryTerminalApp() -> [TerminalTab] {
+        let script = """
+        tell application "Terminal"
+            set output to ""
+            set winIdx to 0
+            repeat with w in windows
+                set selTab to selected tab of w
+                set tabIdx to 0
+                repeat with t in tabs of w
+                    set isSel to (t = selTab)
+                    set output to output & winIdx & "\t" & tabIdx & "\t" & (tty of t) & "\t" & (custom title of t) & "\t" & isSel & linefeed
+                    set tabIdx to tabIdx + 1
+                end repeat
+                set winIdx to winIdx + 1
+            end repeat
+            return output
+        end tell
+        """
+
+        let raw = osascript(script)
+        guard !raw.isEmpty else { return [] }
+
+        var tabs: [TerminalTab] = []
+        for line in raw.split(separator: "\n", omittingEmptySubsequences: true) {
+            let cols = line.split(separator: "\t", maxSplits: 4, omittingEmptySubsequences: false)
+            guard cols.count >= 5,
+                  let windowIndex = Int(cols[0]),
+                  let tabIndex = Int(cols[1])
+            else { continue }
+
+            let tty = normalizeTTY(String(cols[2]))
+            guard tty.hasPrefix("ttys") else { continue }
+
+            tabs.append(TerminalTab(
+                app: .terminal,
+                windowIndex: windowIndex,
+                tabIndex: tabIndex,
+                tty: tty,
+                isActiveTab: String(cols[4]).lowercased() == "true",
+                title: String(cols[3]),
+                sessionId: nil
+            ))
+        }
+        return tabs
+    }
+
+    static func isAppRunning(_ name: String) -> Bool {
+        NSWorkspace.shared.runningApplications.contains { $0.localizedName == name }
+    }
+
+    private static func osascript(_ source: String) -> String {
+        ProcessQuery.shell(["/usr/bin/osascript", "-e", source])
+    }
+}

--- a/swift/Sources/LatticesTerminalKit/TerminalSynthesizer.swift
+++ b/swift/Sources/LatticesTerminalKit/TerminalSynthesizer.swift
@@ -1,0 +1,345 @@
+import Foundation
+
+public enum TerminalSynthesizer {
+    public static func synthesize(
+        processTable: [Int: ProcessEntry],
+        interesting: [ProcessEntry],
+        tmuxSessions: [TmuxSession],
+        terminalTabs: [TerminalTab],
+        terminalWindows: [TerminalWindow],
+        paneCaptureByPaneId: [String: TerminalPaneCapture] = [:],
+        observedAt: Date = Date()
+    ) -> [TerminalInstance] {
+        let allProcessesByTTY = groupProcessesByTTY(Array(processTable.values))
+        let interestingByTTY = groupProcessesByTTY(interesting)
+        let tmuxByTTY = buildTmuxLookup(processTable: processTable, tmuxSessions: tmuxSessions)
+        let tabByTTY = Dictionary(uniqueKeysWithValues: terminalTabs.map { ($0.tty, $0) })
+        let windowsByApp = buildWindowsByApp(terminalWindows)
+        let windowsByTTY = buildWindowsByTTY(processTable: processTable, terminalWindows: terminalWindows)
+
+        var allTTYs = Set(interestingByTTY.keys)
+        allTTYs.formUnion(tmuxByTTY.keys)
+        allTTYs.formUnion(tabByTTY.keys)
+        allTTYs.formUnion(windowsByTTY.keys)
+
+        var instances: [TerminalInstance] = []
+        for tty in allTTYs.sorted() {
+            let procs = interestingByTTY[tty] ?? []
+            let ttyProcs = allProcessesByTTY[tty] ?? []
+            let ttyPids = Set(ttyProcs.map(\.pid))
+            let shellPid = ttyProcs.first { !ttyPids.contains($0.ppid) }?.pid
+            let cwdEntry = procs.last(where: { $0.cwd != nil })
+            let shellCwd = shellPid.flatMap { processTable[$0]?.cwd }
+            let cwd = cwdEntry?.cwd ?? shellCwd
+            let cwdSource: TerminalCWDSource? = cwdEntry?.cwd != nil ? .interestingProcess : (shellCwd != nil ? .shell : nil)
+
+            let tab = tabByTTY[tty]
+            let tmux = tmuxByTTY[tty]
+            let resolvedWindow = resolveWindow(
+                tmuxSession: tmux?.session,
+                tab: tab,
+                tty: tty,
+                windowsByApp: windowsByApp,
+                allWindows: terminalWindows,
+                windowsByTTY: windowsByTTY
+            )
+
+            let window = resolvedWindow?.window
+            let app = tab?.app ?? window.flatMap { TerminalApp.named($0.app) }
+            let appName = tab?.app.rawValue ?? window?.app
+            let detectedHarnesses = detectHarnesses(in: procs)
+            let stableKey = makeStableKey(
+                tty: tty,
+                appName: appName,
+                appPid: window?.pid,
+                terminalSessionId: tab?.sessionId,
+                tmuxSession: tmux?.session,
+                tmuxPaneId: tmux?.paneId
+            )
+            let focusHandle = makeFocusHandle(
+                window: window,
+                terminalSessionId: tab?.sessionId,
+                tmuxSession: tmux?.session,
+                tmuxPaneId: tmux?.paneId
+            )
+            let placementHandle = window.map { "cg-window:\($0.wid)" }
+            let capabilities = makeCapabilities(
+                app: app,
+                window: window,
+                tab: tab,
+                tmuxPaneId: tmux?.paneId,
+                cwd: cwd
+            )
+            let provenance = makeProvenance(
+                cwdSource: cwdSource,
+                windowResolution: resolvedWindow?.resolution,
+                hasTmux: tmux != nil,
+                hasHarness: !detectedHarnesses.isEmpty
+            )
+            let paneCapture = tmux.flatMap { paneCaptureByPaneId[$0.paneId] }
+
+            instances.append(TerminalInstance(
+                observedAt: observedAt,
+                stableKey: stableKey,
+                tty: tty,
+                app: app,
+                appName: appName,
+                appBundleIdentifier: window?.bundleIdentifier ?? app?.bundleIdentifier,
+                appPid: window?.pid,
+                windowIndex: tab?.windowIndex,
+                tabIndex: tab?.tabIndex,
+                isActiveTab: tab?.isActiveTab ?? false,
+                tabTitle: tab?.title,
+                terminalSessionId: tab?.sessionId,
+                processes: procs,
+                detectedHarnesses: detectedHarnesses,
+                shellPid: shellPid,
+                cwd: cwd,
+                cwdSource: cwdSource,
+                tmuxSession: tmux?.session,
+                tmuxPaneId: tmux?.paneId,
+                windowId: window?.wid,
+                windowTitle: window?.title,
+                windowResolution: resolvedWindow?.resolution,
+                focusHandle: focusHandle,
+                placementHandle: placementHandle,
+                capabilities: capabilities,
+                provenance: provenance,
+                paneCapture: paneCapture
+            ))
+        }
+
+        return instances.sorted { a, b in
+            if a.hasClaude != b.hasClaude { return a.hasClaude }
+            if a.isActiveTab != b.isActiveTab { return a.isActiveTab }
+            if (a.appName ?? "") != (b.appName ?? "") { return (a.appName ?? "") < (b.appName ?? "") }
+            return a.tty < b.tty
+        }
+    }
+
+    private static func groupProcessesByTTY(_ processes: [ProcessEntry]) -> [String: [ProcessEntry]] {
+        var grouped: [String: [ProcessEntry]] = [:]
+        for entry in processes {
+            let tty = TerminalQuery.normalizeTTY(entry.tty)
+            guard tty != "??" else { continue }
+            grouped[tty, default: []].append(entry)
+        }
+        for tty in grouped.keys {
+            grouped[tty]?.sort { $0.pid < $1.pid }
+        }
+        return grouped
+    }
+
+    private static func detectHarnesses(in processes: [ProcessEntry]) -> [DetectedHarness] {
+        var seen: Set<String> = []
+        var harnesses: [DetectedHarness] = []
+
+        for process in processes {
+            let command = process.comm.lowercased()
+            let args = process.args.lowercased()
+            let kind: TerminalHarnessKind?
+            if command == "claude" || args.contains("claude") {
+                kind = .claude
+            } else if command == "codex" || args.contains("codex") {
+                kind = .codex
+            } else {
+                kind = nil
+            }
+
+            guard let kind else { continue }
+            let key = "\(kind.rawValue):\(process.pid)"
+            guard !seen.contains(key) else { continue }
+            seen.insert(key)
+            harnesses.append(DetectedHarness(
+                kind: kind,
+                pid: process.pid,
+                command: process.comm,
+                args: process.args,
+                evidence: "process:\(process.pid):\(process.comm)"
+            ))
+        }
+
+        return harnesses
+    }
+
+    private static func makeStableKey(
+        tty: String,
+        appName: String?,
+        appPid: Int32?,
+        terminalSessionId: String?,
+        tmuxSession: String?,
+        tmuxPaneId: String?
+    ) -> String {
+        if let tmuxSession, let tmuxPaneId {
+            return "tmux:\(tmuxSession):\(tmuxPaneId)"
+        }
+        if let terminalSessionId {
+            return "terminal-session:\(terminalSessionId)"
+        }
+        if let appName, let appPid {
+            return "terminal-window:\(appName):\(appPid):\(tty)"
+        }
+        return "tty:\(tty)"
+    }
+
+    private static func makeFocusHandle(
+        window: TerminalWindow?,
+        terminalSessionId: String?,
+        tmuxSession: String?,
+        tmuxPaneId: String?
+    ) -> String? {
+        if let window {
+            return "cg-window:\(window.wid)"
+        }
+        if let terminalSessionId {
+            return "terminal-session:\(terminalSessionId)"
+        }
+        if let tmuxSession, let tmuxPaneId {
+            return "tmux:\(tmuxSession):\(tmuxPaneId)"
+        }
+        return nil
+    }
+
+    private static func makeCapabilities(
+        app: TerminalApp?,
+        window: TerminalWindow?,
+        tab: TerminalTab?,
+        tmuxPaneId: String?,
+        cwd: String?
+    ) -> TerminalCapabilities {
+        let focusGranularity: TerminalFocusGranularity
+        if tmuxPaneId != nil {
+            focusGranularity = .pane
+        } else if tab != nil {
+            focusGranularity = .tab
+        } else if window != nil {
+            focusGranularity = .window
+        } else {
+            focusGranularity = .none
+        }
+
+        return TerminalCapabilities(
+            canFocus: window != nil || tab != nil || tmuxPaneId != nil,
+            canPlace: window != nil,
+            canCapturePane: tmuxPaneId != nil,
+            canResolveCwd: cwd != nil,
+            focusGranularity: focusGranularity,
+            requiresAutomation: app == .terminal || app == .iterm2
+        )
+    }
+
+    private static func makeProvenance(
+        cwdSource: TerminalCWDSource?,
+        windowResolution: TerminalWindowResolution?,
+        hasTmux: Bool,
+        hasHarness: Bool
+    ) -> TerminalJoinProvenance {
+        let windowConfidence: TerminalConfidence?
+        switch windowResolution {
+        case .latticesTag:
+            windowConfidence = .high
+        case .appWindowIndex, .processTreeTTY:
+            windowConfidence = .medium
+        case nil:
+            windowConfidence = nil
+        }
+
+        let notes = windowResolution == .processTreeTTY
+            ? ["window joined by terminal owner process tree; tab identity may be unavailable"]
+            : []
+
+        return TerminalJoinProvenance(
+            tty: .high,
+            cwd: cwdSource == nil ? nil : .medium,
+            window: windowConfidence,
+            tmux: hasTmux ? .high : nil,
+            harness: hasHarness ? .medium : nil,
+            notes: notes
+        )
+    }
+
+    private static func buildTmuxLookup(
+        processTable: [Int: ProcessEntry],
+        tmuxSessions: [TmuxSession]
+    ) -> [String: (session: String, paneId: String)] {
+        var tmuxByTTY: [String: (session: String, paneId: String)] = [:]
+        for session in tmuxSessions {
+            for pane in session.panes {
+                guard let entry = processTable[pane.pid] else { continue }
+                let tty = TerminalQuery.normalizeTTY(entry.tty)
+                guard tty != "??" else { continue }
+                tmuxByTTY[tty] = (session: session.name, paneId: pane.id)
+            }
+        }
+        return tmuxByTTY
+    }
+
+    private static func buildWindowsByApp(_ windows: [TerminalWindow]) -> [String: [TerminalWindow]] {
+        var result: [String: [TerminalWindow]] = [:]
+        for window in windows {
+            result[window.app, default: []].append(window)
+        }
+        for app in result.keys {
+            result[app]?.sort {
+                if $0.zIndex != $1.zIndex { return $0.zIndex < $1.zIndex }
+                return $0.wid < $1.wid
+            }
+        }
+        return result
+    }
+
+    private static func buildWindowsByTTY(
+        processTable: [Int: ProcessEntry],
+        terminalWindows: [TerminalWindow]
+    ) -> [String: TerminalWindow] {
+        var windowsByTTY: [String: TerminalWindow] = [:]
+
+        for window in terminalWindows.sorted(by: { $0.zIndex < $1.zIndex }) {
+            let rootPid = Int(window.pid)
+            var candidates: [ProcessEntry] = []
+            if let root = processTable[rootPid] {
+                candidates.append(root)
+            }
+            candidates.append(contentsOf: ProcessQuery.descendants(of: rootPid, in: processTable))
+
+            let ttys = Set(candidates.compactMap { entry -> String? in
+                let tty = TerminalQuery.normalizeTTY(entry.tty)
+                return tty.hasPrefix("ttys") ? tty : nil
+            })
+
+            for tty in ttys where windowsByTTY[tty] == nil {
+                windowsByTTY[tty] = window
+            }
+        }
+
+        return windowsByTTY
+    }
+
+    private static func resolveWindow(
+        tmuxSession: String?,
+        tab: TerminalTab?,
+        tty: String,
+        windowsByApp: [String: [TerminalWindow]],
+        allWindows: [TerminalWindow],
+        windowsByTTY: [String: TerminalWindow]
+    ) -> (window: TerminalWindow, resolution: TerminalWindowResolution)? {
+        if let session = tmuxSession {
+            let tag = LatticesTerminalTag.windowTag(for: session)
+            if let match = allWindows.first(where: { $0.latticesSession == session || $0.title.contains(tag) }) {
+                return (match, .latticesTag)
+            }
+        }
+
+        if let tab = tab,
+           let appWindows = windowsByApp[tab.app.rawValue],
+           tab.windowIndex < appWindows.count {
+            return (appWindows[tab.windowIndex], .appWindowIndex)
+        }
+
+        if let window = windowsByTTY[tty] {
+            return (window, .processTreeTTY)
+        }
+
+        return nil
+    }
+}

--- a/swift/Sources/LatticesTerminalKit/TerminalWindowQuery.swift
+++ b/swift/Sources/LatticesTerminalKit/TerminalWindowQuery.swift
@@ -1,0 +1,73 @@
+import CoreGraphics
+import Foundation
+
+public enum TerminalWindowQuery {
+    public static func listTerminalWindows(
+        apps: [TerminalApp] = TerminalApp.allCases,
+        additionalAppNames: [String] = []
+    ) -> [TerminalWindow] {
+        let appNames = Set(apps.map(\.rawValue) + additionalAppNames)
+        guard let list = CGWindowListCopyWindowInfo(
+            [.optionAll, .excludeDesktopElements],
+            kCGNullWindowID
+        ) as? [[String: Any]]
+        else { return [] }
+
+        var windows: [TerminalWindow] = []
+        var zIndex = 0
+
+        for info in list {
+            guard let wid = info[kCGWindowNumber as String] as? UInt32,
+                  let ownerName = info[kCGWindowOwnerName as String] as? String,
+                  appNames.contains(ownerName),
+                  let pid = info[kCGWindowOwnerPID as String] as? Int32,
+                  let boundsDict = info[kCGWindowBounds as String] as? NSDictionary
+            else {
+                zIndex += 1
+                continue
+            }
+
+            var rect = CGRect.zero
+            guard CGRectMakeWithDictionaryRepresentation(boundsDict, &rect),
+                  rect.width >= 50,
+                  rect.height >= 50
+            else {
+                zIndex += 1
+                continue
+            }
+
+            let layer = info[kCGWindowLayer as String] as? Int ?? 0
+            guard layer == 0 else {
+                zIndex += 1
+                continue
+            }
+
+            let title = info[kCGWindowName as String] as? String ?? ""
+            let isOnScreen = info[kCGWindowIsOnscreen as String] as? Bool ?? false
+            let bundleIdentifier = TerminalApp.named(ownerName)?.bundleIdentifier
+            windows.append(TerminalWindow(
+                wid: wid,
+                app: ownerName,
+                bundleIdentifier: bundleIdentifier,
+                pid: pid,
+                title: title,
+                frame: TerminalFrame(
+                    x: Double(rect.origin.x),
+                    y: Double(rect.origin.y),
+                    w: Double(rect.width),
+                    h: Double(rect.height)
+                ),
+                isOnScreen: isOnScreen,
+                latticesSession: LatticesTerminalTag.extractSessionName(from: title),
+                axVerified: true,
+                zIndex: zIndex
+            ))
+            zIndex += 1
+        }
+
+        return windows.sorted {
+            if $0.zIndex != $1.zIndex { return $0.zIndex < $1.zIndex }
+            return $0.wid < $1.wid
+        }
+    }
+}

--- a/swift/Sources/LatticesTerminalKit/TmuxQuery.swift
+++ b/swift/Sources/LatticesTerminalKit/TmuxQuery.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+public enum TmuxQuery {
+    public static let resolvedPath: String? = {
+        let candidates = [
+            "/opt/homebrew/bin/tmux",
+            "/usr/local/bin/tmux",
+            "/usr/bin/tmux",
+            "/opt/local/bin/tmux",
+        ]
+        for path in candidates where FileManager.default.isExecutableFile(atPath: path) {
+            return path
+        }
+
+        let result = ProcessQuery.shell(["/usr/bin/which", "tmux"])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if !result.isEmpty && FileManager.default.isExecutableFile(atPath: result) {
+            return result
+        }
+        return nil
+    }()
+
+    public static var isAvailable: Bool {
+        resolvedPath != nil
+    }
+
+    public static func listSessions() -> [TmuxSession] {
+        guard let tmux = resolvedPath else { return [] }
+
+        let sessionsRaw = ProcessQuery.shell([
+            tmux, "list-sessions", "-F",
+            "#{session_name}\t#{session_windows}\t#{session_created}\t#{session_attached}"
+        ])
+        guard !sessionsRaw.isEmpty else { return [] }
+
+        let panesRaw = ProcessQuery.shell([
+            tmux, "list-panes", "-a", "-F",
+            "#{session_name}\t#{window_index}\t#{window_name}\t#{pane_id}\t#{pane_title}\t#{pane_current_command}\t#{pane_pid}\t#{pane_active}"
+        ])
+
+        var panesBySession: [String: [TmuxPane]] = [:]
+        for line in panesRaw.split(separator: "\n") {
+            let cols = line.split(separator: "\t", omittingEmptySubsequences: false).map(String.init)
+            guard cols.count >= 8 else { continue }
+
+            let pane = TmuxPane(
+                id: cols[3],
+                windowIndex: Int(cols[1]) ?? 0,
+                windowName: cols[2],
+                title: cols[4],
+                currentCommand: cols[5],
+                pid: Int(cols[6]) ?? 0,
+                isActive: cols[7] == "1"
+            )
+            panesBySession[cols[0], default: []].append(pane)
+        }
+
+        var sessions: [TmuxSession] = []
+        for line in sessionsRaw.split(separator: "\n") {
+            let cols = line.split(separator: "\t", omittingEmptySubsequences: false).map(String.init)
+            guard cols.count >= 4 else { continue }
+
+            let name = cols[0]
+            sessions.append(TmuxSession(
+                name: name,
+                windowCount: Int(cols[1]) ?? 1,
+                attached: cols[3] != "0",
+                panes: panesBySession[name] ?? []
+            ))
+        }
+
+        return sessions.sorted { $0.name < $1.name }
+    }
+
+    public static func capturePane(paneId: String, lineLimit: Int = 120) -> String? {
+        guard let tmux = resolvedPath else { return nil }
+        let clamped = max(1, min(lineLimit, 2_000))
+        let raw = ProcessQuery.shell([
+            tmux, "capture-pane", "-p", "-S", "-\(clamped)", "-t", paneId
+        ])
+        return raw.isEmpty ? nil : raw
+    }
+}

--- a/swift/Tests/LatticesTerminalKitTests/LatticesTerminalKitTests.swift
+++ b/swift/Tests/LatticesTerminalKitTests/LatticesTerminalKitTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+@testable import LatticesTerminalKit
+
+final class LatticesTerminalKitTests: XCTestCase {
+    func testNormalizesTTY() {
+        XCTAssertEqual(TerminalQuery.normalizeTTY("/dev/ttys003"), "ttys003")
+        XCTAssertEqual(TerminalQuery.normalizeTTY("ttys004"), "ttys004")
+    }
+
+    func testExtractsLatticesSessionTag() {
+        XCTAssertEqual(
+            LatticesTerminalTag.extractSessionName(from: "[lattices:myapp-a1b2c3] zsh"),
+            "myapp-a1b2c3"
+        )
+        XCTAssertNil(LatticesTerminalTag.extractSessionName(from: "plain terminal"))
+    }
+
+    func testSynthesizerPrefersLatticesTagOverAppWindowIndex() {
+        let processTable = [
+            100: ProcessEntry(pid: 100, ppid: 1, pgid: 100, tty: "ttys001", comm: "zsh", args: "zsh"),
+            101: ProcessEntry(pid: 101, ppid: 100, pgid: 100, tty: "ttys001", comm: "claude", args: "claude", cwd: "/repo")
+        ]
+        let sessions = [
+            TmuxSession(
+                name: "repo-a1b2c3",
+                windowCount: 1,
+                attached: true,
+                panes: [
+                    TmuxPane(
+                        id: "%1",
+                        windowIndex: 0,
+                        windowName: "main",
+                        title: "claude",
+                        currentCommand: "claude",
+                        pid: 100,
+                        isActive: true
+                    )
+                ]
+            )
+        ]
+        let tabs = [
+            TerminalTab(
+                app: .iterm2,
+                windowIndex: 0,
+                tabIndex: 0,
+                tty: "ttys001",
+                isActiveTab: true,
+                title: "repo",
+                sessionId: "iterm-session"
+            )
+        ]
+        let windows = [
+            TerminalWindow(
+                wid: 10,
+                app: "iTerm2",
+                pid: 200,
+                title: "unrelated",
+                frame: TerminalFrame(x: 0, y: 0, w: 800, h: 600),
+                isOnScreen: true,
+                zIndex: 0
+            ),
+            TerminalWindow(
+                wid: 11,
+                app: "iTerm2",
+                pid: 201,
+                title: "[lattices:repo-a1b2c3] zsh",
+                frame: TerminalFrame(x: 0, y: 0, w: 800, h: 600),
+                isOnScreen: true,
+                latticesSession: "repo-a1b2c3",
+                zIndex: 1
+            )
+        ]
+
+        let instances = TerminalSynthesizer.synthesize(
+            processTable: processTable,
+            interesting: [processTable[101]!],
+            tmuxSessions: sessions,
+            terminalTabs: tabs,
+            terminalWindows: windows
+        )
+
+        XCTAssertEqual(instances.count, 1)
+        XCTAssertEqual(instances[0].windowId, 11)
+        XCTAssertEqual(instances[0].windowResolution, .latticesTag)
+        XCTAssertEqual(instances[0].tmuxSession, "repo-a1b2c3")
+        XCTAssertTrue(instances[0].hasClaude)
+    }
+
+    func testSynthesizerMapsGhosttyByProcessTreeTTY() {
+        let processTable = [
+            300: ProcessEntry(pid: 300, ppid: 1, pgid: 300, tty: "??", comm: "Ghostty", args: "Ghostty"),
+            301: ProcessEntry(pid: 301, ppid: 300, pgid: 300, tty: "ttys009", comm: "zsh", args: "zsh", cwd: "/repo"),
+            302: ProcessEntry(pid: 302, ppid: 301, pgid: 300, tty: "ttys009", comm: "node", args: "node server.js", cwd: "/repo")
+        ]
+        let windows = [
+            TerminalWindow(
+                wid: 42,
+                app: "Ghostty",
+                pid: 300,
+                title: "repo",
+                frame: TerminalFrame(x: 0, y: 0, w: 900, h: 600),
+                isOnScreen: true,
+                zIndex: 0
+            )
+        ]
+
+        let instances = TerminalSynthesizer.synthesize(
+            processTable: processTable,
+            interesting: [processTable[302]!],
+            tmuxSessions: [],
+            terminalTabs: [],
+            terminalWindows: windows
+        )
+
+        XCTAssertEqual(instances.count, 1)
+        XCTAssertEqual(instances[0].tty, "ttys009")
+        XCTAssertEqual(instances[0].app, .ghostty)
+        XCTAssertEqual(instances[0].windowId, 42)
+        XCTAssertEqual(instances[0].windowResolution, .processTreeTTY)
+        XCTAssertEqual(instances[0].cwd, "/repo")
+    }
+}


### PR DESCRIPTION
## Summary

- Adopts the HUD composer/workspace controls across the macOS app shell, command mode, Studio layers, motion mode, and unified command bar surfaces.
- Adds terminal inventory support via `LatticesTerminalKit`, including tmux/window/process modeling and tests.
- Improves Desktop Inventory interactions: embedded key handling, selected-window distribution, page-aware status telemetry, OCR review status, and supporting docs.

## Validation

- `swift build --package-path apps/mac`
- `swift test --package-path swift`

## Notes

The macOS build still emits existing Swift deprecation/concurrency warnings, but it links successfully.