### PR TITLE
✨ Workspace assistant voice path and Hyper+G in-place UX

### DIFF
--- a/.github/workflows/release-package-npm.yml
+++ b/.github/workflows/release-package-npm.yml
@@ -85,6 +85,13 @@ jobs:
 
       - name: Publish to npm
         if: ${{ github.event_name == 'push' || inputs.publish }}
-        run: npm publish --provenance --access public
+        run: |
+          set -euo pipefail
+          # Primary package (@arach/lattices) — updates the public npm page.
+          npm publish --provenance --access public
+          # Back-compat alias for existing @lattices/cli installs/imports.
+          npm pkg set name=@lattices/cli
+          npm publish --provenance --access public
+          npm pkg set name=@arach/lattices
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@
 - Window navigation falls through CG → AX → AppleScript depending on macOS permissions
 - Space switching uses private SkyLight framework APIs loaded via dlopen at runtime
 - The daemon runs on ws://127.0.0.1:9399 with 35+ RPC methods and real-time events
+- Bare `lattices` (no args) shows a home/status screen — use `lattices start` (alias: `lattices tmux`) to create or attach a session
+- `lattices search <q> --deep` and `--all` both request all search sources (index + live terminal inspection)
 
 ## Project Structure
 
@@ -62,21 +64,28 @@ bun link
 
 Verify: `lattices help` should print usage info.
 
-## 3. Launch a workspace
+## 3. Orient yourself
 
 ```bash
 cd ~/your-project
 lattices
 ```
 
-This creates a tmux session with two panes side by side:
-- Left pane (60%): `claude` (AI coding agent)
-- Right pane (40%): your dev command (auto-detected from `package.json`)
+Bare `lattices` (no arguments) prints a home screen: current directory,
+session name, config state, pane list, tmux/app status, and common
+commands. It does **not** create or attach a tmux session.
 
-No config file needed — lattices auto-detects your package manager
-and dev script.
+## 4. Start a session
 
-## 4. Customize with .lattices.json
+```bash
+lattices start
+```
+
+Alias: `lattices tmux`. Creates or reattaches the current directory's
+tmux session with your configured panes (or a shell plus an auto-detected
+dev server when no `.lattices.json` exists).
+
+## 5. Customize with .lattices.json
 
 For more control, add a config to your project:
 
@@ -96,9 +105,9 @@ This generates a `.lattices.json` like:
 }
 ```
 
-Edit it to match your workflow, then run `lattices` again to apply.
+Edit it to match your workflow, then run `lattices start` again to apply.
 
-## 5. Launch the menu bar app
+## 6. Launch the menu bar app
 
 ```bash
 lattices app
@@ -202,11 +211,13 @@ Tiling uses AppleScript bounds and respects the menu bar and dock.
 ## How it works
 
 1. You create a `.lattices.json` file in your project root (or run `lattices init`)
-2. lattices reads the config and creates a tmux session with your layout
-3. Each pane gets its command (claude, dev server, tests, etc.)
-4. The session persists in the background until you kill it
-5. You can attach/detach from any terminal at any time
-6. If `ensure` is enabled, exited commands auto-restart on reattach
+2. The menu bar app discovers the project and adds it to the command palette
+3. You can tile windows, switch layers, search via OCR, and use the agent API
+4. With tmux installed, `lattices start` also creates persistent terminal sessions:
+   - Each pane gets its command (shell, dev server, tests, etc.)
+   - The session persists in the background until you kill it
+   - You can attach/detach from any terminal at any time
+   - If `ensure` is enabled, exited commands auto-restart on reattach
 
 ## Architecture
 
@@ -282,7 +293,7 @@ and other macOS window managers.
 
 ### Ensure/prefill restoration
 
-When you run `lattices` (no arguments) and a session already exists:
+When you run `lattices start` and a session already exists:
 
 1. lattices checks the `ensure` / `prefill` flag in `.lattices.json`
 2. For each pane, it queries `#{pane_current_command}` via tmux
@@ -466,7 +477,9 @@ Run `lattices init` in your project directory to generate a starter
 
 | Command                    | Description                                      |
 |----------------------------|--------------------------------------------------|
-| `lattices`                   | Create or attach to session for current project   |
+| `lattices`                   | Show workspace status and common commands         |
+| `lattices start`             | Create or attach to session for current project   |
+| `lattices tmux`              | Alias for `lattices start`                        |
 | `lattices init`              | Generate .lattices.json config for this project     |
 | `lattices ls`                | List active tmux sessions                         |
 | `lattices kill [name]`       | Kill a session (defaults to current project)      |
@@ -480,6 +493,9 @@ Run `lattices init` in your project directory to generate a starter
 | `lattices app build`         | Rebuild the menu bar app from source              |
 | `lattices app restart`       | Rebuild and relaunch the menu bar app             |
 | `lattices app quit`          | Stop the menu bar app                             |
+| `lattices search <query>`      | Search windows by title, app, session, OCR       |
+| `lattices search <q> --deep`   | Deep search: index + live terminal inspection    |
+| `lattices search <q> --all`    | Same as `--deep` (all search sources)            |
 | `lattices help`              | Show help                                         |
 
 Aliases: `ls`/`list`, `kill`/`rm`, `sync`/`reconcile`,
@@ -669,7 +685,7 @@ For each project found, the app reads:
 
 The app calls the lattices CLI for session operations:
 
-- **Launch** — runs `lattices` in the project directory, which creates
+- **Launch** — runs `lattices start` in the project directory, which creates
   or reattaches to the session
 - **Sync** — runs `lattices sync` to reconcile panes to the config
 - **Restart** — runs `lattices restart <pane>` to kill and re-run a
@@ -873,7 +889,7 @@ to per-project configs.
 - **Session naming**: `lattices-group-<id>` (e.g. `lattices-group-vox`)
 - **tmux mapping**: 1 group = 1 tmux session, each tab = 1 tmux window,
   each window has its own panes from that project's `.lattices.json`
-- **Independent launch still works**: `cd vox-ios && lattices` creates
+- **Independent launch still works**: `cd vox-ios && lattices start` creates
   its own standalone session as before
 
 ### Tab group fields
@@ -1865,9 +1881,9 @@ inside a single shell with no way to manage windows or switch contexts.
 
 lattices solves both sides:
 
-- **For you** — run `lattices` in any project to get a pre-configured
-  tmux session. Use the menu bar app to launch, tile, and navigate
-  sessions with a command palette.
+- **For you** — run `lattices start` in any project to get a pre-configured
+  tmux session (bare `lattices` shows status without attaching). Use the
+  menu bar app to launch, tile, and navigate sessions with a command palette.
 - **For agents** — the daemon API exposes 35+ RPC methods over WebSocket.
   Agents can discover projects, launch sessions, tile windows, and
   switch workspace layers programmatically.
@@ -1884,8 +1900,11 @@ lattices solves both sides:
 ## Quick taste
 
 ```bash
-# Launch a workspace (auto-detects your project)
-cd ~/my-project && lattices
+# Check workspace status for the current directory
+lattices
+
+# Start or reattach a tmux session (auto-detects your project)
+cd ~/my-project && lattices start
 
 # Or give agents programmatic control
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,8 +44,8 @@ The CLI has a tiered search system for finding windows across the desktop:
 ### `lattices search <query>` — Index search
 Calls the daemon's `windows.search` API. Searches window titles, app names, session tags, and OCR content. Fast — uses already-indexed data. Returns scored results (title/session: 3, app: 2, ocr: 1).
 
-### `lattices search <query> --deep` — Deep search
-Starts with index search, then **inspects** candidates live using terminal process data (`terminals.search`). Discovers windows the index missed (e.g. an iTerm window where 4/4 tabs have `~/dev/vox` in their cwd but "vox" doesn't appear in the window title). Each matching tab adds score weight, so terminal windows with many matching tabs rank highest.
+### `lattices search <query> --deep` / `--all` — Deep search
+Both flags request all search sources (`sources: ["all"]`). Starts with index search, then **inspects** candidates live using terminal process data (`terminals.search`). Discovers windows the index missed (e.g. an iTerm window where 4/4 tabs have `~/dev/vox` in their cwd but "vox" doesn't appear in the window title). Each matching tab adds score weight, so terminal windows with many matching tabs rank highest.
 
 ### `lattices place <query> [position]` — Search + act
 Runs deep search, takes the top result, focuses it by wid, and tiles it to a position. Default position: `bottom-right`.
@@ -57,6 +57,6 @@ Runs deep search, takes the top result, focuses it by wid, and tiles it to a pos
 
 ### Search tips for agents
 - Use `lattices search <query>` first. If the results are clear, act on them.
-- Use `--deep` when looking for terminal windows by project name, since project names often only appear in cwd/tab data, not window titles.
+- Use `--deep` or `--all` when looking for terminal windows by project name, since project names often only appear in cwd/tab data, not window titles.
 - Use `--json` for programmatic consumption, `--wid` to pipe into other commands.
 - `lattices call windows.search '{"query":"..."}' ` for raw API access.

--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ your project directory.
 ### Install the CLI
 
 ```sh
-npm install -g @lattices/cli
+npm install -g @arach/lattices
 ```
 
-The CLI and app work independently — use either or both.
+Also published as `@lattices/cli` for existing installs. The CLI and app work
+independently — use either or both.
 
 ### Build from source
 
@@ -169,7 +170,7 @@ events over WebSocket. Anything you can do from the app, an agent or
 script can do over the API.
 
 ```js
-import { daemonCall } from '@lattices/cli/daemon-client'
+import { daemonCall } from '@arach/lattices/daemon-client'
 
 // Search windows by content — title, app, session tags, OCR
 const results = await daemonCall('windows.search', { query: 'myproject' })

--- a/README.md
+++ b/README.md
@@ -1,243 +1,71 @@
-<picture>
-  <img alt="lattices" src="apps/site/public/og.png" />
-</picture>
+![lattices](https://lattices.dev/og.png)
 
 # lattices
 
-The agentic workspace manager for macOS.
+**Turn your Mac into a workspace you can drive — by hand, by voice, or by agent.**
 
-Lattices turns your Mac workspace into a coherent API, so agents can see and
-control windows, terminal sessions, screen text, and layouts. It also gives you
-an assistant to control that workspace in plain language.
+Menu bar app + CLI + local WebSocket daemon. Tile windows, keep terminal
+sessions alive, search what's on screen, and switch whole project contexts
+in one keystroke.
 
-**[lattices.dev](https://lattices.dev)** · [Docs](https://lattices.dev/docs/overview) · [Download](https://github.com/arach/lattices/releases/latest)
+**[lattices.dev](https://lattices.dev)** · [Docs](https://lattices.dev/docs/overview) · [Download app](https://github.com/arach/lattices/releases/latest)
+
+## What you can do
+
+**Spin up a project in seconds** — `lattices start` opens a tmux layout from
+`.lattices.json` (or auto-detects your dev server). Sessions survive reboots.
+
+**Tile anything, instantly** — snap windows to halves, quarters, and grids from
+the command palette (`Cmd+Shift+M`), hotkeys, or `lattices place myapp left`.
+
+**Find windows by what they contain** — search titles, apps, terminal cwd, tmux
+session tags, and OCR text: `lattices search vox --deep`.
+
+**Switch whole workspaces** — layers tile multiple projects at once
+(`Cmd+Option+1/2/3`). Tab groups bundle related repos into one session.
+
+**Read the screen** — continuous UI text + periodic Vision OCR, searchable from
+CLI or API: `lattices scan search "error"`.
+
+**Talk to your desktop** — voice commands for tile, focus, search, and launch
+(beta, via the menu bar app).
+
+**Give agents the keys** — 35+ daemon RPC methods on `ws://127.0.0.1:9399`.
+Launch sessions, tile windows, switch layers, subscribe to live events.
 
 ## Install
-
-### Download the app
-
-Grab the signed DMG from the [latest release](https://github.com/arach/lattices/releases/latest):
-
-```sh
-# Or direct download:
-curl -LO https://github.com/arach/lattices/releases/latest/download/Lattices.dmg
-open Lattices.dmg
-```
-
-Drag **Lattices.app** into Applications. On first launch, a setup wizard
-walks you through granting Accessibility, Screen Recording, and choosing
-your project directory.
-
-### Install the CLI
 
 ```sh
 npm install -g @arach/lattices
 ```
 
-Also published as `@lattices/cli` for existing installs. The CLI and app work
-independently — use either or both.
+Also on npm as `@lattices/cli`. macOS only. Optional: `brew install tmux` for
+persistent sessions; [download the app](https://github.com/arach/lattices/releases/latest)
+for palette, layers, and voice.
 
-### Build from source
-
-```sh
-git clone https://github.com/arach/lattices.git
-cd lattices
-
-# Install CLI dependencies
-npm install
-
-# Build/install/relaunch the dev app at the stable permission target
-./scripts/run.sh
-```
-
-To build a signed, notarized DMG for distribution:
+## Try it
 
 ```sh
-# Requires a Developer ID certificate and notarytool keychain profile
-./tools/release/build-dmg.sh
-
-# Create/update v<package.json version> and upload DMG assets
-./tools/release/ship.sh
+lattices app          # menu bar companion (daemon + palette)
+lattices start        # tmux workspace for this repo
+lattices search api --deep
+lattices place frontend left
 ```
 
-See [Release](docs/release.md) for the CI and local maintainer workflows.
-
-## Quick start
-
-```sh
-# Show workspace status for the current directory
-lattices
-
-# Launch the menu bar app
-lattices app
-
-# Start or reattach a tmux session
-lattices start
-
-# Open the command palette from anywhere
-# Cmd+Shift+M
-```
-
-## Persistent terminal sessions
-
-Declare your dev environment in a `.lattices.json`: which panes, which
-commands, what layout. Lattices builds it, runs it, and keeps it alive.
-Close your laptop, reboot, come back a week later — your editor, dev
-server, and test runner are exactly where you left them.
-
-```sh
-cd my-project && lattices start
-```
-
-No config? It opens a shell in the project and, when it can, starts your
-detected dev command in a second pane.
-
-### Configuration
-
-Drop a `.lattices.json` in your project root:
-
-```json
-{
-  "ensure": true,
-  "panes": [
-    { "name": "shell", "size": 60 },
-    { "name": "server", "cmd": "pnpm dev" },
-    { "name": "tests",  "cmd": "pnpm test --watch" }
-  ]
-}
-```
-
-### Layouts
-
-```
-2 panes              3+ panes
-
-┌──────────┬───────┐ ┌──────────┬───────┐
-│  shell   │server │ │  shell   │server │
-│  (60%)   │(40%)  │ │  (60%)   ├───────┤
-└──────────┴───────┘ │          │tests  │
-                     └──────────┴───────┘
-```
-
-### Workspace layers
-
-Group projects into switchable contexts. `Cmd+Option+1` tiles your
-frontend and API side by side. `Cmd+Option+2` for the mobile stack.
-Sessions stay alive across switches.
-
-### Tab groups
-
-Bundle related repos as tabs in one session. Each tab gets its own
-pane layout from its `.lattices.json`.
-
-```sh
-lattices group vox         # Launch iOS, macOS, Web, API as tabs
-lattices tab vox iOS       # Switch to the iOS tab
-```
-
-## Window tiling and awareness
-
-A native menu bar app tracks every window across all your monitors.
-Tile with hotkeys, organize into switchable layers, snap to grids.
-
-It reads your windows too — extracting text from UI elements every
-60 seconds and running Vision OCR on background windows every 2 hours.
-Everything is searchable.
-
-```sh
-lattices scan                  # View current screen text
-lattices scan search "error"   # Search across all indexed text
-lattices scan recent           # Browse scan history
-lattices scan deep             # Trigger a Vision OCR scan now
-```
-
-## Voice commands (beta)
-
-Speak to control your workspace — tile windows, search, focus apps,
-and launch projects with natural language. Powered by
-[Vox](https://github.com/arach/vox) for transcription and
-local NLEmbedding for intent matching, with Claude fallback for
-ambiguous commands.
-
-Trigger with `Hyper+3` (configurable). Press Space to speak, Space to
-stop. The panel shows what was heard, the matched intent, extracted
-parameters, and execution results.
-
-## A programmable desktop
-
-The menu bar app runs a daemon with 35 RPC methods and 5 real-time
-events over WebSocket. Anything you can do from the app, an agent or
-script can do over the API.
+## For agents & scripts
 
 ```js
 import { daemonCall } from '@arach/lattices/daemon-client'
 
-// Search windows by content — title, app, session tags, OCR
-const results = await daemonCall('windows.search', { query: 'myproject' })
-
-// Launch and tile
-await daemonCall('session.launch', { path: '/Users/you/dev/frontend' })
-await daemonCall('window.tile', { session: 'frontend-a1b2c3', position: 'left' })
-
-// Read the screen
-await daemonCall('ocr.scan')
-const errors = await daemonCall('ocr.search', { query: 'error OR failed' })
+await daemonCall('session.launch', { path: '/Users/you/dev/api' })
+await daemonCall('window.tile', { session: 'api-a1b2c3', position: 'right' })
+const hits = await daemonCall('windows.search', { query: 'myproject' })
 ```
 
-Or from the CLI:
+Full API: [lattices.dev/docs/api](https://lattices.dev/docs/api)
 
-```sh
-lattices search myproject           # Find windows by content
-lattices search myproject --deep    # Include terminal tab/process data
-lattices search myproject --all     # Same as --deep (all search sources)
-lattices place myproject left       # Search + focus + tile in one step
-```
+## More
 
-Claude Code skills, MCP servers, or your own scripts can drive your
-desktop the same way you do.
-
-## CLI
-
-```
-lattices                    Show workspace status and common commands
-lattices start              Create or reattach to current project session
-lattices tmux               Alias for lattices start
-lattices init               Generate .lattices.json
-lattices ls                 List active sessions
-lattices kill [name]        Kill a session
-lattices search <query>     Search windows by title, app, session, OCR
-lattices search <q> --deep  Deep search: index + terminal inspection
-lattices search <q> --all   Same as --deep (all search sources)
-lattices place <query> [pos]  Deep search + focus + tile
-lattices focus <session>    Raise a session's window
-lattices tile <position>    Tile frontmost window
-lattices group [id]         Launch or attach a tab group
-lattices tab <group> [tab]  Switch tab within a group
-lattices scan               View current screen text
-lattices scan search <q>    Search indexed text
-lattices scan deep          Trigger Vision OCR now
-lattices app                Launch the menu bar app
-lattices help               Show help
-```
-
-## Requirements
-
-- macOS 26.0+
-- Node.js 18+
-
-### Optional
-
-- tmux for persistent terminal sessions (`brew install tmux`)
-- Swift 6.2 / Xcode 26+ to build the menu bar app from source
-
-## Docs
-
-Full documentation at [lattices.dev/docs](https://lattices.dev/docs/overview), including:
-
-- [API reference](https://lattices.dev/docs/api) — all 35 daemon methods
-- [Layers](https://lattices.dev/docs/layers) — workspace layers and tab groups
-- [Voice commands](https://lattices.dev/docs/voice) — Vox integration
-
-## License
+`lattices help` for the full CLI · [layers & groups](https://lattices.dev/docs/layers) · [voice](https://lattices.dev/docs/voice)
 
 MIT

--- a/README.md
+++ b/README.md
@@ -64,8 +64,14 @@ See [Release](docs/release.md) for the CI and local maintainer workflows.
 ## Quick start
 
 ```sh
+# Show workspace status for the current directory
+lattices
+
 # Launch the menu bar app
 lattices app
+
+# Start or reattach a tmux session
+lattices start
 
 # Open the command palette from anywhere
 # Cmd+Shift+M
@@ -182,6 +188,7 @@ Or from the CLI:
 ```sh
 lattices search myproject           # Find windows by content
 lattices search myproject --deep    # Include terminal tab/process data
+lattices search myproject --all     # Same as --deep (all search sources)
 lattices place myproject left       # Search + focus + tile in one step
 ```
 
@@ -199,6 +206,7 @@ lattices ls                 List active sessions
 lattices kill [name]        Kill a session
 lattices search <query>     Search windows by title, app, session, OCR
 lattices search <q> --deep  Deep search: index + terminal inspection
+lattices search <q> --all   Same as --deep (all search sources)
 lattices place <query> [pos]  Deep search + focus + tile
 lattices focus <session>    Raise a session's window
 lattices tile <position>    Tile frontmost window

--- a/apps/mac/Info.plist
+++ b/apps/mac/Info.plist
@@ -26,9 +26,9 @@
         </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>0.6.1</string>
+    <string>0.6.2</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.6.1</string>
+    <string>0.6.2</string>
     <key>LSMinimumSystemVersion</key>
     <string>13.0</string>
     <key>LSUIElement</key>

--- a/apps/mac/Info.plist
+++ b/apps/mac/Info.plist
@@ -26,9 +26,9 @@
         </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>0.5.0</string>
+    <string>0.6.1</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.5.0</string>
+    <string>0.6.1</string>
     <key>LSMinimumSystemVersion</key>
     <string>13.0</string>
     <key>LSUIElement</key>

--- a/apps/mac/Sources/AppShell/SettingsView.swift
+++ b/apps/mac/Sources/AppShell/SettingsView.swift
@@ -2,7 +2,7 @@ import DeckKit
 import AVFoundation
 import SwiftUI
 import HudsonUI
-#if canImport(HudsonVoice)
+#if LATTICES_VOICE && canImport(HudsonVoice)
 import HudsonVoice
 #endif
 
@@ -2442,7 +2442,7 @@ struct SettingsContentView: View {
             VStack(alignment: .leading, spacing: 12) {
                 voiceMicrophoneAccessCard
 
-                #if canImport(HudsonVoice)
+                #if LATTICES_VOICE && canImport(HudsonVoice)
                 settingsCard {
                     VStack(alignment: .leading, spacing: 10) {
                         HStack(spacing: 10) {

--- a/apps/mac/Sources/Core/Daemon/LatticesApi.swift
+++ b/apps/mac/Sources/Core/Daemon/LatticesApi.swift
@@ -2,7 +2,7 @@ import AppKit
 import ApplicationServices
 import DeckKit
 import Foundation
-#if canImport(HudsonVoice)
+#if LATTICES_VOICE && canImport(HudsonVoice)
 import HudsonVoice
 #endif
 
@@ -2562,7 +2562,9 @@ final class LatticesApi {
                     "provider": .string(audio.providerName),
                     "available": .bool(audio.provider?.isAvailable ?? false),
                     "listening": .bool(audio.isListening),
-                    "lastTranscript": audio.lastTranscript.map { .string($0) } ?? .null
+                    "lastTranscript": audio.lastTranscript.map { .string($0) } ?? .null,
+                    "assistantHandoffPrompt": audio.assistantHandoffPrompt.map { .string($0) } ?? .null,
+                    "lastError": audio.provider?.lastErrorMessage.map { .string($0) } ?? .null
                 ])
             }
         ))
@@ -2708,7 +2710,7 @@ final class LatticesApi {
             params: [],
             returns: .custom("Voice runtime reachability: { ok, runtimeAvailable, runtimeHost, service, transport, endpoint, port, pid, capabilityPath }"),
             handler: { _ in
-                #if canImport(HudsonVoice)
+                #if LATTICES_VOICE && canImport(HudsonVoice)
                 let runtime = HudsonVoiceRuntimeResolver.resolve(clientId: "lattices")
                 return .object([
                     "ok": .bool(true),
@@ -2719,7 +2721,8 @@ final class LatticesApi {
                     "endpoint": runtime.map { .string($0.endpoint.url.absoluteString) } ?? .null,
                     "port": runtime.map { .int(Int($0.endpoint.port)) } ?? .null,
                     "pid": runtime?.pid.map { .int($0) } ?? .null,
-                    "capabilityPath": .null,
+                    "capabilityPath": runtime?.capabilityPath.map { .string($0) } ?? .null,
+                    "requiresAuth": .bool(runtime?.authToken != nil),
                     "runtimeError": .null,
                     "note": .string("HudsonVoice is compiled in; Lattices uses HudsonVoice's Vox WebSocket contract for live sessions."),
                 ])

--- a/apps/mac/Sources/Core/Desktop/WindowTiler.swift
+++ b/apps/mac/Sources/Core/Desktop/WindowTiler.swift
@@ -135,6 +135,128 @@ private class HighlightBorderView: NSView {
     }
 }
 
+/// Persistent selection rings on real desktop windows (Hyper+G). Each picked window
+/// gets its own borderless overlay at the maximum window level so the ring sits on
+/// the window itself — not buried under the full-screen Hyperspace panel.
+final class WindowSelectionOverlay {
+    static let shared = WindowSelectionOverlay()
+
+    struct Entry {
+        var wid: UInt32
+        var frame: NSRect
+        var slot: Int?
+    }
+
+    private var windows: [UInt32: NSWindow] = [:]
+
+    func sync(_ entries: [Entry]) {
+        let keep = Set(entries.map(\.wid))
+        for wid in windows.keys where !keep.contains(wid) {
+            windows[wid]?.orderOut(nil)
+            windows.removeValue(forKey: wid)
+        }
+        for entry in entries { upsert(entry) }
+        if entries.isEmpty { clear() }
+    }
+
+    func clear() {
+        windows.values.forEach { $0.orderOut(nil) }
+        windows.removeAll()
+    }
+
+    private func upsert(_ entry: Entry) {
+        let expanded = entry.frame.insetBy(dx: -6, dy: -6)
+
+        if let existing = windows[entry.wid] {
+            if existing.frame != expanded {
+                existing.setFrame(expanded, display: true)
+                existing.contentView?.frame = NSRect(origin: .zero, size: expanded.size)
+            }
+            if let border = existing.contentView as? SelectedWindowBorderView {
+                border.slot = entry.slot
+            }
+            existing.orderFrontRegardless()
+            return
+        }
+
+        let window = NSWindow(
+            contentRect: expanded,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.maximumWindow)))
+        window.hasShadow = false
+        window.ignoresMouseEvents = true
+        window.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
+
+        let borderView = SelectedWindowBorderView(frame: NSRect(origin: .zero, size: expanded.size), slot: entry.slot)
+        window.contentView = borderView
+        window.alphaValue = 1
+        window.orderFrontRegardless()
+        windows[entry.wid] = window
+    }
+}
+
+private class SelectedWindowBorderView: NSView {
+    var slot: Int? { didSet { needsDisplay = true } }
+
+    init(frame: NSRect, slot: Int?) {
+        self.slot = slot
+        super.init(frame: frame)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override var isOpaque: Bool { false }
+
+    override func draw(_ dirtyRect: NSRect) {
+        let accent = NSColor(calibratedRed: 0.38, green: 0.92, blue: 1.0, alpha: 1.0)
+        let borderWidth: CGFloat = 3
+        let cornerRadius: CGFloat = 12
+
+        let glowRect = bounds.insetBy(dx: 1, dy: 1)
+        let glowPath = NSBezierPath(roundedRect: glowRect, xRadius: cornerRadius + 2, yRadius: cornerRadius + 2)
+        glowPath.lineWidth = borderWidth + 4
+        accent.withAlphaComponent(0.22).setStroke()
+        glowPath.stroke()
+
+        let rect = bounds.insetBy(dx: borderWidth / 2 + 2, dy: borderWidth / 2 + 2)
+        let path = NSBezierPath(roundedRect: rect, xRadius: cornerRadius, yRadius: cornerRadius)
+        path.lineWidth = borderWidth
+        accent.withAlphaComponent(0.95).setStroke()
+        path.stroke()
+
+        let innerRect = rect.insetBy(dx: 3, dy: 3)
+        let innerPath = NSBezierPath(roundedRect: innerRect, xRadius: max(cornerRadius - 3, 6), yRadius: max(cornerRadius - 3, 6))
+        innerPath.lineWidth = 1
+        NSColor.white.withAlphaComponent(0.72).setStroke()
+        innerPath.stroke()
+
+        if let slot {
+            let badge = "\(slot)" as NSString
+            let font = NSFont.monospacedSystemFont(ofSize: 11, weight: .bold)
+            let attrs: [NSAttributedString.Key: Any] = [
+                .font: font,
+                .foregroundColor: NSColor.black.withAlphaComponent(0.86),
+            ]
+            let size = badge.size(withAttributes: attrs)
+            let padH: CGFloat = 7
+            let padV: CGFloat = 3
+            let badgeW = size.width + padH * 2
+            let badgeH = size.height + padV * 2
+            let badgeRect = NSRect(x: rect.minX + 8, y: rect.maxY - badgeH - 8, width: badgeW, height: badgeH)
+            let badgePath = NSBezierPath(roundedRect: badgeRect, xRadius: 8, yRadius: 8)
+            accent.withAlphaComponent(0.95).setFill()
+            badgePath.fill()
+            badge.draw(at: NSPoint(x: badgeRect.minX + padH, y: badgeRect.minY + padV), withAttributes: attrs)
+        }
+    }
+}
+
 // MARK: - Grid Tiling
 
 /// Compute fractional (x, y, w, h) for a cell in a cols×rows grid.
@@ -452,6 +574,19 @@ private enum CGS {
 }
 
 enum WindowTiler {
+    enum BatchActivation {
+        case none
+        case frontmostOnly
+        case allApps
+    }
+
+    private struct ResolvedBatchMove {
+        let wid: UInt32
+        let pid: Int32
+        let frame: CGRect
+        let axWindow: AXUIElement
+    }
+
     /// Whether CGS move-between-spaces APIs are available
     static var canMoveWindowsBetweenSpaces: Bool {
         CGS.addWindowsToSpaces != nil && CGS.removeWindowsFromSpaces != nil
@@ -1749,8 +1884,11 @@ enum WindowTiler {
     }
 
     /// Move AND raise windows in a single CG+AX pass (avoids duplicate lookups).
-    /// Does not reactivate lattices at the end — caller controls that.
-    static func batchMoveAndRaiseWindows(_ moves: [(wid: UInt32, pid: Int32, frame: CGRect)]) {
+    /// Does not reactivate lattices at the end — caller controls that separately.
+    static func batchMoveAndRaiseWindows(
+        _ moves: [(wid: UInt32, pid: Int32, frame: CGRect)],
+        activation: BatchActivation = .frontmostOnly
+    ) {
         guard !moves.isEmpty else { return }
         let diag = DiagnosticLog.shared
 
@@ -1759,72 +1897,138 @@ enum WindowTiler {
             byPid[move.pid, default: []].append((wid: move.wid, target: move.frame))
         }
 
-        var processed = 0
-        var activatedPids = Set<Int32>()
+        let appRefs = appRefs(for: Set(byPid.keys))
+        setEnhancedUserInterface(false, for: appRefs)
 
-        // Freeze screen rendering for smooth batch moves
-        let cid = _SLSMainConnectionID?()
-        if let cid { _ = _SLSDisableUpdate?(cid) }
-
-        for (pid, windowMoves) in byPid {
-            let appRef = AXUIElementCreateApplication(pid)
-
-            // Disable enhanced UI — breaks macOS tile lock so resize works
-            AXUIElementSetAttributeValue(appRef, "AXEnhancedUserInterface" as CFString, false as CFTypeRef)
-
+        var axByWid: [UInt32: AXUIElement] = [:]
+        for (pid, _) in byPid {
+            guard let appRef = appRefs[pid] else { continue }
             var windowsRef: CFTypeRef?
             let err = AXUIElementCopyAttributeValue(appRef, kAXWindowsAttribute as CFString, &windowsRef)
             guard err == .success, let axWindows = windowsRef as? [AXUIElement] else { continue }
 
-            // Build wid → AXUIElement map using _AXUIElementGetWindow
-            var axByWid: [UInt32: AXUIElement] = [:]
             for axWin in axWindows {
                 var windowId: CGWindowID = 0
                 if _AXUIElementGetWindow(axWin, &windowId) == .success {
                     axByWid[windowId] = axWin
                 }
             }
-
-            for wm in windowMoves {
-                guard let axWin = axByWid[wm.wid] else { continue }
-
-                var newPos = CGPoint(x: wm.target.origin.x, y: wm.target.origin.y)
-                var newSize = CGSize(width: wm.target.width, height: wm.target.height)
-
-                // Size → Position → Size (same pattern as single-window tiler)
-                if let sv = AXValueCreate(.cgSize, &newSize) {
-                    AXUIElementSetAttributeValue(axWin, kAXSizeAttribute as CFString, sv)
-                }
-                if let pv = AXValueCreate(.cgPoint, &newPos) {
-                    AXUIElementSetAttributeValue(axWin, kAXPositionAttribute as CFString, pv)
-                }
-                if let sv = AXValueCreate(.cgSize, &newSize) {
-                    AXUIElementSetAttributeValue(axWin, kAXSizeAttribute as CFString, sv)
-                }
-
-                // Raise
-                AXUIElementPerformAction(axWin, kAXRaiseAction as CFString)
-                AXUIElementSetAttributeValue(axWin, kAXMainAttribute as CFString, kCFBooleanTrue)
-
-                processed += 1
-            }
-
-            // Re-enable enhanced UI
-            AXUIElementSetAttributeValue(appRef, "AXEnhancedUserInterface" as CFString, true as CFTypeRef)
-
-            // Activate each app once so its windows come to front
-            if !activatedPids.contains(pid) {
-                if let app = NSRunningApplication(processIdentifier: pid) {
-                    app.activate()
-                    activatedPids.insert(pid)
-                }
-            }
         }
 
-        // Unfreeze screen rendering
-        if let cid { _ = _SLSReenableUpdate?(cid) }
-        DesktopModel.shared.markInteraction(wids: moves.map(\.wid))
+        let resolvedMoves = moves.compactMap { move -> ResolvedBatchMove? in
+            guard let axWindow = axByWid[move.wid] else {
+                return nil
+            }
+            return ResolvedBatchMove(wid: move.wid, pid: move.pid, frame: move.frame, axWindow: axWindow)
+        }
+
+        let processed = commitResolvedBatchMoves(
+            resolvedMoves,
+            requestedWids: moves.map(\.wid),
+            appRefs: appRefs,
+            activation: activation
+        )
         diag.success("batchMoveAndRaiseWindows: processed \(processed)/\(moves.count) windows")
+    }
+
+    /// Same batch path for callers that already resolved AX windows on the hot path.
+    static func batchMoveAndRaiseWindows(
+        _ moves: [(wid: UInt32, pid: Int32, frame: CGRect, axWindow: AXUIElement)],
+        activation: BatchActivation = .frontmostOnly
+    ) {
+        guard !moves.isEmpty else { return }
+        let resolvedMoves = moves.map {
+            ResolvedBatchMove(wid: $0.wid, pid: $0.pid, frame: $0.frame, axWindow: $0.axWindow)
+        }
+        let appRefs = appRefs(for: Set(moves.map(\.pid)))
+        setEnhancedUserInterface(false, for: appRefs)
+        let processed = commitResolvedBatchMoves(
+            resolvedMoves,
+            requestedWids: moves.map(\.wid),
+            appRefs: appRefs,
+            activation: activation
+        )
+        DiagnosticLog.shared.success("batchMoveAndRaiseWindows: processed \(processed)/\(moves.count) pre-resolved windows")
+    }
+
+    private static func appRefs(for pids: Set<Int32>) -> [Int32: AXUIElement] {
+        var refs: [Int32: AXUIElement] = [:]
+        for pid in pids {
+            refs[pid] = AXUIElementCreateApplication(pid)
+        }
+        return refs
+    }
+
+    private static func setEnhancedUserInterface(_ enabled: Bool, for appRefs: [Int32: AXUIElement]) {
+        let value = enabled as CFTypeRef
+        for appRef in appRefs.values {
+            AXUIElementSetAttributeValue(appRef, "AXEnhancedUserInterface" as CFString, value)
+        }
+    }
+
+    private static func commitResolvedBatchMoves(
+        _ moves: [ResolvedBatchMove],
+        requestedWids: [UInt32],
+        appRefs: [Int32: AXUIElement],
+        activation: BatchActivation
+    ) -> Int {
+        guard !moves.isEmpty else {
+            setEnhancedUserInterface(true, for: appRefs)
+            DesktopModel.shared.markInteraction(wids: requestedWids)
+            return 0
+        }
+
+        var processed = 0
+
+        // Freeze screen rendering only while writing frames and raises.
+        let cid = _SLSMainConnectionID?()
+        if let cid { _ = _SLSDisableUpdate?(cid) }
+
+        for move in moves {
+            setFrameTriplet(move.axWindow, to: move.frame)
+            AXUIElementPerformAction(move.axWindow, kAXRaiseAction as CFString)
+            AXUIElementSetAttributeValue(move.axWindow, kAXMainAttribute as CFString, kCFBooleanTrue)
+            processed += 1
+        }
+
+        if let cid { _ = _SLSReenableUpdate?(cid) }
+
+        setEnhancedUserInterface(true, for: appRefs)
+        activateApps(for: moves, activation: activation)
+        DesktopModel.shared.markInteraction(wids: requestedWids)
+        return processed
+    }
+
+    private static func setFrameTriplet(_ axWindow: AXUIElement, to frame: CGRect) {
+        var newPos = CGPoint(x: frame.origin.x, y: frame.origin.y)
+        var newSize = CGSize(width: frame.width, height: frame.height)
+
+        // Size → Position → Size (same pattern as single-window tiler)
+        if let sv = AXValueCreate(.cgSize, &newSize) {
+            AXUIElementSetAttributeValue(axWindow, kAXSizeAttribute as CFString, sv)
+        }
+        if let pv = AXValueCreate(.cgPoint, &newPos) {
+            AXUIElementSetAttributeValue(axWindow, kAXPositionAttribute as CFString, pv)
+        }
+        if let sv = AXValueCreate(.cgSize, &newSize) {
+            AXUIElementSetAttributeValue(axWindow, kAXSizeAttribute as CFString, sv)
+        }
+    }
+
+    private static func activateApps(for moves: [ResolvedBatchMove], activation: BatchActivation) {
+        switch activation {
+        case .none:
+            return
+        case .frontmostOnly:
+            guard let pid = moves.last?.pid else { return }
+            NSRunningApplication(processIdentifier: pid)?.activate()
+        case .allApps:
+            var activatedPids = Set<Int32>()
+            for move in moves where !activatedPids.contains(move.pid) {
+                NSRunningApplication(processIdentifier: move.pid)?.activate()
+                activatedPids.insert(move.pid)
+            }
+        }
     }
 
     // MARK: - Grid Layout Strategy

--- a/apps/mac/Sources/Core/HudsonKit/HudsonKitBridge.swift
+++ b/apps/mac/Sources/Core/HudsonKit/HudsonKitBridge.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-#if canImport(HudsonVoice)
+#if LATTICES_VOICE && canImport(HudsonVoice)
 import HudsonVoice
 #endif
 
@@ -34,7 +34,7 @@ enum HudsonKitSwitch {
     /// (the `HudsonVoice` product only exists when the app is built with
     /// `HUDSONKIT_WITH_VOICE=1`).
     static var voiceAvailable: Bool {
-        #if canImport(HudsonVoice)
+        #if LATTICES_VOICE && canImport(HudsonVoice)
         return true
         #else
         return false
@@ -42,7 +42,7 @@ enum HudsonKitSwitch {
     }
 }
 
-#if canImport(HudsonVoice)
+#if LATTICES_VOICE && canImport(HudsonVoice)
 /// The HudsonKit-backed voice surface. `HudVoicePanel` manages its own live
 /// session against the embedded runtime hosted by Lattices.
 struct HudsonVoiceSurface: View {

--- a/apps/mac/Sources/Core/Overlays/Motion/WindowMotionMode.swift
+++ b/apps/mac/Sources/Core/Overlays/Motion/WindowMotionMode.swift
@@ -59,6 +59,7 @@ final class WindowMotionMode {
         }
         let tEligible = CACurrentMediaTime()
         let inPlace = entry == .inPlace
+        AppFeedback.shared.warmUp()
         let p = MotionPanel(eligible: eligible, inPlace: inPlace)
         p.loadStart = t0
         let tInit = CACurrentMediaTime()
@@ -373,6 +374,8 @@ private final class MotionPanel: NSPanel {
     private let stackMargin: CGFloat = 24
     private var keyObserver: Any?
     private var layoutRefreshTimer: Timer?   // keep Current View frames live while surveying
+    private var layoutFingerprintByScreen: [String: Int] = [:]
+    private var captureRebuildWorkItemsByScreenID: [String: DispatchWorkItem] = [:]
     /// In-place tools (Hyper+G): float Current View + inventory over the live desktop.
     /// Hyperspace (Hyper+Space) keeps the full scrim + screenshot survey.
     private let inPlaceMode: Bool
@@ -632,6 +635,7 @@ private final class MotionPanel: NSPanel {
         commandPanel?.close()
         commandPanel = nil
         animators.values.forEach { $0.cancel() }
+        WindowSelectionOverlay.shared.clear()
         removeExposeHost()
         orderOut(nil)
     }
@@ -641,6 +645,7 @@ private final class MotionPanel: NSPanel {
     /// can always clear a survey that a prior race left orphaned (no key monitor,
     /// no resign observer) and stuck on top. Cheap; runs only on activate/deactivate.
     static func teardownStrayPanels() {
+        WindowSelectionOverlay.shared.clear()
         for window in NSApp.windows where window is HyperspaceScreenPanel || window is MotionPanel {
             window.orderOut(nil)
             window.close()
@@ -761,6 +766,7 @@ private final class MotionPanel: NSPanel {
                     ?? validSurveyScreen(screenForEvent(event))
                     ?? activeSurveyScreen
                 if let screen {
+                    if !stagedIntents.isEmpty { AppFeedback.shared.commitTactile() }
                     commitStagedIntents(on: screen)
                     DiagnosticLog.shared.info("In-place confirm — commit staged + exit")
                 }
@@ -771,6 +777,7 @@ private final class MotionPanel: NSPanel {
                     ?? activeSurveyScreen
                 if let screen {
                     let count = pickOrderByScreen[MotionPanel.screenID(screen)]?.count ?? 0
+                    if count > 0 { AppFeedback.shared.commitTactile() }
                     DiagnosticLog.shared.info("Motion confirm — gather \(count) from Exposé + exit")
                     gatherInPlace(on: screen)
                     onExit?()
@@ -778,6 +785,7 @@ private final class MotionPanel: NSPanel {
             } else {
                 // Deferred gridding: lay the picked set out now (if any), then leave.
                 if !group.isEmpty {
+                    AppFeedback.shared.commitTactile()
                     DiagnosticLog.shared.info("Motion confirm — grid \(group.count) + exit")
                     relayoutGroup()
                 } else {
@@ -814,6 +822,7 @@ private final class MotionPanel: NSPanel {
                 return
             case 14 where !mods.contains(.shift) && !inPlaceMode: collapseExpose(); return  // E — collapse survey
             case 5  where !mods.contains(.shift):                            // G — grid selection (stay in mode)
+                AppFeedback.shared.commitTactile()
                 if let eventScreen { gatherInPlace(on: eventScreen) }
                 return
             case 3  where !mods.contains(.shift) && inPlaceMode:             // F — fill available space
@@ -860,6 +869,7 @@ private final class MotionPanel: NSPanel {
             toggleExpose()
             return
         case 5:                                             // G — grid the group (in Exposé: gather but stay)
+            AppFeedback.shared.commitTactile()
             if exposed { gatherInPlace() } else { distributeGroup() }
             return
         case 3:                                             // F — grow into open space until a neighbor
@@ -1219,28 +1229,40 @@ private final class MotionPanel: NSPanel {
             return
         }
         let rects = balancedGrid(members.count)
-        var moves: [(wid: UInt32, pid: Int32, frame: CGRect)] = []
-        moves.reserveCapacity(members.count)
+        var resolvedMoves: [(wid: UInt32, pid: Int32, frame: CGRect, axWindow: AXUIElement)] = []
+        var fallbackMoves: [(wid: UInt32, pid: Int32, frame: CGRect)] = []
+        resolvedMoves.reserveCapacity(members.count)
+        fallbackMoves.reserveCapacity(members.count)
         for (i, m) in members.enumerated() {
             let r = rects[i]
             let target = WindowTiler.tileFrame(fractions: (r.minX, r.minY, r.width, r.height), on: screen)
-            if let el = ax(for: m) { recordOriginal(m.wid, el) }
-            moves.append((wid: m.wid, pid: m.pid, frame: target))
+            if let el = ax(for: m) {
+                recordOriginal(m.wid, el)
+                resolvedMoves.append((wid: m.wid, pid: m.pid, frame: target, axWindow: el))
+            } else {
+                fallbackMoves.append((wid: m.wid, pid: m.pid, frame: target))
+            }
         }
-        guard !moves.isEmpty else { return }
+        guard !resolvedMoves.isEmpty || !fallbackMoves.isEmpty else { return }
         raising {
-            WindowTiler.batchMoveAndRaiseWindows(moves)
+            if fallbackMoves.isEmpty {
+                WindowTiler.batchMoveAndRaiseWindows(resolvedMoves)
+            } else {
+                WindowTiler.batchMoveAndRaiseWindows(
+                    resolvedMoves.map { (wid: $0.wid, pid: $0.pid, frame: $0.frame) } + fallbackMoves
+                )
+            }
         }
-        AppFeedback.shared.playTapSound()
-        DiagnosticLog.shared.info("Motion grid — \(moves.count) windows")
+        DiagnosticLog.shared.info("Motion grid — \(resolvedMoves.count + fallbackMoves.count) windows")
     }
 
     /// Refresh inventory chrome after a grid snap without blocking the batch move.
-    private func refreshAfterGridMove() {
+    private func refreshAfterGridMove(on screen: NSScreen) {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             DesktopModel.shared.poll()
-            self.rebuildExposeView()
+            self.layoutFingerprintByScreen[MotionPanel.screenID(screen)] = self.layoutFingerprint(for: screen)
+            self.rebuildExposeView(screens: [screen])
             self.updateLegend()
             self.refreshBorders()
             self.updateStack()
@@ -1251,10 +1273,11 @@ private final class MotionPanel: NSPanel {
     /// G — make sure the aimed window is part of the group, then lay out the grid.
     private func distributeGroup() {
         if !group.contains(activeEntry.wid) { togglePicked(activeEntry.wid) }
+        let screen = activeSurveyScreen
         relayoutGroup()
         updateLegend()
-        if inPlaceMode {
-            refreshAfterGridMove()
+        if inPlaceMode, let screen {
+            refreshAfterGridMove(on: screen)
         } else {
             refreshBorders()
             updateStack()
@@ -1297,6 +1320,9 @@ private final class MotionPanel: NSPanel {
         installExposeHosts()
         captureCount = allMembers.count
         allMembers.forEach { captureThumb(for: $0) }              // seed from the shared cache; capture only misses
+        DesktopModel.shared.poll()
+        layoutFingerprintByScreen.removeAll()
+        for screen in screens { layoutFingerprintByScreen[MotionPanel.screenID(screen)] = layoutFingerprint(for: screen) }
         rebuildExposeView()
         checkCapturesSettled()                                     // every tile a cache hit → already done
         startLayoutRefresh()
@@ -1329,17 +1355,24 @@ private final class MotionPanel: NSPanel {
         updateStack()
     }
 
+    /// Stage a location without rebuilding — callers batch and rebuild once.
+    private func stageDrop(_ wid: UInt32, _ placement: PlacementSpec?) {
+        if let placement {
+            stagedIntents[wid, default: StagedIntent()].location = placement
+        }
+    }
+
     /// A tile was dropped in the survey. A non-nil placement stages a location for
     /// that window (badge shows; nothing real moves until gather); nil means the
     /// drop missed every target — no change, we just rebuild to clear the drag
     /// placeholder. Either way the rebuild here un-suppresses the spread (rebuilds
     /// are skipped while a drag is in flight so the SwiftUI gesture survives).
     private func handleDrop(_ wid: UInt32, _ placement: PlacementSpec?) {
+        stageDrop(wid, placement)
         if let placement {
-            stagedIntents[wid, default: StagedIntent()].location = placement
             DiagnosticLog.shared.info("Hyperspace stage — wid=\(wid) location \(placement.wireValue)")
         }
-        rebuildExposeView()
+        rebuildExposeForActiveScreen()
     }
 
     /// Stage a balanced sub-grid for a multi-window drop onto the lattice, anchored at `anchor`.
@@ -1353,15 +1386,14 @@ private final class MotionPanel: NSPanel {
         for (i, wid) in wids.enumerated() {
             let cell = cells[i]
             guard let gp = GridPlacement(columns: cols, rows: rows, column: cell.col, row: cell.row) else { continue }
-            handleDrop(wid, PlacementSpec.grid(gp))
+            stageDrop(wid, PlacementSpec.grid(gp))
         }
         DiagnosticLog.shared.info("Hyperspace stage — \(wids.count) windows grid @ \(anchor.col),\(anchor.row) (\(res.name))")
+        rebuildExposeForActiveScreen()
     }
 
-    /// A tile was dropped on a Layers pile. The ＋ pile stages a brand-new layer; any
-    /// other pile toggles a staged join (multi-membership). Only *stages* — nothing is
-    /// written to StudioLayerStore until gather, so Esc still discards cleanly.
-    private func handleLayerDrop(_ wid: UInt32, _ layerKey: String) {
+    /// Stage a layer join without rebuilding — callers batch and rebuild once.
+    private func stageLayerDrop(_ wid: UInt32, _ layerKey: String) {
         if layerKey == HyperspaceDrag.newLayerKey {
             stagedIntents[wid, default: StagedIntent()].newLayer.toggle()
         } else if stagedIntents[wid]?.layers.contains(layerKey) == true {
@@ -1369,8 +1401,39 @@ private final class MotionPanel: NSPanel {
         } else {
             stagedIntents[wid, default: StagedIntent()].layers.insert(layerKey)
         }
+    }
+
+    /// A tile was dropped on a Layers pile. The ＋ pile stages a brand-new layer; any
+    /// other pile toggles a staged join (multi-membership). Only *stages* — nothing is
+    /// written to StudioLayerStore until gather, so Esc still discards cleanly.
+    private func handleLayerDrop(_ wid: UInt32, _ layerKey: String) {
+        stageLayerDrop(wid, layerKey)
         DiagnosticLog.shared.info("Hyperspace stage — wid=\(wid) layer \(layerKey)")
-        rebuildExposeView()
+        rebuildExposeForActiveScreen()
+    }
+
+    private func handleLayerDrops(_ wids: [UInt32], _ layerKey: String) {
+        guard !wids.isEmpty else { return }
+        for wid in wids { stageLayerDrop(wid, layerKey) }
+        DiagnosticLog.shared.info("Hyperspace stage — \(wids.count) window(s) layer \(layerKey)")
+        rebuildExposeForActiveScreen()
+    }
+
+    /// In-place: rebuild one screen; hyperspace survey: rebuild all.
+    private func rebuildExposeForActiveScreen() {
+        if inPlaceMode, let screen = activeSurveyScreen {
+            rebuildExposeView(screens: [screen])
+        } else {
+            rebuildExposeView()
+        }
+    }
+
+    private func rebuildExposeForScreenInteraction(on screen: NSScreen) {
+        if inPlaceMode {
+            rebuildExposeView(screens: [screen])
+        } else {
+            rebuildExposeView()
+        }
     }
 
     /// Edit mode: drop one rule clause from a layer (the ✕ on a pile's rule chip).
@@ -1511,7 +1574,7 @@ private final class MotionPanel: NSPanel {
                     id: w.wid,
                     frac: MotionPanel.frac(of: layoutFrame(for: freshEntry(w)), in: screenAX),
                     tint: Color(nsColor: MotionPanel.tint(for: w.app)),
-                    image: thumbs[w.wid])
+                    image: inPlaceMode ? nil : thumbs[w.wid])
             }
             let stagedCount = stagedIntents.values.filter { $0.layers.contains(layer.id) }.count
             return ExposeView.LayerPile(id: layer.id, name: layer.name, count: onScreen.count,
@@ -1559,12 +1622,28 @@ private final class MotionPanel: NSPanel {
         return interArea / smallerArea >= 0.15
     }
 
+    /// Cheap hash of on-screen window frames — skip full ExposeView rebuilds when nothing moved.
+    private func layoutFingerprint(for screen: NSScreen) -> Int {
+        let windows = liveMembers(on: screen)
+        var hasher = Hasher()
+        hasher.combine(windows.count)
+        for w in windows {
+            let f = layoutCGFrame(for: w)
+            hasher.combine(w.wid)
+            hasher.combine(Int64(f.origin.x.rounded()))
+            hasher.combine(Int64(f.origin.y.rounded()))
+            hasher.combine(Int64(f.width.rounded()))
+            hasher.combine(Int64(f.height.rounded()))
+        }
+        return hasher.finalize()
+    }
+
     /// Every window currently on a screen, as fractional footprints — the Current View's
     /// always-on baseline ("what this display looks like right now"). Uses live members
     /// + CG frames (not the open-time snapshot) and paints back-to-front so frontmost
     /// reads on top; windows covered by a front neighbor are marked `behind`.
+    /// Caller must poll DesktopModel first when frames need to be fresh.
     private func currentLayout(on screen: NSScreen) -> [ExposeView.LayerMember] {
-        DesktopModel.shared.poll()
         let screenAX = MotionPanel.axRect(of: screen)
         let windows = liveMembers(on: screen).sorted { $0.zIndex < $1.zIndex }
         let frames = windows.map { layoutCGFrame(for: $0) }
@@ -1577,7 +1656,7 @@ private final class MotionPanel: NSPanel {
                 id: w.wid,
                 frac: MotionPanel.frac(of: frame, in: screenAX),
                 tint: Color(nsColor: MotionPanel.tint(for: w.app)),
-                image: thumbs[w.wid],
+                image: inPlaceMode ? nil : thumbs[w.wid],
                 behind: behind)
         }
     }
@@ -1604,8 +1683,9 @@ private final class MotionPanel: NSPanel {
         let id = MotionPanel.screenID(screen)
         pickOrderByScreen[id] = []
         restorePickState(for: screen)
-        rebuildExposeView()
+        rebuildExposeView(screens: [screen])
         updateLegend()
+        refreshBorders()
         updateStack()
     }
 
@@ -1630,7 +1710,8 @@ private final class MotionPanel: NSPanel {
             WindowTiler.tileWindowById(wid: wid, pid: entry.pid, to: placement, on: screen)
         }
         DesktopModel.shared.poll()
-        rebuildExposeView()
+        invalidateLayoutFingerprint(for: screen)
+        rebuildExposeView(screens: [screen])
         updateLegend()
         refreshBorders()
         DispatchQueue.main.async { [weak self] in self?.makeKey() }
@@ -1645,15 +1726,24 @@ private final class MotionPanel: NSPanel {
             return
         }
         DesktopModel.shared.poll()
-        let frameA = layoutFrame(for: entryA)
-        let frameB = layoutFrame(for: entryB)
+        let axA = ax(for: entryA)
+        let axB = ax(for: entryB)
+        let frameA = axA.flatMap { RealWindowAnimator.axFrame($0) } ?? layoutCGFrame(for: entryA)
+        let frameB = axB.flatMap { RealWindowAnimator.axFrame($0) } ?? layoutCGFrame(for: entryB)
         if originalFrames[widA] == nil { originalFrames[widA] = frameA }
         if originalFrames[widB] == nil { originalFrames[widB] = frameB }
         raising {
-            WindowTiler.batchMoveAndRaiseWindows([
-                (wid: widA, pid: entryA.pid, frame: frameB),
-                (wid: widB, pid: entryB.pid, frame: frameA),
-            ])
+            if let axA, let axB {
+                WindowTiler.batchMoveAndRaiseWindows([
+                    (wid: widA, pid: entryA.pid, frame: frameB, axWindow: axA),
+                    (wid: widB, pid: entryB.pid, frame: frameA, axWindow: axB),
+                ])
+            } else {
+                WindowTiler.batchMoveAndRaiseWindows([
+                    (wid: widA, pid: entryA.pid, frame: frameB),
+                    (wid: widB, pid: entryB.pid, frame: frameA),
+                ])
+            }
         }
         let id = MotionPanel.screenID(screen)
         pickOrderByScreen[id]?.removeAll { $0 == widA || $0 == widB }
@@ -1661,12 +1751,13 @@ private final class MotionPanel: NSPanel {
             restorePickState(for: screen)
         }
         DiagnosticLog.shared.info("Hyperspace swap — \(entryA.app) ↔ \(entryB.app)")
-        rebuildExposeView()
+        invalidateLayoutFingerprint(for: screen)
+        rebuildExposeView(screens: [screen])
         updateLegend()
         refreshBorders()
         updateStack()
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { [weak self] in
-            self?.rebuildExposeView()
+            self?.rebuildExposeView(screens: [screen])
         }
     }
 
@@ -1737,7 +1828,7 @@ private final class MotionPanel: NSPanel {
             raising { RealWindowAnimator.raise(el) }              // a single pick just comes forward
         }
         if inPlaceMode {
-            refreshAfterGridMove()
+            refreshAfterGridMove(on: screen)
             return
         }
         removeExposeHost()
@@ -1947,22 +2038,24 @@ private final class MotionPanel: NSPanel {
         reassignHandHints(on: screen)
     }
 
-    private func reassignHandHints(on screen: NSScreen) {
-        guard exposed else { return }
+    @discardableResult
+    private func reassignHandHints(on screen: NSScreen, rebuild: Bool = true) -> Bool {
+        guard exposed else { return false }
         let id = MotionPanel.screenID(screen)
         let order = exposeOrderByScreen[id] ?? []
         let frames = exposeFramesByScreen[id] ?? [:]
         let (hf, hm) = (handKeysMode && frames.count >= order.count)
             ? computeHandHints(order: order, frames: frames)
             : readingHints(for: order)
-        guard hf != hintForByScreen[id] else { return }
+        guard hf != hintForByScreen[id] else { return false }
         hintForByScreen[id] = hf
         hintMapByScreen[id] = hm
         if activeSurveyScreen.map(MotionPanel.screenID) == id {
             hintFor = hf
             hintMap = hm
         }
-        rebuildExposeView()
+        if rebuild { rebuildExposeView(screens: [screen]) }
+        return true
     }
 
     /// Per-cluster shortcut: ⇧+letter plucks the whole group at once (e.g. ⇧I →
@@ -2071,10 +2164,33 @@ private final class MotionPanel: NSPanel {
     /// Poll DesktopModel and refresh Current View outlines while the survey is open.
     private func startLayoutRefresh() {
         stopLayoutRefresh()
-        layoutRefreshTimer = Timer.scheduledTimer(withTimeInterval: 0.75, repeats: true) { [weak self] _ in
-            guard let self, self.exposed, !self.dismissed, !self.dragModel.isActive else { return }
-            self.rebuildExposeView()
+        let interval: TimeInterval = inPlaceMode ? 1.5 : 0.75
+        layoutRefreshTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            self?.refreshLiveLayoutIfChanged()
         }
+    }
+
+    /// Timer tick: poll once, rebuild only when a window actually moved or resized.
+    private func refreshLiveLayoutIfChanged() {
+        guard exposed, !dismissed, !dragModel.isActive else { return }
+        DesktopModel.shared.poll()
+        var changedScreens: [NSScreen] = []
+        for screen in surveyScreens() {
+            let id = MotionPanel.screenID(screen)
+            let fp = layoutFingerprint(for: screen)
+            if layoutFingerprintByScreen[id] != fp {
+                layoutFingerprintByScreen[id] = fp
+                changedScreens.append(screen)
+            }
+        }
+        if !changedScreens.isEmpty {
+            rebuildExposeView(screens: changedScreens)
+            if inPlaceMode { refreshBorders() }
+        }
+    }
+
+    private func invalidateLayoutFingerprint(for screen: NSScreen) {
+        layoutFingerprintByScreen.removeValue(forKey: MotionPanel.screenID(screen))
     }
 
     private func stopLayoutRefresh() {
@@ -2082,7 +2198,13 @@ private final class MotionPanel: NSPanel {
         layoutRefreshTimer = nil
     }
 
+    private func cancelCaptureRebuilds() {
+        captureRebuildWorkItemsByScreenID.values.forEach { $0.cancel() }
+        captureRebuildWorkItemsByScreenID.removeAll()
+    }
+
     private func removeExposeHost() {
+        cancelCaptureRebuilds()
         exposePanelsByScreenID.values.forEach { $0.close() }
         exposePanelsByScreenID.removeAll()
         exposeHostsByScreenID.values.forEach { $0.removeFromSuperview() }
@@ -2092,8 +2214,9 @@ private final class MotionPanel: NSPanel {
 
     /// Rebuild the spread's view-model from current picks/aim/captures. Cheap —
     /// the cluster *structure* is fixed for the life of a survey; only the per-tile
-    /// pick slot, highlight, and image change.
-    private func rebuildExposeView() {
+    /// pick slot, highlight, and image change. In-place mode can target one screen
+    /// to avoid rebuilding every monitor on each pick.
+    private func rebuildExposeView(screens: [NSScreen]? = nil) {
         guard exposed else { return }
         // Replacing host.rootView mid-drag would tear down the in-flight SwiftUI
         // gesture and abort the drag. Skip while a drag is live; handleDrop()
@@ -2102,9 +2225,15 @@ private final class MotionPanel: NSPanel {
         if exposeHostsByScreenID.isEmpty { installExposeHosts() }
         exposeHost = activeSurveyScreen.flatMap { exposeHostsByScreenID[MotionPanel.screenID($0)] }
 
-        for screen in surveyScreens() {
+        let targets = screens ?? surveyScreens()
+        for screen in targets {
+            rebuildExposeScreen(screen)
+        }
+    }
+
+    private func rebuildExposeScreen(_ screen: NSScreen) {
             let id = MotionPanel.screenID(screen)
-            guard let host = exposeHostsByScreenID[id] else { continue }
+            guard let host = exposeHostsByScreenID[id] else { return }
             let members = surveyMembers(on: screen)
             if exposeClustersByScreen[id] == nil {
                 rebuildSurveyState(for: screen, resetAim: true)
@@ -2142,6 +2271,7 @@ private final class MotionPanel: NSPanel {
                     self?.handleGridGroupDrop(wids, res: res, anchor: anchor)
                 },
                 onDropLayer: { [weak self] wid, key in self?.handleLayerDrop(wid, key) },
+                onDropLayers: { [weak self] wids, key in self?.handleLayerDrops(wids, key) },
                 onSwap: { [weak self] a, b in self?.swapWindows(widA: a, widB: b, on: screen) },
                 onGridSelection: { [weak self] in self?.gatherInPlace(on: screen) },
                 onSwapFirstTwo: { [weak self] in
@@ -2175,7 +2305,15 @@ private final class MotionPanel: NSPanel {
                 onHandKeys: { [weak self] on in
                     guard let self else { return }
                     self.handKeysMode = on
-                    self.surveyScreens().forEach { self.reassignHandHints(on: $0) }
+                    let changed = self.surveyScreens().filter {
+                        self.reassignHandHints(on: $0, rebuild: false)
+                    }
+                    guard !changed.isEmpty else { return }
+                    if self.inPlaceMode {
+                        self.rebuildExposeView(screens: changed)
+                    } else {
+                        self.rebuildExposeView()
+                    }
                 },
                 onExit: { [weak self] in self?.onExit?() },   // ✕ — leave, keep what's on screen
                 onNewLayer: { [weak self] in self?.presentNewLayer() },
@@ -2186,7 +2324,6 @@ private final class MotionPanel: NSPanel {
                 onRemoveClause: { [weak self] id, idx in self?.removeLayerClause(id, idx) },
                 onDeleteLayer: { [weak self] id in self?.deleteLayer(id) },
                 loadSummary: loadSummaryText())
-        }
     }
 
     /// Compact load readout for the survey: time-to-first-paint and time-to-all-
@@ -2271,8 +2408,13 @@ private final class MotionPanel: NSPanel {
         } else {
             restorePickState(for: screen)
         }
-        rebuildExposeView()
+        if inPlaceMode {
+            rebuildExposeView(screens: [screen])
+        } else {
+            rebuildExposeView()
+        }
         updateLegend()
+        refreshBorders()
         updateStack()
     }
 
@@ -2320,8 +2462,9 @@ private final class MotionPanel: NSPanel {
         } else {
             restorePickState(for: screen)
         }
-        rebuildExposeView()
+        rebuildExposeForScreenInteraction(on: screen)
         updateLegend()
+        refreshBorders()
         updateStack()
     }
 
@@ -2329,6 +2472,9 @@ private final class MotionPanel: NSPanel {
 
     private func activateClusterSearch(_ clusterID: Int, on screen: NSScreen) {
         let screenID = MotionPanel.screenID(screen)
+        let previouslyActiveScreens = activeClusterSearchByScreen.keys.compactMap { id in
+            NSScreen.screens.first(where: { MotionPanel.screenID($0) == id })
+        }
         activeClusterSearchByScreen.removeAll()
         activeClusterSearchByScreen[screenID] = clusterID
         var queries = clusterSearchQueryByScreen[screenID] ?? [:]
@@ -2337,7 +2483,14 @@ private final class MotionPanel: NSPanel {
         if activeSurveyScreen.map(MotionPanel.screenID) != screenID {
             setActiveSurveyScreen(screen)
         }
-        rebuildExposeView()
+        if inPlaceMode {
+            let uniqueTargets = ([screen] + previouslyActiveScreens)
+                .reduce(into: [String: NSScreen]()) { $0[MotionPanel.screenID($1)] = $1 }
+            let targets = Array(uniqueTargets.values)
+            rebuildExposeView(screens: targets)
+        } else {
+            rebuildExposeView()
+        }
     }
 
     private func clearClusterSearch(_ clusterID: Int, on screen: NSScreen) {
@@ -2349,7 +2502,7 @@ private final class MotionPanel: NSPanel {
         if activeSurveyScreen.map(MotionPanel.screenID) != screenID {
             setActiveSurveyScreen(screen)
         }
-        rebuildExposeView()
+        rebuildExposeForScreenInteraction(on: screen)
     }
 
     private func activeClusterSearchTarget() -> (screen: NSScreen, screenID: String, clusterID: Int)? {
@@ -2373,14 +2526,14 @@ private final class MotionPanel: NSPanel {
             } else {
                 setClusterSearchQuery("", clusterID: target.clusterID, screenID: target.screenID)
             }
-            rebuildExposeView()
+            rebuildExposeForScreenInteraction(on: target.screen)
             return true
         case 51:                                                    // Delete / Backspace
             var q = clusterSearchQueryByScreen[target.screenID]?[target.clusterID] ?? ""
             if !q.isEmpty {
                 q.removeLast()
                 setClusterSearchQuery(q, clusterID: target.clusterID, screenID: target.screenID)
-                rebuildExposeView()
+                rebuildExposeForScreenInteraction(on: target.screen)
             }
             return true
         case 36, 76:                                                // Return — pluck visible matches
@@ -2392,7 +2545,7 @@ private final class MotionPanel: NSPanel {
             guard !blocked, let text = clusterSearchText(from: event) else { return false }
             let current = clusterSearchQueryByScreen[target.screenID]?[target.clusterID] ?? ""
             setClusterSearchQuery(current + text, clusterID: target.clusterID, screenID: target.screenID)
-            rebuildExposeView()
+            rebuildExposeForScreenInteraction(on: target.screen)
             return true
         }
     }
@@ -2439,8 +2592,9 @@ private final class MotionPanel: NSPanel {
         } else {
             restorePickState(for: screen)
         }
-        rebuildExposeView()
+        rebuildExposeForScreenInteraction(on: screen)
         updateLegend()
+        refreshBorders()
         updateStack()
     }
 
@@ -2510,7 +2664,7 @@ private final class MotionPanel: NSPanel {
         pickOrderByScreen[id] = order
         if activeSurveyScreen.map(MotionPanel.screenID) != id { setActiveSurveyScreen(screen) }
         else { restorePickState(for: screen) }
-        rebuildExposeView(); updateLegend(); updateStack()
+        rebuildExposeForScreenInteraction(on: screen); updateLegend(); refreshBorders(); updateStack()
     }
 
     /// Stage a named placement for the plucked set on this screen — the same staging
@@ -2520,8 +2674,9 @@ private final class MotionPanel: NSPanel {
         let picked = pickOrderByScreen[id] ?? []
         guard !picked.isEmpty else { NSSound.beep(); return }
         let spec = PlacementSpec.grid(gp)
-        for wid in picked { handleDrop(wid, spec) }
-        rebuildExposeView()
+        for wid in picked { stageDrop(wid, spec) }
+        DiagnosticLog.shared.info("Hyperspace stage — \(picked.count) selected window(s) \(spec.wireValue)")
+        rebuildExposeForScreenInteraction(on: screen)
     }
 
     // MARK: - Display-scoped survey
@@ -2748,7 +2903,7 @@ private final class MotionPanel: NSPanel {
             exposeAim = exposeAimByScreen[id] ?? 0
         }
         if let wid = order[safe: exposeAimByScreen[id] ?? 0] { aimWindow(wid, on: screen) }
-        rebuildExposeView()
+        rebuildExposeForScreenInteraction(on: screen)
     }
 
     /// True if the window's center sits on `screen` (AppKit coords, like screen(for:)).
@@ -2791,30 +2946,36 @@ private final class MotionPanel: NSPanel {
         borderLayers.removeAll()
 
         // During the screenshot survey the SwiftUI spread (ExposeView) draws
-        // everything; real-window chrome would just double up behind it.
-        if exposed { return }
+        // everything; Hyper+G is the exception because its survey floats above the
+        // live desktop and selected windows need an on-screen selected state.
+        if exposed && !inPlaceMode { return }
 
         let activeWid = activeEntry.wid
 
-        // Outlines for the picked set (always) and, in Exposé, every spread window —
-        // drawn first so the aimed window's preview sits on top of them. The aimed
-        // window is handled separately below.
-        for entry in eligible where entry.wid != activeWid {
-            let inGroup = group.contains(entry.wid)
-            guard inGroup || exposed else { continue }
-            guard let el = ax(for: entry), let axf = RealWindowAnimator.axFrame(el) else { continue }
-            let local = panelLocal(appKitFrame(fromAX: axf))
-            let layer = CALayer()
-            layer.frame = local
-            layer.cornerRadius = 10
-            layer.cornerCurve = .continuous
-            layer.borderWidth = 1.5
-            let color = MotionPanel.tint(for: entry.app)
-            // Un-picked spread windows sit back at a dim alpha; picked read fuller.
-            layer.borderColor = color.withAlphaComponent(inGroup ? 0.6 : 0.28).cgColor
-            if inGroup { layer.backgroundColor = color.withAlphaComponent(0.05).cgColor }
-            root.addSublayer(layer)
-            borderLayers.append(layer)
+        // Selected-window chrome on the real desktop. Hyper+G draws via dedicated
+        // per-window overlays above the survey panel; plain motion mode uses the
+        // chrome host beneath the instruction strip.
+        if inPlaceMode {
+            var overlayEntries: [WindowSelectionOverlay.Entry] = []
+            for (_, order) in pickOrderByScreen {
+                for (idx, wid) in order.enumerated() {
+                    guard let entry = eligible.first(where: { $0.wid == wid }) else { continue }
+                    overlayEntries.append(WindowSelectionOverlay.Entry(
+                        wid: wid,
+                        frame: liveAppKitFrame(for: entry),
+                        slot: idx + 1
+                    ))
+                }
+            }
+            WindowSelectionOverlay.shared.sync(overlayEntries)
+            if exposed { return }
+        } else {
+            for (idx, wid) in pickOrder.enumerated() {
+                guard group.contains(wid),
+                      let entry = eligible.first(where: { $0.wid == wid }) else { continue }
+                let local = panelLocal(liveAppKitFrame(for: entry))
+                addSelectedWindowChrome(root: root, frame: local, app: entry.app, slot: idx + 1)
+            }
         }
 
         // The aimed window — a *fake* bring-to-front. We never raise the real window
@@ -2871,11 +3032,66 @@ private final class MotionPanel: NSPanel {
         borderLayers.append(border)
     }
 
+    private func addSelectedWindowChrome(root: CALayer, frame local: CGRect, app: String, slot: Int?) {
+        let accent = MotionPanel.selectedChromeColor
+        let appTint = MotionPanel.tint(for: app)
+        let outerFrame = local.insetBy(dx: -5, dy: -5)
+
+        let glow = CALayer()
+        glow.frame = outerFrame
+        glow.cornerRadius = 14
+        glow.cornerCurve = .continuous
+        glow.borderWidth = 3
+        glow.borderColor = accent.withAlphaComponent(0.92).cgColor
+        glow.backgroundColor = appTint.withAlphaComponent(0.055).cgColor
+        glow.shadowColor = accent.cgColor
+        glow.shadowOpacity = 0.62
+        glow.shadowRadius = 13
+        glow.shadowOffset = .zero
+        root.addSublayer(glow)
+        borderLayers.append(glow)
+
+        let inner = CALayer()
+        inner.frame = local.insetBy(dx: 2, dy: 2)
+        inner.cornerRadius = 8
+        inner.cornerCurve = .continuous
+        inner.borderWidth = 1
+        inner.borderColor = NSColor.white.withAlphaComponent(0.78).cgColor
+        root.addSublayer(inner)
+        borderLayers.append(inner)
+
+        if let slot {
+            let badge = CATextLayer()
+            badge.contentsScale = NSScreen.main?.backingScaleFactor ?? 2
+            badge.string = "\(slot)"
+            badge.fontSize = 11
+            badge.alignmentMode = .center
+            badge.foregroundColor = NSColor.black.withAlphaComponent(0.86).cgColor
+            badge.backgroundColor = accent.withAlphaComponent(0.95).cgColor
+            badge.cornerRadius = 8
+            badge.masksToBounds = true
+            badge.frame = CGRect(x: outerFrame.minX + 8, y: outerFrame.maxY - 26, width: 26, height: 18)
+            root.addSublayer(badge)
+            borderLayers.append(badge)
+        }
+    }
+
     // MARK: - Geometry
 
     private func appKitFrame(fromAX ax: CGRect) -> NSRect {
         let primaryH = NSScreen.screens.first?.frame.height ?? 0
         return NSRect(x: ax.origin.x, y: primaryH - ax.origin.y - ax.height, width: ax.width, height: ax.height)
+    }
+
+    /// Live on-screen frame in global AppKit coords — AX when available, else polled entry.
+    private func liveAppKitFrame(for entry: WindowEntry) -> NSRect {
+        let axf: CGRect
+        if let el = ax(for: entry), let live = RealWindowAnimator.axFrame(el) {
+            axf = live
+        } else {
+            axf = CGRect(x: entry.frame.x, y: entry.frame.y, width: entry.frame.w, height: entry.frame.h)
+        }
+        return appKitFrame(fromAX: axf)
     }
 
     private func panelLocal(_ global: NSRect) -> NSRect {
@@ -2941,6 +3157,10 @@ private final class MotionPanel: NSPanel {
         for b in app.utf8 { v = (v &* 33) &+ UInt64(b) }
         let hue = CGFloat(v % 360) / 360.0
         return NSColor(hue: hue, saturation: 0.58, brightness: 0.98, alpha: 1)
+    }
+
+    static var selectedChromeColor: NSColor {
+        NSColor(calibratedRed: 0.38, green: 0.92, blue: 1.0, alpha: 1.0)
     }
 
     // MARK: - Legend
@@ -3081,11 +3301,29 @@ private final class MotionPanel: NSPanel {
             self.captureFrame[wid] = self.liveFrame(for: entry)   // remember the size this shot represents
             WindowPreviewStore.shared.ingest(cgImage: cg, for: wid, frame: entry.frame)  // write back to the shared cache
             self.updateStack()
-            if self.exposed { self.rebuildExposeView() }          // a survey tile's capture just landed
+            self.scheduleCaptureRebuild(for: entry)               // a survey tile's capture just landed
             self.checkCapturesSettled()
             // A fresh capture for the aimed window is its fake bring-to-front image.
             if wid == self.activeEntry.wid { self.refreshBorders() }
         }
+    }
+
+    private func scheduleCaptureRebuild(for entry: WindowEntry) {
+        guard exposed, !dismissed else { return }
+        guard let screen = validSurveyScreen(screen(for: entry)) ?? activeSurveyScreen else {
+            rebuildExposeView()
+            return
+        }
+        let id = MotionPanel.screenID(screen)
+        guard captureRebuildWorkItemsByScreenID[id] == nil else { return }
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.captureRebuildWorkItemsByScreenID[id] = nil
+            guard self.exposed, !self.dismissed else { return }
+            self.rebuildExposeView(screens: [screen])
+        }
+        captureRebuildWorkItemsByScreenID[id] = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.035, execute: work)
     }
 
     /// Mark (once) the moment every survey tile has its image — captures done,
@@ -3579,6 +3817,7 @@ struct ExposeView: View {
     var onDrop: (UInt32, PlacementSpec?) -> Void = { _, _ in }
     var onDropGridGroup: ([UInt32], LatticeRes, HoverCell) -> Void = { _, _, _ in }
     var onDropLayer: (UInt32, String) -> Void = { _, _ in }
+    var onDropLayers: ([UInt32], String) -> Void = { _, _ in }
     var onSwap: (UInt32, UInt32) -> Void = { _, _ in }
     var onGridSelection: () -> Void = {}
     var onSwapFirstTwo: () -> Void = {}
@@ -4539,8 +4778,6 @@ struct ExposeView: View {
             else if drag.hoverSurveyWid == t.id { drag.hoverSurveyWid = nil }
         }
         .contextMenu { windowContextMenu(t) }
-        .animation(.easeOut(duration: 0.14), value: linked)
-        .animation(.easeOut(duration: 0.14), value: picked)
     }
 
     private func pickSlot(for wid: UInt32) -> Int? {
@@ -5109,12 +5346,18 @@ struct ExposeView: View {
         return LayoutMetrics(visual: visual, hit: hit)
     }
 
-    // Cross-link: hover from Current View or the survey lattice, plus any plucked picks.
+    // Cross-link: hover from Current View or the survey lattice.
     private var activeLinkWid: UInt32? {
         drag.hoverLayoutWid ?? drag.hoverSurveyWid
     }
 
+    /// Windows that render a screenshot peek in Current View. In-place mode keeps picks
+    /// as lightweight outlines (slot badge + stroke) and only lifts a thumb on hover.
     private var peekWids: Set<UInt32> {
+        if inPlace {
+            if let w = activeLinkWid { return [w] }
+            return []
+        }
         var s = pickedWids
         if let w = activeLinkWid { s.insert(w) }
         return s
@@ -5158,22 +5401,40 @@ struct ExposeView: View {
         let shape = RoundedRectangle(cornerRadius: 2, style: .continuous)
         let stroke: Color = dragged ? HUDChrome.cyan
             : (picked ? Palette.running : (hovered ? .white : tint))
-        let lineW: CGFloat = dragged ? 2 : (picked || hovered ? 1.75 : (behind ? 0.75 : 1))
-        let fillOpacity = dragged ? 0.16 : (picked ? 0.12 : (hovered ? 0.09 : (behind ? 0.02 : 0.05)))
-        let strokeOpacity = dragged ? 1.0 : (behind ? 0.5 : (hovered ? 1.0 : 0.82))
-        return shape
-            .fill(tint.opacity(fillOpacity))
-            .overlay(
-                shape.stroke(
-                    stroke.opacity(strokeOpacity),
-                    style: StrokeStyle(lineWidth: lineW, dash: behind ? [4, 3] : [])
+        let lineW: CGFloat = dragged ? 2
+            : (picked ? (inPlace ? 2.5 : 1.75) : (hovered ? 1.75 : (behind ? 0.75 : 1)))
+        let fillOpacity = dragged ? 0.16
+            : (picked ? (inPlace ? 0.2 : 0.12) : (hovered ? 0.09 : (behind ? 0.02 : 0.05)))
+        let strokeOpacity = dragged ? 1.0
+            : (picked ? 1.0 : (behind ? 0.5 : (hovered ? 1.0 : 0.82)))
+        let dash: [CGFloat] = behind && !picked ? [4, 3] : []
+        return ZStack {
+            if picked && inPlace {
+                shape
+                    .stroke(Palette.running.opacity(0.42), lineWidth: 5)
+                    .blur(radius: 1.5)
+            }
+            shape
+                .fill(tint.opacity(fillOpacity))
+                .overlay(
+                    shape.stroke(
+                        stroke.opacity(strokeOpacity),
+                        style: StrokeStyle(lineWidth: lineW, dash: dash)
+                    )
                 )
-            )
-            .shadow(color: dragged ? HUDChrome.cyan.opacity(0.4)
-                    : (hovered ? tint.opacity(0.35) : .clear),
-                    radius: dragged ? 5 : (hovered ? 4 : 0))
-            .frame(width: rect.width, height: rect.height)
-            .position(x: rect.midX, y: rect.midY)
+                .overlay {
+                    if picked && inPlace {
+                        shape.strokeBorder(Color.white.opacity(0.55), lineWidth: 0.75)
+                    }
+                }
+        }
+        .shadow(color: dragged ? HUDChrome.cyan.opacity(0.4)
+                : (picked && inPlace ? Palette.running.opacity(0.55)
+                   : (hovered ? tint.opacity(0.35) : .clear)),
+                radius: dragged ? 5 : (picked && inPlace ? 7 : (hovered ? 4 : 0)))
+        .scaleEffect(picked && inPlace && !dragged ? 1.04 : 1, anchor: .center)
+        .frame(width: rect.width, height: rect.height)
+        .position(x: rect.midX, y: rect.midY)
     }
 
     // Expanded invisible pad + visual outline + grab affordance. The pad is what you
@@ -5199,10 +5460,17 @@ struct ExposeView: View {
                 } else {
                     currentViewOutlineAt(metrics.visual, m.tint,
                                          picked: picked, hovered: hovered, dragged: lifted, behind: m.behind)
-                        .scaleEffect(hovered && !lifted ? 1.06 : 1, anchor: .center)
+                        .scaleEffect(hovered && !lifted && !picked ? 1.06 : 1, anchor: .center)
                 }
             }
-            .animation(.spring(response: 0.2, dampingFraction: 0.72), value: peeking)
+            if picked && !lifted && !peeking {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: max(8, min(12, metrics.visual.width * 0.22)), weight: .bold))
+                    .foregroundColor(Palette.running)
+                    .shadow(color: .black.opacity(0.5), radius: 2)
+                    .position(x: metrics.visual.maxX - 8, y: metrics.visual.minY + 8)
+                    .allowsHitTesting(false)
+            }
             if hovered && !lifted && !drag.isActive && !peeking {
                 Image(systemName: "arrow.up.forward")
                     .font(.system(size: 9, weight: .bold))
@@ -5212,7 +5480,7 @@ struct ExposeView: View {
                     .allowsHitTesting(false)
             }
         }
-        .opacity(lifted ? 0.3 : (m.behind && !peeking ? 0.72 : 1))
+        .opacity(lifted ? 0.3 : (m.behind && !peeking && !picked ? 0.72 : 1))
         .overlay {
             if lifted {
                 RoundedRectangle(cornerRadius: 2, style: .continuous)
@@ -5795,7 +6063,7 @@ struct ExposeView: View {
         if !wasDragging && dist < 12 {
             onTap()
         } else if let layerKey {
-            for w in dragWids { onDropLayer(w, layerKey) }
+            onDropLayers(dragWids, layerKey)
             if let pulseFrame { drag.firePulse(at: pulseFrame) }
         } else if let cell = gridCell {
             if dragWids.count > 1 {

--- a/apps/mac/Sources/Core/Overlays/Motion/WindowMotionMode.swift
+++ b/apps/mac/Sources/Core/Overlays/Motion/WindowMotionMode.swift
@@ -236,6 +236,22 @@ enum LatticeRes: Int, CaseIterable {
 /// `GridPlacement(column:row:)`.
 struct HoverCell: Equatable { let col: Int; let row: Int }
 
+/// Balanced cell assignments within a lattice grid, anchored at the drop cell.
+/// Short final rows are centered — same logic as `MotionPanel.balancedGrid`.
+private func balancedGridCells(count: Int, latticeCols: Int, latticeRows: Int,
+                               anchorCol: Int, anchorRow: Int) -> [(col: Int, row: Int)]? {
+    guard count > 0 else { return [] }
+    let subCols = max(1, Int(ceil(Double(count).squareRoot())))
+    let subRows = max(1, Int(ceil(Double(count) / Double(subCols))))
+    guard anchorCol + subCols <= latticeCols, anchorRow + subRows <= latticeRows else { return nil }
+    return (0..<count).map { i in
+        let r = i / subCols, c = i % subCols
+        let itemsInRow = min(subCols, count - r * subCols)
+        let xOffset = (subCols - itemsInRow) / 2
+        return (col: anchorCol + xOffset + c, row: anchorRow + r)
+    }
+}
+
 /// Ephemeral drag state for the intent layer. Owned by `MotionPanel` (so it
 /// survives the frequent ExposeView rebuilds) and observed by every screen's
 /// ExposeView. The drag is scoped to one screen via `screenID`; only that screen
@@ -262,6 +278,8 @@ final class HyperspaceDrag: ObservableObject {
     @Published var screenID: String = ""     // which screen owns the in-flight drag
     /// Where the in-flight drag started — survey tile vs Current View outline.
     var dragSource: DragSource?
+    /// Full selection when dragging a picked window (2+); otherwise just the one window.
+    var dragWids: [UInt32] = []
 
     enum DragSource { case survey, currentView }
 
@@ -290,6 +308,7 @@ final class HyperspaceDrag: ObservableObject {
 
     func reset() {
         wid = nil
+        dragWids = []
         image = nil
         dragSource = nil
         hoverCell = nil
@@ -1169,6 +1188,8 @@ private final class MotionPanel: NSPanel {
         return (cols, rows)
     }
 
+
+
     /// Balanced grid: `n` items in ceil(√n) columns, but each row is centered so a
     /// short final row sits in the middle instead of leaving a lopsided blank corner
     /// (e.g. 3 → two on top, one centered below). Returns normalized rects
@@ -1319,6 +1340,22 @@ private final class MotionPanel: NSPanel {
             DiagnosticLog.shared.info("Hyperspace stage — wid=\(wid) location \(placement.wireValue)")
         }
         rebuildExposeView()
+    }
+
+    /// Stage a balanced sub-grid for a multi-window drop onto the lattice, anchored at `anchor`.
+    private func handleGridGroupDrop(_ wids: [UInt32], res: LatticeRes, anchor: HoverCell) {
+        let (cols, rows) = res.dims
+        guard let cells = balancedGridCells(count: wids.count, latticeCols: cols, latticeRows: rows,
+                                            anchorCol: anchor.col, anchorRow: anchor.row) else {
+            NSSound.beep()
+            return
+        }
+        for (i, wid) in wids.enumerated() {
+            let cell = cells[i]
+            guard let gp = GridPlacement(columns: cols, rows: rows, column: cell.col, row: cell.row) else { continue }
+            handleDrop(wid, PlacementSpec.grid(gp))
+        }
+        DiagnosticLog.shared.info("Hyperspace stage — \(wids.count) windows grid @ \(anchor.col),\(anchor.row) (\(res.name))")
     }
 
     /// A tile was dropped on a Layers pile. The ＋ pile stages a brand-new layer; any
@@ -2101,6 +2138,9 @@ private final class MotionPanel: NSPanel {
                 usableInset: MotionPanel.usableInset(of: screen),
                 onPick: { [weak self] wid in self?.exposeToggle(wid, on: screen) },
                 onDrop: { [weak self] wid, spec in self?.handleDrop(wid, spec) },
+                onDropGridGroup: { [weak self] wids, res, anchor in
+                    self?.handleGridGroupDrop(wids, res: res, anchor: anchor)
+                },
                 onDropLayer: { [weak self] wid, key in self?.handleLayerDrop(wid, key) },
                 onSwap: { [weak self] a, b in self?.swapWindows(widA: a, widB: b, on: screen) },
                 onGridSelection: { [weak self] in self?.gatherInPlace(on: screen) },
@@ -3537,6 +3577,7 @@ struct ExposeView: View {
     var usableInset = EdgeInsets()   // full panel(frame) → visibleFrame, so the Place stage clears the menu bar/Dock
     var onPick: (UInt32) -> Void = { _ in }
     var onDrop: (UInt32, PlacementSpec?) -> Void = { _, _ in }
+    var onDropGridGroup: ([UInt32], LatticeRes, HoverCell) -> Void = { _, _, _ in }
     var onDropLayer: (UInt32, String) -> Void = { _, _ in }
     var onSwap: (UInt32, UInt32) -> Void = { _, _ in }
     var onGridSelection: () -> Void = {}
@@ -4416,36 +4457,56 @@ struct ExposeView: View {
         let linked = activeLinkWid == t.id
         let picked = t.pickSlot != nil
         let lit = surveyHighlightWids?.contains(t.id) == true
+        let hasSelection = !pickedWids.isEmpty
+        let dimmed = hasSelection && !picked
         let shape = RoundedRectangle(cornerRadius: 8, style: .continuous)
         let thumbW: CGFloat = 72
         let thumbH: CGFloat = 44
         return HStack(spacing: 8) {
+            if picked {
+                RoundedRectangle(cornerRadius: 2, style: .continuous)
+                    .fill(Palette.running)
+                    .frame(width: 3, height: thumbH)
+            }
             ZStack {
-                shape.fill(t.tint.opacity(0.22))
+                shape.fill(t.tint.opacity(picked ? 0.32 : 0.22))
                 if let img = t.image {
                     Image(nsImage: img).resizable().aspectRatio(contentMode: .fill)
+                }
+                if picked {
+                    shape.fill(Palette.running.opacity(0.12))
                 }
             }
             .frame(width: thumbW, height: thumbH)
             .clipShape(shape)
-            .overlay(shape.strokeBorder(linked ? HUDChrome.cyan : t.tint.opacity(0.55), lineWidth: linked ? 2 : 0.75))
+            .overlay(shape.strokeBorder(
+                linked ? HUDChrome.cyan
+                    : (picked ? Palette.running : t.tint.opacity(0.55)),
+                lineWidth: linked ? 2 : (picked ? 2 : 0.75)))
             VStack(alignment: .leading, spacing: 2) {
                 Text(t.app)
                     .font(Typo.monoBold(10))
-                    .foregroundColor(.white)
+                    .foregroundColor(picked ? .white : .white.opacity(dimmed ? 0.65 : 1))
                     .lineLimit(1)
                 Text(t.title)
                     .font(Typo.mono(8.5))
-                    .foregroundColor(Palette.textMuted)
+                    .foregroundColor(picked ? Palette.running.opacity(0.9) : Palette.textMuted)
                     .lineLimit(1)
             }
             Spacer(minLength: 0)
-            if let slot = t.pickSlot {
-                Text("\(slot)")
-                    .font(Typo.monoBold(9))
-                    .foregroundColor(Palette.bg)
-                    .padding(.horizontal, 5).padding(.vertical, 2)
-                    .background(Capsule().fill(Palette.running))
+            if picked {
+                HStack(spacing: 4) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(Palette.running)
+                    if let slot = t.pickSlot {
+                        Text("\(slot)")
+                            .font(Typo.monoBold(9))
+                            .foregroundColor(Palette.bg)
+                            .padding(.horizontal, 5).padding(.vertical, 2)
+                            .background(Capsule().fill(Palette.running))
+                    }
+                }
             } else if inPlace, !t.hint.isEmpty {
                 Text(t.hint)
                     .font(Typo.monoBold(9))
@@ -4457,12 +4518,14 @@ struct ExposeView: View {
         .padding(.horizontal, 6).padding(.vertical, 5)
         .background(
             RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .fill(lit ? Color.white.opacity(0.08) : Color.white.opacity(0.03))
+                .fill(picked ? Palette.running.opacity(0.14)
+                      : (lit ? Color.white.opacity(0.08) : Color.white.opacity(0.03)))
                 .overlay(RoundedRectangle(cornerRadius: 10, style: .continuous)
                     .strokeBorder(linked ? HUDChrome.cyan.opacity(0.7)
-                                    : (picked ? Palette.running.opacity(0.5) : Palette.border),
-                                  lineWidth: linked ? 1.5 : 0.5))
+                                    : (picked ? Palette.running.opacity(0.75) : Palette.border),
+                                  lineWidth: linked ? 1.5 : (picked ? 1.5 : 0.5)))
         )
+        .opacity(dimmed ? 0.48 : 1)
         .contentShape(Rectangle())
         .highPriorityGesture(TapGesture().onEnded { onPick(t.id) })
         .gesture(
@@ -4477,6 +4540,11 @@ struct ExposeView: View {
         }
         .contextMenu { windowContextMenu(t) }
         .animation(.easeOut(duration: 0.14), value: linked)
+        .animation(.easeOut(duration: 0.14), value: picked)
+    }
+
+    private func pickSlot(for wid: UInt32) -> Int? {
+        pickedOrder.firstIndex(of: wid).map { $0 + 1 }
     }
 
     @ViewBuilder
@@ -5155,6 +5223,17 @@ struct ExposeView: View {
                     .allowsHitTesting(false)
             }
         }
+        .overlay(alignment: .topLeading) {
+            if picked, let slot = pickSlot(for: m.id), !lifted {
+                Text("\(slot)")
+                    .font(Typo.monoBold(8))
+                    .foregroundColor(Palette.bg)
+                    .padding(.horizontal, 4).padding(.vertical, 1)
+                    .background(Capsule().fill(Palette.running))
+                    .position(x: metrics.visual.minX + 10, y: metrics.visual.minY + 8)
+                    .allowsHitTesting(false)
+            }
+        }
         .zIndex(peeking ? 100 : (hovered || picked ? 10 : (m.behind ? 0 : 1)))
         .onHover { over in
             if over {
@@ -5208,8 +5287,12 @@ struct ExposeView: View {
     }
 
     private var currentViewSub: String {
-        if drag.isActive, drag.screenID == screenID, drag.dragSource == .currentView {
-            return drag.hoverGrid ? "release on cell" : "drag to grid →"
+        if drag.isActive, drag.screenID == screenID {
+            let n = drag.dragWids.count
+            if drag.hoverGrid || drag.hoverCell != nil {
+                return n > 1 ? "release \(n) on cell" : "release on cell"
+            }
+            return n > 1 ? "drag \(n) to grid →" : "drag to grid →"
         }
         if !pickedOrder.isEmpty { return "\(pickedOrder.count) selected" }
         if inPlace { return inPlaceCommandsVisible ? "shortcuts" : "hover for shortcuts" }
@@ -5321,11 +5404,14 @@ struct ExposeView: View {
     // Dropping a window on a cell stages that position.
     private var gridSection: some View {
         let draggingHere = dragOnThisScreen && drag.isActive
+        let dragN = drag.dragWids.count
         let sub: String = {
             guard draggingHere else { return "drop a position" }
-            if drag.hoverCell != nil { return "release here" }
-            if drag.hoverGrid { return "pick a cell" }
-            return "drop here"
+            if drag.hoverCell != nil {
+                return dragN > 1 ? "release \(dragN) here" : "release here"
+            }
+            if drag.hoverGrid { return dragN > 1 ? "pick anchor cell" : "pick a cell" }
+            return dragN > 1 ? "drop \(dragN) here" : "drop here"
         }()
         let armed = dragOnThisScreen && drag.isActive && (drag.hoverCell != nil || drag.hoverGrid)
         return sectionCard(title: "Grid", icon: "rectangle.split.2x2", sub: sub,
@@ -5578,6 +5664,16 @@ struct ExposeView: View {
             .scaleEffect(armed ? 0.62 : 1, anchor: .center)
             .opacity(armed ? 1 : 0.92)
             .animation(.spring(response: 0.22, dampingFraction: 0.72), value: armed)
+            .overlay(alignment: .topTrailing) {
+                if drag.dragWids.count > 1 {
+                    Text("\(drag.dragWids.count)")
+                        .font(Typo.monoBold(10))
+                        .foregroundColor(Palette.bg)
+                        .padding(.horizontal, 6).padding(.vertical, 3)
+                        .background(Capsule().fill(Palette.running))
+                        .offset(x: 8, y: -8)
+                }
+            }
             .position(drag.location)
             .allowsHitTesting(false)
         }
@@ -5623,6 +5719,11 @@ struct ExposeView: View {
             .onEnded { handleLayoutDragEnd(m, $0) }
     }
 
+    private func dragWidsFor(_ wid: UInt32) -> [UInt32] {
+        if pickedWids.contains(wid), pickedOrder.count >= 2 { return pickedOrder }
+        return [wid]
+    }
+
     private func handleDragChange(wid: UInt32, image: NSImage?, ghostTint: Color? = nil,
                                   source: HyperspaceDrag.DragSource,
                                   tileW: CGFloat, tileH: CGFloat, _ v: DragGesture.Value) {
@@ -5631,6 +5732,7 @@ struct ExposeView: View {
         if drag.wid == nil {
             guard dist >= 10 else { return }
             drag.wid = wid
+            drag.dragWids = dragWidsFor(wid)
             drag.image = image
             drag.ghostTint = image == nil ? ghostTint : nil
             drag.screenID = screenID
@@ -5659,20 +5761,33 @@ struct ExposeView: View {
                                onTap: () -> Void, _ v: DragGesture.Value) {
         let dist = hypot(v.translation.width, v.translation.height)
         let wasDragging = drag.wid != nil
+        let dragWids = drag.dragWids.isEmpty ? [wid] : drag.dragWids
         // Resolve the drop target before reset() clears the hover state. Priority:
         // Grid cell → layer pile → miss.
-        var spec: PlacementSpec?
+        var gridCell: HoverCell?
         var pulseFrame: CGRect?
         if wasDragging,
            let frame = drag.latticeFrames[screenID], frame.contains(v.location),
            let cell = drag.hoverCell {
+            gridCell = cell
             let (cols, rows) = drag.res.dims
-            spec = GridPlacement(columns: cols, rows: rows, column: cell.col, row: cell.row).map(PlacementSpec.grid)
             let cw = frame.width / CGFloat(cols), ch = frame.height / CGFloat(rows)
-            pulseFrame = CGRect(x: frame.minX + CGFloat(cell.col) * cw,
-                                y: frame.minY + CGFloat(cell.row) * ch, width: cw, height: ch)
+            if dragWids.count > 1,
+               let cells = balancedGridCells(count: dragWids.count, latticeCols: cols, latticeRows: rows,
+                                             anchorCol: cell.col, anchorRow: cell.row),
+               let last = cells.last {
+                let spanCols = last.col - cell.col + 1
+                let spanRows = last.row - cell.row + 1
+                pulseFrame = CGRect(x: frame.minX + CGFloat(cell.col) * cw,
+                                    y: frame.minY + CGFloat(cell.row) * ch,
+                                    width: cw * CGFloat(spanCols), height: ch * CGFloat(spanRows))
+            } else {
+                pulseFrame = CGRect(x: frame.minX + CGFloat(cell.col) * cw,
+                                    y: frame.minY + CGFloat(cell.row) * ch, width: cw, height: ch)
+            }
         }
-        let layerKey = (wasDragging && spec == nil) ? drag.hoverLayer : nil
+        let layerKey = (wasDragging && gridCell == nil) ? drag.hoverLayer : nil
+        let dropRes = drag.res
         if let layerKey { pulseFrame = drag.layerFrames[screenID]?[layerKey] }
         let fromLayout = drag.dragSource == .currentView
         drag.reset()
@@ -5680,11 +5795,19 @@ struct ExposeView: View {
         if !wasDragging && dist < 12 {
             onTap()
         } else if let layerKey {
-            onDropLayer(wid, layerKey)
+            for w in dragWids { onDropLayer(w, layerKey) }
+            if let pulseFrame { drag.firePulse(at: pulseFrame) }
+        } else if let cell = gridCell {
+            if dragWids.count > 1 {
+                onDropGridGroup(dragWids, dropRes, cell)
+            } else {
+                let (cols, rows) = dropRes.dims
+                let spec = GridPlacement(columns: cols, rows: rows, column: cell.col, row: cell.row).map(PlacementSpec.grid)
+                onDrop(wid, spec)
+            }
             if let pulseFrame { drag.firePulse(at: pulseFrame) }
         } else {
-            onDrop(wid, spec)
-            if spec != nil, let pulseFrame { drag.firePulse(at: pulseFrame) }
+            onDrop(wid, nil)
         }
     }
 
@@ -5980,10 +6103,12 @@ struct ExposeView: View {
 
     @ViewBuilder
     private func inPlaceLayerMenu(_ t: Tile) -> some View {
-        let joinable = layers.filter { !$0.isNew }
-        if !joinable.isEmpty {
-            Divider()
-            Menu("Add to Layer") {
+        Divider()
+        Menu("Add to Layer", systemImage: "square.stack.3d.up") {
+            Button("New Layer") { onNewLayer() }
+            let joinable = layers.filter { !$0.isNew }
+            if !joinable.isEmpty {
+                Divider()
                 ForEach(joinable) { p in
                     Button(p.name) { onDropLayer(t.id, p.id) }
                 }

--- a/apps/mac/Sources/Core/Overlays/UnifiedCommandBar/UnifiedCommandBarView.swift
+++ b/apps/mac/Sources/Core/Overlays/UnifiedCommandBar/UnifiedCommandBarView.swift
@@ -482,7 +482,7 @@ struct UnifiedCommandBarView: View {
 
     private var voiceRetryable: Bool {
         let result = state.voice.executionResult ?? ""
-        return result == "No speech detected" || result == "Transcription failed"
+        return VoiceCommandState.isRetryableFailure(result)
     }
 
     private var settingsButton: some View {

--- a/apps/mac/Sources/Core/Overlays/UnifiedCommandBar/UnifiedCommandBarWindow.swift
+++ b/apps/mac/Sources/Core/Overlays/UnifiedCommandBar/UnifiedCommandBarWindow.swift
@@ -352,7 +352,7 @@ final class UnifiedCommandBarWindow {
 
     private func voiceResultCanRetry(_ voice: VoiceCommandState) -> Bool {
         let result = voice.executionResult ?? ""
-        return result == "No speech detected" || result == "Transcription failed"
+        return VoiceCommandState.isRetryableFailure(result)
     }
 
     // MARK: - Natural-language command
@@ -406,10 +406,13 @@ final class UnifiedCommandBarWindow {
     /// (slash stripped so a command-mode "/x" reads as plain "x").
     private func assistantPrompt() -> String {
         guard let st = state else { return "" }
-        if st.voiceActive { return st.voice.finalText }
+        if st.voiceActive {
+            return st.voice.assistantHandoffPrompt
+                ?? IntentHeuristics.assistantPromptText(st.voice.finalText)
+        }
         var q = st.query
         if q.hasPrefix("/") { q.removeFirst() }
-        return q
+        return IntentHeuristics.assistantPromptText(q)
     }
 
     /// Open the `.pi` assistant and stream the prompt; the bar steps aside.
@@ -423,13 +426,29 @@ final class UnifiedCommandBarWindow {
         }
     }
 
+    /// Reveal the assistant for a voice prompt that `AudioLayer` has already
+    /// queued into `WorkspaceAssistantSession`.
+    private func showAssistantForQueuedVoiceHandoff() {
+        dismiss()
+        DispatchQueue.main.async {
+            ScreenMapWindowController.shared.showAssistant()
+        }
+    }
+
     /// A conversational voice utterance (a question with no workspace action ran)
     /// is handed to the assistant rather than answered headlessly in the bar.
     private func maybeEscalateVoiceQuestion() {
         guard let st = state, st.voice.phase == .result,
-              st.voice.intentName == nil,
-              IntentHeuristics.shouldAskAssistant(st.voice.finalText) else { return }
-        handToAssistant(st.voice.finalText)
+              st.voice.intentName == nil else { return }
+
+        if let prompt = st.voice.assistantHandoffPrompt,
+           !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            showAssistantForQueuedVoiceHandoff()
+            return
+        }
+
+        guard IntentHeuristics.shouldAskAssistant(st.voice.finalText) else { return }
+        handToAssistant(IntentHeuristics.assistantPromptText(st.voice.finalText))
     }
 
     /// Tab-to-complete: fill the field with the highlighted suggestion fully

--- a/apps/mac/Sources/Core/Overlays/Voice/VoiceComponents.swift
+++ b/apps/mac/Sources/Core/Overlays/Voice/VoiceComponents.swift
@@ -55,6 +55,7 @@ final class VoiceCommandState: ObservableObject {
 
     // Agent advisor response
     @Published var agentResponse: AgentResponse?
+    @Published var assistantHandoffPrompt: String?
 
     // Listening timer
     @Published var listenStartTime: Date = Date()
@@ -70,29 +71,53 @@ final class VoiceCommandState: ObservableObject {
     private var cancelled = false
 
     func startListening() {
-        // Capture runs through AudioLayer; this gate only lets the overlay show a
-        // "connecting" phase while the embedded voice runtime becomes discoverable.
-        if AudioLayer.shared.provider?.isAvailable == true {
-            beginListening()
-        } else {
-            phase = .connecting
-            waitForVoiceRuntime(attempts: 0)
-        }
+        // Capture runs through AudioLayer; this gate only lets the overlay enter
+        // listening once the Vox/HudsonVoice socket is actually reachable.
+        cancelled = false
+        phase = .connecting
+        executionResult = "Connecting to voice runtime..."
+        waitForVoiceRuntime(attempts: 0)
     }
 
     private func waitForVoiceRuntime(attempts: Int) {
-        if AudioLayer.shared.provider?.isAvailable == true {
-            beginListening()
-        } else if attempts < 20 {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-                self?.waitForVoiceRuntime(attempts: attempts + 1)
-            }
-        } else {
-            appendLog("Voice runtime not running")
-            executionResult = "Voice runtime not running — try again after it starts."
-            resultSummary = executionResult ?? ""
+        guard !cancelled else { return }
+        guard let provider = AudioLayer.shared.provider else {
+            let message = "No voice provider available"
+            appendLog(message)
+            executionResult = message
+            resultSummary = message
             syncLogs()
             phase = .result
+            return
+        }
+
+        guard provider.isAvailable else {
+            retryOrFailVoiceRuntime(provider: provider, attempts: attempts)
+            return
+        }
+
+        provider.checkHealth { [weak self] ok in
+            guard let self, !self.cancelled else { return }
+            if ok {
+                self.beginListening()
+            } else {
+                self.retryOrFailVoiceRuntime(provider: provider, attempts: attempts)
+            }
+        }
+    }
+
+    private func retryOrFailVoiceRuntime(provider: any AudioProvider, attempts: Int) {
+        guard attempts < 20 else {
+            let message = provider.lastErrorMessage ?? "Voice runtime not running - try again after it starts."
+            appendLog(message)
+            executionResult = message
+            resultSummary = message
+            syncLogs()
+            phase = .result
+            return
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            self?.waitForVoiceRuntime(attempts: attempts + 1)
         }
     }
 
@@ -109,6 +134,7 @@ final class VoiceCommandState: ObservableObject {
         resultItems = []
         resultSummary = ""
         agentResponse = nil
+        assistantHandoffPrompt = nil
         // Snapshot log position and observe changes reactively (no polling race)
         logSnapshot = DiagnosticLog.shared.entries.count
         logLines = []
@@ -216,6 +242,7 @@ final class VoiceCommandState: ObservableObject {
         resultSummary = entry.resultItems.isEmpty ? "" : "\(entry.resultItems.count) result\(entry.resultItems.count == 1 ? "" : "s")"
         logLines = entry.logLines
         agentResponse = nil
+        assistantHandoffPrompt = nil
         phase = .result
     }
 
@@ -256,6 +283,8 @@ final class VoiceCommandState: ObservableObject {
                 self.agentResponse = resp
             }
 
+            self.assistantHandoffPrompt = audio.assistantHandoffPrompt
+
             // Mirror any execution failure so the UI can flag it
             self.executionError = audio.executionError
         }
@@ -269,27 +298,11 @@ final class VoiceCommandState: ObservableObject {
 
             let result = audio.executionResult
 
-            // Terminal errors — log them, go to idle (not a separate error phase)
-            if result == "No speech detected" {
-                appendLog("No speech detected")
-                self.executionResult = result
-                self.resultSummary = "No speech detected — try again."
-                syncLogs()
-                self.phase = .result
-                return
-            }
-            if result == "Transcription failed" {
-                appendLog("Transcription failed")
-                self.executionResult = result
-                self.resultSummary = "Transcription failed — try again."
-                syncLogs()
-                self.phase = .result
-                return
-            }
-            if let result, result.hasPrefix("Mic in use") {
+            // Terminal errors — log them, go to result (not a separate error phase)
+            if let result, Self.isRetryableFailure(result) {
                 appendLog(result)
                 self.executionResult = result
-                self.resultSummary = result
+                self.resultSummary = Self.failureSummary(result)
                 syncLogs()
                 self.phase = .result
                 return
@@ -492,6 +505,25 @@ final class VoiceCommandState: ObservableObject {
         case "session-locator": return "session locator"
         case "app-launch": return "app launch"
         default: return resolution.replacingOccurrences(of: "-", with: " ")
+        }
+    }
+
+    static func isRetryableFailure(_ result: String) -> Bool {
+        result == "No speech detected"
+            || result == "Transcription failed"
+            || result.hasPrefix("Transcription failed:")
+            || result.hasPrefix("Voice runtime")
+            || result.hasPrefix("Mic in use")
+    }
+
+    static func failureSummary(_ result: String) -> String {
+        switch result {
+        case "No speech detected":
+            return "No speech detected - try again."
+        case "Transcription failed":
+            return "Transcription failed - try again."
+        default:
+            return result
         }
     }
 }

--- a/apps/mac/Sources/Core/Pi/WorkspaceAssistantSession.swift
+++ b/apps/mac/Sources/Core/Pi/WorkspaceAssistantSession.swift
@@ -326,7 +326,7 @@ final class WorkspaceAssistantSession: ObservableObject {
 
     private static let dockHeightDefaultsKey = "PiChatDockHeight"
 
-    #if canImport(HudsonVoice)
+    #if LATTICES_VOICE && canImport(HudsonVoice)
     /// Drains finalized voice transcripts from the Hudson-powered mic into the composer draft.
     private var voiceInputCancellable: AnyCancellable?
     #endif
@@ -358,7 +358,7 @@ final class WorkspaceAssistantSession: ObservableObject {
         refreshBinaryAvailability()
         cleanupLingeringAuthHelpers()
 
-        #if canImport(HudsonVoice)
+        #if LATTICES_VOICE && canImport(HudsonVoice)
         // Splice finalized voice transcripts into the draft (one-shot, then drain),
         // mirroring OpenScout's HUDDockState lastFinalText subscription.
         voiceInputCancellable = WorkspaceVoiceInput.shared.$lastFinalText

--- a/apps/mac/Sources/Core/Pi/WorkspaceAssistantUI.swift
+++ b/apps/mac/Sources/Core/Pi/WorkspaceAssistantUI.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 import HudsonUI
-#if canImport(HudsonVoice)
+#if LATTICES_VOICE && canImport(HudsonVoice)
 import HudsonVoice
 #endif
 
@@ -491,14 +491,14 @@ struct WorkspaceAssistantComposer: View {
     var style: WorkspaceAssistantStyle = .workspace
     var focus: FocusState<Bool>.Binding
 
-    #if canImport(HudsonVoice)
+    #if LATTICES_VOICE && canImport(HudsonVoice)
     @ObservedObject private var voice = WorkspaceVoiceInput.shared
     @State private var micPulse = false
     #endif
 
     var body: some View {
         VStack(spacing: 7) {
-            #if canImport(HudsonVoice)
+            #if LATTICES_VOICE && canImport(HudsonVoice)
             if voice.state.isCaptureActive || voice.state.isProcessing {
                 dictationStrip
             }
@@ -558,14 +558,14 @@ struct WorkspaceAssistantComposer: View {
     /// exists; attachments stay hidden until the chat path wires them.
     @ViewBuilder
     private var micAccessory: some View {
-        #if canImport(HudsonVoice)
+        #if LATTICES_VOICE && canImport(HudsonVoice)
         micButton
         #else
         EmptyView()
         #endif
     }
 
-    #if canImport(HudsonVoice)
+    #if LATTICES_VOICE && canImport(HudsonVoice)
     /// HudsonVoice-powered mic. Tap to dictate into the draft; tap again to commit.
     /// Filled-circle states (after OpenScout's ScoutMicButton): a soft halo breathes
     /// while recording; the glyph, fill, and ring track idle/recording/processing.

--- a/apps/mac/Sources/Core/Pi/WorkspaceVoiceInput.swift
+++ b/apps/mac/Sources/Core/Pi/WorkspaceVoiceInput.swift
@@ -1,6 +1,6 @@
 import Combine
 import Foundation
-#if canImport(HudsonVoice)
+#if LATTICES_VOICE && canImport(HudsonVoice)
 import HudsonVoice
 #endif
 
@@ -42,7 +42,7 @@ enum WorkspaceDictationBuffer {
     }
 }
 
-#if canImport(HudsonVoice)
+#if LATTICES_VOICE && canImport(HudsonVoice)
 
 /// One-session-at-a-time dictation controller backed by HudVoxLiveSession.
 /// Tap the mic to start; tap again to commit and surface the transcript on

--- a/apps/mac/Sources/Core/System/DiagnosticLog.swift
+++ b/apps/mac/Sources/Core/System/DiagnosticLog.swift
@@ -131,6 +131,7 @@ final class AppFeedback {
         guard let url = Bundle.main.url(forResource: "tap", withExtension: "wav") else { return nil }
         return NSSound(contentsOf: url, byReference: true)
     }()
+    private var didWarmTapSound = false
 
     private init() {}
 
@@ -166,11 +167,52 @@ final class AppFeedback {
         playTap()
     }
 
+    func warmUp() {
+        runOnMain { self.warmUpTapSoundOnMain() }
+    }
+
+    func warmUpTapSound() {
+        warmUp()
+    }
+
+    func commitTactile() {
+        runOnMain {
+            NSHapticFeedbackManager.defaultPerformer.perform(.alignment, performanceTime: .now)
+            self.playPreparedTapOnMain()
+        }
+    }
+
     private func playTap() {
         DispatchQueue.main.async {
             self.tapSound?.stop()
             self.tapSound?.play()
         }
+    }
+
+    private func runOnMain(_ work: @escaping () -> Void) {
+        if Thread.isMainThread {
+            work()
+        } else {
+            DispatchQueue.main.async(execute: work)
+        }
+    }
+
+    private func warmUpTapSoundOnMain() {
+        guard !didWarmTapSound, let sound = tapSound else { return }
+        didWarmTapSound = true
+        let volume = sound.volume
+        sound.volume = 0
+        sound.currentTime = 0
+        sound.play()
+        sound.stop()
+        sound.currentTime = 0
+        sound.volume = volume
+    }
+
+    private func playPreparedTapOnMain() {
+        guard let sound = tapSound else { return }
+        sound.currentTime = 0
+        sound.play()
     }
 }
 

--- a/apps/mac/Sources/Core/Voice/AudioProvider.swift
+++ b/apps/mac/Sources/Core/Voice/AudioProvider.swift
@@ -1,5 +1,5 @@
 import AppKit
-#if canImport(HudsonVoice)
+#if LATTICES_VOICE && canImport(HudsonVoice)
 import HudsonVoice
 #endif
 
@@ -11,6 +11,7 @@ import HudsonVoice
 protocol AudioProvider: AnyObject {
     var isAvailable: Bool { get }
     var isListening: Bool { get }
+    var lastErrorMessage: String? { get }
 
     /// Start listening. Transcription arrives via the callback.
     func startListening(onTranscript: @escaping (Transcription) -> Void)
@@ -46,12 +47,13 @@ final class AudioLayer: ObservableObject {
     @Published var provider: (any AudioProvider)?
     @Published var providerName: String = "none"
     @Published var agentResponse: AgentResponse?
+    @Published var assistantHandoffPrompt: String?
 
     private var pendingVoiceStart = false
     private var voiceConnectionRetry: DispatchWorkItem?
 
     private init() {
-        #if canImport(HudsonVoice)
+        #if LATTICES_VOICE && canImport(HudsonVoice)
         provider = HudVoxAudioProvider()
         providerName = "hudson-voice"
         #else
@@ -75,6 +77,7 @@ final class AudioLayer: ObservableObject {
         executionData = nil
         executionError = nil
         agentResponse = nil
+        assistantHandoffPrompt = nil
         didExecuteIntent = false
         DiagnosticLog.shared.info("AudioLayer: voice capture starting")
 
@@ -91,15 +94,6 @@ final class AudioLayer: ObservableObject {
     private func startVoiceCommandWhenReady(provider: any AudioProvider, attempt: Int) {
         guard pendingVoiceStart, !isListening else { return }
 
-        // `isAvailable` reflects whether a HudsonVoice endpoint can be resolved.
-        // Health/session errors still surface from HudsonVoice when capture starts.
-        if provider.isAvailable {
-            pendingVoiceStart = false
-            DiagnosticLog.shared.info("AudioLayer: voice provider ready")
-            beginVoiceCommand(provider: provider)
-            return
-        }
-
         if attempt == 0 {
             executionResult = "Connecting to voice runtime..."
         }
@@ -107,10 +101,28 @@ final class AudioLayer: ObservableObject {
         guard attempt < 40 else {
             pendingVoiceStart = false
             DiagnosticLog.shared.warn("AudioLayer: voice runtime not reachable before voice start")
-            setFinalResult("Voice runtime unavailable", warning: true)
+            setFinalResult(provider.lastErrorMessage ?? "Voice runtime unavailable", warning: true)
             return
         }
 
+        guard provider.isAvailable else {
+            scheduleVoiceStartRetry(provider: provider, attempt: attempt)
+            return
+        }
+
+        provider.checkHealth { [weak self] ok in
+            guard let self, self.pendingVoiceStart, !self.isListening else { return }
+            guard ok else {
+                self.scheduleVoiceStartRetry(provider: provider, attempt: attempt)
+                return
+            }
+            self.pendingVoiceStart = false
+            DiagnosticLog.shared.info("AudioLayer: voice provider ready")
+            self.beginVoiceCommand(provider: provider)
+        }
+    }
+
+    private func scheduleVoiceStartRetry(provider: any AudioProvider, attempt: Int) {
         let retry = DispatchWorkItem { [weak self] in
             guard let self else { return }
             self.startVoiceCommandWhenReady(provider: provider, attempt: attempt + 1)
@@ -181,7 +193,8 @@ final class AudioLayer: ObservableObject {
                     DiagnosticLog.shared.info("AudioLayer: heard final transcript — \(t.text)")
                     EventBus.shared.post(.voiceCommand(text: t.text, confidence: t.confidence))
                     self.executeVoiceIntent(t)
-                } else if !self.didExecuteIntent {
+                } else if !self.didExecuteIntent,
+                          self.executionResult == nil || self.executionResult == "Transcribing..." {
                     self.setFinalResult("No speech detected", warning: true)
                 }
             }
@@ -191,15 +204,24 @@ final class AudioLayer: ObservableObject {
     private func executeVoiceIntent(_ transcription: Transcription) {
         didExecuteIntent = true
         let matcher = PhraseMatcher.shared
+        let text = transcription.text
 
         // Clear previous agent response + any stale failure flag
         agentResponse = nil
         executionError = nil
         executionData = nil
+        assistantHandoffPrompt = nil
 
         DiagnosticLog.shared.info("AudioLayer: resolving voice request")
 
-        if let match = matcher.match(text: transcription.text) {
+        if let prompt = IntentHeuristics.assistantWakePrompt(text) {
+            DiagnosticLog.shared.info("AudioLayer: route → Assistant wake word")
+            matchedIntent = nil
+            matchedSlots = [:]
+            executionResult = "thinking..."
+            handoffToAssistant(prompt: prompt)
+
+        } else if let match = matcher.match(text: text) {
             DiagnosticLog.shared.info("AudioLayer: route → local intent")
             matchedIntent = match.intentName
             matchConfidence = match.confidence
@@ -220,16 +242,16 @@ final class AudioLayer: ObservableObject {
             }
 
             // Fire parallel provider-backed advisor for 5+ word utterances.
-            fireAdvisor(transcript: transcription.text, matched: "\(match.intentName)(\(matchedSlots))")
+            fireAdvisor(transcript: text, matched: "\(match.intentName)(\(matchedSlots))")
 
-        } else if shouldAnswerWithAssistant(transcription.text) {
+        } else if shouldAnswerWithAssistant(text) {
             DiagnosticLog.shared.info("AudioLayer: route → Assistant question")
-            DiagnosticLog.shared.info("AudioLayer: question-like voice request, asking Assistant provider")
+            DiagnosticLog.shared.info("AudioLayer: question-like voice request, handing to Assistant")
             matchedIntent = nil
             matchedSlots = [:]
             executionResult = "thinking..."
             executionData = nil
-            assistantQuestion(transcription: transcription)
+            handoffToAssistant(prompt: IntentHeuristics.assistantPromptText(text))
 
         } else {
             // No local match — ask the selected Assistant provider.
@@ -277,7 +299,7 @@ final class AudioLayer: ObservableObject {
             guard let self else { return }
             guard let resolved else {
                 DiagnosticLog.shared.info("AudioLayer: Assistant provider returned no intent")
-                self.setFinalResult("Assistant couldn't resolve an action for that request", warning: true)
+                self.handoffToAssistant(prompt: IntentHeuristics.assistantPromptText(transcription.text))
                 return
             }
 
@@ -357,27 +379,21 @@ final class AudioLayer: ObservableObject {
         setFinalResult("Couldn't run: \(message)", error: message, warning: true)
     }
 
-    private func assistantQuestion(transcription: Transcription) {
-        let assistant = WorkspaceAssistantSession.shared
-        guard assistant.isProviderInferenceReady else {
-            DiagnosticLog.shared.info("AudioLayer: Assistant provider not ready for question")
-            setFinalResult("Connect an Assistant provider in Settings", warning: true)
+    private func handoffToAssistant(prompt rawPrompt: String) {
+        let prompt = IntentHeuristics.assistantPromptText(rawPrompt)
+        guard !prompt.isEmpty else {
+            setFinalResult("Assistant prompt was empty", warning: true)
             return
         }
 
-        assistant.answerVoiceQuestion(transcription.text) { [weak self] response in
-            guard let self else { return }
-            guard let response else {
-                DiagnosticLog.shared.info("AudioLayer: Assistant provider returned no answer")
-                self.setFinalResult("Assistant couldn't answer that question", warning: true)
-                return
-            }
-            self.agentResponse = response
-            if let commentary = response.commentary {
-                DiagnosticLog.shared.info("AudioLayer: Assistant answered — \(commentary.prefix(160))")
-            }
-            self.setFinalResult("Answered as a question; no workspace action ran.")
-        }
+        assistantHandoffPrompt = prompt
+        matchedIntent = nil
+        matchedSlots = [:]
+        executionError = nil
+        executionData = nil
+        DiagnosticLog.shared.info("AudioLayer: handing voice transcript to Assistant")
+        WorkspaceAssistantSession.shared.send(prompt)
+        setFinalResult("Sent to Assistant")
     }
 
     // Question-vs-command classification lives in `IntentHeuristics` so the typed
@@ -521,7 +537,7 @@ final class AudioLayer: ObservableObject {
 // `VoxClient` WebSocket). HudsonVoice opens its own socket per capture rather
 // than holding one open.
 
-#if canImport(HudsonVoice)
+#if LATTICES_VOICE && canImport(HudsonVoice)
 final class HudVoxAudioProvider: AudioProvider {
     private var session: HudVoxLiveSession?
     private var pumpTask: Task<Void, Never>?
@@ -529,21 +545,36 @@ final class HudVoxAudioProvider: AudioProvider {
     private var stopCompletion: ((Transcription?) -> Void)?
     private var _isListening = false
     private var finalDelivered = false
+    private var lastProviderError: String?
 
     var isAvailable: Bool { HudsonVoiceRuntimeResolver.resolve(clientId: "lattices") != nil }
     var isListening: Bool { _isListening }
+    var lastErrorMessage: String? { lastProviderError }
 
     func checkHealth(completion: @escaping (Bool) -> Void) {
         guard let runtime = HudsonVoiceRuntimeResolver.resolve(clientId: "lattices") else {
+            lastProviderError = "Voice runtime unavailable"
             completion(false)
             return
         }
         Task {
-            let ok = (try? await HudVoxProbe.health(
-                endpoint: runtime.endpoint,
-                clientId: runtime.options.clientId
-            )) != nil
-            await MainActor.run { completion(ok) }
+            do {
+                _ = try await HudVoxProbe.health(
+                    endpoint: runtime.endpoint,
+                    clientId: runtime.options.clientId
+                )
+                await MainActor.run {
+                    self.lastProviderError = nil
+                    completion(true)
+                }
+            } catch {
+                let message = Self.voiceRuntimeMessage(for: error, endpoint: runtime.endpoint)
+                await MainActor.run {
+                    self.lastProviderError = message
+                    DiagnosticLog.shared.warn("HudVoxAudioProvider: health check failed — \(message)")
+                    completion(false)
+                }
+            }
         }
     }
 
@@ -557,6 +588,9 @@ final class HudVoxAudioProvider: AudioProvider {
             DiagnosticLog.shared.warn("HudVoxAudioProvider: cannot start because HudsonVoice runtime is unavailable")
             _isListening = false
             self.onTranscript = nil
+            lastProviderError = "Voice runtime unavailable"
+            AudioLayer.shared.setFinalResult("Voice runtime unavailable", warning: true)
+            onTranscript(Transcription(text: "", confidence: 0, source: "hudson-voice", isPartial: false, durationMs: nil))
             return
         }
         let endpoint = runtime.endpoint
@@ -632,8 +666,10 @@ final class HudVoxAudioProvider: AudioProvider {
         _isListening = false
         if !finalDelivered {
             if let error {
-                DiagnosticLog.shared.warn("HudVoxAudioProvider: session error — \(error.localizedDescription)")
-                AudioLayer.shared.setFinalResult("Transcription failed", warning: true)
+                let message = Self.voiceRuntimeMessage(for: error)
+                lastProviderError = message
+                DiagnosticLog.shared.warn("HudVoxAudioProvider: session error — \(message)")
+                AudioLayer.shared.setFinalResult(message, error: message, warning: true)
                 onTranscript?(Transcription(text: "", confidence: 0, source: "hudson-voice", isPartial: false, durationMs: nil))
             }
             stopCompletion?(nil)
@@ -642,6 +678,23 @@ final class HudVoxAudioProvider: AudioProvider {
         }
         session = nil
         pumpTask = nil
+    }
+
+    private static func voiceRuntimeMessage(for error: Error, endpoint: HudVoxEndpoint? = nil) -> String {
+        let raw = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+        let detail = raw.isEmpty ? String(describing: error) : raw
+        if detail.localizedCaseInsensitiveContains("unauthorized") {
+            return "Voice runtime rejected Lattices: unauthorized"
+        }
+        if detail.localizedCaseInsensitiveContains("could not connect")
+            || detail.localizedCaseInsensitiveContains("connection refused")
+            || detail.localizedCaseInsensitiveContains("network connection was lost") {
+            if let endpoint {
+                return "Voice runtime unavailable at \(endpoint.url.absoluteString)"
+            }
+            return "Voice runtime unavailable"
+        }
+        return "Transcription failed: \(detail)"
     }
 }
 #endif

--- a/apps/mac/Sources/Core/Voice/HandsOffSession.swift
+++ b/apps/mac/Sources/Core/Voice/HandsOffSession.swift
@@ -1,5 +1,5 @@
 import AppKit
-#if canImport(HudsonVoice)
+#if LATTICES_VOICE && canImport(HudsonVoice)
 import HudsonVoice
 #endif
 
@@ -413,7 +413,7 @@ final class HandsOffSession: ObservableObject {
 
     /// Cancel any active voice recording session without transcribing.
     private func cancelVoxSession() {
-        #if canImport(HudsonVoice)
+        #if LATTICES_VOICE && canImport(HudsonVoice)
         guard let session = voxSession else { return }
         DiagnosticLog.shared.info("HandsOff: cancelling voice session")
         voxSession = nil
@@ -425,14 +425,14 @@ final class HandsOffSession: ObservableObject {
 
     // MARK: - Voice capture
 
-    #if canImport(HudsonVoice)
+    #if LATTICES_VOICE && canImport(HudsonVoice)
     /// Live HudsonVoice session for the current dictation turn, plus its event pump.
     private var voxSession: HudVoxLiveSession?
     private var voxPump: Task<Void, Never>?
     #endif
 
     private func beginListening() {
-        #if canImport(HudsonVoice)
+        #if LATTICES_VOICE && canImport(HudsonVoice)
         // HudsonVoice opens a fresh capture on start. We only gate on whether an
         // endpoint can be resolved; session errors are handled by the stream.
         if HudsonVoiceRuntimeResolver.resolve(clientId: "lattices") != nil {
@@ -451,7 +451,7 @@ final class HandsOffSession: ObservableObject {
     }
 
     private func retryListenIfReady(attempts: Int) {
-        #if canImport(HudsonVoice)
+        #if LATTICES_VOICE && canImport(HudsonVoice)
         if HudsonVoiceRuntimeResolver.resolve(clientId: "lattices") != nil {
             startDictation()
         } else if attempts > 0 {
@@ -470,7 +470,7 @@ final class HandsOffSession: ObservableObject {
     private var turnProcessed = false
 
     private func startDictation() {
-        #if canImport(HudsonVoice)
+        #if LATTICES_VOICE && canImport(HudsonVoice)
         state = .listening
         lastTranscript = nil
         turnProcessed = false
@@ -615,7 +615,7 @@ final class HandsOffSession: ObservableObject {
         }
     }
 
-    #if canImport(HudsonVoice)
+    #if LATTICES_VOICE && canImport(HudsonVoice)
     @MainActor
     private func handleVoxEvent(_ event: HudVoiceEvent) {
         switch event {
@@ -666,7 +666,7 @@ final class HandsOffSession: ObservableObject {
     func finishListening() {
         guard state == .listening else { return }
         playSound("Tink")
-        #if canImport(HudsonVoice)
+        #if LATTICES_VOICE && canImport(HudsonVoice)
         let session = voxSession
         Task { try? await session?.stop() }
         #endif

--- a/apps/mac/Sources/Core/Voice/IntentHeuristics.swift
+++ b/apps/mac/Sources/Core/Voice/IntentHeuristics.swift
@@ -4,9 +4,51 @@ import Foundation
 /// path (`AudioLayer`) classify utterances the same way — one source of truth
 /// for "is this a Lattices question to hand to the assistant, or a command?".
 enum IntentHeuristics {
+    /// If the utterance explicitly addresses the assistant, return the prompt
+    /// after the wake phrase. This lets "assistant ..." bypass command matching.
+    static func assistantWakePrompt(_ text: String) -> String? {
+        let trimmed = normalizedWhitespace(text)
+        guard !trimmed.isEmpty else { return nil }
+
+        let lower = trimmed.lowercased()
+        let wakePhrases = [
+            "ask the assistant",
+            "ask assistant",
+            "hey lattices",
+            "hey lattice",
+            "assistant",
+            "lattices",
+            "lattice"
+        ]
+
+        for phrase in wakePhrases {
+            if lower == phrase {
+                return trimmed
+            }
+            guard lower.hasPrefix(phrase) else { continue }
+
+            let index = trimmed.index(trimmed.startIndex, offsetBy: phrase.count)
+            guard let first = trimmed[index...].first,
+                  first.isWhitespace || first.isPunctuation else { continue }
+            let remainder = trimmed[index...]
+                .trimmingCharacters(in: CharacterSet.whitespacesAndNewlines.union(.punctuationCharacters))
+            if !remainder.isEmpty {
+                return remainder
+            }
+        }
+
+        return nil
+    }
+
+    static func assistantPromptText(_ text: String) -> String {
+        assistantWakePrompt(text) ?? normalizedWhitespace(text)
+    }
+
     /// True when an utterance is a Lattices-flavoured *question* (and not a
     /// command) — i.e. it should be answered by the assistant rather than run.
     static func shouldAskAssistant(_ text: String) -> Bool {
+        if assistantWakePrompt(text) != nil { return true }
+
         let lower = text.lowercased()
         let questionStarters = [
             "what", "how", "why", "where", "when", "who",
@@ -41,5 +83,13 @@ enum IntentHeuristics {
         return commandWords.contains { word in
             lower.range(of: "\\b\(NSRegularExpression.escapedPattern(for: word))\\b", options: .regularExpression) != nil
         }
+    }
+
+    private static func normalizedWhitespace(_ text: String) -> String {
+        text
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/apps/mac/Sources/Core/Voice/LatticesVoiceRuntime.swift
+++ b/apps/mac/Sources/Core/Voice/LatticesVoiceRuntime.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-#if canImport(HudsonVoice)
+#if LATTICES_VOICE && canImport(HudsonVoice)
 import HudsonVoice
 #endif
 
 enum LatticesVoiceRuntime {
     static func start() {
-        #if canImport(HudsonVoice)
+        #if LATTICES_VOICE && canImport(HudsonVoice)
         DiagnosticLog.shared.info("HudsonVoice: live session client compiled in")
         #else
         DiagnosticLog.shared.info("HudsonVoice: runtime host skipped because HudsonVoice is not compiled into this build")
@@ -14,7 +14,7 @@ enum LatticesVoiceRuntime {
     }
 
     static func stop() {
-        #if canImport(HudsonVoice)
+        #if LATTICES_VOICE && canImport(HudsonVoice)
         DiagnosticLog.shared.info("HudsonVoice: live session client stopped")
         #endif
     }

--- a/apps/mac/Sources/Core/Voice/VoxEndpointResolver.swift
+++ b/apps/mac/Sources/Core/Voice/VoxEndpointResolver.swift
@@ -1,28 +1,154 @@
-#if canImport(HudsonVoice)
+#if LATTICES_VOICE && canImport(HudsonVoice)
+import Darwin
 import Foundation
 import HudsonVoice
 
 /// Resolves the voice runtime Lattices should use.
 ///
-/// HudsonVoice speaks Vox's local WebSocket JSON-RPC contract directly and is the
-/// only voice path: Lattices always connects to HudsonVoice's default endpoint.
-/// Vox is no longer a standalone service, so there is no runtime-file discovery
-/// and no fallback chain.
+/// HudsonVoice speaks Vox's local WebSocket JSON-RPC contract directly. Prefer
+/// the runtime file written by Vox so dev builds can move ports without making
+/// Lattices point at a stale default.
 enum HudsonVoiceRuntimeResolver {
+    private struct RuntimeFile: Decodable {
+        let host: String?
+        let port: UInt16?
+        let pid: Int?
+        let serviceName: String?
+        let service: String?
+        let transport: String?
+        let webSocketUrl: String?
+        let authToken: String?
+    }
+
     static func resolve(
         clientId: String = "lattices",
         mode: HudVoiceMode? = nil
-    ) -> (endpoint: HudVoxEndpoint, options: HudVoxLiveSessionOptions, source: String, pid: Int?)? {
-        let endpoint = HudVoxEndpoint(
-            host: "127.0.0.1",
-            port: HudVoxEndpoint.defaultPort
-        )
+    ) -> (endpoint: HudVoxEndpoint, options: HudVoxLiveSessionOptions, source: String, pid: Int?, authToken: String?, capabilityPath: String?)? {
+        let runtime = resolvedRuntime()
+        let endpoint = HudVoxEndpoint(host: runtime.host, port: runtime.port)
         let options = HudVoxLiveSessionOptions(
             clientId: clientId,
             mode: mode ?? .pushToTalk,
             metadata: ["hostApp": "lattices"]
         )
-        return (endpoint: endpoint, options: options, source: "hudson-voice", pid: nil)
+        return (
+            endpoint: endpoint,
+            options: options,
+            source: runtime.source,
+            pid: runtime.pid,
+            authToken: runtime.authToken,
+            capabilityPath: runtime.path
+        )
+    }
+
+    private static func resolvedRuntime() -> (host: String, port: UInt16, source: String, pid: Int?, authToken: String?, path: String?) {
+        for candidate in runtimeFileCandidates() {
+            guard let runtime = readRuntimeFile(candidate.url),
+                  let port = runtime.port,
+                  port > 0,
+                  runtime.pid.map(processIsAlive) ?? true else { continue }
+            // HudVoxLiveSession does not currently expose an auth-token field,
+            // so authenticated Hudson capability files cannot be used safely yet.
+            guard nonEmpty(runtime.authToken) == nil else { continue }
+
+            let host = runtime.host
+                ?? hostFromWebSocketURL(runtime.webSocketUrl)
+                ?? "127.0.0.1"
+            guard isLoopback(host) else { continue }
+
+            return (
+                host: host,
+                port: port,
+                source: candidate.source,
+                pid: runtime.pid,
+                authToken: nonEmpty(runtime.authToken),
+                path: candidate.url.path
+            )
+        }
+
+        let env = ProcessInfo.processInfo.environment
+        if let rawPort = env["VOX_PORT"] ?? env["HUDSON_VOICE_VOX_PORT"],
+           let port = UInt16(rawPort) {
+            return (
+                host: nonEmpty(env["VOX_HOST"]) ?? "127.0.0.1",
+                port: port,
+                source: "env",
+                pid: nil,
+                authToken: nonEmpty(env["VOX_AUTH_TOKEN"]),
+                path: nil
+            )
+        }
+
+        // Vox's current daemon default is 42137. HudsonVoice's older 42138
+        // default is intentionally avoided here because it makes Lattices miss
+        // a running Vox dev daemon and surface a fake transcription failure.
+        return (
+            host: "127.0.0.1",
+            port: 42137,
+            source: "vox-default",
+            pid: nil,
+            authToken: nil,
+            path: nil
+        )
+    }
+
+    private static func runtimeFileCandidates() -> [(url: URL, source: String)] {
+        var candidates: [(URL, String)] = []
+        let env = ProcessInfo.processInfo.environment
+
+        if let path = nonEmpty(env["VOX_RUNTIME_PATH"]) {
+            candidates.append((URL(fileURLWithPath: path), "vox"))
+        }
+        candidates.append((
+            FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".vox", isDirectory: true)
+                .appendingPathComponent("runtime.json"),
+            "vox"
+        ))
+
+        let support = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+        if let path = nonEmpty(env["HUDSON_VOICE_RUNTIME_PATH"]) {
+            candidates.append((URL(fileURLWithPath: path), "hudson-voice"))
+        }
+        candidates.append((
+            support
+                .appendingPathComponent("Hudson", isDirectory: true)
+                .appendingPathComponent("Vox", isDirectory: true)
+                .appendingPathComponent("hudson-voice-runtime.json"),
+            "hudson-voice"
+        ))
+
+        var seen = Set<String>()
+        return candidates.filter { candidate in
+            let key = candidate.0.standardizedFileURL.path
+            return seen.insert(key).inserted
+        }
+    }
+
+    private static func readRuntimeFile(_ url: URL) -> RuntimeFile? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder().decode(RuntimeFile.self, from: data)
+    }
+
+    private static func hostFromWebSocketURL(_ raw: String?) -> String? {
+        guard let raw, let url = URL(string: raw), let host = url.host else { return nil }
+        return host
+    }
+
+    private static func isLoopback(_ host: String) -> Bool {
+        let lowered = host.lowercased()
+        return lowered == "localhost" || lowered == "127.0.0.1" || lowered == "::1"
+    }
+
+    private static func processIsAlive(_ pid: Int) -> Bool {
+        guard pid > 0 else { return false }
+        return kill(pid_t(pid), 0) == 0 || errno == EPERM
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
     }
 }
 #endif

--- a/bin/cli/capture.ts
+++ b/bin/cli/capture.ts
@@ -1,0 +1,252 @@
+import {
+  hasFlag,
+  nonFlagArgs,
+  parseFlagValue,
+  parseOptionalNumber,
+} from "./helpers.ts";
+import { withDaemon } from "./daemon.ts";
+
+export async function captureCommand(subcommand?: string, ...rawArgs: string[]): Promise<void> {
+  const sub = subcommand || "window";
+  const dashIndex = rawArgs.indexOf("--");
+  const commandArgs = dashIndex >= 0 ? rawArgs.slice(0, dashIndex) : rawArgs;
+  const childArgs = dashIndex >= 0 ? rawArgs.slice(dashIndex + 1) : [];
+  const jsonFlag = hasFlag(commandArgs, "json");
+  const positional = nonFlagArgs(commandArgs);
+
+  if (["stop", "stop-recording", "stopRecording"].includes(sub)) {
+    const params: Record<string, unknown> = {};
+    const runId = positional[0] || parseFlagValue(commandArgs, "run-id") || parseFlagValue(commandArgs, "runId") || parseFlagValue(commandArgs, "id");
+    const stopFile = parseFlagValue(commandArgs, "stop-file") || parseFlagValue(commandArgs, "stopFile");
+    const finishedFile = parseFlagValue(commandArgs, "finished-file") || parseFlagValue(commandArgs, "finishedFile");
+    const timeoutMs = Number(parseFlagValue(commandArgs, "timeout-ms") || parseFlagValue(commandArgs, "timeoutMs") || 30000);
+    if (runId) params.runId = runId;
+    if (stopFile) params.stopFile = stopFile;
+    if (finishedFile) params.finishedFile = finishedFile;
+    if (Number.isFinite(timeoutMs)) params.timeoutMs = timeoutMs;
+    params.wait = !hasFlag(commandArgs, "no-wait");
+
+    await withDaemon(async ({ daemonCall }) => {
+      const result = await daemonCall("capture.stopRecording", params, timeoutMs + 5000) as any;
+      if (jsonFlag) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      console.log(result.finished ? "Recording finished." : "Recording stop requested.");
+      if (result.run?.id) console.log(`  run: ${result.run.id}`);
+      if (result.marker) console.log(`  marker: ${result.marker}`);
+    });
+    return;
+  }
+
+  const isRecordCommand = [
+    "record-command",
+    "recordCommand",
+    "record-run",
+    "recordRun",
+    "record-exec",
+    "recordExec",
+  ].includes(sub);
+
+  if (isRecordCommand) {
+    if (!childArgs.length) {
+      console.log(`lattices capture record-command — record while running a command
+
+Usage:
+  lattices capture record-command --app Scout --filename demo.mov -- <command> [...args]
+`);
+      return;
+    }
+
+    const params: Record<string, unknown> = { source: "cli" };
+    const explicitWid = positional[0] ? Number(positional[0]) : NaN;
+    if (Number.isFinite(explicitWid)) params.wid = explicitWid;
+
+    const session = parseFlagValue(commandArgs, "session");
+    const app = parseFlagValue(commandArgs, "app");
+    const title = parseFlagValue(commandArgs, "title");
+    const filename = parseFlagValue(commandArgs, "filename");
+    const runId = parseFlagValue(commandArgs, "run-id") || parseFlagValue(commandArgs, "runId");
+    const mode = parseFlagValue(commandArgs, "mode");
+    const fps = parseOptionalNumber(commandArgs, "fps");
+    const scale = parseOptionalNumber(commandArgs, "scale");
+    const timeoutMs = Number(parseFlagValue(commandArgs, "timeout-ms") || parseFlagValue(commandArgs, "timeoutMs") || 30000);
+    if (session) params.session = session;
+    if (app) params.app = app;
+    if (title) params.title = title;
+    if (filename) params.filename = filename;
+    if (runId) params.runId = runId;
+    if (mode) params.mode = mode;
+    if (fps !== undefined) params.fps = fps;
+    if (scale !== undefined) params.scale = scale;
+
+    for (const [flag, key] of [["x", "x"], ["y", "y"], ["width", "width"], ["height", "height"], ["w", "w"], ["h", "h"]] as const) {
+      const value = parseOptionalNumber(commandArgs, flag);
+      if (value !== undefined) params[key] = value;
+    }
+
+    const recordsRegion = hasFlag(commandArgs, "region") ||
+      (params.x !== undefined && params.y !== undefined &&
+        (params.width !== undefined || params.w !== undefined) &&
+        (params.height !== undefined || params.h !== undefined));
+    const method = recordsRegion ? "capture.recordRegion" : "capture.recordWindow";
+
+    await withDaemon(async ({ daemonCall }) => {
+      const start = await daemonCall(method, params, 20000) as any;
+      let childExitCode = 0;
+      let childError: string | undefined;
+
+      try {
+        const proc = Bun.spawn(childArgs, {
+          cwd: process.cwd(),
+          env: process.env,
+          stdin: "inherit",
+          stdout: "inherit",
+          stderr: "inherit",
+        });
+        childExitCode = await proc.exited;
+      } catch (error) {
+        childExitCode = 127;
+        childError = (error as Error).message;
+      }
+
+      const stop = await daemonCall(
+        "capture.stopRecording",
+        { runId: start.run?.id, wait: true, timeoutMs },
+        timeoutMs + 5000
+      ) as any;
+
+      if (jsonFlag) {
+        console.log(JSON.stringify({
+          ok: childExitCode === 0 && stop.ok !== false,
+          child: {
+            command: childArgs,
+            exitCode: childExitCode,
+            error: childError,
+          },
+          recording: start,
+          stopResult: stop,
+        }, null, 2));
+      } else {
+        const artifact = start.artifact || {};
+        const run = stop.run || start.run || {};
+        console.log(`Recording finished.`);
+        console.log(`  run: ${run.id || start.run?.id || "?"}`);
+        console.log(`  artifact: ${artifact.path || "?"}`);
+        console.log(`  child exit: ${childExitCode}`);
+        if (childError) console.log(`  child error: ${childError}`);
+      }
+
+      if (childExitCode !== 0 && !hasFlag(commandArgs, "ignore-child-failure")) {
+        process.exitCode = childExitCode;
+      }
+    });
+    return;
+  }
+
+  const isRecord = ["record", "record-window", "recording", "video"].includes(sub);
+  const isRecordRegion = ["record-region", "recordRegion", "region-recording"].includes(sub) ||
+    (sub === "record" && ["region", "rect"].includes(positional[0] || ""));
+
+  if (isRecord || isRecordRegion) {
+    const params: Record<string, unknown> = { source: "cli" };
+    const targetKind = sub === "record" ? positional[0] : undefined;
+    const positionalOffset = targetKind === "window" || targetKind === "region" || targetKind === "rect" ? 1 : 0;
+    const explicitWid = positional[positionalOffset] ? Number(positional[positionalOffset]) : NaN;
+    if (Number.isFinite(explicitWid)) params.wid = explicitWid;
+
+    const session = parseFlagValue(commandArgs, "session");
+    const app = parseFlagValue(commandArgs, "app");
+    const title = parseFlagValue(commandArgs, "title");
+    const filename = parseFlagValue(commandArgs, "filename");
+    const runId = parseFlagValue(commandArgs, "run-id") || parseFlagValue(commandArgs, "runId");
+    const mode = parseFlagValue(commandArgs, "mode");
+    const fps = parseOptionalNumber(commandArgs, "fps");
+    const scale = parseOptionalNumber(commandArgs, "scale");
+    const durationMs = parseOptionalNumber(commandArgs, "duration-ms", "durationMs", "duration");
+    if (session) params.session = session;
+    if (app) params.app = app;
+    if (title) params.title = title;
+    if (filename) params.filename = filename;
+    if (runId) params.runId = runId;
+    if (mode) params.mode = mode;
+    if (fps !== undefined) params.fps = fps;
+    if (scale !== undefined) params.scale = scale;
+
+    for (const [flag, key] of [["x", "x"], ["y", "y"], ["width", "width"], ["height", "height"], ["w", "w"], ["h", "h"]] as const) {
+      const value = parseOptionalNumber(commandArgs, flag);
+      if (value !== undefined) params[key] = value;
+    }
+
+    await withDaemon(async ({ daemonCall }) => {
+      const method = isRecordRegion ? "capture.recordRegion" : "capture.recordWindow";
+      const result = await daemonCall(method, params, 20000) as any;
+
+      if (durationMs !== undefined && durationMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, durationMs));
+        const stop = await daemonCall(
+          "capture.stopRecording",
+          { runId: result.run?.id, wait: true, timeoutMs: 30000 },
+          35000
+        ) as any;
+        result.stopResult = stop;
+      }
+
+      if (jsonFlag) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      const artifact = result.artifact || {};
+      const run = result.stopResult?.run || result.run || {};
+      console.log(`Recording ${result.stopResult ? "finished" : "started"}.`);
+      console.log(`  run: ${run.id || result.run?.id || "?"}`);
+      console.log(`  artifact: ${artifact.path || "?"}`);
+      if (!result.stopResult) {
+        console.log(`  stop: lattices capture stop ${result.run?.id || ""}`);
+      }
+    });
+    return;
+  }
+
+  if (!["window", "screenshot", "shot"].includes(sub)) {
+    console.log(`lattices capture — capture run artifacts
+
+Usage:
+  lattices capture window [wid] [--json]
+  lattices capture screenshot [wid] [--session name] [--app name]
+  lattices capture record window [wid] [--app name] [--duration-ms 5000] [--json]
+  lattices capture record region --x N --y N --width N --height N [--duration-ms 5000]
+  lattices capture record-command --app Scout --filename demo.mov -- <command> [...args]
+  lattices capture stop <run-id>
+`);
+    return;
+  }
+
+  const params: Record<string, unknown> = { source: "cli" };
+  const explicitWid = positional[0] ? Number(positional[0]) : NaN;
+  if (Number.isFinite(explicitWid)) params.wid = explicitWid;
+  const session = parseFlagValue(commandArgs, "session");
+  const app = parseFlagValue(commandArgs, "app");
+  const title = parseFlagValue(commandArgs, "title");
+  const filename = parseFlagValue(commandArgs, "filename");
+  const runId = parseFlagValue(commandArgs, "run-id") || parseFlagValue(commandArgs, "runId");
+  if (session) params.session = session;
+  if (app) params.app = app;
+  if (title) params.title = title;
+  if (filename) params.filename = filename;
+  if (runId) params.runId = runId;
+
+  await withDaemon(async ({ daemonCall }) => {
+    const result = await daemonCall("capture.screenshotWindow", params, 20000) as any;
+    if (jsonFlag) {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+    const artifact = result.artifact || {};
+    const run = result.run || {};
+    const target = result.target || {};
+    console.log(`Captured ${target.app || "window"} ${target.wid ? `wid:${target.wid}` : ""}`);
+    console.log(`  run: ${run.id || "?"}`);
+    console.log(`  artifact: ${artifact.path || "?"}`);
+  });
+}

--- a/bin/cli/daemon.ts
+++ b/bin/cli/daemon.ts
@@ -1,0 +1,22 @@
+export type DaemonClient = typeof import("../daemon-client.ts");
+
+export async function withDaemon<T>(
+  fn: (client: DaemonClient) => Promise<T>,
+  opts?: { message?: string; exitCode?: number }
+): Promise<T> {
+  const message = opts?.message ?? "Daemon not running. Start with: lattices app";
+  const exitCode = opts?.exitCode ?? 1;
+
+  const client = await import("../daemon-client.ts");
+  if (!(await client.isDaemonRunning())) {
+    console.error(message);
+    process.exit(exitCode);
+  }
+
+  try {
+    return await fn(client);
+  } catch (e: unknown) {
+    console.error(`Error: ${(e as Error).message}`);
+    process.exit(exitCode);
+  }
+}

--- a/bin/cli/helpers.ts
+++ b/bin/cli/helpers.ts
@@ -1,0 +1,105 @@
+import { execSync } from "node:child_process";
+
+export interface ExecOpts {
+  encoding?: string;
+  stdio?: string | string[];
+  cwd?: string;
+  [key: string]: any;
+}
+
+export function run(cmd: string, opts: ExecOpts = {}): string {
+  return execSync(cmd, { encoding: "utf8", ...opts } as any).trim();
+}
+
+export function runQuiet(cmd: string): string | null {
+  try {
+    return run(cmd, { stdio: "pipe" });
+  } catch {
+    return null;
+  }
+}
+
+export function parseFlagValue(args: string[], name: string): string | undefined {
+  const prefix = `--${name}=`;
+  const exact = `--${name}`;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i].startsWith(prefix)) return args[i].slice(prefix.length);
+    if (args[i] === exact) return args[i + 1];
+  }
+  return undefined;
+}
+
+export function parseOptionalNumber(args: string[], ...names: string[]): number | undefined {
+  for (const name of names) {
+    const raw = parseFlagValue(args, name);
+    if (raw === undefined || raw === "") continue;
+    const value = Number(raw);
+    if (Number.isFinite(value)) return value;
+  }
+  return undefined;
+}
+
+export function hasFlag(args: string[], name: string): boolean {
+  return args.includes(`--${name}`);
+}
+
+export function nonFlagArgs(args: string[]): string[] {
+  const valueFlags = new Set([
+    "id", "state", "ttl", "ttlMs", "x", "y", "gap", "placement", "style", "name", "scale",
+    "hud-url", "hudUrl", "hud-html", "hudHTML", "hudHtml", "hud-title", "hudTitle",
+    "hud-width", "hudWidth", "hud-height", "hudHeight", "width", "height",
+    "manifest", "root", "max-depth", "maxDepth", "read-access", "readAccess",
+    "pause", "limit", "session", "app", "name", "bundle-id", "bundleId", "bundleIdentifier",
+    "path", "app-path", "appPath", "title", "filename", "run-id", "runId",
+    "text", "tty", "wid", "treatment", "mode", "phase", "transport", "capture",
+    "appearance", "cursor-style", "cursorStyle", "shape", "marker-shape", "markerShape",
+    "cursor-shape", "cursorShape", "angle-deg", "angleDeg", "rotation-deg", "rotationDeg",
+    "rotation", "angle", "color", "duration-ms", "durationMs",
+    "type-interval-ms", "typeIntervalMs", "typing-interval-ms", "typingIntervalMs", "label",
+    "caption", "treatment-label", "treatmentLabel", "variant",
+    "caption-title", "captionTitle", "caption-body", "captionBody",
+    "caption-detail", "captionDetail", "caption-tags", "captionTags",
+    "caption-mode", "captionMode", "caption-eyebrow", "captionEyebrow",
+    "caption-lead-ms", "captionLeadMs", "caption-sound", "captionSound",
+    "caption-placement", "captionPlacement", "caption-margin", "captionMargin",
+    "caption-x", "captionX", "caption-y", "captionY",
+    "caption-x-ratio", "captionXRatio", "caption-y-ratio", "captionYRatio",
+    "caption-left-ratio", "captionLeftRatio", "caption-top-ratio", "captionTopRatio",
+    "sound", "sfx",
+    "trail", "effect", "path-style", "pathStyle", "motion", "easing", "velocity",
+    "trajectory", "curve", "arc", "glow", "bloom", "idle", "settle", "presence",
+    "edge", "edge-effect", "edgeEffect", "arrival",
+    "fps", "w", "h", "stop-file", "stopFile", "finished-file", "finishedFile",
+    "timeout-ms", "timeoutMs", "duration",
+    "x", "y", "x-ratio", "xRatio", "y-ratio", "yRatio",
+    "relative-x", "relativeX", "relative-y", "relativeY",
+    "window-x", "windowX", "window-y", "windowY", "button",
+  ]);
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg.startsWith("--")) {
+      out.push(arg);
+      continue;
+    }
+    const flagName = arg.slice(2);
+    if (!arg.includes("=") && valueFlags.has(flagName)) i++;
+  }
+  return out;
+}
+
+export function relativeTime(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return "just now";
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+}
+
+export function pause(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/bin/cli/layer.ts
+++ b/bin/cli/layer.ts
@@ -1,0 +1,178 @@
+import { withDaemon, type DaemonClient } from "./daemon.ts";
+
+export async function layerCommand(sub?: string, ...rest: string[]): Promise<void> {
+  await withDaemon(async (client) => {
+    const { daemonCall } = client;
+
+    if (sub === "create") {
+      await layerCreateCommand(client, rest);
+      return;
+    }
+    if (sub === "snap") {
+      await layerSnapCommand(client, rest[0]);
+      return;
+    }
+    if (sub === "session" || sub === "sessions") {
+      await layerSessionCommand(client, rest[0]);
+      return;
+    }
+    if (sub === "clear") {
+      await daemonCall("session.layers.clear");
+      console.log("Cleared all session layers.");
+      return;
+    }
+    if (sub === "delete" || sub === "rm") {
+      if (!rest[0]) { console.log("Usage: lattices layer delete <name>"); return; }
+      await daemonCall("session.layers.delete", { name: rest[0] });
+      console.log(`Deleted session layer "${rest[0]}".`);
+      return;
+    }
+
+    if (sub === undefined || sub === null || sub === "") {
+      const result = await daemonCall("layers.list") as any;
+      if (!result.layers.length) {
+        console.log("No layers configured.");
+        return;
+      }
+      console.log("Layers:\n");
+      for (const layer of result.layers) {
+        const active = layer.index === result.active ? " \x1b[32m● active\x1b[0m" : "";
+        console.log(`  [${layer.index}] ${layer.label}  (${layer.projectCount} projects)${active}`);
+      }
+      return;
+    }
+    const idx = parseInt(sub, 10);
+    if (!isNaN(idx)) {
+      await daemonCall("layer.activate", { index: idx, mode: "launch" });
+      console.log(`Activated layer ${idx}`);
+    } else {
+      await daemonCall("layer.activate", { name: sub, mode: "launch" });
+      console.log(`Activated layer "${sub}"`);
+    }
+  });
+}
+
+// ── Layer create: build a session layer from window specs ────────────
+// Usage: lattices layer create <name> [wid:123 wid:456 ...]
+//        lattices layer create <name> --json '[{"app":"Chrome","tile":"left"},...]'
+export async function layerCreateCommand(client: DaemonClient, args: string[]): Promise<void> {
+  const { daemonCall } = client;
+  const name = args[0];
+  if (!name) {
+    console.log("Usage: lattices layer create <name> [wid:123 ...] [--json '<specs>']");
+    return;
+  }
+
+  const jsonIdx = args.indexOf("--json");
+  if (jsonIdx !== -1 && args[jsonIdx + 1]) {
+    // JSON mode: parse window specs with tile positions
+    const specs = JSON.parse(args[jsonIdx + 1]) as Array<{
+      wid?: number; app?: string; title?: string; tile?: string;
+    }>;
+
+    // Collect wids, resolve app-based specs
+    const windowIds: number[] = [];
+    const windows: Array<{ app: string; contentHint?: string }> = [];
+    const tiles: Array<{ wid?: number; app?: string; title?: string; tile: string }> = [];
+
+    for (const spec of specs) {
+      if (spec.wid) {
+        windowIds.push(spec.wid);
+        if (spec.tile) tiles.push({ wid: spec.wid, tile: spec.tile });
+      } else if (spec.app) {
+        windows.push({ app: spec.app, contentHint: spec.title });
+        if (spec.tile) tiles.push({ app: spec.app, title: spec.title, tile: spec.tile });
+      }
+    }
+
+    await daemonCall("session.layers.create", {
+      name,
+      ...(windowIds.length ? { windowIds } : {}),
+      ...(windows.length ? { windows } : {}),
+    }) as any;
+
+    console.log(`Created session layer "${name}" with ${specs.length} window(s).`);
+
+    // Apply tile positions
+    for (const t of tiles) {
+      try {
+        await daemonCall("window.place", {
+          ...(t.wid ? { wid: t.wid } : { app: t.app, title: t.title }),
+          placement: t.tile,
+        });
+      } catch { /* window may not be resolved yet */ }
+    }
+
+    if (tiles.length) console.log(`Tiled ${tiles.length} window(s).`);
+    return;
+  }
+
+  // Simple wid mode: lattices layer create <name> wid:123 wid:456
+  const wids = args.slice(1)
+    .filter(a => a.startsWith("wid:"))
+    .map(a => parseInt(a.slice(4), 10))
+    .filter(n => !isNaN(n));
+
+  await daemonCall("session.layers.create", {
+    name,
+    ...(wids.length ? { windowIds: wids } : {}),
+  }) as any;
+
+  console.log(`Created session layer "${name}"${wids.length ? ` with ${wids.length} window(s)` : ""}.`);
+}
+
+// ── Layer snap: snapshot current visible windows into a session layer ─
+export async function layerSnapCommand(client: DaemonClient, name?: string): Promise<void> {
+  const { daemonCall } = client;
+  const layerName = name || `snap-${new Date().toISOString().slice(11, 19).replace(/:/g, "")}`;
+
+  // Get all current windows
+  const windows = await daemonCall("windows.list") as any[];
+  const visibleWids = windows
+    .filter((w: any) => !w.isMinimized && w.app !== "lattices")
+    .map((w: any) => w.wid);
+
+  if (!visibleWids.length) {
+    console.log("No visible windows to snapshot.");
+    return;
+  }
+
+  await daemonCall("session.layers.create", {
+    name: layerName,
+    windowIds: visibleWids,
+  });
+
+  console.log(`Snapped ${visibleWids.length} window(s) → session layer "${layerName}".`);
+}
+
+// ── Layer session: list or switch session layers ─────────────────────
+export async function layerSessionCommand(client: DaemonClient, nameOrIndex?: string): Promise<void> {
+  const { daemonCall } = client;
+  const result = await daemonCall("session.layers.list") as any;
+
+  if (!nameOrIndex) {
+    // List session layers
+    if (!result.layers.length) {
+      console.log("No session layers. Create one with: lattices layer create <name>");
+      return;
+    }
+    console.log("Session layers:\n");
+    for (let i = 0; i < result.layers.length; i++) {
+      const l = result.layers[i];
+      const active = i === result.activeIndex ? " \x1b[32m● active\x1b[0m" : "";
+      const winCount = l.windows?.length || 0;
+      console.log(`  [${i}] ${l.name}  (${winCount} windows)${active}`);
+    }
+    return;
+  }
+
+  // Switch by index or name
+  const idx = parseInt(nameOrIndex, 10);
+  if (!isNaN(idx)) {
+    await daemonCall("session.layers.switch", { index: idx });
+    console.log(`Switched to session layer ${idx}.`);
+  } else {
+    await daemonCall("session.layers.switch", { name: nameOrIndex });
+    console.log(`Switched to session layer "${nameOrIndex}".`);
+  }
+}

--- a/bin/cli/runs.ts
+++ b/bin/cli/runs.ts
@@ -1,0 +1,43 @@
+import { hasFlag, nonFlagArgs, parseFlagValue } from "./helpers.ts";
+import { withDaemon } from "./daemon.ts";
+
+function runLine(run: any): string {
+  const count = Array.isArray(run.artifacts) ? run.artifacts.length : 0;
+  const completed = run.completedAt ? ` completed=${run.completedAt}` : "";
+  return `  ${run.id}  ${run.state || "?"}  artifacts=${count}  ${run.title || "Untitled run"}${completed}`;
+}
+
+export async function runsCommand(rawArgs: string[] = []): Promise<void> {
+  const jsonFlag = hasFlag(rawArgs, "json");
+  const positional = nonFlagArgs(rawArgs);
+  const sub = positional[0];
+
+  await withDaemon(async ({ daemonCall }) => {
+    if (sub && sub !== "list") {
+      const run = await daemonCall("runs.get", { id: sub }) as any;
+      if (jsonFlag) {
+        console.log(JSON.stringify(run, null, 2));
+        return;
+      }
+      console.log(runLine(run));
+      console.log(`  artifacts: ${run.artifactDirectoryPath}`);
+      for (const artifact of run.artifacts || []) {
+        console.log(`    ${artifact.kind}  ${artifact.path}`);
+      }
+      return;
+    }
+
+    const limit = Number(parseFlagValue(rawArgs, "limit") || 20);
+    const runs = await daemonCall("runs.list", { limit }) as any[];
+    if (jsonFlag) {
+      console.log(JSON.stringify(runs, null, 2));
+      return;
+    }
+    if (!runs.length) {
+      console.log("No runs yet.");
+      return;
+    }
+    console.log(`Runs (${runs.length}):\n`);
+    for (const run of runs) console.log(runLine(run));
+  });
+}

--- a/bin/cli/search.ts
+++ b/bin/cli/search.ts
@@ -1,0 +1,141 @@
+import { relativeTime } from "./helpers.ts";
+import { withDaemon, type DaemonClient } from "./daemon.ts";
+
+export interface SearchResult {
+  score: number;
+  window: any;
+  tabs: { tab: number; cwd: string; title: string; hasClaude: boolean; tmuxSession: string }[];
+  reasons: string[];
+}
+
+export interface SearchOptions {
+  sources?: string[];
+  after?: string;
+  before?: string;
+  recency?: boolean;
+  mode?: string;
+}
+
+async function searchWithClient(client: DaemonClient, query: string, opts: SearchOptions = {}): Promise<SearchResult[]> {
+  const { daemonCall } = client;
+  const params: Record<string, any> = { query };
+  if (opts.sources) params.sources = opts.sources;
+  if (opts.after) params.after = opts.after;
+  if (opts.before) params.before = opts.before;
+  if (opts.recency !== undefined) params.recency = opts.recency;
+  if (opts.mode) params.mode = opts.mode;
+  const hits = await daemonCall("lattices.search", params, 10000) as any[];
+  return hits.map((w: any) => ({
+    score: w.score || 0,
+    window: w,
+    tabs: (w.terminalTabs || []).map((t: any) => ({
+      tab: t.tabIndex, cwd: t.cwd, title: t.tabTitle, hasClaude: t.hasClaude, tmuxSession: t.tmuxSession,
+    })),
+    reasons: w.matchSources || [],
+  }));
+}
+
+export async function search(query: string, opts: SearchOptions = {}): Promise<SearchResult[]> {
+  return withDaemon(client => searchWithClient(client, query, opts));
+}
+
+export async function deepSearch(query: string): Promise<SearchResult[]> {
+  return search(query, { sources: ["all"] });
+}
+
+export function printResults(ranked: SearchResult[]): void {
+  if (!ranked.length) return;
+  for (const r of ranked) {
+    const w = r.window;
+    const age = w.lastInteraction ? ` \x1b[2m${relativeTime(w.lastInteraction)}\x1b[0m` : "";
+    console.log(`  \x1b[1m${w.app}\x1b[0m  "${w.title}"  wid:${w.wid}  score:${r.score}  (${r.reasons.join(", ")})${age}`);
+    for (const t of r.tabs) {
+      const claude = t.hasClaude ? " \x1b[32m●\x1b[0m" : "";
+      const tmux = t.tmuxSession ? ` \x1b[36m[${t.tmuxSession}]\x1b[0m` : "";
+      console.log(`    tab ${t.tab}: ${t.cwd || t.title}${claude}${tmux}`);
+    }
+    if (w.ocrSnippet) console.log(`    ocr: "${w.ocrSnippet}"`);
+  }
+  console.log();
+}
+
+export async function searchCommand(
+  query: string | undefined,
+  flags: Set<string>,
+  rawArgs: string[] = []
+): Promise<void> {
+  if (!query) {
+    console.log("Usage: lattices search <query> [--quick | --terminal | --all | --deep | --sources=... | --after=... | --before=... | --json | --wid]");
+    return;
+  }
+
+  const opts: SearchOptions = {};
+
+  const sourcesFlag = rawArgs.find(a => a.startsWith("--sources="));
+  if (sourcesFlag) {
+    opts.sources = sourcesFlag.slice("--sources=".length).split(",");
+  } else if (flags.has("--all") || flags.has("--deep")) {
+    opts.sources = ["all"];
+  } else if (flags.has("--quick")) {
+    opts.sources = ["titles", "apps", "sessions"];
+  } else if (flags.has("--terminal")) {
+    opts.sources = ["terminals"];
+  }
+
+  const afterFlag = rawArgs.find(a => a.startsWith("--after="));
+  if (afterFlag) opts.after = afterFlag.slice("--after=".length);
+  const beforeFlag = rawArgs.find(a => a.startsWith("--before="));
+  if (beforeFlag) opts.before = beforeFlag.slice("--before=".length);
+
+  if (flags.has("--no-recency")) opts.recency = false;
+
+  const ranked = await search(query, opts);
+  const jsonOut = flags.has("--json");
+  const widOnly = flags.has("--wid");
+
+  if (jsonOut) {
+    console.log(JSON.stringify(ranked.map(r => ({
+      wid: r.window.wid, app: r.window.app, title: r.window.title,
+      score: r.score, reasons: r.reasons, tabs: r.tabs, ocrSnippet: r.window.ocrSnippet,
+    })), null, 2));
+    return;
+  }
+
+  if (widOnly) {
+    for (const r of ranked) console.log(r.window.wid);
+    return;
+  }
+
+  if (!ranked.length) {
+    console.log(`No results for "${query}"`);
+    return;
+  }
+
+  printResults(ranked);
+}
+
+export async function placeCommand(query?: string, tilePosition?: string): Promise<void> {
+  if (!query) {
+    console.log("Usage: lattices place <query> [position]");
+    return;
+  }
+
+  await withDaemon(async (client) => {
+    const { daemonCall } = client;
+    const ranked = await searchWithClient(client, query, { sources: ["all"] });
+
+    if (!ranked.length) {
+      console.log(`No window matching "${query}"`);
+      return;
+    }
+
+    const pos = tilePosition || "bottom-right";
+    const win = ranked[0].window;
+    await daemonCall("window.focus", { wid: win.wid });
+    await daemonCall("intents.execute", {
+      intent: "tile_window",
+      slots: { position: pos, wid: win.wid }
+    }, 3000);
+    console.log(`${win.app} "${win.title}" (wid:${win.wid}) → ${pos}`);
+  });
+}

--- a/bin/cli/session.ts
+++ b/bin/cli/session.ts
@@ -1,0 +1,32 @@
+import { createHash } from "node:crypto";
+import { basename, resolve } from "node:path";
+import { runQuiet } from "./helpers.ts";
+
+export function pathHash(dir: string): string {
+  return createHash("sha256").update(resolve(dir)).digest("hex").slice(0, 6);
+}
+
+export function toSessionName(dir: string): string {
+  const base = basename(dir).replace(/[^a-zA-Z0-9_-]/g, "-");
+  return `${base}-${pathHash(dir)}`;
+}
+
+export function esc(str: string): string {
+  return str.replace(/'/g, "'\\''");
+}
+
+export function slugify(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/\.app$/i, "")
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "app";
+}
+
+export function sessionExists(name: string): boolean {
+  return runQuiet(`tmux has-session -t "${name}" 2>&1`) !== null;
+}
+
+export function toGroupSessionName(groupId: string): string {
+  return `lattices-group-${groupId}`;
+}

--- a/bin/client.ts
+++ b/bin/client.ts
@@ -1,5 +1,6 @@
 // Public API — re-exports from daemon-client for a cleaner import path.
-// Usage: import { daemonCall, isDaemonRunning } from '@lattices/cli'
+// Usage: import { daemonCall, isDaemonRunning } from '@arach/lattices'
+// Also published as @lattices/cli for back-compat.
 
 export { daemonCall, isDaemonRunning } from "./daemon-client.ts";
 export {

--- a/bin/lattices-app.ts
+++ b/bin/lattices-app.ts
@@ -564,7 +564,7 @@ async function ensureBinary(): Promise<void> {
   console.error(
     "Could not find a bundled lattices app or download one.\n" +
     "Options:\n" +
-    "  \u2022 Reinstall or update @lattices/cli\n" +
+    "  \u2022 Reinstall or update @arach/lattices\n" +
     "  \u2022 Developers can build from source with: lattices-app build\n" +
     "  \u2022 Download manually from:   https://github.com/" + REPO + "/releases"
   );

--- a/bin/lattices.ts
+++ b/bin/lattices.ts
@@ -1,10 +1,27 @@
 #!/usr/bin/env bun
 
-import { createHash } from "node:crypto";
 import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { basename, dirname, isAbsolute, resolve } from "node:path";
 import { homedir } from "node:os";
+import { withDaemon, type DaemonClient } from "./cli/daemon.ts";
+import {
+  hasFlag,
+  nonFlagArgs,
+  parseFlagValue,
+  parseOptionalNumber,
+  pause,
+  run,
+  runQuiet,
+} from "./cli/helpers.ts";
+import { searchCommand, placeCommand } from "./cli/search.ts";
+import {
+  esc,
+  sessionExists,
+  slugify,
+  toGroupSessionName,
+  toSessionName,
+} from "./cli/session.ts";
 
 // Daemon client (lazy-loaded to avoid blocking startup for TTY commands)
 let _daemonClient: typeof import("./daemon-client.ts") | undefined;
@@ -19,25 +36,6 @@ const args: string[] = process.argv.slice(2);
 const command: string | undefined = args[0];
 
 // ── Helpers ──────────────────────────────────────────────────────────
-
-interface ExecOpts {
-  encoding?: string;
-  stdio?: string | string[];
-  cwd?: string;
-  [key: string]: any;
-}
-
-function run(cmd: string, opts: ExecOpts = {}): string {
-  return execSync(cmd, { encoding: "utf8", ...opts } as any).trim();
-}
-
-function runQuiet(cmd: string): string | null {
-  try {
-    return run(cmd, { stdio: "pipe" });
-  } catch {
-    return null;
-  }
-}
 
 function hasTmux(): boolean {
   return runQuiet("which tmux") !== null;
@@ -78,102 +76,8 @@ function isInsideTmux(): boolean {
   return !!process.env.TMUX;
 }
 
-function sessionExists(name: string): boolean {
-  return runQuiet(`tmux has-session -t "${name}" 2>&1`) !== null;
-}
-
-function pathHash(dir: string): string {
-  return createHash("sha256").update(resolve(dir)).digest("hex").slice(0, 6);
-}
-
-function toSessionName(dir: string): string {
-  const base = basename(dir).replace(/[^a-zA-Z0-9_-]/g, "-");
-  return `${base}-${pathHash(dir)}`;
-}
-
-function esc(str: string): string {
-  return str.replace(/'/g, "'\\''");
-}
-
 function appleScriptString(str: string): string {
   return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-}
-
-function slugify(str: string): string {
-  return str
-    .toLowerCase()
-    .replace(/\.app$/i, "")
-    .replace(/[^a-z0-9_-]+/g, "-")
-    .replace(/^-+|-+$/g, "") || "app";
-}
-
-function parseFlagValue(args: string[], name: string): string | undefined {
-  const prefix = `--${name}=`;
-  const exact = `--${name}`;
-  for (let i = 0; i < args.length; i++) {
-    if (args[i].startsWith(prefix)) return args[i].slice(prefix.length);
-    if (args[i] === exact) return args[i + 1];
-  }
-  return undefined;
-}
-
-function parseOptionalNumber(args: string[], ...names: string[]): number | undefined {
-  for (const name of names) {
-    const raw = parseFlagValue(args, name);
-    if (raw === undefined || raw === "") continue;
-    const value = Number(raw);
-    if (Number.isFinite(value)) return value;
-  }
-  return undefined;
-}
-
-function hasFlag(args: string[], name: string): boolean {
-  return args.includes(`--${name}`);
-}
-
-function nonFlagArgs(args: string[]): string[] {
-  const valueFlags = new Set([
-    "id", "state", "ttl", "ttlMs", "x", "y", "gap", "placement", "style", "name", "scale",
-    "hud-url", "hudUrl", "hud-html", "hudHTML", "hudHtml", "hud-title", "hudTitle",
-    "hud-width", "hudWidth", "hud-height", "hudHeight", "width", "height",
-    "manifest", "root", "max-depth", "maxDepth", "read-access", "readAccess",
-    "pause", "limit", "session", "app", "name", "bundle-id", "bundleId", "bundleIdentifier",
-    "path", "app-path", "appPath", "title", "filename", "run-id", "runId",
-    "text", "tty", "wid", "treatment", "mode", "phase", "transport", "capture",
-    "appearance", "cursor-style", "cursorStyle", "shape", "marker-shape", "markerShape",
-    "cursor-shape", "cursorShape", "angle-deg", "angleDeg", "rotation-deg", "rotationDeg",
-    "rotation", "angle", "color", "duration-ms", "durationMs",
-    "type-interval-ms", "typeIntervalMs", "typing-interval-ms", "typingIntervalMs", "label",
-    "caption", "treatment-label", "treatmentLabel", "variant",
-    "caption-title", "captionTitle", "caption-body", "captionBody",
-    "caption-detail", "captionDetail", "caption-tags", "captionTags",
-    "caption-mode", "captionMode", "caption-eyebrow", "captionEyebrow",
-    "caption-lead-ms", "captionLeadMs", "caption-sound", "captionSound",
-    "caption-placement", "captionPlacement", "caption-margin", "captionMargin",
-    "caption-x", "captionX", "caption-y", "captionY",
-    "caption-x-ratio", "captionXRatio", "caption-y-ratio", "captionYRatio",
-    "caption-left-ratio", "captionLeftRatio", "caption-top-ratio", "captionTopRatio",
-    "sound", "sfx",
-    "trail", "effect", "path-style", "pathStyle", "motion", "easing", "velocity",
-    "trajectory", "curve", "arc", "glow", "bloom", "idle", "settle", "presence",
-    "edge", "edge-effect", "edgeEffect", "arrival",
-    "fps", "w", "h", "stop-file", "stopFile", "finished-file", "finishedFile",
-    "timeout-ms", "timeoutMs", "duration",
-    "x", "y", "x-ratio", "xRatio", "y-ratio", "yRatio",
-    "relative-x", "relativeX", "relative-y", "relativeY",
-    "window-x", "windowX", "window-y", "windowY", "button",
-  ]);
-  const out: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (!arg.startsWith("--")) {
-      out.push(arg);
-      continue;
-    }
-    const flagName = arg.slice(2);
-    if (!arg.includes("=") && valueFlags.has(flagName)) i++;
-  }
-  return out;
 }
 
 // ── Config ───────────────────────────────────────────────────────────
@@ -202,10 +106,6 @@ function readWorkspaceConfig(): any | null {
     console.warn(`Warning: invalid workspace.json — ${(e as Error).message}`);
     return null;
   }
-}
-
-function toGroupSessionName(groupId: string): string {
-  return `lattices-group-${groupId}`;
 }
 
 /** Get ordered pane IDs for a specific window within a session */
@@ -949,8 +849,7 @@ async function daemonStatusCommand(): Promise<void> {
 }
 
 async function windowsCommand(jsonFlag: boolean): Promise<void> {
-  try {
-    const { daemonCall } = await getDaemonClient();
+  await withDaemon(async ({ daemonCall }) => {
     const windows = await daemonCall("windows.list") as any[];
     if (jsonFlag) {
       console.log(JSON.stringify(windows, null, 2));
@@ -970,9 +869,7 @@ async function windowsCommand(jsonFlag: boolean): Promise<void> {
       console.log(`    ${Math.round(w.frame.w)}×${Math.round(w.frame.h)} at (${Math.round(w.frame.x)},${Math.round(w.frame.y)})`);
       console.log();
     }
-  } catch {
-    console.log("Daemon not running. Start with: lattices app");
-  }
+  });
 }
 
 async function windowAssignCommand(wid?: string, layerId?: string): Promise<void> {
@@ -1016,175 +913,10 @@ async function focusCommand(session?: string): Promise<void> {
     console.log("Usage: lattices focus <session-name>");
     return;
   }
-  try {
-    const { daemonCall } = await getDaemonClient();
+  await withDaemon(async ({ daemonCall }) => {
     await daemonCall("window.focus", { session });
     console.log(`Focused: ${session}`);
-  } catch (e: unknown) {
-    console.log(`Error: ${(e as Error).message}`);
-  }
-}
-
-// ── Search ───────────────────────────────────────────────────────────
-
-interface SearchResult {
-  score: number;
-  window: any;
-  tabs: { tab: number; cwd: string; title: string; hasClaude: boolean; tmuxSession: string }[];
-  reasons: string[];
-}
-
-function relativeTime(iso: string): string {
-  const ms = Date.now() - new Date(iso).getTime();
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return "just now";
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ago`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h ago`;
-  const d = Math.floor(h / 24);
-  return `${d}d ago`;
-}
-
-// Unified search via lattices.search daemon API.
-// All search surfaces should go through this one function.
-interface SearchOptions {
-  sources?: string[];    // e.g. ["titles", "apps", "cwd", "ocr"] — omit for smart default
-  after?: string;        // ISO8601 — only windows interacted after this time
-  before?: string;       // ISO8601 — only windows interacted before this time
-  recency?: boolean;     // boost recently-focused windows (default true)
-  mode?: string;         // legacy compat: "quick", "complete", "terminal"
-}
-
-async function search(query: string, opts: SearchOptions = {}): Promise<SearchResult[]> {
-  const { daemonCall } = await getDaemonClient();
-  const params: Record<string, any> = { query };
-  if (opts.sources) params.sources = opts.sources;
-  if (opts.after) params.after = opts.after;
-  if (opts.before) params.before = opts.before;
-  if (opts.recency !== undefined) params.recency = opts.recency;
-  if (opts.mode) params.mode = opts.mode; // legacy fallback
-  const hits = await daemonCall("lattices.search", params, 10000) as any[];
-  return hits.map((w: any) => ({
-    score: w.score || 0,
-    window: w,
-    tabs: (w.terminalTabs || []).map((t: any) => ({
-      tab: t.tabIndex, cwd: t.cwd, title: t.tabTitle, hasClaude: t.hasClaude, tmuxSession: t.tmuxSession,
-    })),
-    reasons: w.matchSources || [],
-  }));
-}
-
-// Convenience aliases
-async function deepSearch(query: string): Promise<SearchResult[]> { return search(query, { sources: ["all"] }); }
-async function terminalSearch(query: string): Promise<SearchResult[]> { return search(query, { sources: ["terminals"] }); }
-
-// Format and print search results
-function printResults(ranked: SearchResult[]): void {
-  if (!ranked.length) return;
-  for (const r of ranked) {
-    const w = r.window;
-    const age = w.lastInteraction ? ` \x1b[2m${relativeTime(w.lastInteraction)}\x1b[0m` : "";
-    console.log(`  \x1b[1m${w.app}\x1b[0m  "${w.title}"  wid:${w.wid}  score:${r.score}  (${r.reasons.join(", ")})${age}`);
-    for (const t of r.tabs) {
-      const claude = t.hasClaude ? " \x1b[32m●\x1b[0m" : "";
-      const tmux = t.tmuxSession ? ` \x1b[36m[${t.tmuxSession}]\x1b[0m` : "";
-      console.log(`    tab ${t.tab}: ${t.cwd || t.title}${claude}${tmux}`);
-    }
-    if (w.ocrSnippet) console.log(`    ocr: "${w.ocrSnippet}"`);
-  }
-  console.log();
-}
-
-// ── search command ───────────────────────────────────────────────────
-
-async function searchCommand(query: string | undefined, flags: Set<string>, rawArgs: string[] = []): Promise<void> {
-  if (!query) {
-    console.log("Usage: lattices search <query> [--quick | --terminal | --all | --sources=... | --after=... | --before=... | --json | --wid]");
-    return;
-  }
-
-  // Build search options from flags
-  const opts: SearchOptions = {};
-
-  // Source selection: explicit --sources, or legacy --quick/--terminal, or default
-  const sourcesFlag = rawArgs.find(a => a.startsWith("--sources="));
-  if (sourcesFlag) {
-    opts.sources = sourcesFlag.slice("--sources=".length).split(",");
-  } else if (flags.has("--all")) {
-    opts.sources = ["all"];
-  } else if (flags.has("--quick")) {
-    opts.sources = ["titles", "apps", "sessions"];
-  } else if (flags.has("--terminal")) {
-    opts.sources = ["terminals"];
-  }
-  // else: omit → smart default on daemon side
-
-  // Time filters
-  const afterFlag = rawArgs.find(a => a.startsWith("--after="));
-  if (afterFlag) opts.after = afterFlag.slice("--after=".length);
-  const beforeFlag = rawArgs.find(a => a.startsWith("--before="));
-  if (beforeFlag) opts.before = beforeFlag.slice("--before=".length);
-
-  // No-recency flag
-  if (flags.has("--no-recency")) opts.recency = false;
-
-  const ranked = await search(query, opts);
-  const jsonOut = flags.has("--json");
-  const widOnly = flags.has("--wid");
-
-  if (jsonOut) {
-    console.log(JSON.stringify(ranked.map(r => ({
-      wid: r.window.wid, app: r.window.app, title: r.window.title,
-      score: r.score, reasons: r.reasons, tabs: r.tabs, ocrSnippet: r.window.ocrSnippet,
-    })), null, 2));
-    return;
-  }
-
-  if (widOnly) {
-    for (const r of ranked) console.log(r.window.wid);
-    return;
-  }
-
-  if (!ranked.length) {
-    console.log(`No results for "${query}"`);
-    return;
-  }
-
-  printResults(ranked);
-}
-
-// ── place command ────────────────────────────────────────────────────
-
-async function placeCommand(query?: string, tilePosition?: string): Promise<void> {
-  if (!query) {
-    console.log("Usage: lattices place <query> [position]");
-    return;
-  }
-  try {
-    const { daemonCall } = await getDaemonClient();
-    const ranked = await deepSearch(query);
-
-    if (!ranked.length) {
-      console.log(`No window matching "${query}"`);
-      return;
-    }
-
-    const pos = tilePosition || "bottom-right";
-    const win = ranked[0].window;
-    await daemonCall("window.focus", { wid: win.wid });
-    await daemonCall("intents.execute", {
-      intent: "tile_window",
-      slots: { position: pos, wid: win.wid }
-    }, 3000);
-    console.log(`${win.app} "${win.title}" (wid:${win.wid}) → ${pos}`);
-  } catch (e: unknown) {
-    console.log(`Error: ${(e as Error).message}`);
-  }
-}
-
-function pause(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
+  });
 }
 
 function receiptLine(receipt: any): string {
@@ -1280,8 +1012,7 @@ async function placementSmokeCommand(rawArgs: string[] = []): Promise<void> {
 }
 
 async function sessionsCommand(jsonFlag: boolean): Promise<void> {
-  try {
-    const { daemonCall } = await getDaemonClient();
+  await withDaemon(async ({ daemonCall }) => {
     const sessions = await daemonCall("tmux.sessions") as any[];
     if (jsonFlag) {
       console.log(JSON.stringify(sessions, null, 2));
@@ -1296,37 +1027,36 @@ async function sessionsCommand(jsonFlag: boolean): Promise<void> {
       const windows = s.windowCount || s.windows || "?";
       console.log(`  \x1b[1m${s.name}\x1b[0m  (${windows} windows)`);
     }
-  } catch {
-    console.log("Daemon not running. Start with: lattices app");
-  }
+  });
 }
 
 async function terminalsCommand(rawArgs: string[] = []): Promise<void> {
-  const { daemonCall } = await getDaemonClient();
-  const jsonFlag = hasFlag(rawArgs, "json");
-  const refresh = hasFlag(rawArgs, "refresh");
-  const terminals = await daemonCall("terminals.list", { refresh }, refresh ? 15000 : undefined) as any[];
+  await withDaemon(async ({ daemonCall }) => {
+    const jsonFlag = hasFlag(rawArgs, "json");
+    const refresh = hasFlag(rawArgs, "refresh");
+    const terminals = await daemonCall("terminals.list", { refresh }, refresh ? 15000 : undefined) as any[];
 
-  if (jsonFlag) {
-    console.log(JSON.stringify(terminals, null, 2));
-    return;
-  }
-  if (!terminals.length) {
-    console.log("No terminal instances found.");
-    return;
-  }
+    if (jsonFlag) {
+      console.log(JSON.stringify(terminals, null, 2));
+      return;
+    }
+    if (!terminals.length) {
+      console.log("No terminal instances found.");
+      return;
+    }
 
-  console.log(`Terminals (${terminals.length}):\n`);
-  for (const terminal of terminals) {
-    const app = terminal.app || "terminal";
-    const wid = terminal.windowId ? ` wid=${terminal.windowId}` : "";
-    const cwd = terminal.cwd ? ` cwd=${terminal.cwd}` : "";
-    const session = terminal.tmuxSession ? ` session=${terminal.tmuxSession}` : "";
-    const claude = terminal.hasClaude ? " claude" : "";
-    console.log(`  ${app} ${terminal.tty}${wid}${session}${claude}`);
-    if (terminal.displayName) console.log(`    ${terminal.displayName}`);
-    if (cwd) console.log(`   ${cwd.trim()}`);
-  }
+    console.log(`Terminals (${terminals.length}):\n`);
+    for (const terminal of terminals) {
+      const app = terminal.app || "terminal";
+      const wid = terminal.windowId ? ` wid=${terminal.windowId}` : "";
+      const cwd = terminal.cwd ? ` cwd=${terminal.cwd}` : "";
+      const session = terminal.tmuxSession ? ` session=${terminal.tmuxSession}` : "";
+      const claude = terminal.hasClaude ? " claude" : "";
+      console.log(`  ${app} ${terminal.tty}${wid}${session}${claude}`);
+      if (terminal.displayName) console.log(`    ${terminal.displayName}`);
+      if (cwd) console.log(`   ${cwd.trim()}`);
+    }
+  });
 }
 
 function runLine(run: any): string {
@@ -2020,14 +1750,11 @@ async function callCommand(method?: string, ...rest: string[]): Promise<void> {
     console.log('  lattices call window.place \'{"session":"vox","placement":"left"}\'');
     return;
   }
-  try {
-    const { daemonCall } = await getDaemonClient();
+  await withDaemon(async ({ daemonCall }) => {
     const params = rest[0] ? JSON.parse(rest[0]) : null;
     const result = await daemonCall(method, params, 15000);
     console.log(JSON.stringify(result, null, 2));
-  } catch (e: unknown) {
-    console.log(`Error: ${(e as Error).message}`);
-  }
+  });
 }
 
 interface AppActorAsset {
@@ -2812,20 +2539,19 @@ async function hudCommand(sub?: string, ...rest: string[]): Promise<void> {
 }
 
 async function layerCommand(sub?: string, ...rest: string[]): Promise<void> {
-  try {
-    const { daemonCall } = await getDaemonClient();
+  await withDaemon(async (client) => {
+    const { daemonCall } = client;
 
-    // ── Subcommands ──
     if (sub === "create") {
-      await layerCreateCommand(rest);
+      await layerCreateCommand(client, rest);
       return;
     }
     if (sub === "snap") {
-      await layerSnapCommand(rest[0]);
+      await layerSnapCommand(client, rest[0]);
       return;
     }
     if (sub === "session" || sub === "sessions") {
-      await layerSessionCommand(rest[0]);
+      await layerSessionCommand(client, rest[0]);
       return;
     }
     if (sub === "clear") {
@@ -2840,7 +2566,6 @@ async function layerCommand(sub?: string, ...rest: string[]): Promise<void> {
       return;
     }
 
-    // ── List or switch (original behavior) ──
     if (sub === undefined || sub === null || sub === "") {
       const result = await daemonCall("layers.list") as any;
       if (!result.layers.length) {
@@ -2862,16 +2587,14 @@ async function layerCommand(sub?: string, ...rest: string[]): Promise<void> {
       await daemonCall("layer.activate", { name: sub, mode: "launch" });
       console.log(`Activated layer "${sub}"`);
     }
-  } catch (e: unknown) {
-    console.log(`Error: ${(e as Error).message}`);
-  }
+  });
 }
 
 // ── Layer create: build a session layer from window specs ────────────
 // Usage: lattices layer create <name> [wid:123 wid:456 ...]
 //        lattices layer create <name> --json '[{"app":"Chrome","tile":"left"},...]'
-async function layerCreateCommand(args: string[]): Promise<void> {
-  const { daemonCall } = await getDaemonClient();
+async function layerCreateCommand(client: DaemonClient, args: string[]): Promise<void> {
+  const { daemonCall } = client;
   const name = args[0];
   if (!name) {
     console.log("Usage: lattices layer create <name> [wid:123 ...] [--json '<specs>']");
@@ -2937,8 +2660,8 @@ async function layerCreateCommand(args: string[]): Promise<void> {
 }
 
 // ── Layer snap: snapshot current visible windows into a session layer ─
-async function layerSnapCommand(name?: string): Promise<void> {
-  const { daemonCall } = await getDaemonClient();
+async function layerSnapCommand(client: DaemonClient, name?: string): Promise<void> {
+  const { daemonCall } = client;
   const layerName = name || `snap-${new Date().toISOString().slice(11, 19).replace(/:/g, "")}`;
 
   // Get all current windows
@@ -2961,8 +2684,8 @@ async function layerSnapCommand(name?: string): Promise<void> {
 }
 
 // ── Layer session: list or switch session layers ─────────────────────
-async function layerSessionCommand(nameOrIndex?: string): Promise<void> {
-  const { daemonCall } = await getDaemonClient();
+async function layerSessionCommand(client: DaemonClient, nameOrIndex?: string): Promise<void> {
+  const { daemonCall } = client;
   const result = await daemonCall("session.layers.list") as any;
 
   if (!nameOrIndex) {
@@ -3128,12 +2851,10 @@ async function daemonStatusInventory(): Promise<boolean> {
 // ── OCR commands ──────────────────────────────────────────────────────
 
 async function scanCommand(sub?: string, ...rest: string[]): Promise<void> {
-  const { daemonCall } = await getDaemonClient();
-
   if (!sub || sub === "snapshot" || sub === "ls" || sub === "--full" || sub === "-f" || sub === "--json") {
     const full = sub === "--full" || sub === "-f" || rest.includes("--full") || rest.includes("-f");
     const json = sub === "--json" || rest.includes("--json");
-    try {
+    await withDaemon(async ({ daemonCall }) => {
       const results = await daemonCall("ocr.snapshot", null, 5000) as any[];
       if (!results.length) {
         console.log("No scan results yet. The first scan runs ~60s after launch.");
@@ -3171,9 +2892,7 @@ async function scanCommand(sub?: string, ...rest: string[]): Promise<void> {
         }
         console.log();
       }
-    } catch {
-      console.log("Daemon not running. Start with: lattices app");
-    }
+    });
     return;
   }
 
@@ -3183,7 +2902,7 @@ async function scanCommand(sub?: string, ...rest: string[]): Promise<void> {
       console.log("Usage: lattices scan search <query>");
       return;
     }
-    try {
+    await withDaemon(async ({ daemonCall }) => {
       const results = await daemonCall("ocr.search", { query }, 5000) as any[];
       if (!results.length) {
         console.log(`No matches for "${query}".`);
@@ -3198,9 +2917,7 @@ async function scanCommand(sub?: string, ...rest: string[]): Promise<void> {
         console.log(`    ${snippet}`);
         console.log();
       }
-    } catch (e: unknown) {
-      console.log(`Error: ${(e as Error).message}`);
-    }
+    });
     return;
   }
 
@@ -3208,7 +2925,7 @@ async function scanCommand(sub?: string, ...rest: string[]): Promise<void> {
     const full = rest.includes("--full") || rest.includes("-f");
     const numArg = rest.find(a => !a.startsWith("-"));
     const limit = parseInt(numArg || "", 10) || 20;
-    try {
+    await withDaemon(async ({ daemonCall }) => {
       const results = await daemonCall("ocr.recent", { limit }, 5000) as any[];
       if (!results.length) {
         console.log("No history yet. The first scan runs ~60s after launch.");
@@ -3237,20 +2954,16 @@ async function scanCommand(sub?: string, ...rest: string[]): Promise<void> {
         }
         console.log();
       }
-    } catch {
-      console.log("Daemon not running. Start with: lattices app");
-    }
+    });
     return;
   }
 
   if (sub === "deep" || sub === "now" || sub === "scan") {
-    try {
+    await withDaemon(async ({ daemonCall }) => {
       console.log("Triggering deep scan (Vision OCR)...");
       await daemonCall("ocr.scan", null, 30000);
       console.log("Done.");
-    } catch (e: unknown) {
-      console.log(`Error: ${(e as Error).message}`);
-    }
+    });
     return;
   }
 
@@ -3260,7 +2973,7 @@ async function scanCommand(sub?: string, ...rest: string[]): Promise<void> {
       console.log("Usage: lattices scan history <wid>");
       return;
     }
-    try {
+    await withDaemon(async ({ daemonCall }) => {
       const results = await daemonCall("ocr.history", { wid }, 5000) as any[];
       if (!results.length) {
         console.log(`No history for wid:${wid}.`);
@@ -3278,9 +2991,7 @@ async function scanCommand(sub?: string, ...rest: string[]): Promise<void> {
         }
         console.log();
       }
-    } catch (e: unknown) {
-      console.log(`Error: ${(e as Error).message}`);
-    }
+    });
     return;
   }
 
@@ -3610,8 +3321,7 @@ async function optimizeWindowsCommand(
   request: SpaceOptimizeRequest,
   successVerb: string
 ): Promise<void> {
-  try {
-    const { daemonCall } = await getDaemonClient();
+  await withDaemon(async ({ daemonCall }) => {
     const params: Record<string, unknown> = {
       scope: request.scope,
       strategy: "balanced",
@@ -3632,9 +3342,7 @@ async function optimizeWindowsCommand(
     console.log(
       `${successVerb} ${count} window${count === 1 ? "" : "s"} for ${target}${regionSuffix}.`
     );
-  } catch {
-    console.log("Daemon not running. Start with: lattices app");
-  }
+  });
 }
 
 function gridTileBounds(position: string, screen: ScreenBounds): number[] | null {
@@ -3924,7 +3632,7 @@ switch (command) {
     break;
   case "search":
   case "s":
-    await searchCommand(args[1], new Set(args.slice(2)));
+    await searchCommand(args[1], new Set(args.slice(2)), args.slice(2));
     break;
   case "focus":
     await focusCommand(args[1]);

--- a/bin/lattices.ts
+++ b/bin/lattices.ts
@@ -15,6 +15,9 @@ import {
   runQuiet,
 } from "./cli/helpers.ts";
 import { searchCommand, placeCommand } from "./cli/search.ts";
+import { captureCommand } from "./cli/capture.ts";
+import { layerCommand } from "./cli/layer.ts";
+import { runsCommand } from "./cli/runs.ts";
 import {
   esc,
   sessionExists,
@@ -817,15 +820,16 @@ function restartPane(target?: string): void {
 // ── Daemon-aware commands ────────────────────────────────────────────
 
 async function mouseCommand(sub?: string): Promise<void> {
-  const { daemonCall } = await getDaemonClient();
-  if (sub === "summon") {
-    const result = await daemonCall("mouse.summon") as any;
-    console.log(`🎯 Mouse summoned to (${result.x}, ${result.y})`);
-  } else {
-    // Default: find
-    const result = await daemonCall("mouse.find") as any;
-    console.log(`🔍 Mouse at (${result.x}, ${result.y})`);
-  }
+  await withDaemon(async ({ daemonCall }) => {
+    if (sub === "summon") {
+      const result = await daemonCall("mouse.summon") as any;
+      console.log(`🎯 Mouse summoned to (${result.x}, ${result.y})`);
+    } else {
+      // Default: find
+      const result = await daemonCall("mouse.find") as any;
+      console.log(`🔍 Mouse at (${result.x}, ${result.y})`);
+    }
+  });
 }
 
 async function daemonStatusCommand(): Promise<void> {
@@ -877,18 +881,14 @@ async function windowAssignCommand(wid?: string, layerId?: string): Promise<void
     console.log("Usage: lattices window assign <wid> <layer-id>");
     return;
   }
-  try {
-    const { daemonCall } = await getDaemonClient();
+  await withDaemon(async ({ daemonCall }) => {
     await daemonCall("window.assignLayer", { wid: parseInt(wid), layer: layerId });
     console.log(`Tagged wid:${wid} → layer:${layerId}`);
-  } catch (e: unknown) {
-    console.log(`Error: ${(e as Error).message}`);
-  }
+  });
 }
 
 async function windowLayerMapCommand(jsonFlag: boolean): Promise<void> {
-  try {
-    const { daemonCall } = await getDaemonClient();
+  await withDaemon(async ({ daemonCall }) => {
     const map = await daemonCall("window.layerMap") as any;
     if (jsonFlag) {
       console.log(JSON.stringify(map, null, 2));
@@ -903,9 +903,7 @@ async function windowLayerMapCommand(jsonFlag: boolean): Promise<void> {
     for (const [wid, layer] of entries) {
       console.log(`  wid:${wid} → ${layer}`);
     }
-  } catch {
-    console.log("Daemon not running. Start with: lattices app");
-  }
+  });
 }
 
 async function focusCommand(session?: string): Promise<void> {
@@ -930,85 +928,86 @@ function receiptLine(receipt: any): string {
 }
 
 async function placementSmokeCommand(rawArgs: string[] = []): Promise<void> {
-  const { daemonCall } = await getDaemonClient();
   const pauseMs = Number(parseFlagValue(rawArgs, "pause") || 1200);
   const positional = nonFlagArgs(rawArgs);
 
-  let sessions = positional.slice(0, 2);
-  if (sessions.length < 2) {
-    const tmuxSessions = await daemonCall("tmux.sessions") as any[];
-    sessions = tmuxSessions
-      .map(s => s?.name)
-      .filter((name: unknown): name is string => typeof name === "string" && name.startsWith("lattices-place-"))
-      .slice(0, 2);
-  }
-
-  if (sessions.length < 2) {
-    console.log("Need two named sessions. Usage: lattices dev placement-smoke <session-a> <session-b>");
-    console.log("Tip: launch two small lattices fixture projects first, then rerun this command.");
-    return;
-  }
-
-  const [a, b] = sessions;
-  console.log(`Placement smoke: ${a} + ${b}`);
-
-  for (const session of sessions) {
-    const resolved = await daemonCall("window.resolve", {
-      target: { kind: "session", session },
-      placement: "left",
-    }) as any;
-    console.log(`  resolve ${session}: wid=${resolved.wid ?? "?"} app=${resolved.app ?? "?"} resolution=${resolved.targetResolution ?? "?"}`);
-  }
-
-  const beats = [
-    {
-      label: "beat 1: halves",
-      actions: [
-        { id: "a-left-half", type: "window.place", target: { kind: "session", session: a }, args: { placement: "left" } },
-        { id: "b-right-half", type: "window.place", target: { kind: "session", session: b }, args: { placement: "right" } },
-      ],
-    },
-    {
-      label: "beat 2: 4x4 corners",
-      actions: [
-        { id: "a-top-left-4x4", type: "window.place", target: { kind: "session", session: a }, args: { placement: "grid:4x4:0,0" } },
-        { id: "b-bottom-right-4x4", type: "window.place", target: { kind: "session", session: b }, args: { placement: "grid:4x4:3,3" } },
-      ],
-    },
-    {
-      label: "beat 3: workbench",
-      actions: [
-        {
-          id: "a-workbench-left",
-          type: "window.place",
-          target: { kind: "session", session: a },
-          args: { placement: { kind: "fractions", x: 0.02, y: 0.05, w: 0.62, h: 0.9 } },
-        },
-        {
-          id: "b-console-right",
-          type: "window.place",
-          target: { kind: "session", session: b },
-          args: { placement: { kind: "fractions", x: 0.67, y: 0.12, w: 0.3, h: 0.76 } },
-        },
-      ],
-    },
-  ];
-
-  for (const beat of beats) {
-    console.log(`\n${beat.label}`);
-    const result = await daemonCall("actions.execute", {
-      source: "placement-smoke",
-      actions: beat.actions,
-    }, 15000) as any;
-    console.log(`  batch=${result.status || "?"} request=${result.requestId || "?"}`);
-    for (const receipt of result.receipts || []) {
-      console.log(receiptLine(receipt));
+  await withDaemon(async ({ daemonCall }) => {
+    let sessions = positional.slice(0, 2);
+    if (sessions.length < 2) {
+      const tmuxSessions = await daemonCall("tmux.sessions") as any[];
+      sessions = tmuxSessions
+        .map(s => s?.name)
+        .filter((name: unknown): name is string => typeof name === "string" && name.startsWith("lattices-place-"))
+        .slice(0, 2);
     }
-    await pause(pauseMs);
-  }
 
-  const focused = await daemonCall("window.focus", { session: a }, 5000) as any;
-  console.log(`\nfocus ${a}: ok=${focused.ok === true} wid=${focused.wid ?? "?"} raised=${focused.raised === true}`);
+    if (sessions.length < 2) {
+      console.log("Need two named sessions. Usage: lattices dev placement-smoke <session-a> <session-b>");
+      console.log("Tip: launch two small lattices fixture projects first, then rerun this command.");
+      return;
+    }
+
+    const [a, b] = sessions;
+    console.log(`Placement smoke: ${a} + ${b}`);
+
+    for (const session of sessions) {
+      const resolved = await daemonCall("window.resolve", {
+        target: { kind: "session", session },
+        placement: "left",
+      }) as any;
+      console.log(`  resolve ${session}: wid=${resolved.wid ?? "?"} app=${resolved.app ?? "?"} resolution=${resolved.targetResolution ?? "?"}`);
+    }
+
+    const beats = [
+      {
+        label: "beat 1: halves",
+        actions: [
+          { id: "a-left-half", type: "window.place", target: { kind: "session", session: a }, args: { placement: "left" } },
+          { id: "b-right-half", type: "window.place", target: { kind: "session", session: b }, args: { placement: "right" } },
+        ],
+      },
+      {
+        label: "beat 2: 4x4 corners",
+        actions: [
+          { id: "a-top-left-4x4", type: "window.place", target: { kind: "session", session: a }, args: { placement: "grid:4x4:0,0" } },
+          { id: "b-bottom-right-4x4", type: "window.place", target: { kind: "session", session: b }, args: { placement: "grid:4x4:3,3" } },
+        ],
+      },
+      {
+        label: "beat 3: workbench",
+        actions: [
+          {
+            id: "a-workbench-left",
+            type: "window.place",
+            target: { kind: "session", session: a },
+            args: { placement: { kind: "fractions", x: 0.02, y: 0.05, w: 0.62, h: 0.9 } },
+          },
+          {
+            id: "b-console-right",
+            type: "window.place",
+            target: { kind: "session", session: b },
+            args: { placement: { kind: "fractions", x: 0.67, y: 0.12, w: 0.3, h: 0.76 } },
+          },
+        ],
+      },
+    ];
+
+    for (const beat of beats) {
+      console.log(`\n${beat.label}`);
+      const result = await daemonCall("actions.execute", {
+        source: "placement-smoke",
+        actions: beat.actions,
+      }, 15000) as any;
+      console.log(`  batch=${result.status || "?"} request=${result.requestId || "?"}`);
+      for (const receipt of result.receipts || []) {
+        console.log(receiptLine(receipt));
+      }
+      await pause(pauseMs);
+    }
+
+    const focused = await daemonCall("window.focus", { session: a }, 5000) as any;
+    console.log(`\nfocus ${a}: ok=${focused.ok === true} wid=${focused.wid ?? "?"} raised=${focused.raised === true}`);
+  });
 }
 
 async function sessionsCommand(jsonFlag: boolean): Promise<void> {
@@ -1057,309 +1056,6 @@ async function terminalsCommand(rawArgs: string[] = []): Promise<void> {
       if (cwd) console.log(`   ${cwd.trim()}`);
     }
   });
-}
-
-function runLine(run: any): string {
-  const count = Array.isArray(run.artifacts) ? run.artifacts.length : 0;
-  const completed = run.completedAt ? ` completed=${run.completedAt}` : "";
-  return `  ${run.id}  ${run.state || "?"}  artifacts=${count}  ${run.title || "Untitled run"}${completed}`;
-}
-
-async function runsCommand(rawArgs: string[] = []): Promise<void> {
-  const { daemonCall } = await getDaemonClient();
-  const jsonFlag = hasFlag(rawArgs, "json");
-  const positional = nonFlagArgs(rawArgs);
-  const sub = positional[0];
-
-  try {
-    if (sub && sub !== "list") {
-      const run = await daemonCall("runs.get", { id: sub }) as any;
-      if (jsonFlag) {
-        console.log(JSON.stringify(run, null, 2));
-        return;
-      }
-      console.log(runLine(run));
-      console.log(`  artifacts: ${run.artifactDirectoryPath}`);
-      for (const artifact of run.artifacts || []) {
-        console.log(`    ${artifact.kind}  ${artifact.path}`);
-      }
-      return;
-    }
-
-    const limit = Number(parseFlagValue(rawArgs, "limit") || 20);
-    const runs = await daemonCall("runs.list", { limit }) as any[];
-    if (jsonFlag) {
-      console.log(JSON.stringify(runs, null, 2));
-      return;
-    }
-    if (!runs.length) {
-      console.log("No runs yet.");
-      return;
-    }
-    console.log(`Runs (${runs.length}):\n`);
-    for (const run of runs) console.log(runLine(run));
-  } catch (error) {
-    console.log(`Error: ${(error as Error).message}`);
-  }
-}
-
-async function captureCommand(subcommand?: string, ...rawArgs: string[]): Promise<void> {
-  const sub = subcommand || "window";
-  const dashIndex = rawArgs.indexOf("--");
-  const commandArgs = dashIndex >= 0 ? rawArgs.slice(0, dashIndex) : rawArgs;
-  const childArgs = dashIndex >= 0 ? rawArgs.slice(dashIndex + 1) : [];
-  const jsonFlag = hasFlag(commandArgs, "json");
-  const positional = nonFlagArgs(commandArgs);
-
-  if (["stop", "stop-recording", "stopRecording"].includes(sub)) {
-    const params: Record<string, unknown> = {};
-    const runId = positional[0] || parseFlagValue(commandArgs, "run-id") || parseFlagValue(commandArgs, "runId") || parseFlagValue(commandArgs, "id");
-    const stopFile = parseFlagValue(commandArgs, "stop-file") || parseFlagValue(commandArgs, "stopFile");
-    const finishedFile = parseFlagValue(commandArgs, "finished-file") || parseFlagValue(commandArgs, "finishedFile");
-    const timeoutMs = Number(parseFlagValue(commandArgs, "timeout-ms") || parseFlagValue(commandArgs, "timeoutMs") || 30000);
-    if (runId) params.runId = runId;
-    if (stopFile) params.stopFile = stopFile;
-    if (finishedFile) params.finishedFile = finishedFile;
-    if (Number.isFinite(timeoutMs)) params.timeoutMs = timeoutMs;
-    params.wait = !hasFlag(commandArgs, "no-wait");
-
-    try {
-      const { daemonCall } = await getDaemonClient();
-      const result = await daemonCall("capture.stopRecording", params, timeoutMs + 5000) as any;
-      if (jsonFlag) {
-        console.log(JSON.stringify(result, null, 2));
-        return;
-      }
-      console.log(result.finished ? "Recording finished." : "Recording stop requested.");
-      if (result.run?.id) console.log(`  run: ${result.run.id}`);
-      if (result.marker) console.log(`  marker: ${result.marker}`);
-    } catch (error) {
-      console.log(`Error: ${(error as Error).message}`);
-      process.exitCode = 1;
-    }
-    return;
-  }
-
-  const isRecordCommand = [
-    "record-command",
-    "recordCommand",
-    "record-run",
-    "recordRun",
-    "record-exec",
-    "recordExec",
-  ].includes(sub);
-
-  if (isRecordCommand) {
-    if (!childArgs.length) {
-      console.log(`lattices capture record-command — record while running a command
-
-Usage:
-  lattices capture record-command --app Scout --filename demo.mov -- <command> [...args]
-`);
-      return;
-    }
-
-    const params: Record<string, unknown> = { source: "cli" };
-    const explicitWid = positional[0] ? Number(positional[0]) : NaN;
-    if (Number.isFinite(explicitWid)) params.wid = explicitWid;
-
-    const session = parseFlagValue(commandArgs, "session");
-    const app = parseFlagValue(commandArgs, "app");
-    const title = parseFlagValue(commandArgs, "title");
-    const filename = parseFlagValue(commandArgs, "filename");
-    const runId = parseFlagValue(commandArgs, "run-id") || parseFlagValue(commandArgs, "runId");
-    const mode = parseFlagValue(commandArgs, "mode");
-    const fps = parseOptionalNumber(commandArgs, "fps");
-    const scale = parseOptionalNumber(commandArgs, "scale");
-    const timeoutMs = Number(parseFlagValue(commandArgs, "timeout-ms") || parseFlagValue(commandArgs, "timeoutMs") || 30000);
-    if (session) params.session = session;
-    if (app) params.app = app;
-    if (title) params.title = title;
-    if (filename) params.filename = filename;
-    if (runId) params.runId = runId;
-    if (mode) params.mode = mode;
-    if (fps !== undefined) params.fps = fps;
-    if (scale !== undefined) params.scale = scale;
-
-    for (const [flag, key] of [["x", "x"], ["y", "y"], ["width", "width"], ["height", "height"], ["w", "w"], ["h", "h"]] as const) {
-      const value = parseOptionalNumber(commandArgs, flag);
-      if (value !== undefined) params[key] = value;
-    }
-
-    const recordsRegion = hasFlag(commandArgs, "region") ||
-      (params.x !== undefined && params.y !== undefined &&
-        (params.width !== undefined || params.w !== undefined) &&
-        (params.height !== undefined || params.h !== undefined));
-    const method = recordsRegion ? "capture.recordRegion" : "capture.recordWindow";
-
-    try {
-      const { daemonCall } = await getDaemonClient();
-      const start = await daemonCall(method, params, 20000) as any;
-      let childExitCode = 0;
-      let childError: string | undefined;
-
-      try {
-        const proc = Bun.spawn(childArgs, {
-          cwd: process.cwd(),
-          env: process.env,
-          stdin: "inherit",
-          stdout: "inherit",
-          stderr: "inherit",
-        });
-        childExitCode = await proc.exited;
-      } catch (error) {
-        childExitCode = 127;
-        childError = (error as Error).message;
-      }
-
-      const stop = await daemonCall(
-        "capture.stopRecording",
-        { runId: start.run?.id, wait: true, timeoutMs },
-        timeoutMs + 5000
-      ) as any;
-
-      if (jsonFlag) {
-        console.log(JSON.stringify({
-          ok: childExitCode === 0 && stop.ok !== false,
-          child: {
-            command: childArgs,
-            exitCode: childExitCode,
-            error: childError,
-          },
-          recording: start,
-          stopResult: stop,
-        }, null, 2));
-      } else {
-        const artifact = start.artifact || {};
-        const run = stop.run || start.run || {};
-        console.log(`Recording finished.`);
-        console.log(`  run: ${run.id || start.run?.id || "?"}`);
-        console.log(`  artifact: ${artifact.path || "?"}`);
-        console.log(`  child exit: ${childExitCode}`);
-        if (childError) console.log(`  child error: ${childError}`);
-      }
-
-      if (childExitCode !== 0 && !hasFlag(commandArgs, "ignore-child-failure")) {
-        process.exitCode = childExitCode;
-      }
-    } catch (error) {
-      console.log(`Error: ${(error as Error).message}`);
-    }
-    return;
-  }
-
-  const isRecord = ["record", "record-window", "recording", "video"].includes(sub);
-  const isRecordRegion = ["record-region", "recordRegion", "region-recording"].includes(sub) ||
-    (sub === "record" && ["region", "rect"].includes(positional[0] || ""));
-
-  if (isRecord || isRecordRegion) {
-    const params: Record<string, unknown> = { source: "cli" };
-    const targetKind = sub === "record" ? positional[0] : undefined;
-    const positionalOffset = targetKind === "window" || targetKind === "region" || targetKind === "rect" ? 1 : 0;
-    const explicitWid = positional[positionalOffset] ? Number(positional[positionalOffset]) : NaN;
-    if (Number.isFinite(explicitWid)) params.wid = explicitWid;
-
-    const session = parseFlagValue(commandArgs, "session");
-    const app = parseFlagValue(commandArgs, "app");
-    const title = parseFlagValue(commandArgs, "title");
-    const filename = parseFlagValue(commandArgs, "filename");
-    const runId = parseFlagValue(commandArgs, "run-id") || parseFlagValue(commandArgs, "runId");
-    const mode = parseFlagValue(commandArgs, "mode");
-    const fps = parseOptionalNumber(commandArgs, "fps");
-    const scale = parseOptionalNumber(commandArgs, "scale");
-    const durationMs = parseOptionalNumber(commandArgs, "duration-ms", "durationMs", "duration");
-    if (session) params.session = session;
-    if (app) params.app = app;
-    if (title) params.title = title;
-    if (filename) params.filename = filename;
-    if (runId) params.runId = runId;
-    if (mode) params.mode = mode;
-    if (fps !== undefined) params.fps = fps;
-    if (scale !== undefined) params.scale = scale;
-
-    for (const [flag, key] of [["x", "x"], ["y", "y"], ["width", "width"], ["height", "height"], ["w", "w"], ["h", "h"]] as const) {
-      const value = parseOptionalNumber(commandArgs, flag);
-      if (value !== undefined) params[key] = value;
-    }
-
-    try {
-      const { daemonCall } = await getDaemonClient();
-      const method = isRecordRegion ? "capture.recordRegion" : "capture.recordWindow";
-      const result = await daemonCall(method, params, 20000) as any;
-
-      if (durationMs !== undefined && durationMs > 0) {
-        await new Promise((resolve) => setTimeout(resolve, durationMs));
-        const stop = await daemonCall(
-          "capture.stopRecording",
-          { runId: result.run?.id, wait: true, timeoutMs: 30000 },
-          35000
-        ) as any;
-        result.stopResult = stop;
-      }
-
-      if (jsonFlag) {
-        console.log(JSON.stringify(result, null, 2));
-        return;
-      }
-      const artifact = result.artifact || {};
-      const run = result.stopResult?.run || result.run || {};
-      console.log(`Recording ${result.stopResult ? "finished" : "started"}.`);
-      console.log(`  run: ${run.id || result.run?.id || "?"}`);
-      console.log(`  artifact: ${artifact.path || "?"}`);
-      if (!result.stopResult) {
-        console.log(`  stop: lattices capture stop ${result.run?.id || ""}`);
-      }
-    } catch (error) {
-      console.log(`Error: ${(error as Error).message}`);
-    }
-    return;
-  }
-
-  if (!["window", "screenshot", "shot"].includes(sub)) {
-    console.log(`lattices capture — capture run artifacts
-
-Usage:
-  lattices capture window [wid] [--json]
-  lattices capture screenshot [wid] [--session name] [--app name]
-  lattices capture record window [wid] [--app name] [--duration-ms 5000] [--json]
-  lattices capture record region --x N --y N --width N --height N [--duration-ms 5000]
-  lattices capture record-command --app Scout --filename demo.mov -- <command> [...args]
-  lattices capture stop <run-id>
-`);
-    return;
-  }
-
-  const params: Record<string, unknown> = { source: "cli" };
-  const explicitWid = positional[0] ? Number(positional[0]) : NaN;
-  if (Number.isFinite(explicitWid)) params.wid = explicitWid;
-  const session = parseFlagValue(commandArgs, "session");
-  const app = parseFlagValue(commandArgs, "app");
-  const title = parseFlagValue(commandArgs, "title");
-  const filename = parseFlagValue(commandArgs, "filename");
-  const runId = parseFlagValue(commandArgs, "run-id") || parseFlagValue(commandArgs, "runId");
-  if (session) params.session = session;
-  if (app) params.app = app;
-  if (title) params.title = title;
-  if (filename) params.filename = filename;
-  if (runId) params.runId = runId;
-
-  try {
-    const { daemonCall } = await getDaemonClient();
-    const result = await daemonCall("capture.screenshotWindow", params, 20000) as any;
-    if (jsonFlag) {
-      console.log(JSON.stringify(result, null, 2));
-      return;
-    }
-    const artifact = result.artifact || {};
-    const run = result.run || {};
-    const target = result.target || {};
-    console.log(`Captured ${target.app || "window"} ${target.wid ? `wid:${target.wid}` : ""}`);
-    console.log(`  run: ${run.id || "?"}`);
-    console.log(`  artifact: ${artifact.path || "?"}`);
-  } catch (error) {
-    console.log(`Error: ${(error as Error).message}`);
-    process.exitCode = 1;
-  }
 }
 
 async function computerCommand(subcommand?: string, ...rawArgs: string[]): Promise<void> {
@@ -1607,7 +1303,7 @@ Common flags:
   if (hasFlag(rawArgs, "observe")) params.treatment = "observe";
   if (hasFlag(rawArgs, "click")) params.click = true;
 
-  try {
+  await withDaemon(async ({ daemonCall }) => {
     let result: any;
     if (method === "computer.click" || method === "computer.magicCursor") {
       const cua = await import("./cua.ts");
@@ -1615,7 +1311,6 @@ Common flags:
         ? await cua.click(params as any)
         : await cua.magicCursor(params as any);
     } else {
-      const { daemonCall } = await getDaemonClient();
       result = await daemonCall(method, params, 30000) as any;
     }
     if (jsonFlag) {
@@ -1646,71 +1341,73 @@ Common flags:
     if (result.transport) console.log(`  transport: ${result.transport}`);
     if (result.beforeArtifact?.path) console.log(`  before: ${result.beforeArtifact.path}`);
     if (result.afterArtifact?.path) console.log(`  after: ${result.afterArtifact.path}`);
-  } catch (error) {
-    console.log(`Error: ${(error as Error).message}`);
-  }
+  });
 }
 
 async function voiceCommand(subcommand?: string, ...rest: string[]): Promise<void> {
-  const { daemonCall } = await getDaemonClient();
-  try {
-    switch (subcommand) {
-      case "status": {
-        const status = await daemonCall("voice.status") as any;
-        console.log(`Provider: ${status.provider}`);
-        console.log(`Available: ${status.available}`);
-        console.log(`Listening: ${status.listening}`);
-        if (status.lastTranscript) console.log(`Last: "${status.lastTranscript}"`);
-        break;
-      }
-      case "simulate":
-      case "sim": {
-        const text = rest.join(" ");
-        if (!text) {
-          console.log("Usage: lattices voice simulate <text>");
-          return;
-        }
-        const execute = !rest.includes("--dry-run");
-        const dryFlag = rest.includes("--dry-run");
-        const cleanText = dryFlag ? rest.filter(r => r !== "--dry-run").join(" ") : text;
-        const result = await daemonCall("voice.simulate", { text: cleanText, execute }, 15000) as any;
-        if (!result.parsed) {
-          console.log(`\x1b[33mNo match:\x1b[0m "${cleanText}"`);
-          return;
-        }
-        const slots = Object.entries(result.slots || {}).map(([k,v]) => `${k}: ${v}`).join(", ");
-        const conf = result.confidence ? ` (${(result.confidence * 100).toFixed(0)}%)` : "";
-        console.log(`\x1b[36m${result.intent}\x1b[0m${slots ? `  ${slots}` : ""}${conf}`);
-        if (result.executed) {
-          console.log(`\x1b[32mExecuted\x1b[0m`);
-        } else if (result.error) {
-          console.log(`\x1b[31mError:\x1b[0m ${result.error}`);
-        }
-        break;
-      }
-      case "intents": {
-        const intents = await daemonCall("intents.list") as any[];
-        for (const intent of intents) {
-          const slots = intent.slots.map((s: any) => `${s.name}:${s.type}${s.required ? "*" : ""}`).join(", ");
-          console.log(`  \x1b[1m${intent.intent}\x1b[0m  ${intent.description}`);
-          if (slots) console.log(`    slots: ${slots}`);
-          console.log(`    e.g. "${intent.examples[0]}"`);
-          console.log();
-        }
-        break;
-      }
-      default:
-        console.log("Usage: lattices voice <subcommand>\n");
-        console.log("  status      Show voice provider status");
-        console.log("  simulate    Parse and execute a voice command");
-        console.log("  intents     List all available intents");
-        console.log("\nExamples:");
-        console.log('  lattices voice simulate "tile this left"');
-        console.log('  lattices voice simulate "focus chrome" --dry-run');
-    }
-  } catch (e: unknown) {
-    console.log(`Error: ${(e as Error).message}`);
+  if (subcommand !== "status" && subcommand !== "simulate" && subcommand !== "sim" && subcommand !== "intents") {
+    console.log("Usage: lattices voice <subcommand>\n");
+    console.log("  status      Show voice provider status");
+    console.log("  simulate    Parse and execute a voice command");
+    console.log("  intents     List all available intents");
+    console.log("\nExamples:");
+    console.log('  lattices voice simulate "tile this left"');
+    console.log('  lattices voice simulate "focus chrome" --dry-run');
+    return;
   }
+
+  if (subcommand === "simulate" || subcommand === "sim") {
+    const text = rest.join(" ");
+    if (!text) {
+      console.log("Usage: lattices voice simulate <text>");
+      return;
+    }
+  }
+
+  await withDaemon(async ({ daemonCall }) => {
+    switch (subcommand) {
+    case "status": {
+      const status = await daemonCall("voice.status") as any;
+      console.log(`Provider: ${status.provider}`);
+      console.log(`Available: ${status.available}`);
+      console.log(`Listening: ${status.listening}`);
+      if (status.lastTranscript) console.log(`Last: "${status.lastTranscript}"`);
+      break;
+    }
+    case "simulate":
+    case "sim": {
+      const text = rest.join(" ");
+      const execute = !rest.includes("--dry-run");
+      const dryFlag = rest.includes("--dry-run");
+      const cleanText = dryFlag ? rest.filter(r => r !== "--dry-run").join(" ") : text;
+      const result = await daemonCall("voice.simulate", { text: cleanText, execute }, 15000) as any;
+      if (!result.parsed) {
+        console.log(`\x1b[33mNo match:\x1b[0m "${cleanText}"`);
+        return;
+      }
+      const slots = Object.entries(result.slots || {}).map(([k,v]) => `${k}: ${v}`).join(", ");
+      const conf = result.confidence ? ` (${(result.confidence * 100).toFixed(0)}%)` : "";
+      console.log(`\x1b[36m${result.intent}\x1b[0m${slots ? `  ${slots}` : ""}${conf}`);
+      if (result.executed) {
+        console.log(`\x1b[32mExecuted\x1b[0m`);
+      } else if (result.error) {
+        console.log(`\x1b[31mError:\x1b[0m ${result.error}`);
+      }
+      break;
+    }
+    case "intents": {
+      const intents = await daemonCall("intents.list") as any[];
+      for (const intent of intents) {
+        const slots = intent.slots.map((s: any) => `${s.name}:${s.type}${s.required ? "*" : ""}`).join(", ");
+        console.log(`  \x1b[1m${intent.intent}\x1b[0m  ${intent.description}`);
+        if (slots) console.log(`    slots: ${slots}`);
+        console.log(`    e.g. "${intent.examples[0]}"`);
+        console.log();
+      }
+      break;
+    }
+    }
+  });
 }
 
 async function assistantCommand(subcommand?: string, ...rest: string[]): Promise<void> {
@@ -1947,40 +1644,42 @@ async function actorHUDCommand(rest: string[]): Promise<void> {
     return;
   }
 
-  const { daemonCall } = await getDaemonClient();
   const url = positional[1];
   const clear = hasFlag(rest, "clear");
-  const result = await daemonCall("overlay.actor.hud", {
-    id,
-    clear,
-    ...(url && !clear ? { hudUrl: url } : {}),
-    ...actorHUDOptions(rest),
-  }, 15000) as any;
+  await withDaemon(async ({ daemonCall }) => {
+    const result = await daemonCall("overlay.actor.hud", {
+      id,
+      clear,
+      ...(url && !clear ? { hudUrl: url } : {}),
+      ...actorHUDOptions(rest),
+    }, 15000) as any;
 
-  if (hasFlag(rest, "json")) {
-    console.log(JSON.stringify(result, null, 2));
-  } else if (clear) {
-    console.log(`Cleared HUD for ${id}.`);
-  } else {
-    console.log(`Attached hover HUD to ${id}.`);
-  }
+    if (hasFlag(rest, "json")) {
+      console.log(JSON.stringify(result, null, 2));
+    } else if (clear) {
+      console.log(`Cleared HUD for ${id}.`);
+    } else {
+      console.log(`Attached hover HUD to ${id}.`);
+    }
+  });
 }
 
 async function actorVisibilityCommand(action: string, rest: string[]): Promise<void> {
-  const { daemonCall } = await getDaemonClient();
-  const result = await daemonCall("overlay.actor.visibility", {
-    action,
-    feedback: !hasFlag(rest, "quiet") && action !== "status",
-  }, 15000) as any;
+  await withDaemon(async ({ daemonCall }) => {
+    const result = await daemonCall("overlay.actor.visibility", {
+      action,
+      feedback: !hasFlag(rest, "quiet") && action !== "status",
+    }, 15000) as any;
 
-  if (hasFlag(rest, "json")) {
-    console.log(JSON.stringify(result, null, 2));
-    return;
-  }
+    if (hasFlag(rest, "json")) {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
 
-  const state = result.visible ? "shown" : "hidden";
-  const count = Number(result.actorCount ?? 0);
-  console.log(`Actor layer ${state} (${count} actor${count === 1 ? "" : "s"}).`);
+    const state = result.visible ? "shown" : "hidden";
+    const count = Number(result.actorCount ?? 0);
+    console.log(`Actor layer ${state} (${count} actor${count === 1 ? "" : "s"}).`);
+  });
 }
 
 async function actorAppCommand(rest: string[]): Promise<void> {
@@ -1991,86 +1690,28 @@ async function actorAppCommand(rest: string[]): Promise<void> {
     return;
   }
   const message = positional.slice(1).join(" ") || `Tap to switch to ${appQuery}.`;
-  const asset = ensureAppActorAsset(appQuery);
-  const { daemonCall } = await getDaemonClient();
-  const id = parseFlagValue(rest, "id") || `app-${slugify(asset.appName)}`;
-  const state = parseFlagValue(rest, "state") || "idle";
-  const ttlMs = Number(parseFlagValue(rest, "ttl") || parseFlagValue(rest, "ttlMs") || 0);
-  const x = Number(parseFlagValue(rest, "x") || 520);
-  const y = Number(parseFlagValue(rest, "y") || 340);
-  const placement = parseFlagValue(rest, "placement") || "point";
-  const style = parseFlagValue(rest, "style") || "playful";
-  const dismissible = hasFlag(rest, "dismissible");
-  const labelHidden = shouldHideActorLabel(rest);
-  const closeOnActivate = hasFlag(rest, "close-on-activate") || hasFlag(rest, "closeOnActivate");
-  const scale = Number(parseFlagValue(rest, "scale") || 1);
+  await withDaemon(async ({ daemonCall }) => {
+    const asset = ensureAppActorAsset(appQuery);
+    const id = parseFlagValue(rest, "id") || `app-${slugify(asset.appName)}`;
+    const state = parseFlagValue(rest, "state") || "idle";
+    const ttlMs = Number(parseFlagValue(rest, "ttl") || parseFlagValue(rest, "ttlMs") || 0);
+    const x = Number(parseFlagValue(rest, "x") || 520);
+    const y = Number(parseFlagValue(rest, "y") || 340);
+    const placement = parseFlagValue(rest, "placement") || "point";
+    const style = parseFlagValue(rest, "style") || "playful";
+    const dismissible = hasFlag(rest, "dismissible");
+    const labelHidden = shouldHideActorLabel(rest);
+    const closeOnActivate = hasFlag(rest, "close-on-activate") || hasFlag(rest, "closeOnActivate");
+    const scale = Number(parseFlagValue(rest, "scale") || 1);
 
-  const result = await daemonCall("overlay.actor.publish", {
-    id,
-    renderer: "sprite",
-    asset: asset.id,
-    state,
-    name: parseFlagValue(rest, "name") || asset.appName,
-    message,
-    placement,
-    x,
-    y,
-    style,
-    ttlMs,
-    dismissible,
-    labelHidden,
-    closeOnActivate,
-    scale,
-    ...actorHUDOptions(rest),
-    targetApp: asset.appName,
-    targetBundleId: asset.bundleIdentifier,
-    targetAppPath: asset.appPath,
-  }, 15000) as any;
-
-  if (!hasFlag(rest, "no-move")) {
-    await daemonCall("overlay.actor.moveTo", {
-      id,
-      x: x + 40,
-      y: y + 50,
-      durationMs: 700,
-      easing: "spring",
-    }, 15000);
-  }
-
-  if (hasFlag(rest, "json")) {
-    console.log(JSON.stringify({ ...result, asset: asset.id, appPath: asset.appPath }, null, 2));
-  } else {
-    console.log(`Published ${asset.appName} actor (${id}). Click it to switch to ${asset.appName}.`);
-  }
-}
-
-async function actorSwitcherCommand(rest: string[]): Promise<void> {
-  const appNames = nonFlagArgs(rest);
-  const apps = appNames.length ? appNames : ["Codex", "Talkie"];
-  const { daemonCall } = await getDaemonClient();
-  const startX = Number(parseFlagValue(rest, "x") || 420);
-  const y = Number(parseFlagValue(rest, "y") || 220);
-  const gap = Number(parseFlagValue(rest, "gap") || 270);
-  const ttlMs = Number(parseFlagValue(rest, "ttl") || parseFlagValue(rest, "ttlMs") || 0);
-  const style = parseFlagValue(rest, "style") || "info";
-  const dismissible = hasFlag(rest, "dismissible");
-  const labelHidden = shouldHideActorLabel(rest);
-  const closeOnActivate = hasFlag(rest, "close-on-activate") || hasFlag(rest, "closeOnActivate");
-  const scale = Number(parseFlagValue(rest, "scale") || 1);
-  const results: any[] = [];
-
-  for (let i = 0; i < apps.length; i++) {
-    const asset = ensureAppActorAsset(apps[i]);
-    const id = `switch-${slugify(asset.appName)}`;
-    const x = startX + i * gap;
     const result = await daemonCall("overlay.actor.publish", {
       id,
       renderer: "sprite",
       asset: asset.id,
-      state: "ready",
-      name: asset.appName,
-      message: `Tap to switch to ${asset.appName}.`,
-      placement: "point",
+      state,
+      name: parseFlagValue(rest, "name") || asset.appName,
+      message,
+      placement,
       x,
       y,
       style,
@@ -2084,21 +1725,81 @@ async function actorSwitcherCommand(rest: string[]): Promise<void> {
       targetBundleId: asset.bundleIdentifier,
       targetAppPath: asset.appPath,
     }, 15000) as any;
-    results.push({ ...result, asset: asset.id, appPath: asset.appPath });
-    await daemonCall("overlay.actor.moveTo", {
-      id,
-      x: x + 28,
-      y: y + 36,
-      durationMs: 650,
-      easing: "spring",
-    }, 15000);
-  }
 
-  if (hasFlag(rest, "json")) {
-    console.log(JSON.stringify(results, null, 2));
-  } else {
-    console.log(`Published app switcher for ${apps.join(", ")}.`);
-  }
+    if (!hasFlag(rest, "no-move")) {
+      await daemonCall("overlay.actor.moveTo", {
+        id,
+        x: x + 40,
+        y: y + 50,
+        durationMs: 700,
+        easing: "spring",
+      }, 15000);
+    }
+
+    if (hasFlag(rest, "json")) {
+      console.log(JSON.stringify({ ...result, asset: asset.id, appPath: asset.appPath }, null, 2));
+    } else {
+      console.log(`Published ${asset.appName} actor (${id}). Click it to switch to ${asset.appName}.`);
+    }
+  });
+}
+
+async function actorSwitcherCommand(rest: string[]): Promise<void> {
+  const appNames = nonFlagArgs(rest);
+  const apps = appNames.length ? appNames : ["Codex", "Talkie"];
+  await withDaemon(async ({ daemonCall }) => {
+    const startX = Number(parseFlagValue(rest, "x") || 420);
+    const y = Number(parseFlagValue(rest, "y") || 220);
+    const gap = Number(parseFlagValue(rest, "gap") || 270);
+    const ttlMs = Number(parseFlagValue(rest, "ttl") || parseFlagValue(rest, "ttlMs") || 0);
+    const style = parseFlagValue(rest, "style") || "info";
+    const dismissible = hasFlag(rest, "dismissible");
+    const labelHidden = shouldHideActorLabel(rest);
+    const closeOnActivate = hasFlag(rest, "close-on-activate") || hasFlag(rest, "closeOnActivate");
+    const scale = Number(parseFlagValue(rest, "scale") || 1);
+    const results: any[] = [];
+
+    for (let i = 0; i < apps.length; i++) {
+      const asset = ensureAppActorAsset(apps[i]);
+      const id = `switch-${slugify(asset.appName)}`;
+      const x = startX + i * gap;
+      const result = await daemonCall("overlay.actor.publish", {
+        id,
+        renderer: "sprite",
+        asset: asset.id,
+        state: "ready",
+        name: asset.appName,
+        message: `Tap to switch to ${asset.appName}.`,
+        placement: "point",
+        x,
+        y,
+        style,
+        ttlMs,
+        dismissible,
+        labelHidden,
+        closeOnActivate,
+        scale,
+        ...actorHUDOptions(rest),
+        targetApp: asset.appName,
+        targetBundleId: asset.bundleIdentifier,
+        targetAppPath: asset.appPath,
+      }, 15000) as any;
+      results.push({ ...result, asset: asset.id, appPath: asset.appPath });
+      await daemonCall("overlay.actor.moveTo", {
+        id,
+        x: x + 28,
+        y: y + 36,
+        durationMs: 650,
+        easing: "spring",
+      }, 15000);
+    }
+
+    if (hasFlag(rest, "json")) {
+      console.log(JSON.stringify(results, null, 2));
+    } else {
+      console.log(`Published app switcher for ${apps.join(", ")}.`);
+    }
+  });
 }
 
 type HUDPathField = string | {
@@ -2403,20 +2104,21 @@ function upsertHUDRegistryEntry(resolved: ResolvedHUDManifest, published = false
 }
 
 async function publishHUDManifest(resolved: ResolvedHUDManifest, rest: string[], index = 0): Promise<Record<string, unknown>> {
-  const { daemonCall } = await getDaemonClient();
-  const payload = hudPublishPayload(resolved, rest, index);
-  const result = await daemonCall("overlay.actor.publish", payload, 15000) as Record<string, unknown>;
-  if (!hasFlag(rest, "no-move")) {
-    await daemonCall("overlay.actor.moveTo", {
-      id: resolved.id,
-      x: Number(payload.x) + 24,
-      y: Number(payload.y) + 30,
-      durationMs: 600,
-      easing: "spring",
-    }, 15000);
-  }
-  upsertHUDRegistryEntry(resolved, true);
-  return result;
+  return withDaemon(async ({ daemonCall }) => {
+    const payload = hudPublishPayload(resolved, rest, index);
+    const result = await daemonCall("overlay.actor.publish", payload, 15000) as Record<string, unknown>;
+    if (!hasFlag(rest, "no-move")) {
+      await daemonCall("overlay.actor.moveTo", {
+        id: resolved.id,
+        x: Number(payload.x) + 24,
+        y: Number(payload.y) + 30,
+        durationMs: 600,
+        easing: "spring",
+      }, 15000);
+    }
+    upsertHUDRegistryEntry(resolved, true);
+    return result;
+  });
 }
 
 async function hudRegisterCommand(rest: string[]): Promise<void> {
@@ -2538,186 +2240,8 @@ async function hudCommand(sub?: string, ...rest: string[]): Promise<void> {
   }
 }
 
-async function layerCommand(sub?: string, ...rest: string[]): Promise<void> {
-  await withDaemon(async (client) => {
-    const { daemonCall } = client;
-
-    if (sub === "create") {
-      await layerCreateCommand(client, rest);
-      return;
-    }
-    if (sub === "snap") {
-      await layerSnapCommand(client, rest[0]);
-      return;
-    }
-    if (sub === "session" || sub === "sessions") {
-      await layerSessionCommand(client, rest[0]);
-      return;
-    }
-    if (sub === "clear") {
-      await daemonCall("session.layers.clear");
-      console.log("Cleared all session layers.");
-      return;
-    }
-    if (sub === "delete" || sub === "rm") {
-      if (!rest[0]) { console.log("Usage: lattices layer delete <name>"); return; }
-      await daemonCall("session.layers.delete", { name: rest[0] });
-      console.log(`Deleted session layer "${rest[0]}".`);
-      return;
-    }
-
-    if (sub === undefined || sub === null || sub === "") {
-      const result = await daemonCall("layers.list") as any;
-      if (!result.layers.length) {
-        console.log("No layers configured.");
-        return;
-      }
-      console.log("Layers:\n");
-      for (const layer of result.layers) {
-        const active = layer.index === result.active ? " \x1b[32m● active\x1b[0m" : "";
-        console.log(`  [${layer.index}] ${layer.label}  (${layer.projectCount} projects)${active}`);
-      }
-      return;
-    }
-    const idx = parseInt(sub, 10);
-    if (!isNaN(idx)) {
-      await daemonCall("layer.activate", { index: idx, mode: "launch" });
-      console.log(`Activated layer ${idx}`);
-    } else {
-      await daemonCall("layer.activate", { name: sub, mode: "launch" });
-      console.log(`Activated layer "${sub}"`);
-    }
-  });
-}
-
-// ── Layer create: build a session layer from window specs ────────────
-// Usage: lattices layer create <name> [wid:123 wid:456 ...]
-//        lattices layer create <name> --json '[{"app":"Chrome","tile":"left"},...]'
-async function layerCreateCommand(client: DaemonClient, args: string[]): Promise<void> {
-  const { daemonCall } = client;
-  const name = args[0];
-  if (!name) {
-    console.log("Usage: lattices layer create <name> [wid:123 ...] [--json '<specs>']");
-    return;
-  }
-
-  const jsonIdx = args.indexOf("--json");
-  if (jsonIdx !== -1 && args[jsonIdx + 1]) {
-    // JSON mode: parse window specs with tile positions
-    const specs = JSON.parse(args[jsonIdx + 1]) as Array<{
-      wid?: number; app?: string; title?: string; tile?: string;
-    }>;
-
-    // Collect wids, resolve app-based specs
-    const windowIds: number[] = [];
-    const windows: Array<{ app: string; contentHint?: string }> = [];
-    const tiles: Array<{ wid?: number; app?: string; title?: string; tile: string }> = [];
-
-    for (const spec of specs) {
-      if (spec.wid) {
-        windowIds.push(spec.wid);
-        if (spec.tile) tiles.push({ wid: spec.wid, tile: spec.tile });
-      } else if (spec.app) {
-        windows.push({ app: spec.app, contentHint: spec.title });
-        if (spec.tile) tiles.push({ app: spec.app, title: spec.title, tile: spec.tile });
-      }
-    }
-
-    const result = await daemonCall("session.layers.create", {
-      name,
-      ...(windowIds.length ? { windowIds } : {}),
-      ...(windows.length ? { windows } : {}),
-    }) as any;
-
-    console.log(`Created session layer "${name}" with ${specs.length} window(s).`);
-
-    // Apply tile positions
-    for (const t of tiles) {
-      try {
-        await daemonCall("window.place", {
-          ...(t.wid ? { wid: t.wid } : { app: t.app, title: t.title }),
-          placement: t.tile,
-        });
-      } catch { /* window may not be resolved yet */ }
-    }
-
-    if (tiles.length) console.log(`Tiled ${tiles.length} window(s).`);
-    return;
-  }
-
-  // Simple wid mode: lattices layer create <name> wid:123 wid:456
-  const wids = args.slice(1)
-    .filter(a => a.startsWith("wid:"))
-    .map(a => parseInt(a.slice(4), 10))
-    .filter(n => !isNaN(n));
-
-  const result = await daemonCall("session.layers.create", {
-    name,
-    ...(wids.length ? { windowIds: wids } : {}),
-  }) as any;
-
-  console.log(`Created session layer "${name}"${wids.length ? ` with ${wids.length} window(s)` : ""}.`);
-}
-
-// ── Layer snap: snapshot current visible windows into a session layer ─
-async function layerSnapCommand(client: DaemonClient, name?: string): Promise<void> {
-  const { daemonCall } = client;
-  const layerName = name || `snap-${new Date().toISOString().slice(11, 19).replace(/:/g, "")}`;
-
-  // Get all current windows
-  const windows = await daemonCall("windows.list") as any[];
-  const visibleWids = windows
-    .filter((w: any) => !w.isMinimized && w.app !== "lattices")
-    .map((w: any) => w.wid);
-
-  if (!visibleWids.length) {
-    console.log("No visible windows to snapshot.");
-    return;
-  }
-
-  await daemonCall("session.layers.create", {
-    name: layerName,
-    windowIds: visibleWids,
-  });
-
-  console.log(`Snapped ${visibleWids.length} window(s) → session layer "${layerName}".`);
-}
-
-// ── Layer session: list or switch session layers ─────────────────────
-async function layerSessionCommand(client: DaemonClient, nameOrIndex?: string): Promise<void> {
-  const { daemonCall } = client;
-  const result = await daemonCall("session.layers.list") as any;
-
-  if (!nameOrIndex) {
-    // List session layers
-    if (!result.layers.length) {
-      console.log("No session layers. Create one with: lattices layer create <name>");
-      return;
-    }
-    console.log("Session layers:\n");
-    for (let i = 0; i < result.layers.length; i++) {
-      const l = result.layers[i];
-      const active = i === result.activeIndex ? " \x1b[32m● active\x1b[0m" : "";
-      const winCount = l.windows?.length || 0;
-      console.log(`  [${i}] ${l.name}  (${winCount} windows)${active}`);
-    }
-    return;
-  }
-
-  // Switch by index or name
-  const idx = parseInt(nameOrIndex, 10);
-  if (!isNaN(idx)) {
-    await daemonCall("session.layers.switch", { index: idx });
-    console.log(`Switched to session layer ${idx}.`);
-  } else {
-    await daemonCall("session.layers.switch", { name: nameOrIndex });
-    console.log(`Switched to session layer "${nameOrIndex}".`);
-  }
-}
-
 async function diagCommand(limit?: string): Promise<void> {
-  try {
-    const { daemonCall } = await getDaemonClient();
+  await withDaemon(async ({ daemonCall }) => {
     const result = await daemonCall("diagnostics.list", { limit: parseInt(limit || "", 10) || 40 }) as any;
     if (!result.entries || !result.entries.length) {
       console.log("No diagnostic entries.");
@@ -2729,9 +2253,7 @@ async function diagCommand(limit?: string): Promise<void> {
                    entry.level === "error"   ? "\x1b[31m✗\x1b[0m" : "›";
       console.log(`  \x1b[90m${entry.time}\x1b[0m ${icon} ${entry.message}`);
     }
-  } catch (e: unknown) {
-    console.log(`Error: ${(e as Error).message}`);
-  }
+  });
 }
 
 async function distributeCommand(rawArgs: string[] = []): Promise<void> {

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 0,
   "workspaces": {
     "": {
-      "name": "@lattices/cli",
+      "name": "@arach/lattices",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.58",
         "@ai-sdk/google": "^3.0.43",

--- a/docs/api.md
+++ b/docs/api.md
@@ -1105,6 +1105,9 @@ lattices search vox
 # Deep search — adds terminal tab/process inspection for ranking
 lattices search vox --deep
 
+# Same as --deep (all search sources)
+lattices search vox --all
+
 # Pipeable output
 lattices search vox --wid
 lattices search vox --json
@@ -1752,7 +1755,7 @@ is available at ws://127.0.0.1:9399.
 - Search by content: `daemonCall('windows.search', { query: 'myproject' })`
   Returns windows with `matchSource` ("title", "app", "session", "ocr") and `ocrSnippet`
 - Search terminals: `daemonCall('terminals.search', {})` — tabs, cwds, processes
-- CLI: `lattices search myproject` or `lattices search myproject --deep`
+- CLI: `lattices search myproject`, `lattices search myproject --deep`, or `lattices search myproject --all` (same as `--deep`)
 
 ### Actions
 - Focus a window: `daemonCall('window.focus', { wid: 1234 })`

--- a/docs/assistant-knowledge.md
+++ b/docs/assistant-knowledge.md
@@ -59,8 +59,8 @@ types them and waits. → [Concepts](/docs/concepts), [Configuration](/docs/conf
 ### Screen OCR & search
 The app reads on-screen text via the Accessibility API (~60s) and Apple Vision OCR
 on background windows (~2h), indexing everything with FTS5. Search across titles,
-app names, session tags, and OCR with `lattices search <query>` (add `--deep` to
-inspect terminal tabs by cwd). → [Screen OCR & Search](/docs/ocr).
+app names, session tags, and OCR with `lattices search <query>` (add `--deep` or
+`--all` to inspect terminal tabs by cwd). → [Screen OCR & Search](/docs/ocr).
 
 ### Voice commands
 Natural-language voice control for window management ("put the browser on the
@@ -98,7 +98,7 @@ Settings or the [Tiling reference](/docs/tiling-reference) rather than asserting
 `lattices` · `lattices init` · `lattices sync` · `lattices start` ·
 `lattices restart [pane]` · `lattices tile <position>` · `lattices group [id]` ·
 `lattices layer [name|index]` · `lattices windows --json` ·
-`lattices search <query> [--deep] [--json] [--wid]` · `lattices place <query> [position]` ·
+`lattices search <query> [--deep|--all] [--json] [--wid]` · `lattices place <query> [position]` ·
 `lattices app restart`. Full flags: [Configuration](/docs/config).
 
 ## Config & file locations

--- a/docs/config.md
+++ b/docs/config.md
@@ -152,6 +152,7 @@ Run `lattices init` in your project directory to generate a starter
 | `lattices hud sync`          | Publish all registered HUD actors                 |
 | `lattices search <query>`      | Search windows by title, app, session, OCR       |
 | `lattices search <q> --deep`   | Deep search: index + live terminal inspection    |
+| `lattices search <q> --all`    | Same as `--deep` (all search sources)            |
 | `lattices search <q> --wid`    | Print matching window IDs only (pipeable)        |
 | `lattices place <query> [pos]` | Deep search + focus + tile (default: bottom-right)|
 | `lattices focus <session>`   | Focus a session's window and switch Spaces        |

--- a/docs/ocr.md
+++ b/docs/ocr.md
@@ -65,6 +65,9 @@ lattices search "error"
 # Deep search — also inspects terminal tabs and processes
 lattices search "myproject" --deep
 
+# Same as --deep (all search sources)
+lattices search "myproject" --all
+
 # Search + focus + tile the top result
 lattices place "myproject" left
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -55,7 +55,9 @@ your pane layout:
 
 ```bash
 brew install tmux
-cd ~/your-project && lattices start
+cd ~/your-project
+lattices          # home screen: status only, does not attach
+lattices start    # create or reattach the session
 ```
 
 This creates a tmux session with your configured panes side by side.

--- a/docs/reference/dewey.config.ts
+++ b/docs/reference/dewey.config.ts
@@ -4,7 +4,7 @@ export default {
     name: 'lattices',
     tagline: 'macOS developer workspace manager — tmux sessions with a native menu bar app for tiling, navigation, and project management',
     type: 'cli-tool',
-    version: '0.5.0',
+    version: '0.6.1',
   },
 
   agent: {

--- a/docs/reference/dewey.config.ts
+++ b/docs/reference/dewey.config.ts
@@ -4,7 +4,7 @@ export default {
     name: 'lattices',
     tagline: 'macOS developer workspace manager — tmux sessions with a native menu bar app for tiling, navigation, and project management',
     type: 'cli-tool',
-    version: '0.6.1',
+    version: '0.6.2',
   },
 
   agent: {

--- a/docs/release.md
+++ b/docs/release.md
@@ -124,7 +124,8 @@ GitHub release step.
 
 ## npm releases
 
-The CLI package is published as `@lattices/cli`.
+The CLI package is published as `@arach/lattices` (npm page) and also as
+`@lattices/cli` for back-compat — same tarball, dual publish in CI.
 
 There are two valid npm paths:
 
@@ -141,7 +142,7 @@ NPM_TOKEN
 ```
 
 `NPM_TOKEN` must be an npm automation or granular access token that can
-publish `@lattices/cli`. It currently should authenticate as the npm user
+publish `@arach/lattices` and `@lattices/cli`. It currently should authenticate as the npm user
 `arach`; if a different maintainer publishes, set environment variable
 `NPM_EXPECTED_USER` to that npm username.
 
@@ -155,7 +156,7 @@ gh variable set NPM_EXPECTED_USER --repo arach/lattices --env release --body ara
 Release:
 
 ```sh
-git tag -a npm-v0.5.0 -m "@lattices/cli 0.5.0"
+git tag -a npm-v0.6.1 -m "@arach/lattices 0.6.1"
 git push origin npm-v0.5.0
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lattices/cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The agentic workspace manager for macOS — turn your desktop into a coherent API",
   "packageManager": "bun@1.3.11",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "check": "bun run check:types && bun run check:app",
     "check:types": "tsc --noEmit",
     "check:app": "env CLANG_MODULE_CACHE_PATH=/tmp/lattices-clang-cache SWIFTPM_TESTS_MODULECACHE=/tmp/lattices-swiftpm-cache swift build --package-path apps/mac",
+    "test": "node --experimental-strip-types --test tests/cli.test.mjs",
+    "test:cli": "node --experimental-strip-types --test tests/cli.test.mjs",
     "test:e2e": "node --experimental-strip-types --test tests/e2e-daemon.test.mjs",
     "test:e2e:voice": "node --experimental-strip-types tests/eval-voice.js",
     "typecheck": "bun run check:types",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,15 @@
 {
-  "name": "@lattices/cli",
+  "name": "@arach/lattices",
   "version": "0.6.1",
-  "description": "The agentic workspace manager for macOS — turn your desktop into a coherent API",
+  "description": "macOS workspace manager — menu bar app, CLI, and WebSocket daemon API for tiling, search, layers, and agent control",
+  "homepage": "https://lattices.dev",
+  "bugs": {
+    "url": "https://github.com/arach/lattices/issues"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "packageManager": "bun@1.3.11",
   "engines": {
     "node": ">=18"
@@ -11,13 +19,19 @@
     "lattices-app": "./bin/lattices-app.ts"
   },
   "keywords": [
+    "lattices",
+    "macos",
+    "workspace",
+    "window-manager",
     "tmux",
+    "daemon",
+    "ai-agents",
     "claude",
-    "dev-server",
     "developer-tools",
     "cli",
     "terminal",
-    "multiplexer"
+    "ocr",
+    "tiling"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arach/lattices",
-  "version": "0.6.1",
-  "description": "macOS workspace manager — menu bar app, CLI, and WebSocket daemon API for tiling, search, layers, and agent control",
+  "version": "0.6.2",
+  "description": "Tile windows, search your screen, keep tmux sessions alive, and let AI agents control your Mac — CLI + daemon API",
   "homepage": "https://lattices.dev",
   "bugs": {
     "url": "https://github.com/arach/lattices/issues"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -78,20 +78,20 @@ install_dep bun "oven-sh/bun/bun" "oven-sh/bun"
 # ── Install CLI ───────────────────────────────────────────────────────
 # If run from inside the source repo, link the local checkout instead of
 # fetching from npm. Detected by package.json next to this script with
-# name "@lattices/cli".
+# name "@arach/lattices" (also published as @lattices/cli).
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"   # this script lives in scripts/
 LOCAL_MODE=0
 if [[ -f "$REPO_ROOT/package.json" ]] && \
-   grep -q '"@lattices/cli"' "$REPO_ROOT/package.json"; then
+   grep -qE '"@arach/lattices"|"@lattices/cli"' "$REPO_ROOT/package.json"; then
   LOCAL_MODE=1
 fi
 
 if [[ "$LOCAL_MODE" -eq 1 ]]; then
-  info "Linking @lattices/cli from $REPO_ROOT..."
+  info "Linking @arach/lattices from $REPO_ROOT..."
 else
-  info "Installing @lattices/cli..."
+  info "Installing @arach/lattices..."
 fi
 
 if command -v lattices &>/dev/null; then
@@ -99,9 +99,9 @@ if command -v lattices &>/dev/null; then
 fi
 
 if [[ "$LOCAL_MODE" -eq 1 ]]; then
-  (cd "$REPO_ROOT" && bun link && bun link @lattices/cli)
+  (cd "$REPO_ROOT" && bun link && bun link @arach/lattices)
 else
-  bun install -g @lattices/cli
+  bun install -g @arach/lattices
 fi
 ok "CLI installed → $(command -v lattices)"
 

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { before, test } from "node:test";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { toSessionName, pathHash } from "../bin/cli/session.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const nodeBin = process.execPath;
+const cliEntry = path.join(repoRoot, "bin/lattices.ts");
+const daemonClientUrl = pathToFileURL(
+  path.join(repoRoot, "bin/daemon-client.ts")
+).href;
+
+const { isDaemonRunning } = await import(daemonClientUrl);
+
+/** @type {boolean} */
+let daemonRunning = false;
+
+before(async () => {
+  daemonRunning = await isDaemonRunning();
+});
+
+function runCli(args) {
+  return execFileSync(
+    nodeBin,
+    ["--experimental-strip-types", cliEntry, ...args],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: process.env,
+    }
+  ).trim();
+}
+
+function runCliRaw(args) {
+  try {
+    const stdout = execFileSync(
+      nodeBin,
+      ["--experimental-strip-types", cliEntry, ...args],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: process.env,
+      }
+    );
+    return { stdout: stdout.trim(), stderr: "", status: 0 };
+  } catch (err) {
+    return {
+      stdout: (err.stdout || "").toString().trim(),
+      stderr: (err.stderr || "").toString().trim(),
+      status: err.status ?? 1,
+    };
+  }
+}
+
+// ── session hash parity ──────────────────────────────────────────────
+
+test("session hash: known repo path produces stable session name", () => {
+  const session = toSessionName(repoRoot);
+  assert.equal(session, "lattices-c36f74");
+  assert.equal(pathHash(repoRoot), "c36f74");
+});
+
+test("session hash: format is basename-6hex", () => {
+  const session = toSessionName(repoRoot);
+  assert.match(session, /^[a-zA-Z0-9_-]+-[0-9a-f]{6}$/);
+});
+
+test("session hash: basename sanitization replaces non-alphanumeric chars", () => {
+  const session = toSessionName("/tmp/my.project+name");
+  assert.match(session, /^my-project-name-[0-9a-f]{6}$/);
+  assert.equal(session.slice(0, "my-project-name-".length), "my-project-name-");
+});
+
+test("session hash: different paths with same basename get distinct hashes", () => {
+  const a = toSessionName("/tmp/proj-a/foo");
+  const b = toSessionName("/tmp/proj-b/foo");
+  assert.notEqual(a, b);
+  assert.match(a, /^foo-[0-9a-f]{6}$/);
+  assert.match(b, /^foo-[0-9a-f]{6}$/);
+});
+
+test("session hash: default command prints session name for cwd", () => {
+  const { stdout } = runCliRaw([]);
+  const expected = toSessionName(repoRoot);
+  assert.match(stdout, new RegExp(`session\\s+${expected}`));
+});
+
+// ── default command & help ───────────────────────────────────────────
+
+test("default command: prints home screen guidance", () => {
+  const out = runCli([]);
+  assert.match(out, /let's get you situated/);
+  assert.match(out, /Common commands/);
+});
+
+test("help: mentions lattices start", () => {
+  const out = runCli(["help"]);
+  assert.match(out, /lattices start/);
+});
+
+// ── search --deep ────────────────────────────────────────────────────
+
+test("search --deep: does not crash when daemon is running", async (t) => {
+  if (!daemonRunning) {
+    t.skip("daemon not running — start with: lattices app");
+    return;
+  }
+  const { status, stdout, stderr } = runCliRaw(["search", "foo", "--deep"]);
+  const combined = `${stdout}\n${stderr}`;
+  assert.equal(status, 0, `expected exit 0, got ${status}: ${combined}`);
+});
+
+test("search --deep: exits non-zero with friendly message when daemon is down", async (t) => {
+  if (daemonRunning) {
+    t.skip("daemon is running — stop daemon to exercise daemon-down path");
+    return;
+  }
+  const { status, stdout, stderr } = runCliRaw(["search", "foo", "--deep"]);
+  const combined = `${stdout}\n${stderr}`.trim();
+  assert.equal(status, 1, `expected exit 1, got ${status}: ${combined}`);
+  assert.match(combined, /Daemon not running/i);
+  assert.match(combined, /lattices app/i);
+});


### PR DESCRIPTION
## Summary

Refines the workspace assistant voice integration and polishes Hyper+G in-place window tools.

### Workspace assistant & voice
- Resolve Vox endpoint from the runtime file so dev builds follow port changes instead of a stale default
- Add assistant wake-phrase routing in `IntentHeuristics` ("hey lattices", "ask the assistant", etc.)
- Harden `AudioProvider` session setup and related voice runtime wiring
- Minor command bar window lifecycle and voice UI tweaks

### Hyper+G (in-place mode)
- Show clear selected state in the Windows inventory and Current View map (accent bar, checkmark, slot badges; dim unselected rows)
- Drag a multi-window selection into the Grid — drops stage a balanced sub-grid anchored at the hovered cell
- Add **Add to Layer → New Layer** to the in-place right-click menu

## Test plan
- [ ] `lattices app restart` — app builds and launches
- [ ] Hyper+G: select windows via click / a–z; confirm inventory + Current View show selection
- [ ] Hyper+G: drag 2+ selected windows into Grid; confirm staged placements commit on Enter
- [ ] Hyper+G: right-click → Add to Layer → New Layer opens authoring flow
- [ ] Voice: assistant wake phrases route to workspace assistant instead of command matching
- [ ] Voice: connects when Vox runtime file is present on a non-default port