### PR TITLE
[codex] Compact settings layout and unify window shell adoption

### DIFF
--- a/apps/mac/Sources/AppShell/AppDelegate.swift
+++ b/apps/mac/Sources/AppShell/AppDelegate.swift
@@ -91,9 +91,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         coordinator.registerSurface(id: "commandMode") { CommandModeWindow.shared.isVisible }
         coordinator.registerSurface(id: "commandPalette") { CommandPaletteWindow.shared.isVisible }
         coordinator.registerSurface(id: "mainWindow") { MainWindow.shared.isVisible }
+        coordinator.registerSurface(id: "onboarding") { OnboardingWindowController.shared.isVisible }
         coordinator.registerSurface(id: "permissionsAssistant") { PermissionsAssistantWindowController.shared.isVisible }
         coordinator.registerSurface(id: "permissionDragAssistant") { PermissionDragAssistantWindowController.shared.isVisible }
         coordinator.registerSurface(id: "screenMap") { ScreenMapWindowController.shared.isVisible }
+        coordinator.registerSurface(id: "diagnosticWindow") { DiagnosticWindow.shared.isVisible }
+        coordinator.registerSurface(id: "mouseInputEventViewer") { MouseInputEventViewer.shared.isVisible }
         coordinator.registerSurface(id: "unifiedCommandBar") { UnifiedCommandBarWindow.shared.isVisible }
         coordinator.registerSurface(id: "gridPlacement") { GridPlacementWindow.shared.isVisible }
     }

--- a/apps/mac/Sources/AppShell/AppShellView.swift
+++ b/apps/mac/Sources/AppShell/AppShellView.swift
@@ -89,10 +89,16 @@ struct AppShellView: View {
         } statusBar: {
             statusBar
         }
-        // Full Hudson window chrome: transparent full-size title bar, no separator.
-        // Keep the window non-draggable-by-background so content clicks aren't
-        // swallowed (Lattices manages its own window placement).
-        .background(HudWindowChrome(colorScheme: .dark, isMovableByWindowBackground: false))
+        .background(
+            HudWindowChrome(
+                colorScheme: .dark,
+                titleVisibility: .visible,
+                titlebarAppearsTransparent: false,
+                usesFullSizeContentView: false,
+                isMovableByWindowBackground: false,
+                hidesToolbar: false
+            )
+        )
         .hudsonAppManifest(manifest)
         .onAppear {
             commandState.onDismiss = { windowController.activePage = .home }

--- a/apps/mac/Sources/AppShell/MainWindow.swift
+++ b/apps/mac/Sources/AppShell/MainWindow.swift
@@ -30,24 +30,14 @@ final class MainWindow {
         let view = MainView(scanner: ProjectScanner.shared)
             .preferredColorScheme(.dark)
 
-        let hostingView = NSHostingView(rootView: view)
-        hostingView.frame = NSRect(x: 0, y: 0, width: 380, height: 460)
-
-        let w = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 380, height: 460),
-            styleMask: [.titled, .closable, .resizable, .miniaturizable],
-            backing: .buffered,
-            defer: false
+        let w = AppWindowShell.makeWindow(
+            config: .init(
+                title: "Lattices",
+                initialSize: NSSize(width: 380, height: 460),
+                minSize: NSSize(width: 340, height: 380)
+            ),
+            rootView: view
         )
-        w.contentView = hostingView
-        w.title = "lattices"
-        w.titlebarAppearsTransparent = true
-        w.titleVisibility = .hidden
-        w.isReleasedWhenClosed = false
-        w.backgroundColor = NSColor(red: 0.11, green: 0.11, blue: 0.12, alpha: 1.0)
-        w.appearance = NSAppearance(named: .darkAqua)
-        w.minSize = NSSize(width: 340, height: 380)
-        w.maxSize = NSSize(width: 600, height: 800)
 
         // Position near top-right of screen (close to menu bar area)
         if let screen = NSScreen.main {
@@ -57,8 +47,7 @@ final class MainWindow {
             w.setFrameOrigin(NSPoint(x: x, y: y))
         }
 
-        w.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
+        AppWindowShell.present(w)
 
         window = w
         AppDelegate.updateActivationPolicy()

--- a/apps/mac/Sources/AppShell/OnboardingView.swift
+++ b/apps/mac/Sources/AppShell/OnboardingView.swift
@@ -70,7 +70,12 @@ struct OnboardingView: View {
             .padding(.horizontal, 40)
             .padding(.bottom, 28)
         }
-        .frame(width: 480, height: 470)
+        .frame(
+            minWidth: 480,
+            maxWidth: .infinity,
+            minHeight: 470,
+            maxHeight: .infinity
+        )
         .background(Palette.bg)
         .preferredColorScheme(.dark)
         .onAppear {
@@ -283,6 +288,8 @@ final class OnboardingWindowController {
     private var window: NSWindow?
     private static let completedKey = "onboarding.completed"
 
+    var isVisible: Bool { window?.isVisible ?? false }
+
     var hasCompleted: Bool {
         UserDefaults.standard.bool(forKey: Self.completedKey)
     }
@@ -310,15 +317,11 @@ final class OnboardingWindowController {
         let w = AppWindowShell.makeWindow(
             config: .init(
                 title: "Welcome to Lattices",
-                titleVisible: false,
                 initialSize: NSSize(width: 480, height: 470),
-                minSize: NSSize(width: 480, height: 470),
-                maxSize: NSSize(width: 480, height: 470),
-                miniaturizable: false
+                minSize: NSSize(width: 480, height: 470)
             ),
             rootView: view
         )
-        w.styleMask.remove(.resizable)
         AppWindowShell.positionCentered(w)
         AppWindowShell.present(w)
         self.window = w

--- a/apps/mac/Sources/AppShell/PermissionDragAssistantWindow.swift
+++ b/apps/mac/Sources/AppShell/PermissionDragAssistantWindow.swift
@@ -2,7 +2,7 @@ import AppKit
 import CoreGraphics
 import SwiftUI
 
-private final class PermissionDragAssistantPanel: NSPanel {
+private final class PermissionDragAssistantPanel: NSWindow {
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { true }
 }
@@ -10,7 +10,7 @@ private final class PermissionDragAssistantPanel: NSPanel {
 final class PermissionDragAssistantWindowController: ObservableObject {
     static let shared = PermissionDragAssistantWindowController()
 
-    private var panel: NSPanel?
+    private var panel: NSWindow?
     @Published private(set) var focusedCapability: Capability = .windowControl
 
     var isVisible: Bool { panel?.isVisible ?? false }
@@ -32,7 +32,7 @@ final class PermissionDragAssistantWindowController: ObservableObject {
             onClose: { PermissionDragAssistantWindowController.shared.close() }
         )
 
-        let activePanel: NSPanel
+        let activePanel: NSWindow
         if let panel {
             panel.title = "\(capability.requirementLabel) Helper"
             panel.contentViewController = NSHostingController(rootView: content)
@@ -40,21 +40,18 @@ final class PermissionDragAssistantWindowController: ObservableObject {
         } else {
             let panel = PermissionDragAssistantPanel(
                 contentRect: NSRect(x: 0, y: 0, width: 430, height: 260),
-                styleMask: [.titled, .closable, .utilityWindow, .fullSizeContentView],
+                styleMask: [.titled, .closable, .resizable, .miniaturizable],
                 backing: .buffered,
                 defer: false
             )
             panel.title = "\(capability.requirementLabel) Helper"
-            panel.titleVisibility = .hidden
-            panel.titlebarAppearsTransparent = true
-            panel.isMovableByWindowBackground = true
+            panel.titleVisibility = .visible
+            panel.titlebarAppearsTransparent = false
+            panel.isMovableByWindowBackground = false
             panel.isReleasedWhenClosed = false
             panel.isRestorable = false
-            panel.hidesOnDeactivate = false
-            panel.becomesKeyOnlyIfNeeded = false
             panel.acceptsMouseMovedEvents = true
-            panel.level = .floating
-            panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
+            panel.minSize = NSSize(width: 430, height: 260)
             panel.backgroundColor = NSColor(red: 0.10, green: 0.10, blue: 0.11, alpha: 1.0)
             panel.appearance = NSAppearance(named: .darkAqua)
             panel.contentViewController = NSHostingController(rootView: content)
@@ -102,7 +99,7 @@ final class PermissionDragAssistantWindowController: ObservableObject {
         }
     }
 
-    private func position(_ panel: NSPanel) {
+    private func position(_ panel: NSWindow) {
         let size = CGSize(width: 430, height: 260)
         let anchor = Self.systemSettingsWindowBounds()
             ?? Self.largestCurrentAppWindowBounds(excluding: panel)
@@ -149,7 +146,7 @@ final class PermissionDragAssistantWindowController: ObservableObject {
         panel.setFrame(NSRect(origin: origin, size: size), display: true)
     }
 
-    private func positionOnMainScreen(_ panel: NSPanel, size: CGSize) {
+    private func positionOnMainScreen(_ panel: NSWindow, size: CGSize) {
         let screenFrame = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
         let x = max(screenFrame.minX + 16, screenFrame.maxX - size.width - 32)
         let y = max(screenFrame.minY + 16, screenFrame.maxY - size.height - 72)
@@ -162,7 +159,7 @@ final class PermissionDragAssistantWindowController: ObservableObject {
         }
     }
 
-    private static func largestCurrentAppWindowBounds(excluding panel: NSPanel) -> CGRect? {
+    private static func largestCurrentAppWindowBounds(excluding panel: NSWindow) -> CGRect? {
         let currentPID = ProcessInfo.processInfo.processIdentifier
         return visibleWindowBounds {
             guard let ownerPID = ($0[kCGWindowOwnerPID as String] as? NSNumber)?.intValue,
@@ -340,7 +337,13 @@ private struct PermissionDragAssistantView: View {
             .font(Typo.caption(10))
         }
         .padding(16)
-        .frame(width: 430)
+        .frame(
+            minWidth: 430,
+            maxWidth: .infinity,
+            minHeight: 260,
+            maxHeight: .infinity,
+            alignment: .topLeading
+        )
         .background(PanelBackground())
         .preferredColorScheme(.dark)
         .task(id: capability.rawValue) {

--- a/apps/mac/Sources/AppShell/PermissionsAssistantWindow.swift
+++ b/apps/mac/Sources/AppShell/PermissionsAssistantWindow.swift
@@ -30,10 +30,8 @@ final class PermissionsAssistantWindowController: ObservableObject {
         let w = AppWindowShell.makeWindow(
             config: .init(
                 title: "Lattices Permissions",
-                titleVisible: false,
                 initialSize: NSSize(width: 720, height: 520),
-                minSize: NSSize(width: 640, height: 460),
-                maxSize: NSSize(width: 1100, height: 800)
+                minSize: NSSize(width: 640, height: 460)
             ),
             rootView: host
         )

--- a/apps/mac/Sources/AppShell/SettingsView.swift
+++ b/apps/mac/Sources/AppShell/SettingsView.swift
@@ -30,7 +30,7 @@ struct SettingsContentView: View {
             case .voice: return "Voice"
             case .ai: return "AI"
             case .search: return "Search & OCR"
-            case .companion: return "LATS iOS Companion"
+            case .companion: return "Companion"
             }
         }
 
@@ -56,7 +56,7 @@ struct SettingsContentView: View {
             case .voice: return "Capture"
             case .ai: return "Agents"
             case .search: return "Indexing"
-            case .companion: return "Local Bridge"
+            case .companion: return "LATS iOS Bridge"
             }
         }
 
@@ -249,31 +249,43 @@ struct SettingsContentView: View {
         // unified window is user-resizable; without this, the non-scrolling list
         // (~480pt) overflows short windows and pushes the shell's status bar off
         // the bottom — every section pane already scrolls, so the rail must too.
-        ScrollView {
-            VStack(alignment: .leading, spacing: 14) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Settings")
-                        .font(Typo.monoBold(12))
-                        .foregroundColor(Palette.text)
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 16) {
+                HStack(alignment: .top, spacing: 10) {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 7)
+                            .fill(Palette.running.opacity(0.12))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 7)
+                                    .strokeBorder(Palette.running.opacity(0.24), lineWidth: 0.5)
+                            )
+                        Image(systemName: "gearshape")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundColor(Palette.running)
+                    }
+                    .frame(width: 28, height: 28)
 
-                    Text("Workspace, input, agents, capture.")
-                        .font(Typo.caption(10))
-                        .foregroundColor(Palette.textMuted)
-                        .lineLimit(2)
+                    Text("Settings")
+                        .font(Typo.heading(14))
+                        .foregroundColor(Palette.text)
                 }
 
-                HudDivider(color: HudHairline.subtle)
-
-                VStack(alignment: .leading, spacing: 12) {
+                VStack(alignment: .leading, spacing: 14) {
                     ForEach(SettingsSection.groupedCases, id: \.0) { group, sections in
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text(group.uppercased())
-                                .font(Typo.pixel(11))
-                                .foregroundColor(Palette.textDim.opacity(0.85))
-                                .tracking(1.2)
-                                .padding(.horizontal, 4)
+                        VStack(alignment: .leading, spacing: 7) {
+                            HStack(spacing: 8) {
+                                Text(group.uppercased())
+                                    .font(Typo.pixel(10))
+                                    .foregroundColor(Palette.textDim.opacity(0.82))
+                                    .tracking(1.15)
 
-                            VStack(spacing: 4) {
+                                Rectangle()
+                                    .fill(Palette.border.opacity(0.65))
+                                    .frame(height: 0.5)
+                            }
+                            .padding(.horizontal, 4)
+
+                            VStack(spacing: 5) {
                                 ForEach(sections) { section in
                                     settingsTab(section)
                                 }
@@ -282,9 +294,10 @@ struct SettingsContentView: View {
                     }
                 }
             }
-            .padding(16)
+            .padding(14)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .background(Palette.bg.opacity(0.55))
     }
 
     private func settingsTab(_ section: SettingsSection) -> some View {
@@ -300,23 +313,20 @@ struct SettingsContentView: View {
     }
 
     private func settingsSectionHero(_ section: SettingsSection) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(section.eyebrow)
-                .font(Typo.monoBold(10))
-                .foregroundColor(Palette.textMuted)
+        HStack(spacing: 10) {
+            Image(systemName: section.icon)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(Palette.textMuted.opacity(0.82))
 
             Text(section.title)
-                .font(Typo.heading(18))
+                .font(Typo.heading(14))
                 .foregroundColor(Palette.text)
 
-            Text(section.summary)
-                .font(Typo.mono(10.5))
-                .foregroundColor(Palette.textDim)
-                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 20)
-        .padding(.vertical, 14)
+        .padding(.vertical, 10)
         .background(Palette.bg)
     }
 
@@ -838,15 +848,9 @@ struct SettingsContentView: View {
 
     private var mouseGestureHUDSettingsControls: some View {
         VStack(alignment: .leading, spacing: 10) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Gesture confirmation HUD")
-                    .font(Typo.monoBold(10.5))
-                    .foregroundColor(Palette.text)
-                Text("Controls the new post-gesture confirmation layer. Gesture tracking and rule matching stay independent.")
-                    .font(Typo.caption(9.5))
-                    .foregroundColor(Palette.textMuted)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
+            Text("Gesture confirmation HUD")
+                .font(Typo.monoBold(10.5))
+                .foregroundColor(Palette.text)
 
             HStack(spacing: 12) {
                 HStack {
@@ -896,16 +900,10 @@ struct SettingsContentView: View {
             VStack(alignment: .leading, spacing: 12) {
                 settingsCard {
                     VStack(alignment: .leading, spacing: 10) {
-                        HStack(alignment: .top, spacing: 12) {
-                            VStack(alignment: .leading, spacing: 5) {
-                                Text("Middle-click gestures")
-                                    .font(Typo.monoBold(11))
-                                    .foregroundColor(Palette.text)
-                                Text("Directional gestures can switch Spaces, open the Screen Map, trigger dictation, or run custom shortcut sequences.")
-                                    .font(Typo.caption(10))
-                                    .foregroundColor(Palette.textMuted)
-                                    .fixedSize(horizontal: false, vertical: true)
-                            }
+                        HStack(spacing: 12) {
+                            Text("Middle-click gestures")
+                                .font(Typo.monoBold(11))
+                                .foregroundColor(Palette.text)
                             Spacer()
                             Toggle("", isOn: $prefs.mouseGesturesEnabled)
                                 .toggleStyle(.switch)
@@ -919,23 +917,7 @@ struct SettingsContentView: View {
 
                         cardDivider
 
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text("Active mappings")
-                                .font(Typo.mono(10))
-                                .foregroundColor(Palette.textDim)
-
-                            ForEach(mouseShortcutStore.summaryLines.prefix(8), id: \.self) { line in
-                                Text(line)
-                                    .font(Typo.caption(9))
-                                    .foregroundColor(Palette.textMuted.opacity(0.78))
-                            }
-
-                            if mouseShortcutStore.summaryLines.isEmpty {
-                                Text("No active mappings")
-                                    .font(Typo.caption(9))
-                                    .foregroundColor(Palette.textMuted.opacity(0.6))
-                            }
-                        }
+                        mouseShortcutMappingMatrix(title: "Active mappings", limit: 8)
 
                         cardDivider
 
@@ -946,108 +928,293 @@ struct SettingsContentView: View {
                             mouseGestureController.reArmAfterBreakerTrip()
                         }
 
-                        VStack(alignment: .leading, spacing: 8) {
-                            HStack(spacing: 8) {
-                                Button {
-                                    mouseShortcutStore.openConfiguration()
-                                } label: {
-                                    Text("Configure...")
-                                        .font(Typo.monoBold(10))
-                                        .foregroundColor(Palette.text)
-                                        .padding(.horizontal, 12)
-                                        .padding(.vertical, 4)
-                                        .background(
-                                            RoundedRectangle(cornerRadius: 4)
-                                                .fill(Palette.surfaceHov)
-                                                .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.borderLit, lineWidth: 0.5))
-                                        )
-                                }
-                                .buttonStyle(.plain)
-
-                                Button {
-                                    MouseInputEventViewer.shared.show()
-                                } label: {
-                                    Text("Event Viewer")
-                                        .font(Typo.monoBold(10))
-                                        .foregroundColor(Palette.text)
-                                        .padding(.horizontal, 12)
-                                        .padding(.vertical, 4)
-                                        .background(
-                                            RoundedRectangle(cornerRadius: 4)
-                                                .fill(Palette.surfaceHov)
-                                                .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.borderLit, lineWidth: 0.5))
-                                        )
-                                }
-                                .buttonStyle(.plain)
-
-                                Button {
-                                    mouseShortcutStore.openHistory()
-                                } label: {
-                                    Text("History")
-                                        .font(Typo.monoBold(10))
-                                        .foregroundColor(Palette.text)
-                                        .padding(.horizontal, 12)
-                                        .padding(.vertical, 4)
-                                        .background(
-                                            RoundedRectangle(cornerRadius: 4)
-                                                .fill(Palette.surfaceHov)
-                                                .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.borderLit, lineWidth: 0.5))
-                                        )
-                                }
-                                .buttonStyle(.plain)
-                            }
-
-                            HStack(spacing: 8) {
-                                Button {
-                                    mouseShortcutStore.restoreLatestHistory()
-                                } label: {
-                                    Text("Undo Last")
-                                        .font(Typo.monoBold(10))
-                                        .foregroundColor(mouseShortcutStore.hasHistory ? Palette.text : Palette.textMuted.opacity(0.55))
-                                        .padding(.horizontal, 12)
-                                        .padding(.vertical, 4)
-                                        .background(
-                                            RoundedRectangle(cornerRadius: 4)
-                                                .fill(Palette.surfaceHov.opacity(mouseShortcutStore.hasHistory ? 1 : 0.45))
-                                                .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.borderLit.opacity(mouseShortcutStore.hasHistory ? 1 : 0.45), lineWidth: 0.5))
-                                        )
-                                }
-                                .buttonStyle(.plain)
-                                .disabled(!mouseShortcutStore.hasHistory)
-
-                                Button {
-                                    mouseShortcutStore.restoreDefaults()
-                                } label: {
-                                    Text("Restore Defaults")
-                                        .font(Typo.monoBold(10))
-                                        .foregroundColor(Palette.text)
-                                        .padding(.horizontal, 12)
-                                        .padding(.vertical, 4)
-                                        .background(
-                                            RoundedRectangle(cornerRadius: 4)
-                                                .fill(Palette.surfaceHov)
-                                                .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.borderLit, lineWidth: 0.5))
-                                        )
-                                }
-                                .buttonStyle(.plain)
-                            }
-                        }
-
-                        Text("Rules live in ~/.lattices/mouse-shortcuts.json. Use Event Viewer to discover what buttons your mouse emits.")
-                            .font(Typo.caption(9))
-                            .foregroundColor(Palette.textMuted.opacity(0.7))
-                            .fixedSize(horizontal: false, vertical: true)
-
-                        if !mouseShortcutStore.historySummaryLines.isEmpty {
-                            Text("Recent snapshots: \(mouseShortcutStore.historySummaryLines.prefix(3).joined(separator: ", "))")
-                                .font(Typo.caption(9))
-                                .foregroundColor(Palette.textMuted.opacity(0.62))
-                                .lineLimit(2)
-                        }
+                        mouseShortcutManagementPanel(
+                            detail: "Rules live in ~/.lattices/mouse-shortcuts.json. Use Event Viewer to discover what buttons your mouse emits.",
+                            showHistorySummary: true
+                        )
                     }
                 }
             }
             .padding(16)
+        }
+    }
+
+    private func mouseShortcutMappingMatrix(title: String, limit: Int) -> some View {
+        let allRules = mouseShortcutStore.enabledRules
+        let rules = Array(allRules.prefix(limit))
+        let hiddenCount = max(allRules.count - rules.count, 0)
+        let grouped = Dictionary(grouping: rules, by: \.trigger.button)
+        let sortedButtons = grouped.keys.sorted { mouseShortcutButtonSortOrder($0) < mouseShortcutButtonSortOrder($1) }
+
+        return VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(Typo.monoBold(10))
+                .foregroundColor(Palette.text)
+
+            if rules.isEmpty {
+                mouseShortcutEmptyMappingRow
+            } else {
+                VStack(alignment: .leading, spacing: 10) {
+                    ForEach(sortedButtons, id: \.self) { button in
+                        if let buttonRules = grouped[button] {
+                            mouseShortcutMappingButtonGroup(button: button, rules: buttonRules)
+                        }
+                    }
+                }
+
+                if hiddenCount > 0 {
+                    Text("+\(hiddenCount) more in config")
+                        .font(Typo.mono(8))
+                        .foregroundColor(Palette.textMuted.opacity(0.72))
+                }
+            }
+        }
+    }
+
+    private func mouseShortcutMappingButtonGroup(button: MouseShortcutButton, rules: [MouseShortcutRule]) -> some View {
+        let sortedRules = rules.sorted { lhs, rhs in
+            mouseShortcutTriggerSortOrder(lhs.trigger) < mouseShortcutTriggerSortOrder(rhs.trigger)
+        }
+
+        return VStack(alignment: .leading, spacing: 5) {
+            Text(button.displayLabel)
+                .font(Typo.monoBold(9))
+                .foregroundColor(Palette.textMuted.opacity(0.82))
+
+            VStack(spacing: 0) {
+                ForEach(Array(sortedRules.enumerated()), id: \.element.id) { index, rule in
+                    mouseShortcutMappingTableRow(rule)
+
+                    if index < sortedRules.count - 1 {
+                        Rectangle()
+                            .fill(Palette.border.opacity(0.45))
+                            .frame(height: 0.5)
+                            .padding(.leading, 10)
+                    }
+                }
+            }
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Palette.surface.opacity(0.48))
+                    .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(Palette.border.opacity(0.65), lineWidth: 0.5))
+            )
+        }
+    }
+
+    private var mouseShortcutEmptyMappingRow: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "slash.circle")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(Palette.textMuted.opacity(0.75))
+            Text("No active mappings")
+                .font(Typo.caption(9))
+                .foregroundColor(Palette.textMuted.opacity(0.68))
+            Spacer()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 9)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Palette.surface.opacity(0.48))
+                .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(Palette.border.opacity(0.65), lineWidth: 0.5))
+        )
+    }
+
+    private func mouseShortcutMappingTableRow(_ rule: MouseShortcutRule) -> some View {
+        HStack(spacing: 8) {
+            Text(mouseShortcutGestureLabel(for: rule.trigger))
+                .font(Typo.mono(9))
+                .foregroundColor(Palette.text)
+                .frame(width: 78, alignment: .leading)
+                .lineLimit(1)
+
+            Image(systemName: mouseShortcutTriggerIcon(for: rule.trigger))
+                .font(.system(size: 8, weight: .semibold))
+                .foregroundColor(Palette.textMuted.opacity(0.62))
+                .frame(width: 12)
+
+            Text(mouseShortcutActionSummary(for: rule))
+                .font(Typo.caption(9))
+                .foregroundColor(Palette.textMuted.opacity(0.82))
+                .lineLimit(1)
+
+            Spacer(minLength: 0)
+
+            if rule.effectiveActions.count > 1 {
+                Text("\(rule.effectiveActions.count)x")
+                    .font(Typo.monoBold(8))
+                    .foregroundColor(Palette.textMuted.opacity(0.72))
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 2)
+                    .background(Capsule().fill(Palette.surfaceHov.opacity(0.55)))
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+    }
+
+    private func mouseShortcutManagementPanel(detail: String, showHistorySummary: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 132), spacing: 8, alignment: .leading)],
+                alignment: .leading,
+                spacing: 8
+            ) {
+                mouseShortcutControlButton(icon: "slider.horizontal.3", label: "Configure") {
+                    mouseShortcutStore.openConfiguration()
+                }
+
+                mouseShortcutControlButton(icon: "scope", label: "Event Viewer") {
+                    MouseInputEventViewer.shared.show()
+                }
+
+                mouseShortcutControlButton(icon: "clock.arrow.circlepath", label: "History") {
+                    mouseShortcutStore.openHistory()
+                }
+
+                mouseShortcutControlButton(
+                    icon: "arrow.uturn.backward",
+                    label: "Undo Last",
+                    isEnabled: mouseShortcutStore.hasHistory
+                ) {
+                    mouseShortcutStore.restoreLatestHistory()
+                }
+
+                mouseShortcutControlButton(icon: "arrow.counterclockwise", label: "Defaults") {
+                    mouseShortcutStore.restoreDefaults()
+                }
+            }
+
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Image(systemName: "doc.text")
+                    .font(.system(size: 8, weight: .semibold))
+                    .foregroundColor(Palette.textMuted.opacity(0.66))
+                Text(detail)
+                    .font(Typo.caption(9))
+                    .foregroundColor(Palette.textMuted.opacity(0.72))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if showHistorySummary, !mouseShortcutStore.historySummaryLines.isEmpty {
+                HStack(spacing: 6) {
+                    Text("Recent")
+                        .font(Typo.monoBold(8))
+                        .foregroundColor(Palette.textMuted.opacity(0.68))
+
+                    ForEach(Array(mouseShortcutStore.historySummaryLines.prefix(3)), id: \.self) { snapshot in
+                        Text(snapshot)
+                            .font(Typo.mono(8))
+                            .foregroundColor(Palette.textMuted.opacity(0.7))
+                            .lineLimit(1)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(
+                                Capsule()
+                                    .fill(Palette.surface.opacity(0.55))
+                                    .overlay(Capsule().strokeBorder(Palette.border.opacity(0.55), lineWidth: 0.5))
+                            )
+                    }
+                }
+            }
+        }
+    }
+
+    private func mouseShortcutControlButton(
+        icon: String,
+        label: String,
+        isEnabled: Bool = true,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                Image(systemName: icon)
+                    .font(.system(size: 10, weight: .semibold))
+                Text(label)
+                    .font(Typo.monoBold(9))
+                    .lineLimit(1)
+            }
+            .foregroundColor(isEnabled ? Palette.text : Palette.textMuted.opacity(0.52))
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Palette.surfaceHov.opacity(isEnabled ? 0.88 : 0.38))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(Palette.borderLit.opacity(isEnabled ? 0.75 : 0.32), lineWidth: 0.5)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(!isEnabled)
+    }
+
+    private func mouseShortcutActionSummary(for rule: MouseShortcutRule) -> String {
+        rule.effectiveActions.map(\.label).joined(separator: " + ")
+    }
+
+    private func mouseShortcutGestureLabel(for trigger: MouseShortcutTrigger) -> String {
+        switch trigger.kind {
+        case .click:
+            return "click"
+        case .drag:
+            if let direction = trigger.direction {
+                return "drag \(direction.displayLabel.lowercased())"
+            }
+            return "drag"
+        case .shape:
+            if let shape = trigger.shape {
+                return shape.displayName.lowercased()
+            }
+            return "shape"
+        }
+    }
+
+    private func mouseShortcutButtonSortOrder(_ button: MouseShortcutButton) -> Int {
+        switch button {
+        case .middle: return 0
+        case .button4: return 1
+        case .button5: return 2
+        case .right: return 3
+        case .number: return 4
+        }
+    }
+
+    private func mouseShortcutTriggerSortOrder(_ trigger: MouseShortcutTrigger) -> Int {
+        let kindOrder: Int
+        switch trigger.kind {
+        case .drag: kindOrder = 0
+        case .shape: kindOrder = 1
+        case .click: kindOrder = 2
+        }
+
+        let directionOrder: Int
+        switch trigger.direction {
+        case .left: directionOrder = 0
+        case .right: directionOrder = 1
+        case .up: directionOrder = 2
+        case .down: directionOrder = 3
+        case nil: directionOrder = 4
+        }
+
+        return kindOrder * 10 + directionOrder
+    }
+
+    private func mouseShortcutTriggerIcon(for trigger: MouseShortcutTrigger) -> String {
+        switch trigger.kind {
+        case .click:
+            return "cursorarrow.click"
+        case .shape:
+            return "scribble.variable"
+        case .drag:
+            switch trigger.direction {
+            case .left: return "arrow.left"
+            case .right: return "arrow.right"
+            case .up: return "arrow.up"
+            case .down: return "arrow.down"
+            case nil: return "arrow.up.and.down.and.arrow.left.and.right"
+            }
         }
     }
 
@@ -1419,23 +1586,7 @@ struct SettingsContentView: View {
 
                         cardDivider
 
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text("Active drag mappings")
-                                .font(Typo.mono(10))
-                                .foregroundColor(Palette.textDim)
-
-                            ForEach(mouseShortcutStore.summaryLines.prefix(4), id: \.self) { line in
-                                Text(line)
-                                    .font(Typo.caption(9))
-                                    .foregroundColor(Palette.textMuted.opacity(0.78))
-                            }
-
-                            if mouseShortcutStore.summaryLines.isEmpty {
-                                Text("No active mappings")
-                                    .font(Typo.caption(9))
-                                    .foregroundColor(Palette.textMuted.opacity(0.6))
-                            }
-                        }
+                        mouseShortcutMappingMatrix(title: "Active drag mappings", limit: 4)
 
                         breakerStatusRow(
                             state: mouseGestureController.breakerState,
@@ -1444,96 +1595,10 @@ struct SettingsContentView: View {
                             mouseGestureController.reArmAfterBreakerTrip()
                         }
 
-                        VStack(alignment: .leading, spacing: 8) {
-                            HStack(spacing: 8) {
-                                Button {
-                                    mouseShortcutStore.openConfiguration()
-                                } label: {
-                                    Text("Configure...")
-                                        .font(Typo.monoBold(10))
-                                        .foregroundColor(Palette.text)
-                                        .padding(.horizontal, 12)
-                                        .padding(.vertical, 4)
-                                        .background(
-                                            RoundedRectangle(cornerRadius: 4)
-                                                .fill(Palette.surfaceHov)
-                                                .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.borderLit, lineWidth: 0.5))
-                                        )
-                                }
-                                .buttonStyle(.plain)
-
-                                Button {
-                                    MouseInputEventViewer.shared.show()
-                                } label: {
-                                    Text("Event Viewer")
-                                        .font(Typo.monoBold(10))
-                                        .foregroundColor(Palette.text)
-                                        .padding(.horizontal, 12)
-                                        .padding(.vertical, 4)
-                                        .background(
-                                            RoundedRectangle(cornerRadius: 4)
-                                                .fill(Palette.surfaceHov)
-                                                .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.borderLit, lineWidth: 0.5))
-                                        )
-                                }
-                                .buttonStyle(.plain)
-
-                                Button {
-                                    mouseShortcutStore.openHistory()
-                                } label: {
-                                    Text("History")
-                                        .font(Typo.monoBold(10))
-                                        .foregroundColor(Palette.text)
-                                        .padding(.horizontal, 12)
-                                        .padding(.vertical, 4)
-                                        .background(
-                                            RoundedRectangle(cornerRadius: 4)
-                                                .fill(Palette.surfaceHov)
-                                                .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.borderLit, lineWidth: 0.5))
-                                        )
-                                }
-                                .buttonStyle(.plain)
-                            }
-
-                            HStack(spacing: 8) {
-                                Button {
-                                    mouseShortcutStore.restoreLatestHistory()
-                                } label: {
-                                    Text("Undo Last")
-                                        .font(Typo.monoBold(10))
-                                        .foregroundColor(mouseShortcutStore.hasHistory ? Palette.text : Palette.textMuted.opacity(0.55))
-                                        .padding(.horizontal, 12)
-                                        .padding(.vertical, 4)
-                                        .background(
-                                            RoundedRectangle(cornerRadius: 4)
-                                                .fill(Palette.surfaceHov.opacity(mouseShortcutStore.hasHistory ? 1 : 0.45))
-                                                .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.borderLit.opacity(mouseShortcutStore.hasHistory ? 1 : 0.45), lineWidth: 0.5))
-                                        )
-                                }
-                                .buttonStyle(.plain)
-                                .disabled(!mouseShortcutStore.hasHistory)
-
-                                Button {
-                                    mouseShortcutStore.restoreDefaults()
-                                } label: {
-                                    Text("Restore Defaults")
-                                        .font(Typo.monoBold(10))
-                                        .foregroundColor(Palette.text)
-                                        .padding(.horizontal, 12)
-                                        .padding(.vertical, 4)
-                                        .background(
-                                            RoundedRectangle(cornerRadius: 4)
-                                                .fill(Palette.surfaceHov)
-                                                .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.borderLit, lineWidth: 0.5))
-                                        )
-                                }
-                                .buttonStyle(.plain)
-                            }
-                        }
-
-                        Text("Use Event Viewer to discover what your mouse emits on this machine. The config schema already accepts device selectors, but live gesture matching currently falls back to global rules when macOS doesn't expose the source device.")
-                            .font(Typo.caption(9))
-                            .foregroundColor(Palette.textMuted.opacity(0.7))
+                        mouseShortcutManagementPanel(
+                            detail: "Use Event Viewer to discover what your mouse emits on this machine. The config schema accepts device selectors; live gesture matching falls back to global rules when macOS does not expose the source device.",
+                            showHistorySummary: false
+                        )
                     }
                 }
 

--- a/apps/mac/Sources/Core/Input/MouseInputEventViewer.swift
+++ b/apps/mac/Sources/Core/Input/MouseInputEventViewer.swift
@@ -28,6 +28,8 @@ final class MouseInputEventViewer: ObservableObject {
 
     private init() {}
 
+    var isVisible: Bool { window?.isVisible ?? false }
+
     func show() {
         if let window {
             isCaptureActive = true
@@ -41,8 +43,7 @@ final class MouseInputEventViewer: ObservableObject {
             config: .init(
                 title: "Mouse Shortcut Event Viewer",
                 initialSize: NSSize(width: 980, height: 620),
-                minSize: NSSize(width: 840, height: 460),
-                maxSize: NSSize(width: 1500, height: 1000)
+                minSize: NSSize(width: 840, height: 460)
             ),
             rootView: view
         )
@@ -101,6 +102,7 @@ final class MouseInputEventViewer: ObservableObject {
         }
         window = nil
         isCaptureActive = false
+        AppDelegate.updateActivationPolicy()
     }
 
     private static func modifierLabels(for flags: NSEvent.ModifierFlags) -> [String] {

--- a/apps/mac/Sources/Core/Overlays/AppWindowShell.swift
+++ b/apps/mac/Sources/Core/Overlays/AppWindowShell.swift
@@ -2,10 +2,11 @@ import AppKit
 import SwiftUI
 
 /// NSWindow that strips the blue focus ring AppKit's shared field editor draws
-/// around a focused text field. Lattices' windows are chromeless and dark, so
-/// that ring reads as a stray little blue rectangle. `.textFieldStyle(.plain)`
-/// removes the field's *own* bezel/ring but not the field editor's, so we kill it
-/// here, once, for every text field hosted in the window.
+/// around a focused text field. Lattices windows use dark, custom SwiftUI
+/// content, so that ring reads as a stray little blue rectangle.
+/// `.textFieldStyle(.plain)` removes the field's *own* bezel/ring but not the
+/// field editor's, so we kill it here, once, for every text field hosted in the
+/// window.
 private final class NoFocusRingWindow: NSWindow {
     override func fieldEditor(_ createFlag: Bool, for object: Any?) -> NSText? {
         let editor = super.fieldEditor(createFlag, for: object)
@@ -24,8 +25,9 @@ struct AppWindowShell {
         var titleVisible: Bool = true
         var initialSize: NSSize
         var minSize: NSSize
-        var maxSize: NSSize
+        var maxSize: NSSize? = nil
         var miniaturizable: Bool = true
+        var titlebarAppearsTransparent: Bool = false
         /// Let content fill the whole window, including under the title bar, so
         /// chrome (e.g. a tab strip) can sit in the traffic-light row instead of
         /// below a reserved title band.
@@ -63,14 +65,16 @@ struct AppWindowShell {
 
         w.contentView = container
         w.title = config.title
-        w.titlebarAppearsTransparent = true
+        w.titlebarAppearsTransparent = config.titlebarAppearsTransparent
         w.titleVisibility = config.titleVisible ? .visible : .hidden
         w.isReleasedWhenClosed = false
         w.isRestorable = false
         w.backgroundColor = NSColor(red: 0.11, green: 0.11, blue: 0.12, alpha: 1.0)
         w.appearance = NSAppearance(named: .darkAqua)
         w.minSize = config.minSize
-        w.maxSize = config.maxSize
+        if let maxSize = config.maxSize {
+            w.maxSize = maxSize
+        }
         return w
     }
 

--- a/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapWindowController.swift
+++ b/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapWindowController.swift
@@ -74,11 +74,8 @@ final class ScreenMapWindowController: ObservableObject {
         let w = AppWindowShell.makeWindow(
             config: .init(
                 title: "Lattices",
-                titleVisible: false,
                 initialSize: initialSize,
-                minSize: NSSize(width: 600, height: 400),
-                maxSize: NSSize(width: 2400, height: 1600),
-                fullSizeContent: true
+                minSize: NSSize(width: 600, height: 400)
             ),
             rootView: view
         )

--- a/apps/mac/Sources/Core/Overlays/Studio/StudioLayersView.swift
+++ b/apps/mac/Sources/Core/Overlays/Studio/StudioLayersView.swift
@@ -151,14 +151,25 @@ struct StudioLayersView: View {
 
     private func askAssistantAboutLayer(_ layer: StudioLayer, matches: [WindowEntry]) {
         let spec = store.layerContextJSON(layer, matches: matches)
-        let prompt = """
-        Help me reason about this Lattices Studio layer. Explain what the rules mean, what live windows currently match, and suggest a cleaner rule if the layer is too broad or too narrow.
-
-        \(spec)
-        """
+        let attachment = PiChatAttachment(
+            name: "\(safeAttachmentStem(layer.name))-layer.json",
+            mediaType: "application/json",
+            content: spec,
+            systemImage: "doc.text.magnifyingglass"
+        )
+        let prompt = "Help me reason about the attached Lattices Studio layer. Explain what the rules mean, what live windows currently match, and suggest a cleaner rule if the layer is too broad or too narrow."
         ScreenMapWindowController.shared.showAssistant()
-        PiChatSession.shared.draft = prompt
-        PiChatSession.shared.sendDraft()
+        PiChatSession.shared.send(prompt, attachments: [attachment])
+    }
+
+    private func safeAttachmentStem(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        let scalars = value.unicodeScalars.map { allowed.contains($0) ? Character($0) : "-" }
+        let collapsed = String(scalars)
+            .split(separator: "-", omittingEmptySubsequences: true)
+            .joined(separator: "-")
+            .lowercased()
+        return collapsed.isEmpty ? "studio" : collapsed
     }
 }
 

--- a/apps/mac/Sources/Core/Pi/AgentTurnView.swift
+++ b/apps/mac/Sources/Core/Pi/AgentTurnView.swift
@@ -19,6 +19,13 @@ enum AgentTurnRole: Equatable {
     case system
 }
 
+struct AgentTurnAttachment: Identifiable, Equatable {
+    let id: UUID
+    var name: String
+    var mediaType: String
+    var systemImage: String
+}
+
 /// One turn in an agent conversation. A pure value — the rendering unit's only
 /// input. Adapters (e.g. `PiChatMessageRow`) map their own message types onto it.
 struct AgentTurn: Identifiable, Equatable {
@@ -28,6 +35,7 @@ struct AgentTurn: Identifiable, Equatable {
     var author: String
     var timestamp: Date
     var text: String
+    var attachments: [AgentTurnAttachment]
     /// True while this turn is still being produced (drives streaming visuals).
     var isStreaming: Bool
     /// Name of a tool the agent is currently running, if any.
@@ -39,6 +47,7 @@ struct AgentTurn: Identifiable, Equatable {
         author: String,
         timestamp: Date,
         text: String,
+        attachments: [AgentTurnAttachment] = [],
         isStreaming: Bool = false,
         toolActivity: String? = nil
     ) {
@@ -47,6 +56,7 @@ struct AgentTurn: Identifiable, Equatable {
         self.author = author
         self.timestamp = timestamp
         self.text = text
+        self.attachments = attachments
         self.isStreaming = isStreaming
         self.toolActivity = toolActivity
     }
@@ -119,6 +129,11 @@ struct AgentTurnView: View, Equatable {
             bodyContent(isAssistant: isAssistant)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.leading, 23)
+
+            if !turn.attachments.isEmpty {
+                attachmentChips
+                    .padding(.leading, 23)
+            }
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 12)
@@ -159,6 +174,39 @@ struct AgentTurnView: View, Equatable {
                 .foregroundColor(Palette.textMuted.opacity(isAssistant ? 0.75 : 0.8))
 
             copyButton(size: 23, iconSize: 10)
+        }
+    }
+
+    private var attachmentChips: some View {
+        FlowLayout(spacing: 6, lineSpacing: 6, alignment: .leading) {
+            ForEach(turn.attachments) { attachment in
+                HStack(spacing: 5) {
+                    Image(systemName: attachment.systemImage)
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(Palette.running)
+
+                    Text(attachment.name)
+                        .font(Typo.mono(10))
+                        .foregroundColor(Palette.textDim)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+
+                    Text(attachment.mediaType)
+                        .font(Typo.mono(8))
+                        .foregroundColor(Palette.textMuted)
+                        .lineLimit(1)
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(Palette.running.opacity(0.09))
+                        .overlay(
+                            Capsule(style: .continuous)
+                                .strokeBorder(Palette.running.opacity(0.24), lineWidth: 0.5)
+                        )
+                )
+            }
         }
     }
 

--- a/apps/mac/Sources/Core/Pi/PiChatSession.swift
+++ b/apps/mac/Sources/Core/Pi/PiChatSession.swift
@@ -10,6 +10,29 @@ import HudsonAI
 struct QueuedPrompt: Identifiable, Equatable {
     let id = UUID()
     var text: String
+    var attachments: [PiChatAttachment] = []
+}
+
+struct PiChatAttachment: Identifiable, Equatable {
+    let id: UUID
+    var name: String
+    var mediaType: String
+    var content: String
+    var systemImage: String
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        mediaType: String = "text/plain",
+        content: String,
+        systemImage: String = "doc.text"
+    ) {
+        self.id = id
+        self.name = name
+        self.mediaType = mediaType
+        self.content = content
+        self.systemImage = systemImage
+    }
 }
 
 struct PiChatMessage: Identifiable, Equatable {
@@ -22,12 +45,20 @@ struct PiChatMessage: Identifiable, Equatable {
     let id: UUID
     let role: Role
     var text: String
+    var attachments: [PiChatAttachment]
     let timestamp: Date
 
-    init(id: UUID = UUID(), role: Role, text: String, timestamp: Date) {
+    init(
+        id: UUID = UUID(),
+        role: Role,
+        text: String,
+        attachments: [PiChatAttachment] = [],
+        timestamp: Date
+    ) {
         self.id = id
         self.role = role
         self.text = text
+        self.attachments = attachments
         self.timestamp = timestamp
     }
 }
@@ -588,11 +619,18 @@ final class PiChatSession: ObservableObject {
     }
 
     func send(_ text: String) {
+        send(text, attachments: [])
+    }
+
+    func send(_ text: String, attachments: [PiChatAttachment]) {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-        guard !isSending else { return }
+        if isSending {
+            queuedPrompts.append(QueuedPrompt(text: trimmed, attachments: attachments))
+            return
+        }
 
-        messages.append(PiChatMessage(role: .user, text: trimmed, timestamp: Date()))
+        messages.append(PiChatMessage(role: .user, text: trimmed, attachments: attachments, timestamp: Date()))
 
         if let localResponse = handleImmediateLocalCommand(trimmed) {
             appendLocalAssistantResponse(localResponse)
@@ -628,7 +666,7 @@ final class PiChatSession: ObservableObject {
         settleActiveStreamingMessage(interrupted: false)   // snap any prior reveal to full before a new turn
         turnGeneration &+= 1
         let turnGen = turnGeneration
-        let prompt = providerPrompt(for: trimmed)
+        let prompt = providerPrompt(for: trimmed, attachments: attachments)
         let runtime = chatRuntime(piPath: piPath, provider: provider)
         let inferenceTimer = DiagnosticLog.shared.startTimed("Chat inference via \(provider.name) RPC")
         let messageID = UUID()
@@ -1056,7 +1094,7 @@ final class PiChatSession: ObservableObject {
     private func drainQueuedPrompt() {
         guard !isSending, !queuedPrompts.isEmpty else { return }
         let next = queuedPrompts.removeFirst()
-        send(next.text)
+        send(next.text, attachments: next.attachments)
     }
 
     /// Halt the in-flight turn (cancelling generation on the HudAIClient path; the
@@ -1793,13 +1831,18 @@ final class PiChatSession: ObservableObject {
         return nil
     }
 
-    private func providerPrompt(for userText: String) -> String {
+    private func providerPrompt(for userText: String, attachments: [PiChatAttachment] = []) -> String {
         let knowledge = Self.capabilitiesGuide
         let knowledgeBlock = knowledge.isEmpty ? "" : """
 
             Lattices product knowledge (how the app works; cite the linked docs when a question goes deeper):
             \(knowledge)
             """
+        let attachmentBlock = attachments.isEmpty ? "" : """
+
+        Attached files:
+        \(providerAttachmentBlock(attachments))
+        """
         return """
         You are the Workspace Assistant, the in-app assistant for Lattices.
 
@@ -1807,6 +1850,7 @@ final class PiChatSession: ObservableObject {
 
         For setting changes, inspect or update the relevant local config with tools when available and safe. If you cannot apply the change, say so plainly and give the exact next step. Never claim a setting or file changed unless it actually changed.
         \(knowledgeBlock)
+        \(attachmentBlock)
 
         Structured context:
         \(assistantKnowledgeBrief())
@@ -1814,6 +1858,17 @@ final class PiChatSession: ObservableObject {
         User request:
         \(userText)
         """
+    }
+
+    private func providerAttachmentBlock(_ attachments: [PiChatAttachment]) -> String {
+        attachments.map { attachment in
+            """
+            --- \(attachment.name) (\(attachment.mediaType)) ---
+            \(attachment.content)
+            --- end \(attachment.name) ---
+            """
+        }
+        .joined(separator: "\n\n")
     }
 
     private func voiceAdvisorPrompt(transcript: String, matched: String) -> String {

--- a/apps/mac/Sources/Core/Pi/PiChatUI.swift
+++ b/apps/mac/Sources/Core/Pi/PiChatUI.swift
@@ -445,6 +445,14 @@ struct PiChatMessageRow: View, Equatable {
             author: agentAuthor,
             timestamp: message.timestamp,
             text: message.text,
+            attachments: message.attachments.map {
+                AgentTurnAttachment(
+                    id: $0.id,
+                    name: $0.name,
+                    mediaType: $0.mediaType,
+                    systemImage: $0.systemImage
+                )
+            },
             isStreaming: isStreaming,
             toolActivity: activeToolName
         )

--- a/apps/mac/Sources/Core/System/DiagnosticLog.swift
+++ b/apps/mac/Sources/Core/System/DiagnosticLog.swift
@@ -192,46 +192,37 @@ final class DiagnosticWindow {
             NSEvent.removeMonitor(monitor)
             keyMonitor = nil
         }
+        AppDelegate.updateActivationPolicy()
     }
 
     func show() {
         if let w = window {
-            w.orderFrontRegardless()
+            AppWindowShell.present(w)
             return
         }
 
         let view = DiagnosticOverlayView()
 
-        let hosting = NSHostingController(rootView: view)
         let screen = NSScreen.main
         let screenFrame = screen?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1920, height: 1080)
         let panelWidth: CGFloat = 480
         let panelHeight: CGFloat = max(600, floor(screenFrame.height * 0.55))
-        hosting.preferredContentSize = NSSize(width: panelWidth, height: panelHeight)
 
-        let w = NSPanel(
-            contentRect: NSRect(x: 0, y: 0, width: panelWidth, height: panelHeight),
-            styleMask: [.titled, .closable, .resizable, .utilityWindow, .nonactivatingPanel],
-            backing: .buffered,
-            defer: false
+        let w = AppWindowShell.makeWindow(
+            config: .init(
+                title: "Lattices Activity Log",
+                initialSize: NSSize(width: panelWidth, height: panelHeight),
+                minSize: NSSize(width: 420, height: 360)
+            ),
+            rootView: view
         )
-        w.contentViewController = hosting
-        w.title = "Lattices Activity Log"
-        w.titlebarAppearsTransparent = true
-        w.isMovableByWindowBackground = true
-        w.level = .floating
-        w.isOpaque = false
-        w.backgroundColor = NSColor(red: 0.1, green: 0.1, blue: 0.12, alpha: 1.0)
-        w.hasShadow = true
-        w.alphaValue = 1.0
-        w.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
 
         // Position: right edge, vertically centered
         let x = screenFrame.maxX - panelWidth - 12
         let y = screenFrame.minY + floor((screenFrame.height - panelHeight) / 2)
         w.setFrameOrigin(NSPoint(x: x, y: y))
 
-        w.orderFrontRegardless()
+        AppWindowShell.present(w)
         window = w
 
         // Escape key → dismiss


### PR DESCRIPTION
## What changed

- Compacts and reorganizes the macOS settings surface while keeping the newer HUD composer window shell consistent across app windows.
- Updates onboarding, permissions assistant, screen map, studio layers, and diagnostic surfaces to align with the shared shell behavior.
- Adds Pi chat turn/session UI affordances for queued, edited, and steered agent interactions.

## Why

This follows up on the HUD composer adoption work with a tighter settings layout and more consistent shell integration across the native app. It also rounds out the Pi chat state handling exposed by the newer composer flow.

## Impact

Users should see a denser settings experience, more uniform macOS app chrome behavior, and clearer Pi chat interaction states without changing the CLI/session contract.

## Validation

- `git diff --check`
- `swift build --package-path apps/mac` failed after rebasing onto `main`: HudsonVoice integration symbols are unavailable in the resolved dependency API (`HudsonVoiceRuntime`, `HudsonVoiceRuntimeHost`, `HudsonVoiceSettingsView`, and `HudVoxLiveSessionOptions.authToken`).
- `LATTICES_HUDSON_SOURCE=git HUDSONKIT_WITH_VOICE=1 swift build --package-path apps/mac` failed with the same HudsonVoice API mismatch against Hudson `main` (`12ffbf9`).