### PR TITLE
✨ Hyper+G in-place tools, HUD adoption, and overlay signature

### DIFF
--- a/apps/mac/Sources/AppShell/AppShellView.swift
+++ b/apps/mac/Sources/AppShell/AppShellView.swift
@@ -304,15 +304,13 @@ struct AppShellView: View {
                 if page == .desktopInventory { commandState.enter() }
             })
         case .screenMap:
-            HStack(spacing: 0) {
-                StudioLayersView(selectedLayerId: $selectedStudioLayerId)
-                    .frame(width: 320)
-                ScreenMapView(controller: controller, onNavigate: { page in
+            ScreenMapView(
+                controller: controller,
+                studioLayerScopeId: $selectedStudioLayerId,
+                onNavigate: { page in
                     windowController.activePage = page
-                }, studioLayerScopeId: selectedStudioLayerId, onClearStudioLayerScope: {
-                    selectedStudioLayerId = nil
-                })
-            }
+                }
+            )
         case .desktopInventory:
             CommandModeView(state: commandState, presentation: .embedded)
         case .activity:

--- a/apps/mac/Sources/AppShell/MainView.swift
+++ b/apps/mac/Sources/AppShell/MainView.swift
@@ -375,13 +375,24 @@ struct MainView: View {
                 ScreenMapWindowController.shared.showPage(.screenMap)
             }
             ActionRow(
+                label: "Command Box",
+                detail: "Type slash commands and workspace actions",
+                hotkeyTokens: hotkeyTokens(.commandBar),
+                icon: "text.cursor",
+                accentColor: Palette.textDim
+            ) {
+                MenuBarController.shared.dismissPopover()
+                UnifiedCommandBarWindow.shared.toggle(mode: .command)
+            }
+            ActionRow(
                 label: "Search",
                 detail: "Windows, projects, sessions, processes, and OCR",
                 hotkeyTokens: hotkeyTokens(.omniSearch),
                 icon: "magnifyingglass",
                 accentColor: Palette.textDim
             ) {
-                ScreenMapWindowController.shared.showPage(.desktopInventory)
+                MenuBarController.shared.dismissPopover()
+                UnifiedCommandBarWindow.shared.toggle(mode: .search)
             }
             ActionRow(
                 label: "Command Palette",

--- a/apps/mac/Sources/AppShell/MenuBarController.swift
+++ b/apps/mac/Sources/AppShell/MenuBarController.swift
@@ -90,6 +90,7 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
             ("Assistant", "⌘⇧A", #selector(menuAssistant)),
             ("Home", "", #selector(menuWorkspace)),
             ("Studio", "", #selector(menuLayout)),
+            ("Command Box", "", #selector(menuCommandBox)),
             ("Search", "", #selector(menuSearch)),
             ("Command Palette", "⌘⇧M", #selector(menuCommandPalette)),
         ]
@@ -144,7 +145,8 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
     @objc private func menuAssistant() { AssistantAccess.show() }
     @objc private func menuWorkspace() { ScreenMapWindowController.shared.showPage(.home) }
     @objc private func menuLayout() { ScreenMapWindowController.shared.showPage(.screenMap) }
-    @objc private func menuSearch() { ScreenMapWindowController.shared.showPage(.desktopInventory) }
+    @objc private func menuCommandBox() { UnifiedCommandBarWindow.shared.toggle(mode: .command) }
+    @objc private func menuSearch() { UnifiedCommandBarWindow.shared.toggle(mode: .search) }
     @objc private func menuProjects() { DispatchQueue.main.async { self.showProjectsPopover() } }
     @objc private func menuInitializeProject() { CliActionLauncher.initializeProjectInTerminal() }
     @objc private func menuLaunchProject() { CliActionLauncher.launchProjectInTerminal() }

--- a/apps/mac/Sources/AppShell/SettingsView.swift
+++ b/apps/mac/Sources/AppShell/SettingsView.swift
@@ -12,6 +12,7 @@ struct SettingsContentView: View {
     private enum SettingsSection: String, CaseIterable, Identifiable {
         case general
         case shortcuts
+        case keyboard
         case mouse
         case hyperspace
         case voice
@@ -25,6 +26,7 @@ struct SettingsContentView: View {
             switch self {
             case .general: return "General"
             case .shortcuts: return "Shortcuts"
+            case .keyboard: return "Keyboard"
             case .mouse: return "Mouse"
             case .hyperspace: return "Hyperspace"
             case .voice: return "Voice"
@@ -38,6 +40,7 @@ struct SettingsContentView: View {
             switch self {
             case .general: return "slider.horizontal.3"
             case .shortcuts: return "command"
+            case .keyboard: return "keyboard"
             case .mouse: return "computermouse"
             case .hyperspace: return "square.grid.3x3.fill"
             case .voice: return "waveform.badge.mic"
@@ -51,6 +54,7 @@ struct SettingsContentView: View {
             switch self {
             case .general: return "Workspace"
             case .shortcuts: return "Controls"
+            case .keyboard: return "Keys"
             case .mouse: return "Input"
             case .hyperspace: return "Survey"
             case .voice: return "Capture"
@@ -66,6 +70,8 @@ struct SettingsContentView: View {
                 return "App updates, permissions, terminal defaults, project discovery, and interaction behavior."
             case .shortcuts:
                 return "A full map of global hotkeys for workspace movement and tmux flow."
+            case .keyboard:
+                return "Caps Lock to Hyper, tap-for-Escape, and key-state recovery."
             case .mouse:
                 return "Middle-click gestures, HUD confirmation, and rule configuration."
             case .hyperspace:
@@ -85,7 +91,7 @@ struct SettingsContentView: View {
             switch self {
             case .general, .shortcuts:
                 return "Workspace"
-            case .mouse, .hyperspace, .voice:
+            case .keyboard, .mouse, .hyperspace, .voice:
                 return "Control"
             case .ai, .search:
                 return "Intelligence"
@@ -120,6 +126,7 @@ struct SettingsContentView: View {
     var onBack: (() -> Void)? = nil
 
     @State private var selectedTab: SettingsSection = .general
+    @State private var keyboardRecoveryStatus: String?
     @FocusState private var assistantAuthFieldFocused: Bool
 
     // Hyperspace survey dials — same UserDefaults keys (and defaults) the in-survey
@@ -337,6 +344,8 @@ struct SettingsContentView: View {
             generalContent
         case .shortcuts:
             shortcutsContent
+        case .keyboard:
+            keyboardContent
         case .mouse:
             mouseGesturesContent
         case .hyperspace:
@@ -748,8 +757,8 @@ struct SettingsContentView: View {
     private var inputControlsCard: some View {
         shortcutSectionCard(
             title: "Input Controls",
-            eyebrow: "Gestures & Remaps",
-            summary: "Mouse gestures, drag snapping, and Hyper key remaps live alongside the shortcuts they trigger."
+            eyebrow: "Gestures",
+            summary: "Mouse gestures and drag snapping live alongside the shortcuts they trigger."
         ) {
             VStack(alignment: .leading, spacing: 12) {
                 HStack(alignment: .top, spacing: 12) {
@@ -815,34 +824,127 @@ struct SettingsContentView: View {
                 ) {
                     mouseGestureController.reArmAfterBreakerTrip()
                 }
+            }
+        }
+    }
 
-                cardDivider
+    private var keyboardContent: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                settingsCard {
+                    VStack(alignment: .leading, spacing: 12) {
+                        HStack(alignment: .top, spacing: 12) {
+                            VStack(alignment: .leading, spacing: 5) {
+                                Text("Caps Lock as Hyper")
+                                    .font(Typo.monoBold(12))
+                                    .foregroundColor(Palette.text)
+                                Text("Hold Caps Lock for Hyper. Tap Caps Lock for Escape.")
+                                    .font(Typo.caption(10))
+                                    .foregroundColor(Palette.textMuted)
+                            }
 
-                HStack(alignment: .top, spacing: 12) {
-                    VStack(alignment: .leading, spacing: 5) {
-                        Text("Caps Lock as Hyper")
-                            .font(Typo.monoBold(11))
-                            .foregroundColor(Palette.text)
-                        Text("Hold Caps Lock for Hyper shortcuts, tap it for Escape. Lattices maps the physical key through a private F18 transport while this is enabled.")
-                            .font(Typo.caption(10))
-                            .foregroundColor(Palette.textMuted)
+                            Spacer()
+
+                            Toggle("", isOn: $prefs.keyboardRemapsEnabled)
+                                .toggleStyle(.switch)
+                                .controlSize(.small)
+                                .labelsHidden()
+                        }
+
+                        HStack(spacing: 10) {
+                            statusToken(
+                                prefs.keyboardRemapsEnabled ? "Enabled" : "Off",
+                                color: prefs.keyboardRemapsEnabled ? Palette.running : Palette.textDim
+                            )
+                            statusToken(
+                                keyboardRemapController.capsLockTransportActive ? "Transport active" : "Transport idle",
+                                color: keyboardRemapController.capsLockTransportActive ? Palette.running : Palette.textDim
+                            )
+                            if !permChecker.accessibility {
+                                statusToken("Accessibility needed", color: Palette.detach)
+                            }
+                            Spacer(minLength: 0)
+                        }
+
+                        cardDivider
+
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Active remap")
+                                .font(Typo.mono(10))
+                                .foregroundColor(Palette.textDim)
+
+                            if keyboardRemapStore.summaryLines.isEmpty {
+                                Text("No active keyboard remaps")
+                                    .font(Typo.caption(9.5))
+                                    .foregroundColor(Palette.textMuted.opacity(0.7))
+                            } else {
+                                ForEach(keyboardRemapStore.summaryLines.prefix(3), id: \.self) { line in
+                                    Text(line)
+                                        .font(Typo.caption(9.5))
+                                        .foregroundColor(Palette.textMuted.opacity(0.82))
+                                }
+                            }
+                        }
+
+                        breakerStatusRow(
+                            state: keyboardRemapController.breakerState,
+                            label: "Keyboard remaps"
+                        ) {
+                            keyboardRemapController.reArmAfterBreakerTrip()
+                        }
+
+                        if let keyboardRecoveryStatus {
+                            Text(keyboardRecoveryStatus)
+                                .font(Typo.caption(9.5))
+                                .foregroundColor(Palette.textMuted.opacity(0.8))
+                        }
+
+                        HStack(spacing: 8) {
+                            Button {
+                                let didClear = keyboardRemapController.clearStuckCapsLockState()
+                                keyboardRecoveryStatus = didClear
+                                    ? "Caps Lock state cleared."
+                                    : "Could not clear Caps Lock state; check Accessibility/Input Monitoring."
+                            } label: {
+                                settingsActionLabel("Clear Stuck State", icon: "escape", emphasized: true)
+                            }
+                            .buttonStyle(.plain)
+
+                            Button {
+                                keyboardRemapStore.restoreDefaults()
+                                keyboardRecoveryStatus = "Keyboard remaps restored to defaults."
+                            } label: {
+                                settingsActionLabel("Restore Defaults", icon: "arrow.counterclockwise")
+                            }
+                            .buttonStyle(.plain)
+
+                            Button {
+                                keyboardRemapStore.openConfiguration()
+                            } label: {
+                                settingsActionLabel("Open Config", icon: "doc.text")
+                            }
+                            .buttonStyle(.plain)
+
+                            Spacer()
+                        }
+
+                        if !permChecker.accessibility {
+                            cardDivider
+
+                            permissionSettingsRow(
+                                "Accessibility",
+                                granted: permChecker.accessibility,
+                                detail: "Required for Caps Lock as Hyper and tap-for-Escape handling."
+                            ) {
+                                permChecker.requestAccessibility()
+                            }
+                        }
                     }
-
-                    Spacer()
-
-                    Toggle("", isOn: $prefs.keyboardRemapsEnabled)
-                        .toggleStyle(.switch)
-                        .controlSize(.small)
-                        .labelsHidden()
-                }
-
-                breakerStatusRow(
-                    state: keyboardRemapController.breakerState,
-                    label: "Keyboard remaps"
-                ) {
-                    keyboardRemapController.reArmAfterBreakerTrip()
                 }
             }
+            .padding(16)
+            .frame(maxWidth: 760, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 

--- a/apps/mac/Sources/Core/Actions/HotkeyStore.swift
+++ b/apps/mac/Sources/Core/Actions/HotkeyStore.swift
@@ -280,6 +280,7 @@ class HotkeyStore: ObservableObject {
         bind(.bezel,     19, hyper)      // Hyper+2
         bind(.hud,       20, hyper)      // Hyper+3 (HUD overlay)
         bind(.desktopInventory, 35, hyper) // Hyper+P
+        bind(.omniSearch, 23, hyper)     // Hyper+5 (search command box)
         let cmdCtrl = UInt32(cmdKey | controlKey)
         bind(.handsOff, 46, cmdCtrl)          // Ctrl+Cmd+M
         bind(.activityLog, 37, cmdShift)   // Cmd+Shift+L

--- a/apps/mac/Sources/Core/Actions/PaletteCommand.swift
+++ b/apps/mac/Sources/Core/Actions/PaletteCommand.swift
@@ -8,6 +8,8 @@ struct PaletteCommand: Identifiable {
     let icon: String
     let category: Category
     let badge: String?
+    let keywords: [String]
+    let isHiddenByDefault: Bool
     let action: () -> Void
 
     enum Category: String, CaseIterable {
@@ -24,44 +26,68 @@ struct PaletteCommand: Identifiable {
         }
     }
 
+    init(
+        id: String,
+        title: String,
+        subtitle: String,
+        icon: String,
+        category: Category,
+        badge: String? = nil,
+        keywords: [String] = [],
+        isHiddenByDefault: Bool = false,
+        action: @escaping () -> Void
+    ) {
+        self.id = id
+        self.title = title
+        self.subtitle = subtitle
+        self.icon = icon
+        self.category = category
+        self.badge = badge
+        self.keywords = keywords
+        self.isHiddenByDefault = isHiddenByDefault
+        self.action = action
+    }
+
     /// Fuzzy match score — higher is better, 0 means no match
     func matchScore(query: String) -> Int {
-        let q = query.lowercased()
-        let t = title.lowercased()
-        let s = subtitle.lowercased()
+        let q = normalized(query.trimmingCharacters(in: .whitespacesAndNewlines))
+        guard !q.isEmpty else { return 0 }
 
-        // Exact prefix match on title — best
-        if t.hasPrefix(q) { return 100 }
-        // Word-boundary prefix (e.g. "set" matches "Open Settings")
-        let words = t.split(separator: " ").map(String.init)
-        if words.contains(where: { $0.hasPrefix(q) }) { return 80 }
-        // Contains in title
-        if t.contains(q) { return 60 }
-        // Subtitle prefix
-        if s.hasPrefix(q) { return 50 }
-        // Subtitle contains
+        let terms = words(in: q)
+        let searchableText = ([title, subtitle, badge ?? ""] + keywords)
+            .map(normalized)
+            .joined(separator: " ")
+        if terms.count > 1, terms.contains(where: { !searchableText.contains($0) }) {
+            return 0
+        }
+
+        let t = normalized(title)
+        let s = normalized(subtitle)
+        let keywordText = keywords.map(normalized).joined(separator: " ")
+
+        // Exact and prefix matches keep named actions above incidental text hits.
+        if t == q { return 120 }
+        if t.hasPrefix(q) { return 110 }
+        if words(in: t).contains(where: { $0.hasPrefix(q) }) { return 95 }
+        if t.contains(q) { return 80 }
+        if keywordText.hasPrefix(q) { return 75 }
+        if words(in: keywordText).contains(where: { $0.hasPrefix(q) }) { return 70 }
+        if keywordText.contains(q) { return 60 }
+        if s.hasPrefix(q) { return 55 }
+        if words(in: s).contains(where: { $0.hasPrefix(q) }) { return 50 }
         if s.contains(q) { return 40 }
-        // Subsequence match on title
-        if isSubsequence(q, of: t) { return 20 }
+        if terms.count > 1 { return 35 }
         return 0
     }
 
-    private func isSubsequence(_ needle: String, of haystack: String) -> Bool {
-        var it = haystack.makeIterator()
-        for ch in needle {
-            while let next = it.next() {
-                if next == ch { break }
-            }
-            // If iterator is exhausted before matching all chars, not a subsequence
-            // (handled by the while loop returning nil)
-        }
-        // Verify: re-check properly
-        var hi = haystack.startIndex
-        for ch in needle {
-            guard let found = haystack[hi...].firstIndex(of: ch) else { return false }
-            hi = haystack.index(after: found)
-        }
-        return true
+    private func normalized(_ value: String) -> String {
+        value.lowercased()
+    }
+
+    private func words(in value: String) -> [String] {
+        value.split { ch in
+            !ch.isLetter && !ch.isNumber
+        }.map(String.init)
     }
 }
 
@@ -323,6 +349,13 @@ enum CommandBuilder {
         // Orphan session commands
         let inventory = InventoryManager.shared
         for orphan in inventory.orphans {
+            let orphanKeywords = [
+                "orphan",
+                "unmanaged",
+                "tmux",
+                "session",
+                orphan.name,
+            ]
             commands.append(PaletteCommand(
                 id: "orphan-attach-\(orphan.name)",
                 title: "Attach \(orphan.name)",
@@ -330,6 +363,8 @@ enum CommandBuilder {
                 icon: "play.fill",
                 category: .project,
                 badge: "orphan",
+                keywords: orphanKeywords,
+                isHiddenByDefault: true,
                 action: {
                     let terminal = Preferences.shared.terminal
                     terminal.focusOrAttach(session: orphan.name)
@@ -342,6 +377,8 @@ enum CommandBuilder {
                 icon: "xmark.circle.fill",
                 category: .window,
                 badge: "orphan",
+                keywords: orphanKeywords + ["remove"],
+                isHiddenByDefault: true,
                 action: {
                     SessionManager.killByName(orphan.name)
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
@@ -359,19 +396,87 @@ enum CommandBuilder {
             icon: "bubble.left.and.bubble.right",
             category: .app,
             badge: nil,
+            keywords: ["assistant", "ai", "chat", "help"],
             action: { AssistantAccess.show() }
         ))
 
         commands.append(PaletteCommand(
             id: "app-settings",
             title: "Settings",
-            subtitle: "Terminal, scan root, mode",
+            subtitle: "Terminal, scan root, keyboard, shortcuts, voice, and OCR",
             icon: "gearshape",
             category: .app,
             badge: nil,
+            keywords: ["preferences", "configuration", "general", "keyboard"],
             action: {
                 SettingsWindowController.shared.show()
             }
+        ))
+
+        commands.append(PaletteCommand(
+            id: "app-keyboard-settings",
+            title: "Keyboard Settings",
+            subtitle: "Caps Lock as Hyper and tap-for-Escape",
+            icon: "keyboard",
+            category: .app,
+            badge: nil,
+            keywords: ["caps", "caps lock", "hyper", "escape", "remap", "keyboard remaps"],
+            action: { SettingsWindowController.shared.show(section: "keyboard") }
+        ))
+
+        commands.append(PaletteCommand(
+            id: "app-shortcuts-settings",
+            title: "Shortcuts",
+            subtitle: "Review or change global keyboard shortcuts",
+            icon: "command",
+            category: .app,
+            badge: nil,
+            keywords: ["hotkeys", "key bindings", "keyboard", "controls"],
+            action: { SettingsWindowController.shared.show(section: "shortcuts") }
+        ))
+
+        commands.append(PaletteCommand(
+            id: "app-voice-settings",
+            title: "Voice Capture",
+            subtitle: "Microphone, dictation, and voice command settings",
+            icon: "waveform.badge.mic",
+            category: .app,
+            badge: nil,
+            keywords: ["voice", "dictation", "mic", "microphone", "capture", "talk"],
+            action: { SettingsWindowController.shared.show(section: "voice") }
+        ))
+
+        commands.append(PaletteCommand(
+            id: "app-voice-command",
+            title: "Voice Command",
+            subtitle: "Open the voice capture bar",
+            icon: "mic",
+            category: .app,
+            badge: nil,
+            keywords: ["voice", "dictation", "speak", "command box", "universal box"],
+            action: { UnifiedCommandBarWindow.shared.toggle(mode: .voice) }
+        ))
+
+        commands.append(PaletteCommand(
+            id: "app-command-bar",
+            title: "Command Bar",
+            subtitle: "Type slash commands and workspace actions",
+            icon: "text.cursor",
+            category: .app,
+            badge: nil,
+            keywords: ["universal box", "command box", "slash commands", "actions"],
+            action: { UnifiedCommandBarWindow.shared.toggle(mode: .command) }
+        ))
+
+        commands.append(PaletteCommand(
+            id: "app-search-bar",
+            title: "Search Bar",
+            subtitle: "Search windows, projects, sessions, processes, and OCR",
+            icon: "magnifyingglass",
+            category: .app,
+            badge: nil,
+            keywords: ["universal search", "omni search", "find"],
+            action: { UnifiedCommandBarWindow.shared.toggle(mode: .search) }
         ))
 
         commands.append(PaletteCommand(
@@ -386,12 +491,24 @@ enum CommandBuilder {
 
         commands.append(PaletteCommand(
             id: "app-windows-list",
-            title: "Search",
+            title: "Desktop Inventory",
             subtitle: "Browse windows, displays, spaces, and screen text",
             icon: "magnifyingglass",
             category: .app,
             badge: nil,
+            keywords: ["search", "windows", "ocr", "desktop", "inventory"],
             action: { ScreenMapWindowController.shared.showPage(.desktopInventory) }
+        ))
+
+        commands.append(PaletteCommand(
+            id: "app-search-settings",
+            title: "Search & OCR Settings",
+            subtitle: "OCR cadence, quality, and recent capture visibility",
+            icon: "text.viewfinder",
+            category: .app,
+            badge: nil,
+            keywords: ["search", "ocr", "indexing", "screen text"],
+            action: { SettingsWindowController.shared.show(section: "search") }
         ))
 
         commands.append(PaletteCommand(

--- a/apps/mac/Sources/Core/Input/KeyboardRemapController.swift
+++ b/apps/mac/Sources/Core/Input/KeyboardRemapController.swift
@@ -9,6 +9,7 @@ final class KeyboardRemapController: ObservableObject {
     /// Live state of the event-tap circuit breaker. SettingsView observes
     /// this to surface "paused" / "disabled" status and a re-arm button.
     @Published private(set) var breakerState: EventTapBreaker.State = .armed
+    @Published private(set) var capsLockTransportActive = false
 
     private static let syntheticMarker: Int64 = 0x4C4B524D
 
@@ -49,6 +50,22 @@ final class KeyboardRemapController: ObservableObject {
         }
     }
 
+    @discardableResult
+    func clearStuckCapsLockState() -> Bool {
+        dispatchPrecondition(condition: .onQueue(.main))
+        clearCapsLayer()
+        pressedKeyCodes.removeAll()
+        bypassUntil = CFAbsoluteTimeGetCurrent() + emergencyBypassDuration
+        let cleared = clearCapsLockLatch(reason: "manual settings recovery")
+        if let eventTap {
+            CGEvent.tapEnable(tap: eventTap, enable: true)
+        } else {
+            refresh()
+        }
+        DiagnosticLog.shared.warn("KeyboardRemap: manual Caps Lock recovery \(cleared ? "succeeded" : "failed")")
+        return cleared
+    }
+
     func start() {
         installObserversIfNeeded()
         refresh()
@@ -57,6 +74,7 @@ final class KeyboardRemapController: ObservableObject {
     func stop() {
         removeEventTap()
         capsLockTransport.disable()
+        capsLockTransportActive = capsLockTransport.isActive
         clearCapsLayer()
     }
 
@@ -98,12 +116,14 @@ final class KeyboardRemapController: ObservableObject {
               PermissionChecker.shared.accessibility else {
             removeEventTap()
             capsLockTransport.disable()
+            capsLockTransportActive = capsLockTransport.isActive
             return
         }
 
         KeyboardRemapStore.shared.ensureConfigFile()
         let shouldUseCapsLockTransport = KeyboardRemapStore.shared.capsLockRule?.toIfHeld == .hyper
         capsLockTransport.setEnabled(shouldUseCapsLockTransport)
+        capsLockTransportActive = capsLockTransport.isActive
 
         if eventTap == nil {
             installEventTap()
@@ -174,6 +194,7 @@ final class KeyboardRemapController: ObservableObject {
             CFMachPortInvalidate(tap)
         }
         eventTap = nil
+        capsLockTransportActive = capsLockTransport.isActive
     }
 
     private static let eventTapCallback: CGEventTapCallBack = { _, type, event, userInfo in

--- a/apps/mac/Sources/Core/Overlays/CommandPalette/CommandPaletteView.swift
+++ b/apps/mac/Sources/Core/Overlays/CommandPalette/CommandPaletteView.swift
@@ -10,12 +10,23 @@ struct CommandPaletteView: View {
     @State private var eventMonitor: Any?
     @FocusState private var isSearchFocused: Bool
 
+    private var trimmedQuery: String {
+        query.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var searchableCommands: [PaletteCommand] {
+        trimmedQuery.isEmpty ? commands.filter { !$0.isHiddenByDefault } : commands
+    }
+
     private var filtered: [PaletteCommand] {
-        if query.isEmpty { return commands }
-        return commands
-            .map { ($0, $0.matchScore(query: query)) }
+        if trimmedQuery.isEmpty { return searchableCommands }
+        return searchableCommands
+            .map { ($0, $0.matchScore(query: trimmedQuery)) }
             .filter { $0.1 > 0 }
-            .sorted { $0.1 > $1.1 }
+            .sorted {
+                if $0.1 != $1.1 { return $0.1 > $1.1 }
+                return $0.0.title.localizedCaseInsensitiveCompare($1.0.title) == .orderedAscending
+            }
             .map(\.0)
     }
 
@@ -44,8 +55,10 @@ struct CommandPaletteView: View {
             // Results
             ScrollViewReader { proxy in
                 ScrollView {
-                    if query.isEmpty {
+                    if trimmedQuery.isEmpty {
                         groupedList
+                    } else if filtered.isEmpty {
+                        emptyResults
                     } else {
                         flatList
                     }
@@ -130,6 +143,24 @@ struct CommandPaletteView: View {
             }
         }
         .padding(.vertical, 6)
+    }
+
+    private var emptyResults: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 18, weight: .medium))
+                .foregroundColor(Palette.textMuted)
+
+            Text("No commands found")
+                .font(Typo.body(13))
+                .foregroundColor(Palette.text.opacity(0.85))
+
+            Text("Try a project name, app surface, or settings area.")
+                .font(Typo.caption(10))
+                .foregroundColor(Palette.textMuted)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 72)
     }
 
     // MARK: - Section Header

--- a/apps/mac/Sources/Core/Overlays/Motion/WindowMotionMode.swift
+++ b/apps/mac/Sources/Core/Overlays/Motion/WindowMotionMode.swift
@@ -3450,17 +3450,17 @@ struct ExposeView: View {
     var body: some View {
         ZStack {
             if inPlace {
-                Color.clear.allowsHitTesting(false)
+                inPlaceSignatureBackdrop
             } else {
                 backdrop
                 VStack(spacing: 0) {
-                    intentBand.frame(height: bandHeight)
+                    overlayIntentChrome(mode: "hyperspace", detail: "window survey")
                     survey
                 }
             }
             if inPlace {
                 VStack(spacing: 0) {
-                    floatingIntentChrome
+                    overlayIntentChrome(mode: "in-place", detail: "shared with hyperspace")
                     Spacer(minLength: 0).allowsHitTesting(false)
                 }
                 VStack {
@@ -3481,10 +3481,9 @@ struct ExposeView: View {
         .animation(.spring(response: 0.26, dampingFraction: 0.82), value: rosterPileID)
         .animation(.spring(response: 0.26, dampingFraction: 0.82), value: drag.placeWid)
         .animation(.spring(response: 0.2, dampingFraction: 0.74), value: drag.placeCell)
-        .overlay(alignment: .topLeading) {
-            if !drag.isPlacing, let displayScope {
-                displayBadge(displayScope)
-                    .padding(20)
+        .overlay(alignment: .bottomLeading) {
+            if !drag.isPlacing {
+                LatticesOverlayWatermarkPlacement()
             }
         }
         .overlay(alignment: .topTrailing) {
@@ -3504,7 +3503,7 @@ struct ExposeView: View {
         }
         .overlay(alignment: .top) {
             if !drag.isPlacing {
-                planSummaryBar.padding(.top, bandHeight + 4)   // sits just under the intent band
+                planSummaryBar.padding(.top, intentChromeHeight + 4)   // sits just under the intent strip
             }
         }
         .overlay {
@@ -3827,32 +3826,6 @@ struct ExposeView: View {
         .lineLimit(1)
     }
 
-    private func displayBadge(_ scope: DisplayScope) -> some View {
-        HStack(spacing: 8) {
-            Image(systemName: scope.index == 0 ? "display" : "rectangle.on.rectangle")
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundColor(Palette.running)
-
-            VStack(alignment: .leading, spacing: 1) {
-                Text(scope.label)
-                    .font(Typo.monoBold(10))
-                    .foregroundColor(Palette.text)
-                Text("\(scope.windowCount) \(scope.windowCount == 1 ? "window" : "windows")")
-                    .font(Typo.caption(8.5))
-                    .foregroundColor(Palette.textMuted)
-            }
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 9)
-        .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(.ultraThinMaterial)
-                .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous).fill(Color.black.opacity(0.42)))
-                .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous).strokeBorder(Palette.running.opacity(0.65), lineWidth: 1))
-        )
-        .shadow(color: .black.opacity(0.55), radius: 22, y: 10)
-    }
-
     // Mouse-driven leave: the keyboard has Enter (commit) / Esc (discard), but there was no
     // way out with the trackpad. This ✕ just *closes* the survey, keeping whatever's on screen
     // (Esc remains the explicit discard/revert). Top-right, above the gear.
@@ -4047,6 +4020,9 @@ struct ExposeView: View {
                 VisualEffectBackdrop(material: .hudWindow)
                     .ignoresSafeArea()
 
+                LatticesLatticeGrid(spacing: 26, opacity: 0.04, tint: Palette.running)
+                    .ignoresSafeArea()
+
                 // Ambient floor: how lit the room is. Low = near-black and dramatic,
                 // high = airy. A little blur always survives so it never goes flat.
                 Color.black.opacity(0.82 - ambient * 0.60)
@@ -4167,20 +4143,67 @@ struct ExposeView: View {
         }
     }
 
-    // Floating intent band — full-bleed across the display; Current View is the hero.
-    private var floatingIntentChrome: some View {
-        VStack(spacing: 0) {
-            HStack(spacing: 8) {
-                Text("IN-PLACE")
-                    .font(Typo.monoBold(9))
-                    .foregroundColor(Palette.running)
-                    .tracking(0.8)
-                Text("shared with Hyperspace")
-                    .font(Typo.mono(8.5))
+    // Quiet signature wash under the live desktop — corner mark does the heavy lifting.
+    private var inPlaceSignatureBackdrop: some View {
+        ZStack(alignment: .top) {
+            LinearGradient(
+                colors: [Palette.running.opacity(0.04), .clear],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .frame(height: 140)
+            .frame(maxHeight: .infinity, alignment: .top)
+            LatticesLatticeGrid(spacing: 28, opacity: 0.028, tint: Palette.running)
+                .mask(
+                    LinearGradient(
+                        colors: [.white.opacity(0.5), .clear],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+        }
+        .allowsHitTesting(false)
+    }
+
+    // Inline monitor readout for the strip header — avoids a second top-left chip.
+    private func displayScopeChip(_ scope: DisplayScope) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: scope.index == 0 ? "display" : "rectangle.on.rectangle")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(Palette.running)
+            Text(scope.label)
+                .font(Typo.monoBold(9))
+                .foregroundColor(Palette.text)
+            if scope.count > 1 {
+                Text("\(scope.index + 1)/\(scope.count)")
+                    .font(Typo.mono(8))
                     .foregroundColor(Palette.textMuted)
-                Spacer(minLength: 0)
             }
-            .padding(.horizontal, 16)
+            Text("\(scope.windowCount)")
+                .font(Typo.monoBold(9))
+                .foregroundColor(Palette.running)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 2)
+                .background(
+                    Capsule()
+                        .fill(Palette.running.opacity(0.12))
+                        .overlay(Capsule().strokeBorder(Palette.running.opacity(0.28), lineWidth: 0.5))
+                )
+        }
+        .lineLimit(1)
+    }
+
+    /// Header row + intent band — shared by Hyperspace survey and Hyper+G in-place.
+    private var intentChromeHeight: CGFloat { bandHeight + 44 }
+
+    private func overlayIntentChrome(mode: String, detail: String?) -> some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .center, spacing: 12) {
+                LatticesOverlayStripHeader(mode: mode, detail: detail)
+                Spacer(minLength: 0)
+                if let displayScope { displayScopeChip(displayScope) }
+            }
+            .padding(.horizontal, LatticesOverlayMetrics.edgeInset)
             .padding(.top, 10)
             .padding(.bottom, 6)
             intentBand
@@ -4190,15 +4213,7 @@ struct ExposeView: View {
                 .padding(.bottom, 8)
         }
         .frame(maxWidth: .infinity)
-        .background(
-            Rectangle()
-                .fill(.ultraThinMaterial)
-                .overlay(alignment: .bottom) {
-                    Rectangle()
-                        .fill(Palette.borderLit)
-                        .frame(height: 1)
-                }
-        )
+        .background { LatticesOverlayStripBackground() }
     }
 
     // Bottom-right window inventory — compact roster linked to Current View.
@@ -4329,7 +4344,7 @@ struct ExposeView: View {
                 gridSection.frame(width: sideW)
             }
             .frame(maxWidth: .infinity)
-            .padding(.top, inPlace ? 2 : 16)
+            .padding(.top, inPlace ? 2 : 4)
             .padding(.bottom, inPlace ? 2 : 8)
         }
     }

--- a/apps/mac/Sources/Core/Overlays/Motion/WindowMotionMode.swift
+++ b/apps/mac/Sources/Core/Overlays/Motion/WindowMotionMode.swift
@@ -109,7 +109,6 @@ private enum MotionKeys {
         case 32:    return .topRight    // u
         case 11:    return .bottomLeft  // b
         case 45:    return .bottomRight // n
-        case 3:     return .maximize    // f
         case 8:     return .center      // c
         default:    return nil
         }
@@ -325,6 +324,7 @@ private final class MotionPanel: NSPanel {
 
     private let eligible: [WindowEntry]
     private var reticle = 0                          // index of the active window
+    private var fillAimWid: UInt32?                  // last click/Tab aim — F fills this window
     private var group: Set<UInt32> = []             // plucked window ids
     private var resolved: [UInt32: AXUIElement] = [:]
     private var animators: [UInt32: RealWindowAnimator] = [:]
@@ -490,6 +490,7 @@ private final class MotionPanel: NSPanel {
         }
         if let bestIdx, bestDelta < 80 {
             reticle = bestIdx
+            fillAimWid = eligible[bestIdx].wid
             resolved[eligible[bestIdx].wid] = focused
         }
     }
@@ -790,6 +791,9 @@ private final class MotionPanel: NSPanel {
             case 5  where !mods.contains(.shift):                            // G — grid selection (stay in mode)
                 if let eventScreen { gatherInPlace(on: eventScreen) }
                 return
+            case 3  where !mods.contains(.shift) && inPlaceMode:             // F — fill available space
+                fillAvailableSpace()
+                return
             case 1  where !mods.contains(.shift) && inPlaceMode:             // S — swap first two picks
                 if let eventScreen, let id = screenID,
                    let a = pickOrderByScreen[id]?[safe: 0],
@@ -833,6 +837,9 @@ private final class MotionPanel: NSPanel {
         case 5:                                             // G — grid the group (in Exposé: gather but stay)
             if exposed { gatherInPlace() } else { distributeGroup() }
             return
+        case 3:                                             // F — grow into open space until a neighbor
+            fillAvailableSpace()
+            return
         default:
             break
         }
@@ -867,6 +874,7 @@ private final class MotionPanel: NSPanel {
         let next = ((current + delta) % members.count + members.count) % members.count
         if let idx = eligible.firstIndex(where: { $0.wid == members[next].wid }) {
             reticle = idx
+            fillAimWid = activeEntry.wid
         }
         lastSide = nil
         _ = ax(for: activeEntry)          // resolve + cache
@@ -1021,14 +1029,93 @@ private final class MotionPanel: NSPanel {
 
     /// Place the active window instantly and exactly — snappy, no jittery tween.
     private func placeActive(to target: CGRect) {
-        guard let el = ax(for: activeEntry) else { NSSound.beep(); return }
-        recordOriginal(activeEntry.wid, el)
+        placeEntry(activeEntry, to: target, label: "place")
+    }
+
+    private func placeEntry(_ entry: WindowEntry, to target: CGRect, label: String = "place") {
+        guard let el = ax(for: entry) else { NSSound.beep(); return }
+        recordOriginal(entry.wid, el)
         let before = RealWindowAnimator.axFrame(el) ?? .zero
-        raising { RealWindowAnimator.setFrameRobust(el, target, pid: activeEntry.pid, raise: true) }
+        raising { RealWindowAnimator.setFrameRobust(el, target, pid: entry.pid, raise: true) }
         let after = RealWindowAnimator.axFrame(el) ?? .zero
-        DiagnosticLog.shared.info("Motion place \(activeEntry.app) wid=\(activeEntry.wid) step=\(cycleStep) before=\(rectStr(before)) target=\(rectStr(target)) after=\(rectStr(after))")
+        DiagnosticLog.shared.info("Motion \(label) \(entry.app) wid=\(entry.wid) step=\(cycleStep) before=\(rectStr(before)) target=\(rectStr(target)) after=\(rectStr(after))")
         refreshBorders()
         updateStack()
+        if exposed { rebuildExposeView() }
+    }
+
+    /// F — expand the aimed window until it hits a same-screen neighbor or the
+    /// display edge. Perpendicular overlap counts as a wall (same rule as Screen Map grow).
+    private func fillAvailableSpace(for wid: UInt32? = nil) {
+        guard let target = wid.flatMap({ w in eligible.first(where: { $0.wid == w }) }) ?? fillTargetEntry(),
+              let el = ax(for: target),
+              let me = RealWindowAnimator.axFrame(el) else { NSSound.beep(); return }
+
+        let primaryH = NSScreen.screens.first?.frame.height ?? 0
+        let currentCenter = CGPoint(x: me.midX, y: primaryH - me.midY)
+        guard let screen = NSScreen.screens.first(where: { $0.frame.contains(currentCenter) }) ?? screen(for: target) else {
+            NSSound.beep(); return
+        }
+
+        let bounds = WindowTiler.tileFrame(fractions: (0, 0, 1, 1), on: screen)
+        var left = bounds.minX, right = bounds.maxX, top = bounds.minY, bottom = bounds.maxY
+        let tolerance: CGFloat = 2
+
+        for other in eligible where other.wid != target.wid {
+            guard entry(other, isOn: screen),
+                  let otherEl = ax(for: other),
+                  let of = RealWindowAnimator.axFrame(otherEl) else { continue }
+            if of.maxX <= me.minX + tolerance && of.maxY > me.minY + tolerance && of.minY < me.maxY - tolerance {
+                left = max(left, of.maxX)
+            }
+            if of.minX >= me.maxX - tolerance && of.maxY > me.minY + tolerance && of.minY < me.maxY - tolerance {
+                right = min(right, of.minX)
+            }
+            if of.maxY <= me.minY + tolerance && of.maxX > me.minX + tolerance && of.minX < me.maxX - tolerance {
+                top = max(top, of.maxY)
+            }
+            if of.minY >= me.maxY - tolerance && of.maxX > me.minX + tolerance && of.minX < me.maxX - tolerance {
+                bottom = min(bottom, of.minY)
+            }
+        }
+
+        let newFrame = CGRect(x: left, y: top, width: right - left, height: bottom - top)
+        guard newFrame.width >= 160, newFrame.height >= 120 else { NSSound.beep(); return }
+        if abs(newFrame.minX - me.minX) < tolerance && abs(newFrame.minY - me.minY) < tolerance
+            && abs(newFrame.width - me.width) < tolerance && abs(newFrame.height - me.height) < tolerance {
+            NSSound.beep(); return
+        }
+
+        lastSide = nil
+        placeEntry(target, to: newFrame, label: "fill")
+    }
+
+    /// Pin keyboard actions (F fill, half-tiles, etc.) to the window the user last
+    /// clicked or Tab-aimed — not a stale expose index from mode entry.
+    private func aimWindow(_ wid: UInt32, on surveyScreen: NSScreen? = nil) {
+        fillAimWid = wid
+        if let idx = eligible.firstIndex(where: { $0.wid == wid }) {
+            reticle = idx
+        }
+        let resolvedScreen = surveyScreen
+            ?? activeSurveyScreen
+            ?? eligible.first(where: { $0.wid == wid }).flatMap { self.screen(for: $0) }
+        if let resolvedScreen {
+            let id = MotionPanel.screenID(resolvedScreen)
+            if let order = exposeOrderByScreen[id], let aimIdx = order.firstIndex(of: wid) {
+                exposeAimByScreen[id] = aimIdx
+                if activeSurveyScreen.map(MotionPanel.screenID) == id {
+                    exposeAim = aimIdx
+                }
+            }
+        }
+    }
+
+    private func fillTargetEntry() -> WindowEntry? {
+        if let wid = fillAimWid, let entry = eligible.first(where: { $0.wid == wid }) {
+            return entry
+        }
+        return activeEntry
     }
 
     private func rectStr(_ r: CGRect) -> String {
@@ -1105,15 +1192,32 @@ private final class MotionPanel: NSPanel {
             return
         }
         let rects = balancedGrid(members.count)
+        var moves: [(wid: UInt32, pid: Int32, frame: CGRect)] = []
+        moves.reserveCapacity(members.count)
+        for (i, m) in members.enumerated() {
+            let r = rects[i]
+            let target = WindowTiler.tileFrame(fractions: (r.minX, r.minY, r.width, r.height), on: screen)
+            if let el = ax(for: m) { recordOriginal(m.wid, el) }
+            moves.append((wid: m.wid, pid: m.pid, frame: target))
+        }
+        guard !moves.isEmpty else { return }
         raising {
-            for (i, m) in members.enumerated() {
-                guard let el = ax(for: m) else { continue }
-                let r = rects[i]
-                let target = WindowTiler.tileFrame(fractions: (r.minX, r.minY, r.width, r.height), on: screen)
-                recordOriginal(m.wid, el)
-                RealWindowAnimator.setFrameRobust(el, target, pid: m.pid, raise: true)
-                DiagnosticLog.shared.info("Motion grid \(m.app) wid=\(m.wid) target=\(rectStr(target)) after=\(rectStr(RealWindowAnimator.axFrame(el) ?? .zero))")
-            }
+            WindowTiler.batchMoveAndRaiseWindows(moves)
+        }
+        AppFeedback.shared.playTapSound()
+        DiagnosticLog.shared.info("Motion grid — \(moves.count) windows")
+    }
+
+    /// Refresh inventory chrome after a grid snap without blocking the batch move.
+    private func refreshAfterGridMove() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            DesktopModel.shared.poll()
+            self.rebuildExposeView()
+            self.updateLegend()
+            self.refreshBorders()
+            self.updateStack()
+            self.makeKey()
         }
     }
 
@@ -1122,8 +1226,12 @@ private final class MotionPanel: NSPanel {
         if !group.contains(activeEntry.wid) { togglePicked(activeEntry.wid) }
         relayoutGroup()
         updateLegend()
-        refreshBorders()
-        updateStack()
+        if inPlaceMode {
+            refreshAfterGridMove()
+        } else {
+            refreshBorders()
+            updateStack()
+        }
     }
 
     // MARK: - Screenshot Exposé (the lattice survey)
@@ -1586,12 +1694,7 @@ private final class MotionPanel: NSPanel {
             raising { RealWindowAnimator.raise(el) }              // a single pick just comes forward
         }
         if inPlaceMode {
-            DesktopModel.shared.poll()
-            rebuildExposeView()
-            updateLegend()
-            refreshBorders()
-            updateStack()
-            DispatchQueue.main.async { [weak self] in self?.makeKey() }
+            refreshAfterGridMove()
             return
         }
         removeExposeHost()
@@ -1991,6 +2094,7 @@ private final class MotionPanel: NSPanel {
                 onFocusWindow: { [weak self] wid in self?.focusWindow(wid, on: screen) },
                 onClearSelection: { [weak self] in self?.clearPicks(on: screen) },
                 onApplyPlacement: { [weak self] wid, spec in self?.applyPlacementNow(wid, spec, on: screen) },
+                onFillAvailable: { [weak self] wid in self?.fillAvailableSpace(for: wid) },
                 onOpenHyperspace: {
                     WindowMotionMode.shared.deactivate()
                     WindowMotionMode.shared.toggleHyperspace()
@@ -2083,12 +2187,14 @@ private final class MotionPanel: NSPanel {
     /// Pluck a tile by wid (hint key or click) and refresh the survey + minimap.
     private func exposeToggle(_ wid: UInt32) {
         togglePicked(wid)
+        aimWindow(wid)
         rebuildExposeView()
         updateLegend()
         updateStack()
     }
 
     private func exposeToggle(_ wid: UInt32, on screen: NSScreen) {
+        aimWindow(wid, on: screen)
         let id = MotionPanel.screenID(screen)
         var order = pickOrderByScreen[id] ?? []
         if order.contains(wid) {
@@ -2336,7 +2442,7 @@ private final class MotionPanel: NSPanel {
         let cg = cgPoint(fromAppKitScreen: appKitScreenPoint(from: viewPoint, in: view))
         guard let hit = topWindowAtDesktopClick(cg: cg, on: screen) else { return }
         exposeToggle(hit.wid, on: screen)
-        DiagnosticLog.shared.info("In-place select — click wid=\(hit.wid) app=\(hit.app)")
+        DiagnosticLog.shared.info("In-place select — click wid=\(hit.wid) app=\(hit.app) fillAim=\(hit.wid)")
         DispatchQueue.main.async { [weak self] in
             guard let self, self.exposed, !self.isKeyWindow, self.commandPanel == nil else { return }
             self.makeKey()
@@ -2438,6 +2544,7 @@ private final class MotionPanel: NSPanel {
         guard !exposeOrder.isEmpty else { return }
         let n = exposeOrder.count
         exposeAim = ((exposeAim + delta) % n + n) % n
+        if let wid = exposeOrder[safe: exposeAim] { aimWindow(wid) }
         rebuildExposeView()
     }
 
@@ -2452,6 +2559,7 @@ private final class MotionPanel: NSPanel {
         } else {
             exposeAim = exposeAimByScreen[id] ?? 0
         }
+        if let wid = order[safe: exposeAimByScreen[id] ?? 0] { aimWindow(wid, on: screen) }
         rebuildExposeView()
     }
 
@@ -2834,6 +2942,7 @@ private struct MotionLegend: View {
                     keyHint("a–z", "select")
                     keyHint("S", "swap 2")
                     keyHint("G", "grid")
+                    keyHint("F", "fill")
                     keyHint("drag", "stage")
                     keyHint("⏎", "commit")
                     keyHint("esc", "exit")
@@ -2854,6 +2963,7 @@ private struct MotionLegend: View {
                 keyHint("Space", "select")
                 keyHint("E", "expose")
                 keyHint("G", "grid")
+                keyHint("F", "fill")
                 if groupCount > 0 { keyHint("⌘L", "save layer") }
                 keyHint("←↑→↓", "half · gap")
                 keyHint("⇧/⌥", "nudge/size")
@@ -3285,6 +3395,7 @@ struct ExposeView: View {
     var onFocusWindow: (UInt32) -> Void = { _ in }
     var onClearSelection: () -> Void = {}
     var onApplyPlacement: (UInt32, PlacementSpec) -> Void = { _, _ in }
+    var onFillAvailable: (UInt32) -> Void = { _ in }
     var onOpenHyperspace: () -> Void = {}
     var layers: [LayerPile] = []
     var stagedPlan: [StagedMarker] = []
@@ -3330,7 +3441,7 @@ struct ExposeView: View {
     // The visual-settings rig (lighting/size/zoom/keys/perf) lives behind a gear
     // in the top-right; collapsed by default so it doesn't cover the intent band.
     @State private var dialsOpen = false
-    @State private var guideOpen = true
+    @State private var showInPlaceCommands = false
 
     @State private var perfMode = false
     @State private var perfFlat = false                  // A = true, B = false
@@ -3371,12 +3482,9 @@ struct ExposeView: View {
         .animation(.spring(response: 0.26, dampingFraction: 0.82), value: drag.placeWid)
         .animation(.spring(response: 0.2, dampingFraction: 0.74), value: drag.placeCell)
         .overlay(alignment: .topLeading) {
-            if !drag.isPlacing {
-                VStack(alignment: .leading, spacing: 8) {
-                    if let displayScope { displayBadge(displayScope) }
-                    if inPlace { inPlaceActionGuide }
-                }
-                .padding(20)
+            if !drag.isPlacing, let displayScope {
+                displayBadge(displayScope)
+                    .padding(20)
             }
         }
         .overlay(alignment: .topTrailing) {
@@ -3658,59 +3766,65 @@ struct ExposeView: View {
         onDrop(wid, spec)
     }
 
-    // Compact action reference for In-Place (Hyper+G). No modifier on click — plain tap selects.
-    private var inPlaceActionGuide: some View {
-        let shape = RoundedRectangle(cornerRadius: 12, style: .continuous)
-        return VStack(alignment: .leading, spacing: 0) {
-            Button {
-                withAnimation(.easeOut(duration: 0.16)) { guideOpen.toggle() }
-            } label: {
-                HStack(spacing: 6) {
-                    Text("ACTIONS")
-                        .font(Typo.monoBold(9))
-                        .foregroundColor(Palette.running)
-                        .tracking(0.6)
-                    Spacer(minLength: 0)
-                    Image(systemName: guideOpen ? "chevron.up" : "chevron.down")
-                        .font(.system(size: 9, weight: .semibold))
-                        .foregroundColor(Palette.textMuted)
-                }
-                .padding(.horizontal, 10).padding(.vertical, 8)
-            }
-            .buttonStyle(.plain)
-            if guideOpen {
-                VStack(alignment: .leading, spacing: 5) {
-                    guideAction("Click window", "select (no action)")
-                    guideAction("Right-click", "contextual actions")
-                    guideAction("a–z", "select by letter")
-                    guideAction("S", "swap first two picks")
-                    guideAction("G", "grid selected windows")
-                    guideAction("Drag", "stage → Grid or Layers")
-                    guideAction("Enter", "commit staged + exit")
-                    guideAction("Esc", "discard + exit")
-                    guideAction("Hyper+Space", "full Hyperspace")
-                }
-                .padding(.horizontal, 10).padding(.bottom, 9)
+    private enum InPlaceCommandRail { case leading, trailing }
+
+    // In-place command hints flank the Current View mini-map — mouse + keys on the sides.
+    private func inPlaceCommandRail(_ side: InPlaceCommandRail) -> some View {
+        let leading = side == .leading
+        let hints: [(String, String)] = leading
+            ? [("a–z", "select"), ("S", "swap"), ("G", "grid"), ("F", "fill"), ("drag", "stage")]
+            : [("⏎", "commit"), ("esc", "discard"), ("Hyper+␣", "survey")]
+        return VStack(alignment: leading ? .leading : .trailing, spacing: 6) {
+            inPlaceMouseCommandHint(side: side)
+            ForEach(Array(hints.enumerated()), id: \.offset) { _, hint in
+                inPlaceCommandHint(key: hint.0, label: hint.1, leading: leading)
             }
         }
-        .frame(width: 196, alignment: .leading)
-        .background(
-            shape.fill(Color.black.opacity(0.58))
-                .overlay(shape.strokeBorder(Palette.borderLit, lineWidth: 0.5))
-        )
+        .frame(width: leading ? 76 : 86, alignment: leading ? .leading : .trailing)
     }
 
-    private func guideAction(_ key: String, _ label: String) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 6) {
-            Text(key)
-                .font(Typo.monoBold(8.5))
-                .foregroundColor(.white.opacity(0.88))
-                .frame(width: 72, alignment: .leading)
-            Text(label)
-                .font(Typo.mono(8))
-                .foregroundColor(Palette.textMuted)
-                .lineLimit(2)
+    private func inPlaceCommandHint(key: String, label: String, leading: Bool) -> some View {
+        HStack(spacing: 5) {
+            if !leading { inPlaceCommandLabel(label) }
+            inPlaceCommandKey(key)
+            if leading { inPlaceCommandLabel(label) }
         }
+        .lineLimit(1)
+    }
+
+    private func inPlaceCommandLabel(_ label: String) -> some View {
+        Text(label)
+            .font(Typo.mono(10))
+            .foregroundColor(Palette.textDim)
+    }
+
+    private func inPlaceCommandKey(_ key: String) -> some View {
+        Text(key)
+            .font(Typo.monoBold(10))
+            .foregroundColor(Palette.text)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .background(
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(Color.white.opacity(0.10))
+                    .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(Palette.borderLit, lineWidth: 0.5))
+            )
+    }
+
+    private func inPlaceMouseCommandHint(side: InPlaceCommandRail) -> some View {
+        let leading = side == .leading
+        let icon = leading ? "hand.tap.fill" : "contextualmenu.and.cursorarrow"
+        let key = leading ? "click" : "right-click"
+        let label = leading ? "select" : "actions"
+        return HStack(spacing: 5) {
+            if !leading { inPlaceCommandLabel(label) }
+            Image(systemName: icon)
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(Palette.running.opacity(0.9))
+            inPlaceCommandKey(key)
+            if leading { inPlaceCommandLabel(label) }
+        }
+        .lineLimit(1)
     }
 
     private func displayBadge(_ scope: DisplayScope) -> some View {
@@ -3728,13 +3842,15 @@ struct ExposeView: View {
                     .foregroundColor(Palette.textMuted)
             }
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
         .background(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(Color.black.opacity(0.58))
-                .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous).strokeBorder(Palette.running.opacity(0.55), lineWidth: 0.5))
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(.ultraThinMaterial)
+                .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous).fill(Color.black.opacity(0.42)))
+                .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous).strokeBorder(Palette.running.opacity(0.65), lineWidth: 1))
         )
+        .shadow(color: .black.opacity(0.55), radius: 22, y: 10)
     }
 
     // Mouse-driven leave: the keyboard has Enter (commit) / Esc (discard), but there was no
@@ -4051,10 +4167,10 @@ struct ExposeView: View {
         }
     }
 
-    // Floating intent band — Current View is the hero in in-place mode.
+    // Floating intent band — full-bleed across the display; Current View is the hero.
     private var floatingIntentChrome: some View {
-        VStack(spacing: 6) {
-            HStack(spacing: 6) {
+        VStack(spacing: 0) {
+            HStack(spacing: 8) {
                 Text("IN-PLACE")
                     .font(Typo.monoBold(9))
                     .foregroundColor(Palette.running)
@@ -4064,21 +4180,25 @@ struct ExposeView: View {
                     .foregroundColor(Palette.textMuted)
                 Spacer(minLength: 0)
             }
-            .padding(.horizontal, 4)
+            .padding(.horizontal, 16)
+            .padding(.top, 10)
+            .padding(.bottom, 6)
             intentBand
                 .frame(height: bandHeight)
+                .clipped()
+                .padding(.horizontal, 10)
+                .padding(.bottom, 8)
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity)
         .background(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
+            Rectangle()
                 .fill(.ultraThinMaterial)
-                .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .strokeBorder(Palette.borderLit, lineWidth: 1))
+                .overlay(alignment: .bottom) {
+                    Rectangle()
+                        .fill(Palette.borderLit)
+                        .frame(height: 1)
+                }
         )
-        .shadow(color: .black.opacity(0.45), radius: 24, y: 10)
-        .padding(.horizontal, 20)
-        .padding(.top, 12)
     }
 
     // Bottom-right window inventory — compact roster linked to Current View.
@@ -4200,17 +4320,17 @@ struct ExposeView: View {
     private var intentBand: some View {
         // Three slots: Layers (pick/tag) · Current View (select) · Grid (drop a cell).
         GeometryReader { geo in
-            let sideW = (geo.size.width * (inPlace ? 0.17 : 0.18)).rounded()
-            let centerW = (geo.size.width * (inPlace ? 0.30 : 0.18)).rounded()
-            let gap = (geo.size.width * 0.018).rounded()
+            let sideW = (geo.size.width * (inPlace ? 0.14 : 0.18)).rounded()
+            let centerW = (geo.size.width * (inPlace ? 0.44 : 0.18)).rounded()
+            let gap = (geo.size.width * (inPlace ? 0.01 : 0.018)).rounded()
             HStack(alignment: .top, spacing: gap) {
                 layersSection.frame(width: sideW)
                 currentViewSection.frame(width: centerW)
                 gridSection.frame(width: sideW)
             }
             .frame(maxWidth: .infinity)
-            .padding(.top, inPlace ? 4 : 16)
-            .padding(.bottom, inPlace ? 4 : 8)
+            .padding(.top, inPlace ? 2 : 16)
+            .padding(.bottom, inPlace ? 2 : 8)
         }
     }
 
@@ -4267,15 +4387,19 @@ struct ExposeView: View {
                 // next free cell ([L1][＋] → [L1][L2]/[＋] → …). Eager VStack/HStack — not a
                 // lazy grid — so every pile reports its LayerFrameKey for drag hit-testing.
                 GeometryReader { geo in
-                    let pileW = max(104, min(220, ((geo.size.width - 10) / 2).rounded()))
-                    VStack(alignment: .leading, spacing: 10) {
-                        ForEach(layerRows.indices, id: \.self) { r in
-                            HStack(alignment: .top, spacing: 10) {
-                                ForEach(layerRows[r]) { layerPileView($0, mapW: pileW) }
+                    let pileW = layerPileWidth(in: geo.size)
+                    ScrollView(.vertical, showsIndicators: false) {
+                        VStack(alignment: .leading, spacing: inPlace ? 6 : 10) {
+                            ForEach(layerRows.indices, id: \.self) { r in
+                                HStack(alignment: .top, spacing: inPlace ? 6 : 10) {
+                                    ForEach(layerRows[r]) { layerPileView($0, mapW: pileW) }
+                                }
                             }
                         }
+                        .frame(maxWidth: .infinity, alignment: .topLeading)
                     }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .frame(width: geo.size.width, height: geo.size.height)
+                    .clipped()
                     .onPreferenceChange(LayerFrameKey.self) { drag.layerFrames[screenID] = $0 }
                 }
             }
@@ -4338,9 +4462,11 @@ struct ExposeView: View {
                 }
             }
             Text(pile.isNew ? "new" : pile.name)
-                .font(Typo.mono(9)).foregroundColor(.white.opacity(on ? 0.9 : 0.65))
+                .font(Typo.mono(inPlace ? 8 : 9)).foregroundColor(.white.opacity(on ? 0.9 : 0.65))
                 .lineLimit(1).frame(maxWidth: mapW)
-            layerPileMeta(pile, active: on, width: mapW)
+            if !inPlace {
+                layerPileMeta(pile, active: on, width: mapW)
+            }
         }
         .animation(.spring(response: 0.3, dampingFraction: 0.7), value: pile.stagedCount)
         .scaleEffect(lit ? 1.06 : 1)
@@ -4646,6 +4772,25 @@ struct ExposeView: View {
         (width / min(max(screenAspect, 1.2), 2.6)).rounded()
     }
 
+    /// Pile thumbnail width for the Layers grid. In-place mode gives the side column a
+    /// lot of horizontal space but a short band — size from the vertical budget so piles
+    /// don't spill below the reserved intent zone.
+    private func layerPileWidth(in size: CGSize) -> CGFloat {
+        let colW = max(52, ((size.width - 10) / 2).rounded())
+        guard inPlace else {
+            return max(104, min(220, colW))
+        }
+        let rowCount = CGFloat(max(1, layerRows.count))
+        let rowGap: CGFloat = 6
+        let labelStack: CGFloat = 22   // name under map (+ spacing); meta hidden in-place
+        let hoverPad: CGFloat = 1.08   // pile scaleEffect headroom
+        let availH = max(40, size.height)
+        let perRowH = (availH - rowGap * (rowCount - 1)) / rowCount
+        let mapH = max(22, (perRowH - labelStack) / hoverPad)
+        let wFromH = mapH * min(max(screenAspect, 1.2), 2.6)
+        return min(colW, wFromH, 132).rounded()
+    }
+
     // A layer's screen-map: its member windows drawn as app-tinted rects at their real
     // (screen-relative) positions — the "what does this layer look like" preview. `big`
     // (the expanded map) fills rects with the live thumbnail.
@@ -4890,11 +5035,17 @@ struct ExposeView: View {
             || drag.hoverSurveyWid != nil
     }
 
+    /// In-place shortcut rails: on hover, or pinned while windows are selected.
+    private var inPlaceCommandsVisible: Bool {
+        showInPlaceCommands || !pickedOrder.isEmpty
+    }
+
     private var currentViewSub: String {
         if drag.isActive, drag.screenID == screenID, drag.dragSource == .currentView {
             return drag.hoverGrid ? "release on cell" : "drag to grid →"
         }
-        if !pickedOrder.isEmpty { return "\(pickedOrder.count) selected · S swap · G grid" }
+        if !pickedOrder.isEmpty { return "\(pickedOrder.count) selected" }
+        if inPlace { return inPlaceCommandsVisible ? "shortcuts" : "hover for shortcuts" }
         return "click or a–z to select"
     }
 
@@ -4904,8 +5055,29 @@ struct ExposeView: View {
         sectionCard(title: "Current View", icon: "rectangle.on.rectangle",
                     sub: currentViewSub,
                     live: true, armed: currentViewFocused || (drag.isActive && drag.dragSource == .currentView)) {
-            currentLayoutCanvas
+            if inPlace {
+                HStack(alignment: .center, spacing: inPlaceCommandsVisible ? 4 : 0) {
+                    if inPlaceCommandsVisible {
+                        inPlaceCommandRail(.leading)
+                            .transition(.move(edge: .leading).combined(with: .opacity))
+                    }
+                    currentLayoutCanvas
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    if inPlaceCommandsVisible {
+                        inPlaceCommandRail(.trailing)
+                            .transition(.move(edge: .trailing).combined(with: .opacity))
+                    }
+                }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .contentShape(Rectangle())
+                .animation(.easeOut(duration: 0.16), value: inPlaceCommandsVisible)
+                .onHover { hovering in
+                    showInPlaceCommands = hovering
+                }
+            } else {
+                currentLayoutCanvas
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
         }
     }
 
@@ -4913,7 +5085,8 @@ struct ExposeView: View {
     // a wireframe of the desktop (including stacked-behind windows as dashed footprints).
     private var currentLayoutCanvas: some View {
         let focused = currentViewFocused
-        let showHint = focused && activeLinkWid == nil && pickedWids.isEmpty && !drag.isActive
+        let showHint = !inPlace && focused && activeLinkWid == nil && pickedWids.isEmpty && !drag.isActive
+        let showHoverCue = inPlace && !inPlaceCommandsVisible && !drag.isActive
         return GeometryReader { geo in
             let box = aspectFit(in: geo.size, aspect: screenAspect)
             ZStack(alignment: .topLeading) {
@@ -4921,6 +5094,21 @@ struct ExposeView: View {
                     .fill(Color.black.opacity(0.38))
                 ForEach(currentLayout) { m in
                     layoutOutlineInteractive(m, box: box)
+                }
+                if showHoverCue {
+                    HStack(spacing: 4) {
+                        Image(systemName: "questionmark.circle")
+                            .font(.system(size: 8, weight: .semibold))
+                        Text("hover for shortcuts")
+                            .font(Typo.mono(9))
+                    }
+                    .foregroundColor(.white.opacity(0.38))
+                    .padding(.horizontal, 7).padding(.vertical, 4)
+                    .background(Capsule().fill(Color.black.opacity(0.32)))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+                    .padding(.bottom, 6)
+                    .allowsHitTesting(false)
+                    .transition(.opacity)
                 }
                 if showHint {
                     Text("click windows to select")
@@ -5074,6 +5262,7 @@ struct ExposeView: View {
             // Glide the highlight between cells instead of snapping.
             .animation(.spring(response: 0.24, dampingFraction: 0.72), value: drag.hoverCell)
             .frame(width: box.width, height: box.height)
+            .clipped()
             .background(                                          // measure the fixed grid box…
                 GeometryReader { g in
                     Color.clear.preference(key: LatticeFrameKey.self,
@@ -5081,6 +5270,7 @@ struct ExposeView: View {
                 }
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)   // …then center it in the section
+            .clipped()
         }
         .onPreferenceChange(LatticeFrameKey.self) { drag.latticeFrames[screenID] = $0 }
     }
@@ -5173,8 +5363,10 @@ struct ExposeView: View {
                 trailing()
             }
             content()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .clipped()
         }
-        .padding(.horizontal, 12).padding(.top, 9).padding(.bottom, 11)
+        .padding(.horizontal, inPlace ? 8 : 12).padding(.top, inPlace ? 7 : 9).padding(.bottom, inPlace ? 6 : 11)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
@@ -5486,6 +5678,9 @@ struct ExposeView: View {
 
     @ViewBuilder
     private func inPlacePlacementMenus(_ t: Tile) -> some View {
+        Button { onFillAvailable(t.id) } label: {
+            Label("Fill Available Space (F)", systemImage: "arrow.up.backward.and.arrow.down.forward")
+        }
         Menu("Apply Now", systemImage: "arrow.up.left.and.arrow.down.right") {
             placementQuickItems(wid: t.id, handler: onApplyPlacement)
         }

--- a/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapView.swift
+++ b/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapView.swift
@@ -147,13 +147,13 @@ struct ScreenMapView: View {
     }
 
     @ObservedObject var controller: ScreenMapController
+    @Binding var studioLayerScopeId: String?
     var onNavigate: ((AppPage) -> Void)? = nil
-    var studioLayerScopeId: String? = nil
-    var onClearStudioLayerScope: (() -> Void)? = nil
     @ObservedObject private var daemon = DaemonServer.shared
     @ObservedObject private var handsOff = HandsOffSession.shared
     @ObservedObject private var diagnosticLog = DiagnosticLog.shared
     @ObservedObject private var studioLayers = StudioLayerStore.shared
+    @ObservedObject private var desktop = DesktopModel.shared
     @StateObject private var piChat = PiChatSession.shared
     @State private var eventMonitor: Any?
     @State private var mouseDownMonitor: Any?
@@ -174,7 +174,10 @@ struct ScreenMapView: View {
     @State private var expandedLayers: Set<Int> = []
     @State private var showUnnamedLayers: Bool = false
     @State private var showSets: Bool = false
+    @State private var showStudioLayers: Bool = true
     @State private var showExplorer: Bool = false
+    @State private var editingStudioLayerId: String?
+    @State private var draftStudioLayerName = ""
     @State private var mouseMovedMonitor: Any?
     @State private var sidebarWidth: CGFloat = 180
     @State private var isDraggingSidebar: Bool = false
@@ -188,6 +191,7 @@ struct ScreenMapView: View {
     @State private var canvasPanStart: NSPoint? = nil
     @State private var canvasPanStartOffset: CGPoint = .zero
     @State private var searchOverlayFrame: CGRect = .zero
+    @FocusState private var isStudioLayerNameFocused: Bool
 
     var body: some View {
         VStack(spacing: 0) {
@@ -198,10 +202,14 @@ struct ScreenMapView: View {
                                       range: 140...320, edge: .trailing)
                 }
                 ZStack {
+                    canvasCenterBackground
                     VStack(spacing: 0) {
                         canvasHeaderBezel
                         screenMapCanvas(editor: controller.editor)
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                            .padding(.horizontal, 14)
+                            .padding(.top, 16)
+                            .padding(.bottom, 12)
                     }
                     .offset(x: canvasTransitionOffset)
                     .opacity(canvasTransitionOpacity)
@@ -258,6 +266,12 @@ struct ScreenMapView: View {
         return studioLayers.layers.first { $0.id == studioLayerScopeId }
     }
 
+    private func clearStudioLayerScope() {
+        studioLayerScopeId = nil
+        editingStudioLayerId = nil
+        isStudioLayerNameFocused = false
+    }
+
     private func scopedWindows(_ windows: [ScreenMapWindowEntry]) -> [ScreenMapWindowEntry] {
         guard let layer = activeStudioLayer else { return windows }
         return windows.filter { screenMapWindow($0, matches: layer) }
@@ -293,15 +307,11 @@ struct ScreenMapView: View {
     // MARK: - Display Toolbar (floating in canvas)
 
     private func displayToolbar(editor: ScreenMapEditorState) -> some View {
-        HStack(spacing: 4) {
+        HStack(spacing: 6) {
             Button {
                 controller.stepDisplayFocus(.previous)
             } label: {
-                Image(systemName: "chevron.left")
-                    .font(.system(size: 8, weight: .semibold))
-                    .foregroundColor(Palette.textDim)
-                    .frame(width: 18, height: 18)
-                    .contentShape(Rectangle())
+                displayToolbarChevron("chevron.left")
             }
             .buttonStyle(.plain)
 
@@ -329,24 +339,31 @@ struct ScreenMapView: View {
             Button {
                 controller.stepDisplayFocus(.next)
             } label: {
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 8, weight: .semibold))
-                    .foregroundColor(Palette.textDim)
-                    .frame(width: 18, height: 18)
-                    .contentShape(Rectangle())
+                displayToolbarChevron("chevron.right")
             }
             .buttonStyle(.plain)
         }
-        .padding(.horizontal, 6)
-        .padding(.vertical, 4)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 5)
         .background(
-            RoundedRectangle(cornerRadius: 8)
-                .fill(Color.black.opacity(0.65))
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color(red: 0.030, green: 0.034, blue: 0.035).opacity(0.94),
+                            Color(red: 0.010, green: 0.012, blue: 0.013).opacity(0.94),
+                        ],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
                 .overlay(
-                    RoundedRectangle(cornerRadius: 8)
-                        .strokeBorder(Color.white.opacity(0.08), lineWidth: 0.5)
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .strokeBorder(Color.white.opacity(0.10), lineWidth: 0.5)
                 )
         )
+        .shadow(color: .black.opacity(0.28), radius: 10, y: 4)
+        .shadow(color: Palette.running.opacity(0.08), radius: 16, y: 0)
     }
 
     private func displayToolbarPill(badge: Int? = nil, name: String, isActive: Bool) -> some View {
@@ -354,28 +371,44 @@ struct ScreenMapView: View {
             if let badge = badge {
                 ZStack {
                     Circle()
-                        .fill(isActive ? Palette.running.opacity(0.5) : Color.white.opacity(0.25))
-                        .frame(width: 14, height: 14)
+                        .fill(isActive ? Palette.running.opacity(0.72) : Color.white.opacity(0.22))
+                        .frame(width: 15, height: 15)
                     Text("\(badge)")
                         .font(.system(size: 7, weight: .bold, design: .monospaced))
-                        .foregroundColor(isActive ? .white : .black)
+                        .foregroundColor(isActive ? Palette.bg : Color.black.opacity(0.72))
                 }
             }
             Text(name)
                 .font(Typo.monoBold(8))
-                .foregroundColor(isActive ? Palette.text : Palette.textDim)
+                .foregroundColor(isActive ? Palette.text : Palette.textMuted)
                 .lineLimit(1)
         }
-        .padding(.horizontal, 6)
-        .padding(.vertical, 3)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 4)
         .background(
-            RoundedRectangle(cornerRadius: 5)
-                .fill(isActive ? Palette.running.opacity(0.15) : Color.white.opacity(0.06))
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(isActive ? Palette.running.opacity(0.16) : Color.white.opacity(0.045))
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 5)
-                .strokeBorder(isActive ? Palette.running.opacity(0.4) : Color.clear, lineWidth: 0.5)
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .strokeBorder(isActive ? Palette.running.opacity(0.42) : Color.white.opacity(0.055), lineWidth: 0.5)
         )
+    }
+
+    private func displayToolbarChevron(_ systemName: String) -> some View {
+        Image(systemName: systemName)
+            .font(.system(size: 8, weight: .bold))
+            .foregroundColor(Palette.textDim)
+            .frame(width: 22, height: 21)
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(Color.white.opacity(0.045))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 5, style: .continuous)
+                            .strokeBorder(Color.white.opacity(0.055), lineWidth: 0.5)
+                    )
+            )
+            .contentShape(Rectangle())
     }
 
     // MARK: - Canvas Header Bezel
@@ -402,9 +435,57 @@ struct ScreenMapView: View {
                 Text("\(visibleWindowCount(in: editor)) windows").font(Typo.mono(8)).foregroundColor(Palette.textMuted)
             } else { Text("Canvas"); Spacer() }
         }
-        .padding(.horizontal, 10).padding(.vertical, 5)
-        .background(Color(red: 0.08, green: 0.08, blue: 0.09))
-        .overlay(alignment: .bottom) { Rectangle().fill(Palette.border).frame(height: 0.5) }
+        .padding(.horizontal, 12)
+        .frame(height: 28)
+        .background(
+            LinearGradient(
+                colors: [
+                    Color(red: 0.082, green: 0.086, blue: 0.090),
+                    Color(red: 0.062, green: 0.064, blue: 0.068),
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
+        .overlay(alignment: .top) {
+            Rectangle().fill(Color.white.opacity(0.035)).frame(height: 0.5)
+        }
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(Palette.border).frame(height: 0.5)
+        }
+    }
+
+    private var canvasCenterBackground: some View {
+        ZStack {
+            LinearGradient(
+                colors: [
+                    Color(red: 0.066, green: 0.068, blue: 0.072),
+                    Color(red: 0.045, green: 0.047, blue: 0.050),
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+
+            Canvas { context, size in
+                let spacing: CGFloat = 28
+                let dot = Color.white.opacity(0.018)
+                for x in stride(from: spacing / 2, to: size.width, by: spacing) {
+                    for y in stride(from: spacing / 2, to: size.height, by: spacing) {
+                        context.fill(
+                            Path(ellipseIn: CGRect(x: x - 0.45, y: y - 0.45, width: 0.9, height: 0.9)),
+                            with: .color(dot)
+                        )
+                    }
+                }
+            }
+
+            VStack(spacing: 0) {
+                Rectangle()
+                    .fill(Palette.running.opacity(0.025))
+                    .frame(height: 1)
+                Spacer()
+            }
+        }
     }
 
     // MARK: - Panel Resize Handle
@@ -1185,6 +1266,11 @@ struct ScreenMapView: View {
             .frame(maxWidth: .infinity)
             .background(Color(red: 0.05, green: 0.05, blue: 0.06))
 
+            if let layer = activeStudioLayer {
+                Rectangle().fill(Palette.border).frame(height: 0.5)
+                studioLayerToolTray(layer: layer, editor: editor)
+            }
+
             // Actions grid (always pinned at bottom)
             Rectangle().fill(Palette.border).frame(height: 0.5)
 
@@ -1239,6 +1325,184 @@ struct ScreenMapView: View {
             inspectorLogTray
         }
         .background(Color(red: 0.06, green: 0.06, blue: 0.07))
+    }
+
+    private func studioLayerToolTray(layer: StudioLayer, editor: ScreenMapEditorState) -> some View {
+        let matches = studioLayers.resolve(layer, in: desktop)
+        let visibleCount = visibleWindowCount(in: editor)
+
+        return VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Text("LAYER")
+                    .font(Typo.monoBold(8))
+                    .foregroundColor(Palette.textMuted)
+                Text("\(visibleCount) visible")
+                    .font(Typo.mono(8))
+                    .foregroundColor(Palette.textMuted)
+                Spacer()
+                studioLayerToolButton("arrow.up.forward.square", help: "Focus matching windows") {
+                    studioLayers.recall(layer)
+                    controller.flash("Recalled \(layer.name)")
+                }
+                studioLayerToolButton("pencil", help: "Rename layer") {
+                    beginStudioLayerRename(layer)
+                }
+                studioLayerToolButton("doc.on.doc", help: "Copy layer spec") {
+                    copyStudioLayerSpec(layer, matches: matches)
+                }
+                studioLayerToolButton("sparkles", help: "Ask assistant about this layer") {
+                    askAssistantAboutStudioLayer(layer, matches: matches)
+                }
+                studioLayerToolButton("trash", tint: Palette.kill.opacity(0.8), help: "Delete layer") {
+                    deleteStudioLayer(layer)
+                }
+                studioLayerToolButton("xmark", help: "Clear layer scope") {
+                    clearStudioLayerScope()
+                    controller.flash("All Desktop")
+                }
+            }
+
+            if editingStudioLayerId == layer.id {
+                TextField("Layer name", text: $draftStudioLayerName)
+                    .textFieldStyle(.plain)
+                    .font(Typo.monoBold(10))
+                    .foregroundColor(Palette.text)
+                    .focused($isStudioLayerNameFocused)
+                    .onSubmit(commitStudioLayerRename)
+                    .onExitCommand(perform: cancelStudioLayerRename)
+                    .onAppear { isStudioLayerNameFocused = true }
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 4)
+                    .background(
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(Palette.surface.opacity(0.9))
+                            .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.running.opacity(0.3), lineWidth: 0.5))
+                    )
+            } else {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(layer.name)
+                        .font(Typo.monoBold(10))
+                        .foregroundColor(Palette.text)
+                        .lineLimit(1)
+                    Text(layer.summary)
+                        .font(Typo.mono(8))
+                        .foregroundColor(Palette.textMuted)
+                        .lineLimit(2)
+                }
+            }
+
+            if matches.isEmpty {
+                Text("No live windows match this rule.")
+                    .font(Typo.mono(8))
+                    .foregroundColor(Palette.textMuted)
+            } else {
+                VStack(alignment: .leading, spacing: 3) {
+                    ForEach(Array(matches.prefix(3)), id: \.wid) { entry in
+                        studioLayerToolWindowRow(entry)
+                    }
+                    if matches.count > 3 {
+                        Text("+\(matches.count - 3) more")
+                            .font(Typo.mono(7))
+                            .foregroundColor(Palette.textMuted)
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 8)
+        .background(Color(red: 0.05, green: 0.05, blue: 0.06))
+    }
+
+    private func studioLayerToolWindowRow(_ entry: WindowEntry) -> some View {
+        HStack(spacing: 5) {
+            Circle()
+                .fill(entry.isOnScreen ? Palette.running.opacity(0.75) : Palette.textMuted.opacity(0.55))
+                .frame(width: 4, height: 4)
+            Text(entry.app)
+                .font(Typo.monoBold(8))
+                .foregroundColor(Palette.textDim)
+                .lineLimit(1)
+                .frame(width: 58, alignment: .leading)
+            Text(entry.title.isEmpty ? "untitled" : entry.title)
+                .font(Typo.mono(8))
+                .foregroundColor(Palette.textMuted)
+                .lineLimit(1)
+        }
+    }
+
+    private func studioLayerToolButton(_ systemName: String, tint: Color = Palette.textMuted,
+                                       help: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(tint)
+                .frame(width: 17, height: 17)
+                .background(
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Palette.surface.opacity(0.7))
+                        .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Palette.border, lineWidth: 0.5))
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(help)
+    }
+
+    private func beginStudioLayerRename(_ layer: StudioLayer) {
+        draftStudioLayerName = layer.name
+        editingStudioLayerId = layer.id
+        isStudioLayerNameFocused = true
+    }
+
+    private func commitStudioLayerRename() {
+        guard let id = editingStudioLayerId else { return }
+        studioLayers.rename(id: id, to: draftStudioLayerName)
+        editingStudioLayerId = nil
+        isStudioLayerNameFocused = false
+        controller.flash("Renamed layer")
+    }
+
+    private func cancelStudioLayerRename() {
+        editingStudioLayerId = nil
+        isStudioLayerNameFocused = false
+    }
+
+    private func copyStudioLayerSpec(_ layer: StudioLayer, matches: [WindowEntry]) {
+        let text = studioLayers.layerContextJSON(layer, matches: matches)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        controller.flash("Copied layer spec")
+    }
+
+    private func askAssistantAboutStudioLayer(_ layer: StudioLayer, matches: [WindowEntry]) {
+        let spec = studioLayers.layerContextJSON(layer, matches: matches)
+        let attachment = PiChatAttachment(
+            name: "\(safeAttachmentStem(layer.name))-layer.json",
+            mediaType: "application/json",
+            content: spec,
+            systemImage: "doc.text.magnifyingglass"
+        )
+        let prompt = "Help me reason about the attached Lattices Studio layer. Explain what the rules mean, what live windows currently match, and suggest a cleaner rule if the layer is too broad or too narrow."
+        ScreenMapWindowController.shared.showAssistant()
+        PiChatSession.shared.send(prompt, attachments: [attachment])
+    }
+
+    private func deleteStudioLayer(_ layer: StudioLayer) {
+        studioLayers.delete(id: layer.id)
+        if studioLayerScopeId == layer.id {
+            clearStudioLayerScope()
+        }
+        controller.flash("Deleted \(layer.name)")
+    }
+
+    private func safeAttachmentStem(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        let scalars = value.unicodeScalars.map { allowed.contains($0) ? Character($0) : "-" }
+        let collapsed = String(scalars)
+            .split(separator: "-", omittingEmptySubsequences: true)
+            .joined(separator: "-")
+            .lowercased()
+        return collapsed.isEmpty ? "studio" : collapsed
     }
 
     private var inspectorVoiceStateLabel: String {
@@ -1527,7 +1791,7 @@ struct ScreenMapView: View {
                             color: Palette.running
                         ) {
                             if activeStudioLayer != nil {
-                                onClearStudioLayerScope?()
+                                clearStudioLayerScope()
                             } else {
                                 editor.selectLayer(nil)
                             }
@@ -1616,6 +1880,9 @@ struct ScreenMapView: View {
             .coordinateSpace(name: "layerSidebar")
 
             Spacer(minLength: 8)
+            collapsibleSection(title: "LAYERS", count: studioLayers.layers.count, isExpanded: $showStudioLayers) {
+                studioLayerExplorer(editor: editor)
+            }
             collapsibleSection(title: "SETS", count: controller.windowSets.count, isExpanded: $showSets) {
                 windowSetsSection(editor: editor)
             }
@@ -1920,6 +2187,91 @@ struct ScreenMapView: View {
         }
     }
 
+    private func studioLayerExplorer(editor: ScreenMapEditorState) -> some View {
+        let allCount = desktop.allWindows().filter(\.isOnScreen).count
+        let visibleLayers = Array(studioLayers.layers.prefix(8))
+
+        return VStack(alignment: .leading, spacing: 4) {
+            studioLayerExplorerRow(
+                title: "All Desktop",
+                subtitle: "whole visible desktop",
+                count: allCount,
+                isActive: activeStudioLayer == nil,
+                tint: Palette.running,
+                systemImage: "display"
+            ) {
+                clearStudioLayerScope()
+                editor.selectLayer(nil)
+                controller.flash("All Desktop")
+            }
+
+            ForEach(visibleLayers) { layer in
+                let matches = studioLayers.resolve(layer, in: desktop)
+                studioLayerExplorerRow(
+                    title: layer.name,
+                    subtitle: layer.summary,
+                    count: matches.count,
+                    isActive: studioLayerScopeId == layer.id,
+                    tint: matches.isEmpty ? Palette.textMuted.opacity(0.8) : Palette.running,
+                    systemImage: "square.stack.3d.up"
+                ) {
+                    studioLayerScopeId = layer.id
+                    controller.flash("Layer · \(layer.name)")
+                }
+            }
+
+            if studioLayers.layers.count > visibleLayers.count {
+                Text("+\(studioLayers.layers.count - visibleLayers.count) more layers")
+                    .font(Typo.mono(7))
+                    .foregroundColor(Palette.textMuted)
+                    .padding(.horizontal, 6)
+                    .padding(.top, 2)
+            }
+        }
+    }
+
+    private func studioLayerExplorerRow(title: String, subtitle: String, count: Int, isActive: Bool,
+                                        tint: Color, systemImage: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 8, weight: .semibold))
+                    .foregroundColor(isActive ? Palette.running : tint)
+                    .frame(width: 12)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(title)
+                        .font(Typo.monoBold(8))
+                        .foregroundColor(isActive ? Palette.text : Palette.textDim)
+                        .lineLimit(1)
+                    Text(subtitle)
+                        .font(Typo.mono(7))
+                        .foregroundColor(Palette.textMuted)
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 4)
+                Text("\(count)")
+                    .font(Typo.monoBold(7))
+                    .foregroundColor(isActive ? Palette.bg : Palette.textMuted)
+                    .frame(minWidth: 14)
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 1)
+                    .background(Capsule().fill(isActive ? Palette.running : Palette.surface.opacity(0.8)))
+            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 4)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(isActive ? Palette.running.opacity(0.10) : Palette.surface.opacity(0.35))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4)
+                            .strokeBorder(isActive ? Palette.running.opacity(0.28) : Color.white.opacity(0.04), lineWidth: 0.5)
+                    )
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
     private func layerTreeHeader(label: String, count: Int, isActive: Bool, color: Color,
                                    isExpandable: Bool = false, isExpanded: Bool = false,
                                    onToggleExpand: (() -> Void)? = nil,
@@ -2040,12 +2392,19 @@ struct ScreenMapView: View {
         .background(
             ZStack {
                 canvasShape
-                    .fill(Color.black.opacity(0.25))
-                canvasShape
-                    .strokeBorder(Color.white.opacity(0.06), lineWidth: 0.5)
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                Color(red: 0.023, green: 0.026, blue: 0.027),
+                                Color(red: 0.009, green: 0.011, blue: 0.012),
+                            ],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
                 Canvas { context, size in
-                    let spacing: CGFloat = 20
-                    let dotColor = Color.white.opacity(0.04)
+                    let spacing: CGFloat = 22
+                    let dotColor = Color.white.opacity(0.035)
                     for x in stride(from: spacing, to: size.width, by: spacing) {
                         for y in stride(from: spacing, to: size.height, by: spacing) {
                             context.fill(
@@ -2055,8 +2414,13 @@ struct ScreenMapView: View {
                         }
                     }
                 }
+                canvasShape
+                    .strokeBorder(Color.white.opacity(0.075), lineWidth: 0.5)
+                canvasShape
+                    .strokeBorder(Palette.running.opacity(0.045), lineWidth: 1)
             }
         )
+        .shadow(color: .black.opacity(0.26), radius: 18, y: 6)
         .overlay(alignment: .topLeading) {
             Group {
                 if let editor = editor {
@@ -2139,11 +2503,13 @@ struct ScreenMapView: View {
         .overlay(alignment: .top) {
             if let editor = controller.editor, editor.displays.count > 1 {
                 displayToolbar(editor: editor)
-                    .padding(.top, 8)
+                    .padding(.top, 10)
             }
         }
         .overlay(alignment: .bottomLeading) {
             canvasContextBadge
+                .padding(.leading, 12)
+                .padding(.bottom, 12)
         }
         .overlay(
             GeometryReader { geo in
@@ -2165,10 +2531,19 @@ struct ScreenMapView: View {
     private func focusedDisplayBackground(mapSize: CGSize) -> some View {
         ZStack(alignment: .topLeading) {
             RoundedRectangle(cornerRadius: 6)
-                .fill(Palette.bg.opacity(0.5))
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Palette.running.opacity(0.070),
+                            Palette.running.opacity(0.032),
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
                 .overlay(
                     RoundedRectangle(cornerRadius: 6)
-                        .strokeBorder(Palette.running.opacity(0.3), lineWidth: 1)
+                        .strokeBorder(Palette.running.opacity(0.34), lineWidth: 0.9)
                 )
                 .contentShape(Rectangle())
                 .onTapGesture { controller.clearSelection() }
@@ -2183,16 +2558,16 @@ struct ScreenMapView: View {
 
             ZStack {
                 RoundedRectangle(cornerRadius: 8)
-                    .fill(Color.white.opacity(0.07))
+                    .fill(Color.white.opacity(0.052))
                     .overlay(
                         RoundedRectangle(cornerRadius: 8)
-                            .strokeBorder(Color.white.opacity(0.18), lineWidth: 1.5)
+                            .strokeBorder(Color.white.opacity(0.145), lineWidth: 1)
                     )
                 RoundedRectangle(cornerRadius: 5)
-                    .fill(Palette.bg.opacity(0.55))
+                    .fill(Color(red: 0.058, green: 0.063, blue: 0.062).opacity(0.72))
                     .overlay(
                         RoundedRectangle(cornerRadius: 5)
-                            .strokeBorder(Color.black.opacity(0.4), lineWidth: 0.5)
+                            .strokeBorder(Color.black.opacity(0.32), lineWidth: 0.5)
                     )
                     .padding(bezel)
 
@@ -2226,10 +2601,10 @@ struct ScreenMapView: View {
     private func singleDisplayBackground(mapSize: CGSize) -> some View {
         ZStack(alignment: .topLeading) {
             RoundedRectangle(cornerRadius: 6)
-                .fill(Palette.bg.opacity(0.5))
+                .fill(Color(red: 0.055, green: 0.059, blue: 0.060).opacity(0.76))
                 .overlay(
                     RoundedRectangle(cornerRadius: 6)
-                        .strokeBorder(Palette.border, lineWidth: 0.5)
+                        .strokeBorder(Color.white.opacity(0.085), lineWidth: 0.5)
                 )
                 .contentShape(Rectangle())
                 .onTapGesture { controller.clearSelection() }

--- a/apps/mac/Sources/Core/Overlays/UnifiedCommandBar/UnifiedCommandBarWindow.swift
+++ b/apps/mac/Sources/Core/Overlays/UnifiedCommandBar/UnifiedCommandBarWindow.swift
@@ -53,9 +53,10 @@ final class UnifiedCommandBarWindow {
             capturedScreen = screenForWindowFrame(entry.frame)
         }
 
-        // Open empty (a welcome shows) regardless of hotkey — "/" enters command
-        // mode, plain text searches. Voice auto-listens below.
         let st = UnifiedCommandBarState()
+        if mode == .command {
+            st.query = "/"
+        }
         state = st
 
         let view = UnifiedCommandBarView(
@@ -67,8 +68,8 @@ final class UnifiedCommandBarWindow {
         )
         .preferredColorScheme(.dark)
 
-        let screen = capturedScreen ?? NSScreen.main ?? NSScreen.screens.first!
-        let panelHeight = min(520, screen.visibleFrame.height - 200)
+        let presentationScreen = invocationScreen()
+        let panelHeight = min(520, presentationScreen.visibleFrame.height - 200)
 
         let p = OverlayPanelShell.makePanel(
             config: .init(
@@ -84,13 +85,12 @@ final class UnifiedCommandBarWindow {
             rootView: view
         )
         p.becomesKeyOnlyIfNeeded = false   // keep the panel key so the field stays focused (no beep) and Esc works
-        OverlayPanelShell.position(p, placement: .topCenter(margin: 120))
-        // Restore the last dragged position if it's still on a screen.
-        if let o = savedOrigin() {
-            let frame = CGRect(origin: o, size: p.frame.size)
-            if NSScreen.screens.contains(where: { $0.visibleFrame.intersects(frame) }) {
-                p.setFrameOrigin(o)
-            }
+        positionPanel(p, on: presentationScreen)
+        // Restore the last dragged position only when it belongs to the screen
+        // that invoked the bar. A stale origin on another monitor is worse than
+        // the default top-center placement.
+        if let o = savedOrigin(for: p.frame.size, on: presentationScreen) {
+            p.setFrameOrigin(o)
         }
         OverlayPanelShell.present(p)
         panel = p
@@ -137,6 +137,29 @@ final class UnifiedCommandBarWindow {
     private func savedOrigin() -> NSPoint? {
         guard let a = UserDefaults.standard.array(forKey: originKey) as? [Double], a.count == 2 else { return nil }
         return NSPoint(x: a[0], y: a[1])
+    }
+
+    private func savedOrigin(for size: CGSize, on screen: NSScreen) -> NSPoint? {
+        guard let origin = savedOrigin() else { return nil }
+        let frame = CGRect(origin: origin, size: size)
+        return screen.visibleFrame.intersects(frame) ? origin : nil
+    }
+
+    private func invocationScreen() -> NSScreen {
+        let mouse = NSEvent.mouseLocation
+        return NSScreen.screens.first(where: { $0.frame.contains(mouse) })
+            ?? capturedScreen
+            ?? NSScreen.main
+            ?? NSScreen.screens[0]
+    }
+
+    private func positionPanel(_ panel: NSWindow, on screen: NSScreen) {
+        let visibleFrame = screen.visibleFrame
+        let size = panel.frame.size
+        panel.setFrameOrigin(NSPoint(
+            x: visibleFrame.midX - size.width / 2,
+            y: visibleFrame.maxY - size.height - 120
+        ))
     }
 
     // MARK: - Key handling

--- a/apps/mac/Sources/UI/LatticesOverlayChrome.swift
+++ b/apps/mac/Sources/UI/LatticesOverlayChrome.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+
+// MARK: - Metrics
+
+/// Shared insets so the strip mark and corner watermark share one vertical axis.
+enum LatticesOverlayMetrics {
+    static let edgeInset: CGFloat = 16
+    static let watermarkBottomInset: CGFloat = 14
+}
+
+// MARK: - Lattice grid
+
+/// Faint dot lattice — signature background for overlay chrome.
+struct LatticesLatticeGrid: View {
+    var spacing: CGFloat = 22
+    var dotSize: CGFloat = 1.2
+    var opacity: Double = 0.05
+    var tint: Color = Palette.running
+
+    var body: some View {
+        Canvas { context, size in
+            let xStart = -spacing
+            let yStart = -spacing
+            for x in stride(from: xStart, through: size.width + spacing, by: spacing) {
+                for y in stride(from: yStart, through: size.height + spacing, by: spacing) {
+                    let rect = CGRect(x: x - dotSize / 2, y: y - dotSize / 2, width: dotSize, height: dotSize)
+                    context.fill(Path(ellipseIn: rect), with: .color(tint.opacity(opacity)))
+                }
+            }
+        }
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+}
+
+// MARK: - Watermark
+
+/// Quiet corner mark — present but easy to ignore.
+struct LatticesOverlayWatermark: View {
+    var size: CGFloat = 56
+    var opacity: Double = 0.07
+
+    var body: some View {
+        LatticesMark(size: size, tint: Palette.running, dimOpacity: 0.10)
+            .opacity(opacity)
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
+    }
+}
+
+/// Bottom-leading placement — left edge lines up with the strip header mark.
+struct LatticesOverlayWatermarkPlacement: View {
+    var body: some View {
+        LatticesOverlayWatermark()
+            .padding(.leading, LatticesOverlayMetrics.edgeInset)
+            .padding(.bottom, LatticesOverlayMetrics.watermarkBottomInset)
+    }
+}
+
+// MARK: - Strip chrome
+
+/// Full-bleed intent strip: lattice under glass, green hairline on top.
+struct LatticesOverlayStripBackground: View {
+    var body: some View {
+        ZStack(alignment: .top) {
+            LatticesLatticeGrid(spacing: 20, opacity: 0.06)
+            Rectangle()
+                .fill(.ultraThinMaterial)
+            LinearGradient(
+                colors: [Palette.running.opacity(0.65), HUDChrome.cyan.opacity(0.35), .clear],
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+            .frame(height: 1)
+            Rectangle()
+                .fill(Palette.borderLit)
+                .frame(height: 1)
+                .frame(maxHeight: .infinity, alignment: .bottom)
+        }
+        .allowsHitTesting(false)
+    }
+}
+
+/// Compact strip header: L-mark + wordmark.
+struct LatticesOverlayStripHeader: View {
+    var mode: String
+    var detail: String? = nil
+
+    var body: some View {
+        HStack(spacing: 8) {
+            LatticesMark(size: 14, tint: Palette.running, dimOpacity: 0.30)
+            HStack(spacing: 5) {
+                Text("lattices")
+                    .font(Typo.monoBold(10))
+                    .foregroundColor(Palette.text.opacity(0.92))
+                    .tracking(0.35)
+                Text("·")
+                    .font(Typo.mono(9))
+                    .foregroundColor(Palette.textMuted)
+                Text(mode)
+                    .font(Typo.monoBold(9))
+                    .foregroundColor(Palette.running)
+                    .tracking(0.5)
+            }
+            if let detail {
+                Text(detail)
+                    .font(Typo.mono(8.5))
+                    .foregroundColor(Palette.textMuted)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+}

--- a/bin/lattices-app.ts
+++ b/bin/lattices-app.ts
@@ -214,34 +214,73 @@ function resolveSigningIdentity(): string | null {
   }
 }
 
+function bundleTeamIdentifier(): string | null {
+  try {
+    const output = execSync(`codesign -dv '${bundlePath}' 2>&1`, { encoding: "utf8" });
+    const match = output.match(/TeamIdentifier=(.+)/);
+    const team = match?.[1]?.trim();
+    return team && team !== "not set" ? team : null;
+  } catch {
+    return null;
+  }
+}
+
+function runCodesign(args: string[]): void {
+  try {
+    execFileSync("codesign", args, { stdio: "pipe" });
+  } catch (error) {
+    const stderr = (error as { stderr?: Buffer | string }).stderr;
+    const detail = stderr ? `\n${String(stderr).trim()}` : "";
+    throw new Error(`codesign ${args.join(" ")}${detail}`);
+  }
+}
+
 function signBundle(): void {
   const identity = resolveSigningIdentity();
-  const entFlag = existsSync(entitlementsPath) ? ` --entitlements '${entitlementsPath}'` : "";
+  const entitlements = existsSync(entitlementsPath) ? entitlementsPath : null;
   const tempBinaryPath = `${binaryPath}.cstemp`;
 
   try {
     if (existsSync(tempBinaryPath)) rmSync(tempBinaryPath, { force: true });
   } catch {}
 
+  const sign = (signer: string, label: string) => {
+    // Sign the Mach-O first, then the bundle — more reliable than --deep and
+    // keeps a stable TeamIdentifier so macOS TCC grants survive rebuilds.
+    const binaryArgs = ["--force", "--options", "runtime", "--sign", signer];
+    if (entitlements) binaryArgs.push("--entitlements", entitlements);
+    binaryArgs.push(binaryPath);
+    runCodesign(binaryArgs);
+
+    const bundleArgs = ["--force", "--options", "runtime", "--sign", signer];
+    if (entitlements) bundleArgs.push("--entitlements", entitlements);
+    bundleArgs.push("--identifier", "dev.lattices.app", bundlePath);
+    runCodesign(bundleArgs);
+
+    const team = bundleTeamIdentifier();
+    if (team) {
+      console.log(`Signed (${label}) — TeamIdentifier=${team}`);
+      return;
+    }
+    if (label === "ad-hoc") return;
+    throw new Error(`codesign reported no TeamIdentifier after ${label} signing`);
+  };
+
   if (identity) {
     console.log(`Signing with: ${identity}`);
     try {
-      execSync(
-        `codesign --force --options runtime --deep --sign '${identity}'${entFlag} --identifier dev.lattices.app '${bundlePath}'`,
-        { stdio: "pipe" }
-      );
+      sign(identity, "developer");
       return;
-    } catch {
-      console.log(`Warning: signing with '${identity}' failed — falling back to ad-hoc.`);
+    } catch (error) {
+      console.log(`Warning: signing with '${identity}' failed — ${(error as Error).message}`);
+      console.log("Warning: falling back to ad-hoc. Privacy permissions will not persist across rebuilds.");
     }
   } else {
     console.log("Warning: no local signing identity found — falling back to ad-hoc.");
+    console.log("Warning: grant Accessibility/Screen Recording again after each rebuild, or install a signing cert.");
   }
 
-  execSync(
-    `codesign --force --options runtime --deep --sign -${entFlag} --identifier dev.lattices.app '${bundlePath}'`,
-    { stdio: "pipe" }
-  );
+  sign("-", "ad-hoc");
 
   try {
     if (existsSync(tempBinaryPath)) rmSync(tempBinaryPath, { force: true });

--- a/docs/hyperspace-grid-snappiness.md
+++ b/docs/hyperspace-grid-snappiness.md
@@ -1,0 +1,210 @@
+# Hyper+G in-place grid — snappiness & satisfaction brief
+
+Context: `relayoutGroup()` already switched from sequential `RealWindowAnimator.setFrameRobust`
+to `WindowTiler.batchMoveAndRaiseWindows` (SLS freeze + one AX pass/app), with UI refresh
+deferred and a tap on commit. This is the "make it even better" pass.
+
+Code anchors:
+- Grid path: `WindowMotionMode.swift:1100 relayoutGroup()` → `:1138 distributeGroup()` (G = keycode 5, `:833`)
+- Batch move: `WindowTiler.swift:1753 batchMoveAndRaiseWindows` (freeze `:1767`, AX enum `:1776`, activate `:1818`, unfreeze `:1825`)
+- Sound: `DiagnosticLog.swift:162 AppFeedback.playTap`
+- Optional anim: `RealWindowAnimator.swift` (Timer 60fps, 0.28s — NOT on the batch path)
+- Chrome flash: `WindowTiler.swift:54 WindowHighlight.flash` (single-window only)
+- No haptics anywhere in the codebase yet → green field.
+
+---
+
+## The governing principle
+
+Perceived latency is bound to the **earliest** feedback the brain receives, not the moment
+pixels finish moving. The AX move is 40–120ms of work we can't fully erase. So the play is:
+**acknowledge on key-down (haptic + sound + overlay), move under cover, let the windows catch
+up.** Every quick win below is a variant of "fire feedback before the slow thing finishes."
+
+---
+
+## Quick wins (ship this week, low risk)
+
+### Q1 — Haptic on key-down (biggest bang, ~10 lines)
+There is zero haptic feedback today. `NSHapticFeedbackManager.defaultPerformer.perform(.alignment, performanceTime: .now)`
+is *exactly* the Loop/Magnet "snap" feel on trackpad/Force Touch. Fire it the instant `G` is
+matched in `keyDown` (`:833`), **before** `distributeGroup()` runs. Costs nothing, lands on the
+keypress, and the windows snapping ~80ms later reads as "instant + tactile."
+
+### Q2 — Decouple + pre-warm the tap sound
+`playTap` does `DispatchQueue.main.async { stop(); play() }`. Three problems:
+- the async hop delays the sound ~1 runloop turn past the keypress,
+- `stop()` then `play()` adds a tiny dead gap,
+- NSSound's *first* play in a session stutters (codec spin-up).
+
+Fixes: (a) prime the sound once on motion-mode entry by playing `tap.wav` at volume 0; (b) fire
+it synchronously on key-down (same site as the haptic), not after the move; (c) consider a
+prepared `AVAudioPlayer` (`prepareToPlay()`) or `AudioServicesPlaySystemSound` for sub-frame
+latency. Net: the *thunk* and the *tap* (haptic) coincide with the keypress, not the landing.
+
+### Q3 — Shrink the SLS freeze window
+`batchMoveAndRaiseWindows` does the slow `kAXWindowsAttribute` enumeration **inside** the
+`SLSDisableUpdate` freeze (`:1776`). The screen is frozen while we do AX queries. Resolve the
+AX elements *before* the freeze, freeze only around the set-frame writes, unfreeze immediately.
+Bonus: `relayoutGroup` already resolves each element via `recordOriginal`'s `ax(for: m)` (`:1113`)
+and then the batch path re-resolves the whole window list — pass the resolved elements in and
+skip the second AX pass entirely. Shorter freeze = less black-flash, snappier reveal.
+
+### Q4 — Stop activating every app
+`batchMoveAndRaiseWindows` calls `app.activate()` once per pid (`:1818`). With windows from N
+apps that's N activations → focus churn, Space flicker, and the overlay can lose key. AX
+`kAXRaiseAction` (already issued at `:1806`) reorders without activating. Activate **only** the
+app that should end up frontmost (the last-picked / aimed window), once. Raise the rest.
+
+### Q5 — Overlay "snap-pop" on the selection chrome
+The real move is a teleport, so add the *sense* of motion in the cheap overlay layer (no AX
+cost). When the grid lands, give each selection border a tiny scale overshoot (1.0→1.04→1.0,
+~120ms, Core Animation) + a one-shot green edge flash converging on the slot. This is the
+Arc/Raycast "it clicked into place" pop. Overlay-only, runs off the AX path, can't add input
+latency.
+
+---
+
+## Bigger bets (more design, higher ceiling)
+
+### B1 — Ghost-slot anticipation (kills perceived latency outright)
+On `G`, **instantly** paint the target grid as outlined ghost slots (you already compute
+`balancedGrid` rects → `tileFrame`). Animate the slots filling (or the picked windows' chrome
+sliding toward their slots) over ~140ms while the real `batchMove` runs underneath. The user
+sees motion begin on the same frame as the keypress; the real windows arrive under the
+animation. This fully decouples felt-speed from AX latency and is the single highest-ceiling
+change. The ghost overlay is also the natural home for Q5's pop.
+
+### B2 — Precompute on selection, commit = pure writes
+Every pluck/unpluck currently recomputes `balancedGrid` + `tileFrame` and re-resolves AX. Cache
+(a) the AX element per picked wid and (b) the target frame map, updated incrementally as the
+selection changes. By the time `G` fires, commit is nothing but the frozen set-frame loop —
+nothing to compute, nothing to resolve, minimal freeze.
+
+### B3 — Staggered cascade fill (the "deliberate fast" feel)
+Real windows must move simultaneously (per-window AX animation = jank — see "avoid"). But the
+*overlay* tiles/borders can land on a micro-stagger in reading order (~10–14ms/cell). The eye
+reads a fast left-to-right cascade as more intentional and premium than a flat simultaneous
+snap, while the actual work stays a single batch. Pure overlay timing.
+
+---
+
+## What to avoid (these ADD latency or jank)
+
+- **Don't animate many real windows via per-tick AX writes.** `RealWindowAnimator`'s 0.28s
+  Timer loop is fine for one window; across a group it's 60fps × N AX position+size writes —
+  AX is slow and serializes, so it stutters and feels *slower* than a clean teleport. Keep the
+  batch teleport; animate the overlay, not the windows.
+- **Don't do AX enumeration / `DesktopModel.poll()` inside the freeze or on the commit path.**
+  Poll/rebuild are already deferred (`refreshAfterGridMove`, `:1125`) — keep it that way; don't
+  let new chrome work creep back onto the hot path.
+- **Don't async-dispatch or `stop()`-then-`play()` the commit sound** (see Q2) — both push the
+  thunk past the keypress.
+- **Don't `app.activate()` per app** (Q4) — multi-app activation is the main source of flicker
+  and overlay focus loss.
+- **Avoid Timer-driven overlay animation.** Use Core Animation / `CADisplayLink`; `Timer` at
+  1/60 drifts and can hitch under load.
+- **Don't add dwell.** `WindowHighlight.flash` defaults to a 0.9s dwell + 0.3s fade — fine for a
+  one-shot locate, wrong for a snap pop. Snap feedback wants ~120–180ms total. Long fades read
+  as lag, not polish.
+
+---
+
+## Recommended ship order
+
+1. **Q1 + Q2** together — one small change at the `G` key site: haptic + synchronous pre-warmed
+   sound on key-down. Instant tactile upgrade, ~20 lines, no risk.
+2. **Q3 + Q4** — tighten `batchMoveAndRaiseWindows` (pre-resolve AX, shorter freeze, single
+   activate). Real latency reduction.
+3. **Q5** — overlay snap-pop on the chrome. First "ooh" moment.
+4. **B1** — ghost-slot anticipation once Q5's overlay exists to build on. This is the headliner.
+
+---
+
+## Implementation sketches
+
+### Sketch 1 — Haptic + tactile commit on key-down (Q1+Q2)
+At `WindowMotionMode.swift:833`, before dispatching the grid:
+```swift
+case 5: // G
+    if exposed { gatherInPlace() }
+    else {
+        AppFeedback.shared.commitTactile()   // haptic + sound, synchronous, NOW
+        distributeGroup()                     // remove the playTapSound() from relayoutGroup
+    }
+    return
+```
+New in `AppFeedback`:
+```swift
+func warmUp() {                       // call on motion-mode entry
+    tapSound?.volume = 0; tapSound?.play(); tapSound?.stop(); tapSound?.volume = 1
+}
+func commitTactile() {                // called on the keypress, on main
+    NSHapticFeedbackManager.defaultPerformer.perform(.alignment, performanceTime: .now)
+    tapSound?.currentTime = 0
+    tapSound?.play()                  // no async hop, no stop() gap
+}
+```
+Remove `AppFeedback.shared.playTapSound()` from `relayoutGroup()` (`:1120`) so the feedback is
+owned by the keypress, not the move completion.
+
+### Sketch 2 — Pre-resolved, minimal-freeze batch (Q3+Q4)
+New overload that trusts caller-resolved elements and freezes only the writes:
+```swift
+static func batchSetFrames(_ moves: [(el: AXUIElement, pid: Int32, frame: CGRect, raise: Bool)],
+                           frontmostPid: Int32?) {
+    // app -> enhanced-UI off, BEFORE freeze
+    let pids = Set(moves.map(\.pid))
+    let appRefs = Dictionary(uniqueKeysWithValues: pids.map { ($0, AXUIElementCreateApplication($0)) })
+    appRefs.values.forEach { AXUIElementSetAttributeValue($0, "AXEnhancedUserInterface" as CFString, false as CFTypeRef) }
+
+    let cid = _SLSMainConnectionID?()
+    if let cid { _ = _SLSDisableUpdate?(cid) }          // freeze ONLY the writes
+    for m in moves {
+        setFrameTriplet(m.el, m.frame)                  // size→pos→size
+        if m.raise { AXUIElementPerformAction(m.el, kAXRaiseAction as CFString) }
+    }
+    if let cid { _ = _SLSReenableUpdate?(cid) }         // unfreeze immediately
+
+    appRefs.values.forEach { AXUIElementSetAttributeValue($0, "AXEnhancedUserInterface" as CFString, true as CFTypeRef) }
+    if let frontmostPid { NSRunningApplication(processIdentifier: frontmostPid)?.activate() }  // ONE activate
+}
+```
+`relayoutGroup` already has `el` in hand from `recordOriginal` — collect it into `moves` and
+call this; no second `kAXWindows` enumeration, freeze shrinks to just the set-frame loop.
+
+### Sketch 3 — Overlay snap-pop on selection chrome (Q5)
+On grid landing, per slot, run a layer animation on the existing selection border view (overlay,
+not the window):
+```swift
+let pop = CAKeyframeAnimation(keyPath: "transform.scale")
+pop.values = [1.0, 1.045, 1.0]; pop.keyTimes = [0, 0.45, 1]
+pop.duration = 0.13; pop.timingFunction = CAMediaTimingFunction(name: .easeOut)
+borderLayer.add(pop, forKey: "snapPop")
+// + a one-shot edge tint that fades over the same 0.13s
+```
+No dwell, no AX. Fire it from `refreshAfterGridMove` (`:1125`) so it rides the deferred turn.
+
+### Sketch 4 — Ghost-slot anticipation (B1)
+On `G`, before the move, draw target slots in the motion overlay and animate the picked windows'
+*chrome* (or ghost rects) from current → slot, while `batchSetFrames` runs underneath:
+```swift
+func previewGrid(_ rects: [CGRect]) {     // rects already from balancedGrid → tileFrame
+    for (i, r) in rects.enumerated() {
+        let slot = ghostLayer(at: currentChromeFrame(i))
+        slot.frame = currentChromeFrame(i)
+        CATransaction.begin()
+        CATransaction.setAnimationDuration(0.14)
+        slot.frame = r                      // slides to target as the real window teleports under it
+        CATransaction.commit()
+    }
+}
+```
+Sequence: keypress → `commitTactile()` (Sketch 1) + `previewGrid()` same frame → `batchSetFrames()`
+→ ghosts fade as real windows land → `refreshAfterGridMove`. Felt latency ≈ 0; the move hides
+under 140ms of overlay motion.
+
+### Sketch 5 — Staggered cascade (B3, optional flourish)
+In `previewGrid`/snap-pop, offset each cell's animation `beginTime` by `index * 0.012` in
+row-major order. Overlay-only; the real batch stays simultaneous. Toggle behind a setting if you
+want a "calm" vs "playful" feel.


### PR DESCRIPTION
## Summary

Ships the Hyper+G in-place window tools and the HUD composer adoption work on `feat/hud-composer-adoption`, plus the shared lattices overlay signature across Hyperspace and in-place modes.

## Highlights

- **Hyper+G in-place** — desktop select, contextual menus, grid/swap/fill, snappier batch moves
- **Intent strip UX** — full-bleed chrome, Current View command rails (hover/selection), layer grid clipping
- **Overlay signature** — lattice grid, branded strip header, subtle corner L-mark aligned with top logo
- **Hyperspace parity** — same strip chrome and watermark treatment as Hyper+G
- **Build/signing** — developer ID signing in `lattices-app.ts` for stable TCC across rebuilds
- **Screen Map / settings** — shell layout and keyboard/command palette polish from the broader branch

## Test plan

- [ ] `bun bin/lattices-app.ts restart` — app builds and signs
- [ ] Hyper+G — select, grid, fill, hover shortcuts, strip + watermark
- [ ] Hyper+Space — survey strip signature matches in-place
- [ ] Permissions survive rebuild (Screen Recording / Accessibility)