### PR TITLE
[codex] Add safe computer window state tools

### DIFF
--- a/apps/mac/Sources/Core/Actions/ComputerUseController.swift
+++ b/apps/mac/Sources/Core/Actions/ComputerUseController.swift
@@ -145,6 +145,90 @@ private struct AXPressCandidate {
     let score: Double
 }
 
+private struct AXSnapshotElement {
+    let id: String
+    let role: String
+    let roleDescription: String?
+    let title: String?
+    let label: String?
+    let value: String?
+    let description: String?
+    let help: String?
+    let identifier: String?
+    let frame: CGRect?
+    let enabled: Bool?
+    let selected: Bool?
+    let focused: Bool?
+    let actions: [String]
+    let path: String
+    let depth: Int
+    let childCount: Int
+
+    var json: JSON {
+        var object: [String: JSON] = [
+            "id": .string(id),
+            "role": .string(role),
+            "path": .string(path),
+            "depth": .int(depth),
+            "childCount": .int(childCount),
+            "actions": .array(actions.map { .string($0) }),
+        ]
+        if let roleDescription {
+            object["roleDescription"] = .string(roleDescription)
+        }
+        if let title {
+            object["title"] = .string(title)
+        }
+        if let label {
+            object["label"] = .string(label)
+        }
+        if let value {
+            object["value"] = .string(value)
+        }
+        if let description {
+            object["description"] = .string(description)
+        }
+        if let help {
+            object["help"] = .string(help)
+        }
+        if let identifier {
+            object["identifier"] = .string(identifier)
+        }
+        if let frame {
+            object["frame"] = .object([
+                "x": .double(frame.origin.x),
+                "y": .double(frame.origin.y),
+                "w": .double(frame.width),
+                "h": .double(frame.height),
+            ])
+        }
+        if let enabled {
+            object["enabled"] = .bool(enabled)
+        }
+        if let selected {
+            object["selected"] = .bool(selected)
+        }
+        if let focused {
+            object["focused"] = .bool(focused)
+        }
+        return .object(object)
+    }
+}
+
+private struct AXSnapshotContext {
+    let maxDepth: Int
+    let maxElements: Int
+    let maxChildrenPerElement: Int
+    let deadline: Date
+    let messagingTimeout: Float
+    var nextElementIndex = 1
+    var elements: [AXSnapshotElement] = []
+    var warnings: [String] = []
+    var hitDepthLimit = false
+    var hitElementLimit = false
+    var hitTimeout = false
+}
+
 final class ComputerUseController {
     static let shared = ComputerUseController()
 
@@ -174,6 +258,118 @@ final class ComputerUseController {
             requireText: false,
             defaultTreatment: .observe
         )
+    }
+
+    func windowState(params: JSON?) throws -> JSON {
+        let source = params?["source"]?.stringValue ?? "daemon"
+        let mode = try windowStateMode(params)
+        let includeAX = mode == "ax" || mode == "both"
+        let shouldCapture = params?["capture"]?.boolValue ?? (mode == "both" || mode == "screenshot")
+        let maxDepth = max(1, min(params?["maxDepth"]?.intValue ?? 8, 14))
+        let maxElements = max(1, min(params?["maxElements"]?.intValue ?? 250, 1_000))
+        let timeoutMs = max(150, min(params?["timeoutMs"]?.intValue ?? 1_200, 5_000))
+        let window = try CaptureController.shared.resolveWindow(params: params)
+        let snapshotId = Self.snapshotId()
+        var run: RunSession?
+
+        do {
+            if shouldCapture {
+                let createdRun = try RunStore.shared.createRun(
+                    title: "Window state \(window.app)",
+                    source: source,
+                    surfaces: [.window(window)]
+                )
+                run = createdRun
+                _ = try RunStore.shared.markRunning(
+                    id: createdRun.id,
+                    summary: "Inspecting window state",
+                    data: [
+                        "action": .string("windowState"),
+                        "snapshotId": .string(snapshotId),
+                        "mode": .string(mode),
+                        "wid": .int(Int(window.wid)),
+                        "app": .string(window.app),
+                    ]
+                )
+            }
+
+            var elements: [AXSnapshotElement] = []
+            var warnings: [String] = []
+            if includeAX {
+                let context = try axSnapshot(
+                    window: window,
+                    maxDepth: maxDepth,
+                    maxElements: maxElements,
+                    timeoutMs: timeoutMs
+                )
+                elements = context.elements
+                warnings.append(contentsOf: context.warnings)
+                if context.hitDepthLimit {
+                    warnings.append("AX traversal reached maxDepth \(maxDepth)")
+                }
+                if context.hitElementLimit {
+                    warnings.append("AX traversal reached maxElements \(maxElements)")
+                }
+                if context.hitTimeout {
+                    warnings.append("AX traversal reached timeoutMs \(timeoutMs)")
+                }
+            } else {
+                warnings.append("AX traversal skipped for mode \(mode)")
+            }
+
+            var artifact: JSON?
+            if shouldCapture, let activeRun = run {
+                let captured = try CaptureController.shared.screenshotWindow(params: .object([
+                    "runId": .string(activeRun.id),
+                    "source": .string(source),
+                    "wid": .int(Int(window.wid)),
+                    "filename": .string("window-state-\(window.wid)-\(Self.fileTimestamp()).png"),
+                ]))
+                artifact = captured["artifact"]
+                let completed = try RunStore.shared.complete(
+                    id: activeRun.id,
+                    summary: "Captured window state",
+                    data: [
+                        "snapshotId": .string(snapshotId),
+                        "mode": .string(mode),
+                        "elementCount": .int(elements.count),
+                        "captured": .bool(artifact != nil),
+                    ]
+                )
+                run = completed
+            }
+
+            var object: [String: JSON] = [
+                "ok": .bool(true),
+                "snapshotId": .string(snapshotId),
+                "target": Encoders.window(window),
+                "mode": .string(mode),
+                "elements": .array(elements.map(\.json)),
+                "elementCount": .int(elements.count),
+                "treeMarkdown": .string(treeMarkdown(for: elements)),
+                "warnings": .array(warnings.map { .string($0) }),
+            ]
+            if let artifact {
+                object["artifact"] = artifact
+            }
+            if let run {
+                object["run"] = run.json
+            }
+            return .object(object)
+        } catch {
+            if let run {
+                _ = try? RunStore.shared.fail(
+                    id: run.id,
+                    summary: "Window state inspection failed",
+                    data: [
+                        "snapshotId": .string(snapshotId),
+                        "wid": .int(Int(window.wid)),
+                        "error": .string(error.localizedDescription),
+                    ]
+                )
+            }
+            throw error
+        }
     }
 
     func typeText(params: JSON?) throws -> JSON {
@@ -2047,6 +2243,193 @@ final class ComputerUseController {
         return nil
     }
 
+    private func windowStateMode(_ params: JSON?) throws -> String {
+        let raw = params?["mode"]?.stringValue
+            ?? params?["stateMode"]?.stringValue
+            ?? params?["state-mode"]?.stringValue
+            ?? "ax"
+        switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "ax", "accessibility":
+            return "ax"
+        case "both", "all", "ax+screenshot", "screenshot+ax":
+            return "both"
+        case "screenshot", "capture", "image":
+            return "screenshot"
+        default:
+            throw RouterError.custom("Unsupported computer.windowState mode '\(raw)'; use ax, both, or screenshot")
+        }
+    }
+
+    private func axSnapshot(
+        window: WindowEntry,
+        maxDepth: Int,
+        maxElements: Int,
+        timeoutMs: Int
+    ) throws -> AXSnapshotContext {
+        guard AXIsProcessTrusted() else {
+            throw RouterError.custom("Accessibility permission is required for computer.windowState")
+        }
+        guard let axWindow = axWindow(pid: window.pid, wid: window.wid) else {
+            throw RouterError.custom("Unable to resolve AX window \(window.wid)")
+        }
+
+        var context = AXSnapshotContext(
+            maxDepth: maxDepth,
+            maxElements: maxElements,
+            maxChildrenPerElement: 160,
+            deadline: Date().addingTimeInterval(Double(timeoutMs) / 1_000.0),
+            messagingTimeout: 0.25
+        )
+        collectAXSnapshotElements(
+            element: axWindow,
+            depth: 0,
+            path: "0",
+            context: &context
+        )
+        return context
+    }
+
+    private func collectAXSnapshotElements(
+        element: AXUIElement,
+        depth: Int,
+        path: String,
+        context: inout AXSnapshotContext
+    ) {
+        guard Date() < context.deadline else {
+            context.hitTimeout = true
+            return
+        }
+        guard context.elements.count < context.maxElements else {
+            context.hitElementLimit = true
+            return
+        }
+        guard depth <= context.maxDepth else {
+            context.hitDepthLimit = true
+            return
+        }
+
+        AXUIElementSetMessagingTimeout(element, context.messagingTimeout)
+        let children = axChildren(element)
+        let id = "e\(context.nextElementIndex)"
+        context.nextElementIndex += 1
+        context.elements.append(AXSnapshotElement(
+            id: id,
+            role: axString(element, attribute: kAXRoleAttribute) ?? "unknown",
+            roleDescription: axString(element, attribute: kAXRoleDescriptionAttribute),
+            title: axAttributeString(element, attribute: kAXTitleAttribute),
+            label: axAttributeString(element, attribute: "AXLabel"),
+            value: axAttributeString(element, attribute: kAXValueAttribute),
+            description: axAttributeString(element, attribute: kAXDescriptionAttribute),
+            help: axAttributeString(element, attribute: kAXHelpAttribute),
+            identifier: axAttributeString(element, attribute: kAXIdentifierAttribute),
+            frame: axFrame(element),
+            enabled: axBool(element, attribute: "AXEnabled"),
+            selected: axBool(element, attribute: "AXSelected"),
+            focused: axBool(element, attribute: "AXFocused"),
+            actions: axActions(element),
+            path: path,
+            depth: depth,
+            childCount: children.count
+        ))
+
+        guard depth < context.maxDepth else {
+            if !children.isEmpty {
+                context.hitDepthLimit = true
+            }
+            return
+        }
+
+        let visibleChildren = children.prefix(context.maxChildrenPerElement)
+        if children.count > context.maxChildrenPerElement {
+            context.warnings.append("Element \(id) had \(children.count) children; visited first \(context.maxChildrenPerElement)")
+        }
+        for (index, child) in visibleChildren.enumerated() {
+            collectAXSnapshotElements(
+                element: child,
+                depth: depth + 1,
+                path: "\(path).\(index)",
+                context: &context
+            )
+            if context.hitTimeout || context.hitElementLimit {
+                return
+            }
+        }
+    }
+
+    private func axChildren(_ element: AXUIElement) -> [AXUIElement] {
+        var childrenRef: CFTypeRef?
+        if AXUIElementCopyAttributeValue(element, kAXVisibleChildrenAttribute as CFString, &childrenRef) == .success,
+           let visible = childrenRef as? [AXUIElement],
+           !visible.isEmpty {
+            return visible
+        }
+
+        childrenRef = nil
+        if AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef) == .success,
+           let children = childrenRef as? [AXUIElement] {
+            return children
+        }
+        return []
+    }
+
+    private func axBool(_ element: AXUIElement, attribute: String) -> Bool? {
+        var ref: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &ref) == .success,
+              let ref else {
+            return nil
+        }
+        if CFGetTypeID(ref) == CFBooleanGetTypeID() {
+            return CFBooleanGetValue((ref as! CFBoolean))
+        }
+        return (ref as? NSNumber)?.boolValue ?? (ref as? Bool)
+    }
+
+    private func axAttributeString(_ element: AXUIElement, attribute: String) -> String? {
+        var ref: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &ref) == .success,
+              let ref else {
+            return nil
+        }
+        let value: String?
+        if let string = ref as? String {
+            value = string
+        } else if let number = ref as? NSNumber {
+            value = number.stringValue
+        } else if let url = ref as? URL {
+            value = url.absoluteString
+        } else {
+            value = nil
+        }
+        return value.flatMap(Self.truncatedAXString)
+    }
+
+    private func treeMarkdown(for elements: [AXSnapshotElement]) -> String {
+        guard !elements.isEmpty else { return "" }
+        return elements.map { element in
+            let indent = String(repeating: "  ", count: element.depth)
+            let label = [
+                element.title,
+                element.label,
+                element.value,
+                element.description,
+                element.identifier,
+            ]
+                .compactMap { $0 }
+                .first { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            var line = "\(indent)- \(element.id) \(element.role)"
+            if let label {
+                line += " \"\(Self.singleLine(label))\""
+            }
+            if !element.actions.isEmpty {
+                line += " actions=\(element.actions.joined(separator: ","))"
+            }
+            if let frame = element.frame {
+                line += " frame=\(Self.compactFrame(frame))"
+            }
+            return line
+        }.joined(separator: "\n")
+    }
+
     private func axWindow(pid: Int32, wid: UInt32) -> AXUIElement? {
         let appRef = AXUIElementCreateApplication(pid)
         AXUIElementSetMessagingTimeout(appRef, 0.5)
@@ -2601,6 +2984,39 @@ final class ComputerUseController {
 
     private static func defaultTypedText() -> String {
         "# lattices computer-use demo: observed, focused, typed; Enter intentionally not pressed"
+    }
+
+    private static func snapshotId() -> String {
+        let suffix = UUID().uuidString
+            .replacingOccurrences(of: "-", with: "")
+            .prefix(8)
+            .lowercased()
+        return "axs_\(fileTimestamp())_\(suffix)"
+    }
+
+    private static func truncatedAXString(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if trimmed.count <= 240 {
+            return trimmed
+        }
+        return String(trimmed.prefix(237)) + "..."
+    }
+
+    private static func singleLine(_ value: String) -> String {
+        let collapsed = value
+            .replacingOccurrences(of: "\r", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\"", with: "'")
+        return truncatedAXString(collapsed) ?? ""
+    }
+
+    private static func compactFrame(_ frame: CGRect) -> String {
+        let x = Int(frame.origin.x.rounded())
+        let y = Int(frame.origin.y.rounded())
+        let w = Int(frame.width.rounded())
+        let h = Int(frame.height.rounded())
+        return "\(x),\(y),\(w),\(h)"
     }
 
     private static func fileTimestamp() -> String {

--- a/apps/mac/Sources/Core/Actions/ComputerUseController.swift
+++ b/apps/mac/Sources/Core/Actions/ComputerUseController.swift
@@ -2308,29 +2308,45 @@ final class ComputerUseController {
             return
         }
 
-        AXUIElementSetMessagingTimeout(element, context.messagingTimeout)
-        let children = axChildren(element)
+        let children = axSnapshotChildren(element, context: &context)
+        guard !context.hitTimeout else { return }
+
         let id = "e\(context.nextElementIndex)"
         context.nextElementIndex += 1
+        let role = axSnapshotString(element, attribute: kAXRoleAttribute, context: &context) ?? "unknown"
+        guard !context.hitTimeout else { return }
+        let roleDescription = axSnapshotString(element, attribute: kAXRoleDescriptionAttribute, context: &context)
+        let title = axSnapshotAttributeString(element, attribute: kAXTitleAttribute, context: &context)
+        let label = axSnapshotAttributeString(element, attribute: "AXLabel", context: &context)
+        let value = axSnapshotAttributeString(element, attribute: kAXValueAttribute, context: &context)
+        let description = axSnapshotAttributeString(element, attribute: kAXDescriptionAttribute, context: &context)
+        let help = axSnapshotAttributeString(element, attribute: kAXHelpAttribute, context: &context)
+        let identifier = axSnapshotAttributeString(element, attribute: kAXIdentifierAttribute, context: &context)
+        let frame = axSnapshotFrame(element, context: &context)
+        let enabled = axSnapshotBool(element, attribute: "AXEnabled", context: &context)
+        let selected = axSnapshotBool(element, attribute: "AXSelected", context: &context)
+        let focused = axSnapshotBool(element, attribute: "AXFocused", context: &context)
+        let actions = axSnapshotActions(element, context: &context)
         context.elements.append(AXSnapshotElement(
             id: id,
-            role: axString(element, attribute: kAXRoleAttribute) ?? "unknown",
-            roleDescription: axString(element, attribute: kAXRoleDescriptionAttribute),
-            title: axAttributeString(element, attribute: kAXTitleAttribute),
-            label: axAttributeString(element, attribute: "AXLabel"),
-            value: axAttributeString(element, attribute: kAXValueAttribute),
-            description: axAttributeString(element, attribute: kAXDescriptionAttribute),
-            help: axAttributeString(element, attribute: kAXHelpAttribute),
-            identifier: axAttributeString(element, attribute: kAXIdentifierAttribute),
-            frame: axFrame(element),
-            enabled: axBool(element, attribute: "AXEnabled"),
-            selected: axBool(element, attribute: "AXSelected"),
-            focused: axBool(element, attribute: "AXFocused"),
-            actions: axActions(element),
+            role: role,
+            roleDescription: roleDescription,
+            title: title,
+            label: label,
+            value: value,
+            description: description,
+            help: help,
+            identifier: identifier,
+            frame: frame,
+            enabled: enabled,
+            selected: selected,
+            focused: focused,
+            actions: actions,
             path: path,
             depth: depth,
             childCount: children.count
         ))
+        guard !context.hitTimeout else { return }
 
         guard depth < context.maxDepth else {
             if !children.isEmpty {
@@ -2354,6 +2370,134 @@ final class ComputerUseController {
                 return
             }
         }
+    }
+
+    private func prepareAXSnapshotCall(
+        _ element: AXUIElement,
+        context: inout AXSnapshotContext
+    ) -> Bool {
+        let remaining = context.deadline.timeIntervalSinceNow
+        guard remaining > 0 else {
+            context.hitTimeout = true
+            return false
+        }
+        AXUIElementSetMessagingTimeout(element, Float(min(Double(context.messagingTimeout), remaining)))
+        return true
+    }
+
+    private func axSnapshotChildren(
+        _ element: AXUIElement,
+        context: inout AXSnapshotContext
+    ) -> [AXUIElement] {
+        var childrenRef: CFTypeRef?
+        if prepareAXSnapshotCall(element, context: &context),
+           AXUIElementCopyAttributeValue(element, kAXVisibleChildrenAttribute as CFString, &childrenRef) == .success,
+           let visible = childrenRef as? [AXUIElement],
+           !visible.isEmpty {
+            return visible
+        }
+
+        childrenRef = nil
+        if prepareAXSnapshotCall(element, context: &context),
+           AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef) == .success,
+           let children = childrenRef as? [AXUIElement] {
+            return children
+        }
+        return []
+    }
+
+    private func axSnapshotBool(
+        _ element: AXUIElement,
+        attribute: String,
+        context: inout AXSnapshotContext
+    ) -> Bool? {
+        var ref: CFTypeRef?
+        guard prepareAXSnapshotCall(element, context: &context),
+              AXUIElementCopyAttributeValue(element, attribute as CFString, &ref) == .success,
+              let ref else {
+            return nil
+        }
+        if CFGetTypeID(ref) == CFBooleanGetTypeID() {
+            return CFBooleanGetValue((ref as! CFBoolean))
+        }
+        return (ref as? NSNumber)?.boolValue ?? (ref as? Bool)
+    }
+
+    private func axSnapshotString(
+        _ element: AXUIElement,
+        attribute: String,
+        context: inout AXSnapshotContext
+    ) -> String? {
+        var ref: CFTypeRef?
+        guard prepareAXSnapshotCall(element, context: &context),
+              AXUIElementCopyAttributeValue(element, attribute as CFString, &ref) == .success else {
+            return nil
+        }
+        return ref as? String
+    }
+
+    private func axSnapshotAttributeString(
+        _ element: AXUIElement,
+        attribute: String,
+        context: inout AXSnapshotContext
+    ) -> String? {
+        var ref: CFTypeRef?
+        guard prepareAXSnapshotCall(element, context: &context),
+              AXUIElementCopyAttributeValue(element, attribute as CFString, &ref) == .success,
+              let ref else {
+            return nil
+        }
+        let value: String?
+        if let string = ref as? String {
+            value = string
+        } else if let number = ref as? NSNumber {
+            value = number.stringValue
+        } else if let url = ref as? URL {
+            value = url.absoluteString
+        } else {
+            value = nil
+        }
+        return value.flatMap(Self.truncatedAXString)
+    }
+
+    private func axSnapshotActions(
+        _ element: AXUIElement,
+        context: inout AXSnapshotContext
+    ) -> [String] {
+        var ref: CFArray?
+        guard prepareAXSnapshotCall(element, context: &context),
+              AXUIElementCopyActionNames(element, &ref) == .success,
+              let actions = ref as? [String] else {
+            return []
+        }
+        return actions
+    }
+
+    private func axSnapshotFrame(
+        _ element: AXUIElement,
+        context: inout AXSnapshotContext
+    ) -> CGRect? {
+        var posRef: CFTypeRef?
+        var sizeRef: CFTypeRef?
+        guard prepareAXSnapshotCall(element, context: &context),
+              AXUIElementCopyAttributeValue(element, kAXPositionAttribute as CFString, &posRef) == .success,
+              prepareAXSnapshotCall(element, context: &context),
+              AXUIElementCopyAttributeValue(element, kAXSizeAttribute as CFString, &sizeRef) == .success,
+              let posRef,
+              let sizeRef,
+              CFGetTypeID(posRef) == AXValueGetTypeID(),
+              CFGetTypeID(sizeRef) == AXValueGetTypeID() else {
+            return nil
+        }
+        let posValue = posRef as! AXValue
+        let sizeValue = sizeRef as! AXValue
+        var point = CGPoint.zero
+        var size = CGSize.zero
+        guard AXValueGetValue(posValue, .cgPoint, &point),
+              AXValueGetValue(sizeValue, .cgSize, &size) else {
+            return nil
+        }
+        return CGRect(origin: point, size: size)
     }
 
     private func axChildren(_ element: AXUIElement) -> [AXUIElement] {

--- a/apps/mac/Sources/Core/Daemon/LatticesApi.swift
+++ b/apps/mac/Sources/Core/Daemon/LatticesApi.swift
@@ -1572,7 +1572,7 @@ final class LatticesApi {
         api.register(Endpoint(
             method: "computer.windowState",
             description: "Inspect a target window's Accessibility tree and return snapshot-local element ids.",
-            access: .read,
+            access: .mutate,
             params: [
                 Param(name: "wid", type: "uint32", required: false, description: "Target window id"),
                 Param(name: "session", type: "string", required: false, description: "Target lattices session"),

--- a/apps/mac/Sources/Core/Daemon/LatticesApi.swift
+++ b/apps/mac/Sources/Core/Daemon/LatticesApi.swift
@@ -350,6 +350,39 @@ final class LatticesApi {
             Field(name: "data", type: "object", required: true, description: "Structured event payload"),
         ]))
 
+        api.model(ApiModel(name: "AXElement", fields: [
+            Field(name: "id", type: "string", required: true, description: "Snapshot-local element id, such as e1"),
+            Field(name: "role", type: "string", required: true, description: "Accessibility role, such as AXButton or AXTextField"),
+            Field(name: "roleDescription", type: "string", required: false, description: "Localized role description"),
+            Field(name: "title", type: "string", required: false, description: "AX title"),
+            Field(name: "label", type: "string", required: false, description: "AX label when available"),
+            Field(name: "value", type: "string", required: false, description: "AX value converted to a short string"),
+            Field(name: "description", type: "string", required: false, description: "AX description"),
+            Field(name: "help", type: "string", required: false, description: "AX help text"),
+            Field(name: "identifier", type: "string", required: false, description: "AX identifier"),
+            Field(name: "frame", type: "Frame", required: false, description: "Screen-coordinate element frame"),
+            Field(name: "enabled", type: "bool", required: false, description: "Whether the element is enabled"),
+            Field(name: "selected", type: "bool", required: false, description: "Whether the element is selected"),
+            Field(name: "focused", type: "bool", required: false, description: "Whether the element is focused"),
+            Field(name: "actions", type: "[string]", required: true, description: "Supported AX action names"),
+            Field(name: "path", type: "string", required: true, description: "Snapshot-local tree path"),
+            Field(name: "depth", type: "int", required: true, description: "Tree depth from the target window"),
+            Field(name: "childCount", type: "int", required: true, description: "Number of AX children reported for the element"),
+        ]))
+
+        api.model(ApiModel(name: "ComputerWindowState", fields: [
+            Field(name: "ok", type: "bool", required: true, description: "Whether the snapshot completed"),
+            Field(name: "snapshotId", type: "string", required: true, description: "Snapshot id for this inspection"),
+            Field(name: "target", type: "Window", required: true, description: "Resolved target window"),
+            Field(name: "mode", type: "string", required: true, description: "ax, both, or screenshot"),
+            Field(name: "elements", type: "[AXElement]", required: true, description: "Accessibility elements in traversal order"),
+            Field(name: "elementCount", type: "int", required: true, description: "Number of returned elements"),
+            Field(name: "treeMarkdown", type: "string", required: true, description: "Compact tree view for humans and agents"),
+            Field(name: "warnings", type: "[string]", required: true, description: "Non-fatal traversal or capture warnings"),
+            Field(name: "artifact", type: "RunArtifact", required: false, description: "Optional screenshot artifact when capture is enabled"),
+            Field(name: "run", type: "RunSession", required: false, description: "Run record when capture is enabled"),
+        ]))
+
         api.model(ApiModel(name: "MouseShortcutConfig", fields: [
             Field(name: "version", type: "int", required: true, description: "Mouse shortcut config version"),
             Field(name: "tuning", type: "object", required: true, description: "Gesture recognition tuning values"),
@@ -1533,6 +1566,28 @@ final class LatticesApi {
             returns: .custom("Object with ok, run, selected target, candidates, and optional artifacts"),
             handler: { params in
                 try ComputerUseController.shared.prepare(params: params)
+            }
+        ))
+
+        api.register(Endpoint(
+            method: "computer.windowState",
+            description: "Inspect a target window's Accessibility tree and return snapshot-local element ids.",
+            access: .read,
+            params: [
+                Param(name: "wid", type: "uint32", required: false, description: "Target window id"),
+                Param(name: "session", type: "string", required: false, description: "Target lattices session"),
+                Param(name: "app", type: "string", required: false, description: "Target app name"),
+                Param(name: "title", type: "string", required: false, description: "Optional title substring for app target"),
+                Param(name: "mode", type: "string", required: false, description: "ax (default), both, or screenshot"),
+                Param(name: "capture", type: "bool", required: false, description: "Capture a screenshot artifact; defaults true for both/screenshot and false for ax"),
+                Param(name: "maxDepth", type: "int", required: false, description: "Maximum AX tree depth to traverse (default 8, max 14)"),
+                Param(name: "maxElements", type: "int", required: false, description: "Maximum elements to return (default 250, max 1000)"),
+                Param(name: "timeoutMs", type: "int", required: false, description: "Traversal timeout in milliseconds (default 1200, max 5000)"),
+                Param(name: "source", type: "string", required: false, description: "Calling surface label when capture creates a run"),
+            ],
+            returns: .object(model: "ComputerWindowState"),
+            handler: { params in
+                try ComputerUseController.shared.windowState(params: params)
             }
         ))
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -212,6 +212,7 @@ methods write into the Lattices run store under
 | `runs.artifacts` | read | List artifacts for one run |
 | `capture.screenshotWindow` | write | Capture a window screenshot as a run artifact |
 | `computer.prepare` | write | Resolve and optionally capture a terminal target without mutating it |
+| `computer.windowState` | read | Inspect a target window's AX tree and return snapshot-local element ids |
 | `computer.focusWindow` | write | Resolve, capture, focus, and verify a target window |
 | `computer.showCursor` | write | Show a visible cursor appearance and record it as a run |
 | `computer.launchApp` | write | Launch or focus a normal macOS app and record the run |
@@ -256,6 +257,7 @@ lattices runs run_20260617-120000_a1b2c3
 lattices terminals
 lattices terminals --refresh
 lattices computer prepare --text "# hello" --treatment stage
+lattices call computer.windowState '{"app":"Finder","maxDepth":4}'
 lattices computer focus-window --wid 7258 --treatment present
 lattices computer cursor --style marker --shape chevron --angle-deg -8 --label typing
 lattices computer launch-app Scout
@@ -306,6 +308,42 @@ artifact, but it does not focus or type.
 await daemonCall('computer.prepare', {
   text: '# review before typing',
   treatment: 'stage'
+})
+```
+
+#### `computer.windowState`
+
+Inspect a target window's Accessibility tree and return snapshot-local element
+ids (`e1`, `e2`, ...), a flat `elements` list, and a compact `treeMarkdown`
+view. `mode: "ax"` avoids Screen Recording. Use `mode: "both"` or
+`capture: true` when you also want a screenshot artifact linked to a run.
+
+**Params**:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `wid` | uint32 | no | Target window id |
+| `session` | string | no | Target lattices session |
+| `app` | string | no | Target app name |
+| `title` | string | no | Optional title substring for app target |
+| `mode` | string | no | `ax` (default), `both`, or `screenshot` |
+| `capture` | bool | no | Capture a screenshot artifact. Defaults true for `both`/`screenshot`, false for `ax` |
+| `maxDepth` | int | no | Maximum AX tree depth. Defaults to `8`, max `14` |
+| `maxElements` | int | no | Maximum elements returned. Defaults to `250`, max `1000` |
+| `timeoutMs` | int | no | Traversal timeout. Defaults to `1200`, max `5000` |
+| `source` | string | no | Calling surface label when capture creates a run |
+
+```js
+await daemonCall('computer.windowState', {
+  app: 'Finder',
+  maxDepth: 4,
+  maxElements: 120
+})
+
+await daemonCall('computer.windowState', {
+  wid: 7258,
+  mode: 'both',
+  source: 'agent'
 })
 ```
 
@@ -1840,3 +1878,18 @@ if (!(await isDaemonRunning())) {
 const status = await daemonCall('daemon.status')
 console.log(`Daemon up for ${Math.round(status.uptime)}s, tracking ${status.windowCount} windows`)
 ```
+
+### Pi extension
+
+Pi users can install the `@arach/pi-lattices` package in
+`packages/pi-lattices/` to expose the daemon as typed `lattices_*` tools:
+
+```bash
+pi install ./packages/pi-lattices --local
+lattices app
+```
+
+The extension wraps the existing daemon and keeps Lattices' macOS-native
+runtime, run artifacts, action receipts, and computer-use `treatment` semantics.
+It does not bundle `cua-driver` or enable browser automation. See
+[Pi Lattices Extension](/docs/pi-lattices) for the tool list and smoke checks.

--- a/docs/api.md
+++ b/docs/api.md
@@ -212,7 +212,7 @@ methods write into the Lattices run store under
 | `runs.artifacts` | read | List artifacts for one run |
 | `capture.screenshotWindow` | write | Capture a window screenshot as a run artifact |
 | `computer.prepare` | write | Resolve and optionally capture a terminal target without mutating it |
-| `computer.windowState` | read | Inspect a target window's AX tree and return snapshot-local element ids |
+| `computer.windowState` | write | Inspect a target window's AX tree and optionally write screenshot/run artifacts |
 | `computer.focusWindow` | write | Resolve, capture, focus, and verify a target window |
 | `computer.showCursor` | write | Show a visible cursor appearance and record it as a run |
 | `computer.launchApp` | write | Launch or focus a normal macOS app and record the run |
@@ -316,7 +316,9 @@ await daemonCall('computer.prepare', {
 Inspect a target window's Accessibility tree and return snapshot-local element
 ids (`e1`, `e2`, ...), a flat `elements` list, and a compact `treeMarkdown`
 view. `mode: "ax"` avoids Screen Recording. Use `mode: "both"` or
-`capture: true` when you also want a screenshot artifact linked to a run.
+`capture: true` when you also want a screenshot artifact linked to a run. The
+endpoint is classified as a write because those capture modes create run
+artifacts.
 
 **Params**:
 

--- a/docs/pi-lattices.md
+++ b/docs/pi-lattices.md
@@ -75,7 +75,7 @@ Daemon-down behavior:
 bun run --cwd packages/pi-lattices smoke:no-daemon
 ```
 
-Live read + safe staged call:
+Live status + safe staged call:
 
 ```bash
 lattices app

--- a/docs/pi-lattices.md
+++ b/docs/pi-lattices.md
@@ -1,0 +1,87 @@
+# Pi Lattices Extension
+
+`@arach/pi-lattices` is a Pi package that turns the Lattices daemon into
+first-class Pi tools. It is implemented in `packages/pi-lattices/` and registers
+strictly-prefixed `lattices_*` tools on Pi session start.
+
+The extension preserves the Lattices runtime model:
+
+- It calls the existing macOS-native daemon at `ws://127.0.0.1:9399`.
+- It does not bundle or route through `cua-driver`.
+- Run-backed computer-use tools keep Lattices `treatment` semantics.
+- Mutation wrappers prefer `treatment: "stage"` unless the caller explicitly
+  asks for `present` or `execute`.
+- Daemon-down failures are tool results with guidance, not registration-time
+  crashes.
+
+## Install
+
+From this repo during development:
+
+```bash
+pi install ./packages/pi-lattices --local
+```
+
+Published package form:
+
+```bash
+pi install npm:@arach/pi-lattices
+```
+
+Start Lattices before using the tools:
+
+```bash
+lattices app
+```
+
+## High-value tools
+
+| Pi tool | Lattices method |
+| --- | --- |
+| `lattices_status` | `daemon.status` |
+| `lattices_api_schema` | `api.schema` |
+| `lattices_windows_list` | `windows.list` |
+| `lattices_windows_search` | `windows.search` |
+| `lattices_window_get` | `windows.get` |
+| `lattices_runs_list` | `runs.list` |
+| `lattices_runs_get` | `runs.get` |
+| `lattices_ocr_snapshot` | `ocr.snapshot` |
+| `lattices_ocr_search` | `ocr.search` |
+| `lattices_computer_window_state` | `computer.windowState` |
+| `lattices_window_focus` | `computer.focusWindow` |
+| `lattices_window_place` | `window.place` |
+| `lattices_capture_window` | `capture.screenshotWindow` |
+| `lattices_computer_prepare` | `computer.prepare` |
+| `lattices_computer_launch_app` | `computer.launchApp` |
+| `lattices_computer_click` | `computer.click` |
+| `lattices_computer_type_window_text` | `computer.typeWindowText` |
+| `lattices_computer_type_text` | `computer.typeText` |
+| `lattices_call` | caller-selected escape hatch |
+
+Use `lattices_call` only when a method is not typed yet. It passes through the
+requested daemon method and does not add an additional confirmation layer.
+
+## Smoke/manual test path
+
+Automated registration smoke:
+
+```bash
+node packages/pi-lattices/test/smoke.mjs
+```
+
+Daemon-down behavior:
+
+```bash
+bun run --cwd packages/pi-lattices smoke:no-daemon
+```
+
+Live read + safe staged call:
+
+```bash
+lattices app
+bun run --cwd packages/pi-lattices smoke:live
+```
+
+The live smoke checks `daemon.status`, then stages a `computer.launchApp` run for
+Finder with `capture: false`. Because the call uses `treatment: "stage"`, it
+records intent without launching or focusing the app.

--- a/docs/proposals/LAT-008-pi-lattices-computer-use.md
+++ b/docs/proposals/LAT-008-pi-lattices-computer-use.md
@@ -1,0 +1,388 @@
+# LAT-008: pi-lattices and Safe Computer Use Expansion
+
+Status: Draft
+Date: 2026-06-28
+Audience: Lattices implementers, Pi package implementers, agent integrations
+
+## Summary
+
+Build `pi-lattices`: a Pi package/extension that exposes Lattices' daemon as
+first-class Pi tools, then expand Lattices' native computer-use surface with the
+best primitives observed in `@amaster.ai/pi-computer-use` / `cua-driver` while
+preserving Lattices' product strengths: macOS-native control, typed daemon
+methods, treatments, run receipts, artifacts, and traceability.
+
+The target is not to wrap `cua-driver` inside Lattices. The target is to bring
+its most useful low-level affordances into Lattices' safer action/runtime model.
+
+## Context
+
+Installed comparison baseline:
+
+- Pi package: `@amaster.ai/pi-computer-use`
+- Underlying driver: bundled `cua-driver`
+- Current Lattices project: `/Users/art/dev/lattices`
+
+Observed `pi-computer-use` strengths:
+
+- Full per-window AX state snapshots with actionable element indices.
+- Direct low-level inputs: click, double-click, right-click, type text, press key,
+  hotkey, scroll, drag, set value.
+- Window-local screenshot pixel coordinate model.
+- Optional screenshot analysis by a vision model.
+- Graceful tool registration/degradation in Pi.
+
+Current Lattices strengths:
+
+- Rich workspace orchestration: projects, sessions, windows, layers, spaces,
+  process and terminal awareness.
+- Local daemon API on `ws://127.0.0.1:9399` with `api.schema`.
+- Run store under `~/Library/Application Support/Lattices/Runs/` with artifacts
+  and trace events.
+- Computer-use `treatment` semantics: `observe`, `stage`, `present`, `execute`.
+- Existing safe endpoints: `computer.prepare`, `computer.focusWindow`,
+  `computer.showCursor`, `computer.magicCursor`, `computer.launchApp`,
+  `computer.typeWindowText`, `computer.click`, `computer.typeText`, plus
+  screenshot/recording endpoints.
+
+## Validation against current repo
+
+The Phase 1 package can be implemented as a wrapper around existing daemon
+methods; no Swift daemon endpoints are required for the MVP.
+
+Confirmed in `docs/api.md` and
+`apps/mac/Sources/Core/Daemon/LatticesApi.swift`:
+
+- `api.schema`, `daemon.status`, `windows.list`, `windows.get`,
+  `windows.search`, `runs.list`, `runs.get`, `ocr.snapshot`, and `ocr.search`
+  are registered read endpoints.
+- `window.place` is the canonical receipt-returning placement mutation;
+  `window.tile` remains a compatibility wrapper.
+- `capture.screenshotWindow` writes run artifacts.
+- `computer.prepare`, `computer.focusWindow`, `computer.launchApp`,
+  `computer.typeWindowText`, `computer.click`, and `computer.typeText` already
+  use the Lattices run/treatment model.
+- `computer.click` now exists and defaults to `stage`, so the older
+  `LAT-006-followup-gaps` click gap is stale.
+- `windows.search` is the typed window search endpoint for the MVP. The richer
+  `lattices.search` endpoint also exists and remains reachable through the
+  `lattices_call` escape hatch.
+- `computer.windowState` is now present as the first Phase 2 read endpoint.
+  Element mutation endpoints such as `computer.elementAction`,
+  `computer.typeElement`, and `computer.setValue` are not yet present as public
+  daemon methods.
+
+MVP wrapper decision: `lattices_window_focus` maps to
+`computer.focusWindow`, not raw `window.focus`, so focus/present calls can stay
+run-/trace-aware and accept `treatment`.
+
+Phase 1 implementation lives in `packages/pi-lattices/` with package docs in
+`docs/pi-lattices.md`.
+
+## Product principles
+
+1. **Keep Lattices macOS-native.** Do not widen scope to cross-platform bundled
+   drivers.
+2. **Prefer read/plan before act.** New tools should fit `observe`/`stage` before
+   `execute`.
+3. **Keep actions receipt-backed.** Every mutation should be traceable through a
+   run or action receipt where practical.
+4. **Prefer semantic targets over coordinates.** Coordinates remain necessary,
+   but AX element IDs and target resolution should be the happy path.
+5. **Avoid destructive primitives by default.** No raw force-kill app tool unless
+   it is strongly scoped and confirmation-gated.
+6. **Make readiness machine-readable.** Agents should be able to discover missing
+   Accessibility, Screen Recording, or app-specific capabilities before acting.
+
+## Phase 1: `pi-lattices` MVP over existing daemon
+
+Create a Pi package, likely under a package path such as
+`packages/pi-lattices/` or a publishable package folder selected by the
+maintainer. It should be installable by Pi as an npm/git/local package.
+
+### Package goals
+
+- Register Pi tools that call the Lattices daemon via the existing websocket
+  protocol / `daemonCall` helper.
+- Fail gracefully when the daemon is down with actionable guidance:
+  `Start Lattices with: lattices app`.
+- Preserve Lattices method names and safety semantics rather than inventing a
+  parallel action model.
+- Include a generic escape hatch, but expose high-value typed tools first.
+
+### Initial Pi tools
+
+Use a consistent prefix such as `lattices_`.
+
+Read/discovery:
+
+- `lattices_status` → `daemon.status`
+- `lattices_api_schema` → `api.schema`
+- `lattices_windows_list` → `windows.list`
+- `lattices_windows_search` → `windows.search` / `lattices.search` as appropriate
+- `lattices_window_get` → `windows.get`
+- `lattices_runs_list` → `runs.list`
+- `lattices_runs_get` → `runs.get`
+- `lattices_ocr_snapshot` → `ocr.snapshot`
+- `lattices_ocr_search` → `ocr.search`
+
+Mutations / computer use:
+
+- `lattices_window_focus` → `window.focus` or `computer.focusWindow`
+- `lattices_window_place` → `window.place`
+- `lattices_capture_window` → `capture.screenshotWindow`
+- `lattices_computer_launch_app` → `computer.launchApp`
+- `lattices_computer_click` → `computer.click`
+- `lattices_computer_type_window_text` → `computer.typeWindowText`
+- `lattices_computer_type_text` → `computer.typeText`
+
+Escape hatch:
+
+- `lattices_call` with `method`, `params`, optional `timeoutMs`.
+
+### MVP acceptance criteria
+
+- Package loads in Pi and registers tools on session start.
+- `lattices_status` returns a daemon status when the app is running.
+- When the daemon is not running, tools return a friendly non-crashing error.
+- Tool schemas are strict enough for agent use and include short descriptions.
+- At least one smoke test or documented manual check demonstrates a read call and
+  a safe staged call.
+- Documentation explains install via `pi install`, local dev usage, and daemon
+  startup requirement.
+
+## Phase 2: AX window state and element IDs
+
+Add a Lattices-native endpoint to inspect a target window's AX tree and create
+an actionable snapshot.
+
+Candidate endpoint:
+
+- `computer.windowState`
+
+Candidate params:
+
+```ts
+{
+  wid?: number
+  app?: string
+  title?: string
+  pid?: number
+  query?: string
+  mode?: 'ax' | 'screenshot' | 'both' | 'ocr'
+  capture?: boolean
+  source?: string
+}
+```
+
+Candidate return shape:
+
+```ts
+{
+  ok: true,
+  snapshotId: string,
+  target: { wid, pid, app, title, frame },
+  mode: 'ax' | 'screenshot' | 'both' | 'ocr',
+  elements: [
+    {
+      id: 'e1',
+      role: 'AXButton',
+      title?: string,
+      label?: string,
+      value?: string,
+      description?: string,
+      frame?: { x, y, w, h },
+      enabled?: boolean,
+      selected?: boolean,
+      focused?: boolean,
+      actions?: string[],
+      path?: string
+    }
+  ],
+  treeMarkdown?: string,
+  artifact?: RunArtifact,
+  warnings?: string[]
+}
+```
+
+Implementation notes:
+
+- Element IDs only need to be stable within a snapshot at first.
+- The server may maintain an in-memory snapshot cache scoped by window/run.
+- Include enough path/role/title metadata to make logs debuggable after cache
+  expiry.
+- `mode: ax` should avoid Screen Recording when only Accessibility is needed.
+- `mode: screenshot` should avoid AX when only visual inspection is needed.
+
+### Element actions
+
+Add semantic element-targeted mutations:
+
+- `computer.elementAction`
+- `computer.typeElement`
+- `computer.setValue`
+
+Candidate `computer.elementAction` params:
+
+```ts
+{
+  snapshotId: string,
+  elementId: string,
+  action?: 'press' | 'showMenu' | 'open' | 'confirm' | 'cancel' | 'focus',
+  treatment?: 'stage' | 'present' | 'execute',
+  capture?: boolean,
+  source?: string
+}
+```
+
+Acceptance:
+
+- Agents can inspect Calculator/Notes/Finder/Chrome window state and perform a
+  button press by element ID without using coordinates.
+- Stage mode records intent without mutating.
+- Execute mode records before/after trace where practical.
+
+## Phase 3: Rich input primitives
+
+Add Lattices-native computer-use endpoints analogous to the useful `cua-driver`
+primitives. Each endpoint must preserve Lattices' treatment/capture/run model.
+
+Candidate endpoints:
+
+- `computer.pressKey`
+- `computer.hotkey`
+- `computer.scroll`
+- `computer.drag`
+- `computer.doubleClick`
+- `computer.rightClick` or improved `computer.click` with `count` and button
+- `computer.setValue` (if not completed in Phase 2)
+
+Design rules:
+
+- Accept `wid|app|title` target resolution where practical.
+- Prefer `elementId` or AX path when provided.
+- Use coordinates only when semantic targets are unavailable.
+- Default risky operations to `stage` unless caller explicitly passes
+  `treatment: 'execute'`.
+- Include `source` in traces.
+
+Acceptance examples:
+
+- Press Return in a selected text field without moving the pointer.
+- Send Cmd+C/Cmd+V to a targeted app/window when safe.
+- Scroll a target window or element.
+- Drag a slider/handle using staged and execute modes.
+- Double-click an openable item.
+
+## Phase 4: Vision, zoom, and verification
+
+Add APIs that let agents reason about screenshots and prove outcomes.
+
+Candidate endpoints:
+
+- `capture.screenshotRegion`
+- `capture.zoomArtifact`
+- `vision.analyzeWindow`
+- `vision.analyzeArtifact`
+- `computer.verify`
+
+`vision.*` should be optional and explicit. It may use configured provider/model
+settings, but should not imply always-on cloud vision.
+
+Candidate `vision.analyzeWindow` params:
+
+```ts
+{
+  wid?: number,
+  app?: string,
+  title?: string,
+  instruction: string,
+  runId?: string,
+  source?: string
+}
+```
+
+Candidate `computer.verify` modes:
+
+- OCR contains/does-not-contain text.
+- AX element value equals/contains expected value.
+- Window/artifact changed or did not change.
+- Vision prompt returns a structured judgment.
+
+Acceptance:
+
+- An agent can capture a window, ask a vision model a targeted question, and
+  inspect the resulting run/artifact linkage.
+- A type/click flow can include a post-action verification step using OCR or AX.
+
+## Phase 5: Browser/page primitives
+
+Consider browser-specific read and action endpoints once the core safe computer
+use surface is in place.
+
+Candidate endpoints:
+
+- `browser.getText`
+- `browser.queryDom`
+- `browser.executeJavascript`
+
+Guardrails:
+
+- Browser mutation and enabling JavaScript automation require explicit user
+  consent.
+- Prefer read-only browser operations by default.
+- Document supported browsers and required app settings.
+
+## Phase 6: Package polish and docs
+
+- Publish/package `pi-lattices` in a way Pi can install via npm/git/local path.
+- Add docs to Lattices and package README.
+- Add smoke test scripts and examples.
+- Add `lattices mcp` only if it complements the Pi extension or shares the same
+  implementation.
+
+## Things not to copy
+
+- Do not replace Lattices daemon/action runtime with `cua-driver`.
+- Do not make raw coordinates the primary API.
+- Do not add unscoped force-kill app tools.
+- Do not silently enable browser automation settings.
+- Do not bypass runs/artifacts/trace for mutating computer-use actions.
+
+## Suggested implementation order
+
+1. Build `pi-lattices` MVP around current daemon methods.
+2. Add `computer.windowState` read endpoint. **Done.**
+3. Add `computer.elementAction` and element-ID support in click/type/set value.
+4. Add keyboard/scroll/drag/double-click primitives.
+5. Add vision/zoom/verify.
+6. Add browser primitives.
+
+## Validation commands
+
+Run the narrowest checks for the touched area. Common commands from this repo:
+
+```bash
+bun run check:types
+bun run check:app
+bun run check
+bun run test:cli
+```
+
+Manual checks will also be necessary for macOS Accessibility and Screen
+Recording behaviors.
+
+## Source references
+
+- `docs/api.md` — current daemon and computer-use API.
+- `apps/mac/Sources/Core/Daemon/LatticesApi.swift` — endpoint registry.
+- `apps/mac/Sources/Core/Actions/ComputerUseController.swift` — existing
+  computer-use implementation.
+- `packages/npm/sdk/cua.mjs` and `packages/npm/sdk/cua.d.ts` — current SDK facade.
+- `docs/proposals/LAT-005-action-runtime-product-spine.md` — action runtime
+  product direction.
+- `docs/proposals/LAT-006-runs-and-capture-in-lattices.md` — runs/capture model.
+- `docs/proposals/LAT-006-followup-gaps.md` — older gap analysis; verify against
+  current `docs/api.md` because some gaps have already been closed.
+- Installed comparison docs:
+  `/Users/art/.pi/agent/npm/node_modules/@amaster.ai/pi-computer-use/README.md`.

--- a/docs/proposals/LAT-008-pi-lattices-computer-use.md
+++ b/docs/proposals/LAT-008-pi-lattices-computer-use.md
@@ -67,7 +67,8 @@ Confirmed in `docs/api.md` and
 - `windows.search` is the typed window search endpoint for the MVP. The richer
   `lattices.search` endpoint also exists and remains reachable through the
   `lattices_call` escape hatch.
-- `computer.windowState` is now present as the first Phase 2 read endpoint.
+- `computer.windowState` is now present as the first Phase 2 window-state
+  endpoint.
   Element mutation endpoints such as `computer.elementAction`,
   `computer.typeElement`, and `computer.setValue` are not yet present as public
   daemon methods.
@@ -352,7 +353,7 @@ Guardrails:
 ## Suggested implementation order
 
 1. Build `pi-lattices` MVP around current daemon methods.
-2. Add `computer.windowState` read endpoint. **Done.**
+2. Add `computer.windowState` window-state endpoint. **Done.**
 3. Add `computer.elementAction` and element-ID support in click/type/set value.
 4. Add keyboard/scroll/drag/double-click primitives.
 5. Add vision/zoom/verify.

--- a/packages/pi-lattices/README.md
+++ b/packages/pi-lattices/README.md
@@ -1,0 +1,118 @@
+# @arach/pi-lattices
+
+Pi extension that exposes the local Lattices macOS daemon as typed `lattices_*`
+tools. It wraps Lattices' existing WebSocket API at `ws://127.0.0.1:9399`; it
+does **not** bundle `cua-driver`, replace the Lattices daemon, or enable browser
+automation.
+
+## Requirements
+
+- macOS with Lattices installed from this repo.
+- The Lattices menu bar app running so the daemon is available:
+
+```bash
+lattices app
+```
+
+If the daemon is not reachable, every tool returns a friendly Pi tool error with
+this startup command instead of throwing during tool registration.
+
+## Install
+
+Local development from the Lattices repo:
+
+```bash
+pi install ./packages/pi-lattices --local
+```
+
+After the package is published:
+
+```bash
+pi install npm:@arach/pi-lattices
+```
+
+Restart Pi after installing so the extension can register tools on session start.
+
+## Tools
+
+All tools use the `lattices_` prefix.
+
+### Read/discovery
+
+| Tool | Daemon method |
+| --- | --- |
+| `lattices_status` | `daemon.status` |
+| `lattices_api_schema` | `api.schema` |
+| `lattices_windows_list` | `windows.list` |
+| `lattices_windows_search` | `windows.search` |
+| `lattices_window_get` | `windows.get` |
+| `lattices_runs_list` | `runs.list` |
+| `lattices_runs_get` | `runs.get` |
+| `lattices_ocr_snapshot` | `ocr.snapshot` |
+| `lattices_ocr_search` | `ocr.search` |
+| `lattices_computer_window_state` | `computer.windowState` |
+
+### Mutations / computer use
+
+| Tool | Daemon method | Safety note |
+| --- | --- | --- |
+| `lattices_window_focus` | `computer.focusWindow` | Defaults to `treatment: "stage"`; pass `present` or `execute` to focus. |
+| `lattices_window_place` | `window.place` | Returns the daemon action receipt. |
+| `lattices_capture_window` | `capture.screenshotWindow` | Creates a run artifact. |
+| `lattices_computer_prepare` | `computer.prepare` | Stages/observes a terminal target. |
+| `lattices_computer_launch_app` | `computer.launchApp` | Defaults to `treatment: "stage"`; pass `present` or `execute` to launch/focus. |
+| `lattices_computer_click` | `computer.click` | Defaults to `treatment: "stage"`; pass `execute` to click. |
+| `lattices_computer_type_window_text` | `computer.typeWindowText` | Defaults to `treatment: "stage"`; pass `execute` to insert text. |
+| `lattices_computer_type_text` | `computer.typeText` | Defaults to `treatment: "stage"`; pass `execute` to insert text. |
+| `lattices_call` | caller-selected | Escape hatch; prefer typed tools first. |
+
+The default `source` for run-backed tools is `pi-lattices` unless the caller
+passes a more specific `source`.
+
+`lattices_call` intentionally does not add an extra safety layer; it is for
+daemon methods that are not yet typed here. Prefer typed tools for actions and
+keep destructive daemon methods out of normal prompts.
+
+## Smoke checks
+
+Registration only:
+
+```bash
+node packages/pi-lattices/test/smoke.mjs
+```
+
+Graceful daemon-down behavior (uses an intentionally unreachable port):
+
+```bash
+bun run --cwd packages/pi-lattices smoke:no-daemon
+```
+
+Live read + safe staged action:
+
+```bash
+lattices app
+bun run --cwd packages/pi-lattices smoke:live
+```
+
+The live smoke calls `lattices_status`, then stages `computer.launchApp` for
+Finder with `capture: false`; it does not launch or focus Finder because the
+`treatment` is `stage`.
+
+## Configuration
+
+By default the extension connects to `ws://127.0.0.1:9399`. For tests or custom
+setups, override with environment variables before starting Pi:
+
+```bash
+export LATTICES_DAEMON_HOST=127.0.0.1
+export LATTICES_DAEMON_PORT=9399
+export LATTICES_DAEMON_TIMEOUT_MS=3000
+```
+
+## Phase 2 direction
+
+`computer.windowState` is now exposed as `lattices_computer_window_state` for
+read-only AX inspection and optional screenshot artifacts. The next expansion
+should add element-id actions (`computer.elementAction`, `computer.typeElement`,
+`computer.setValue`) while keeping treatment/run/artifact semantics in the
+daemon.

--- a/packages/pi-lattices/README.md
+++ b/packages/pi-lattices/README.md
@@ -50,12 +50,12 @@ All tools use the `lattices_` prefix.
 | `lattices_runs_get` | `runs.get` |
 | `lattices_ocr_snapshot` | `ocr.snapshot` |
 | `lattices_ocr_search` | `ocr.search` |
-| `lattices_computer_window_state` | `computer.windowState` |
 
 ### Mutations / computer use
 
 | Tool | Daemon method | Safety note |
 | --- | --- | --- |
+| `lattices_computer_window_state` | `computer.windowState` | `mode: "ax"` inspects only; `both`, `screenshot`, or `capture: true` create run artifacts. |
 | `lattices_window_focus` | `computer.focusWindow` | Defaults to `treatment: "stage"`; pass `present` or `execute` to focus. |
 | `lattices_window_place` | `window.place` | Returns the daemon action receipt. |
 | `lattices_capture_window` | `capture.screenshotWindow` | Creates a run artifact. |
@@ -87,7 +87,7 @@ Graceful daemon-down behavior (uses an intentionally unreachable port):
 bun run --cwd packages/pi-lattices smoke:no-daemon
 ```
 
-Live read + safe staged action:
+Live status + safe staged action:
 
 ```bash
 lattices app
@@ -112,7 +112,7 @@ export LATTICES_DAEMON_TIMEOUT_MS=3000
 ## Phase 2 direction
 
 `computer.windowState` is now exposed as `lattices_computer_window_state` for
-read-only AX inspection and optional screenshot artifacts. The next expansion
+AX inspection and optional run-backed screenshot artifacts. The next expansion
 should add element-id actions (`computer.elementAction`, `computer.typeElement`,
 `computer.setValue`) while keeping treatment/run/artifact semantics in the
 daemon.

--- a/packages/pi-lattices/daemon-client.mjs
+++ b/packages/pi-lattices/daemon-client.mjs
@@ -1,0 +1,203 @@
+import { randomBytes } from "node:crypto";
+import { createConnection } from "node:net";
+
+const DEFAULT_DAEMON_HOST = "127.0.0.1";
+const DEFAULT_DAEMON_PORT = 9399;
+const DEFAULT_TIMEOUT_MS = 3000;
+
+export function daemonConfig(overrides = {}) {
+  const host = overrides.host ?? process.env.LATTICES_DAEMON_HOST ?? DEFAULT_DAEMON_HOST;
+  const rawPort = overrides.port ?? process.env.LATTICES_DAEMON_PORT ?? DEFAULT_DAEMON_PORT;
+  const rawTimeout = overrides.timeoutMs ?? process.env.LATTICES_DAEMON_TIMEOUT_MS ?? DEFAULT_TIMEOUT_MS;
+  const port = Number(rawPort);
+  const timeoutMs = Number(rawTimeout);
+
+  return {
+    host,
+    port: Number.isFinite(port) && port > 0 ? port : DEFAULT_DAEMON_PORT,
+    timeoutMs: Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : DEFAULT_TIMEOUT_MS,
+  };
+}
+
+export async function daemonCall(method, params = null, options = {}) {
+  const { host, port, timeoutMs } = daemonConfig(options);
+  const id = randomBytes(4).toString("hex");
+  const request = JSON.stringify({ id, method, params: params ?? null });
+
+  return new Promise((resolve, reject) => {
+    const socket = createConnection({ host, port });
+    let settled = false;
+    let upgraded = false;
+    let buffer = Buffer.alloc(0);
+
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        socket.destroy();
+        const error = new Error(`Daemon request timed out after ${timeoutMs}ms`);
+        error.code = "LATTICES_DAEMON_TIMEOUT";
+        reject(error);
+      }
+    }, timeoutMs);
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      socket.destroy();
+    };
+
+    socket.on("error", (error) => {
+      if (!settled) {
+        settled = true;
+        cleanup();
+        reject(error);
+      }
+    });
+
+    socket.on("connect", () => {
+      const key = randomBytes(16).toString("base64");
+      const upgrade = [
+        "GET / HTTP/1.1",
+        `Host: ${host}:${port}`,
+        "Upgrade: websocket",
+        "Connection: Upgrade",
+        `Sec-WebSocket-Key: ${key}`,
+        "Sec-WebSocket-Version: 13",
+        "",
+        "",
+      ].join("\r\n");
+      socket.write(upgrade);
+    });
+
+    socket.on("data", (chunk) => {
+      buffer = Buffer.concat([buffer, chunk]);
+
+      if (!upgraded) {
+        const headerEnd = buffer.indexOf("\r\n\r\n");
+        if (headerEnd === -1) return;
+
+        const header = buffer.subarray(0, headerEnd).toString();
+        if (!header.includes("101")) {
+          settled = true;
+          cleanup();
+          const error = new Error("WebSocket upgrade failed");
+          error.code = "LATTICES_DAEMON_UPGRADE";
+          reject(error);
+          return;
+        }
+
+        upgraded = true;
+        buffer = buffer.subarray(headerEnd + 4);
+        sendFrame(socket, request);
+      }
+
+      while (true) {
+        const parsedFrame = parseFrame(buffer);
+        if (!parsedFrame) break;
+        buffer = parsedFrame.rest;
+
+        try {
+          const parsed = JSON.parse(parsedFrame.payload);
+          if (parsed.event || parsed.id !== id) continue;
+
+          if (!settled) {
+            settled = true;
+            cleanup();
+            if (parsed.error) {
+              const error = new Error(parsed.error);
+              error.code = "LATTICES_DAEMON_ERROR";
+              reject(error);
+            } else {
+              resolve(parsed.result);
+            }
+          }
+          return;
+        } catch {
+          if (!settled) {
+            settled = true;
+            cleanup();
+            const error = new Error("Invalid JSON response from Lattices daemon");
+            error.code = "LATTICES_DAEMON_INVALID_JSON";
+            reject(error);
+          }
+          return;
+        }
+      }
+    });
+  });
+}
+
+export function isDaemonUnavailable(error) {
+  const code = error?.code;
+  return code === "ECONNREFUSED"
+    || code === "ECONNRESET"
+    || code === "EHOSTUNREACH"
+    || code === "ENETUNREACH"
+    || code === "ETIMEDOUT"
+    || code === "LATTICES_DAEMON_TIMEOUT"
+    || code === "LATTICES_DAEMON_UPGRADE";
+}
+
+function sendFrame(socket, text) {
+  const payload = Buffer.from(text, "utf8");
+  const mask = randomBytes(4);
+  const len = payload.length;
+
+  let header;
+  if (len < 126) {
+    header = Buffer.alloc(2);
+    header[0] = 0x81;
+    header[1] = 0x80 | len;
+  } else if (len < 65536) {
+    header = Buffer.alloc(4);
+    header[0] = 0x81;
+    header[1] = 0x80 | 126;
+    header.writeUInt16BE(len, 2);
+  } else {
+    header = Buffer.alloc(10);
+    header[0] = 0x81;
+    header[1] = 0x80 | 127;
+    header.writeBigUInt64BE(BigInt(len), 2);
+  }
+
+  const masked = Buffer.alloc(payload.length);
+  for (let i = 0; i < payload.length; i += 1) {
+    masked[i] = payload[i] ^ mask[i % 4];
+  }
+
+  socket.write(Buffer.concat([header, mask, masked]));
+}
+
+function parseFrame(buf) {
+  if (buf.length < 2) return null;
+
+  const isMasked = (buf[1] & 0x80) !== 0;
+  let payloadLen = buf[1] & 0x7f;
+  let offset = 2;
+
+  if (payloadLen === 126) {
+    if (buf.length < 4) return null;
+    payloadLen = buf.readUInt16BE(2);
+    offset = 4;
+  } else if (payloadLen === 127) {
+    if (buf.length < 10) return null;
+    payloadLen = Number(buf.readBigUInt64BE(2));
+    offset = 10;
+  }
+
+  if (isMasked) offset += 4;
+  if (buf.length < offset + payloadLen) return null;
+
+  let payload = buf.subarray(offset, offset + payloadLen);
+  if (isMasked) {
+    const maskKey = buf.subarray(offset - 4, offset);
+    payload = Buffer.alloc(payloadLen);
+    for (let i = 0; i < payloadLen; i += 1) {
+      payload[i] = buf[offset + i] ^ maskKey[i % 4];
+    }
+  }
+
+  return {
+    payload: payload.toString("utf8"),
+    rest: buf.subarray(offset + payloadLen),
+  };
+}

--- a/packages/pi-lattices/index.d.ts
+++ b/packages/pi-lattices/index.d.ts
@@ -1,0 +1,39 @@
+export interface PiToolResultContent {
+  type: "text";
+  text: string;
+}
+
+export interface PiToolResult {
+  content: PiToolResultContent[];
+  details?: unknown;
+  isError?: boolean;
+}
+
+export interface PiToolDefinition {
+  name: string;
+  label: string;
+  description: string;
+  parameters: unknown;
+  execute(
+    toolCallId: string,
+    params?: Record<string, unknown>,
+    signal?: AbortSignal,
+    onUpdate?: unknown,
+    ctx?: unknown
+  ): Promise<PiToolResult>;
+}
+
+export interface PiExtensionApi {
+  on(event: "session_start", handler: (event: unknown, ctx: unknown) => void | Promise<void>): void;
+  registerTool(tool: PiToolDefinition): void;
+}
+
+export interface LatticesToolMetadata {
+  name: string;
+  method: string | null;
+  description: string;
+  parameters: unknown;
+}
+
+export declare const LATTICES_TOOLS: LatticesToolMetadata[];
+export default function latticesPiExtension(pi: PiExtensionApi): void;

--- a/packages/pi-lattices/index.mjs
+++ b/packages/pi-lattices/index.mjs
@@ -7,6 +7,7 @@ const string = (description) => ({ type: "string", description });
 const boolean = (description) => ({ type: "boolean", description });
 const number = (description) => ({ type: "number", description });
 const integer = (description) => ({ type: "integer", minimum: 1, description });
+const nonNegativeInteger = (description) => ({ type: "integer", minimum: 0, description });
 const optionalEnum = (values, description) => ({ type: "string", enum: values, description });
 const object = (properties = {}, required = []) => ({
   type: "object",
@@ -159,7 +160,7 @@ export const LATTICES_TOOLS = [
     description: "Place a target window/session using Lattices' typed placement runtime and return the action receipt.",
     parameters: object({
       ...targetParams,
-      display: integer("Target display index."),
+      display: nonNegativeInteger("Zero-based target display index."),
       placement: {
         description: "Placement shorthand (left, right, maximize, grid:3x2:0,0, etc.) or typed placement object.",
         anyOf: [

--- a/packages/pi-lattices/index.mjs
+++ b/packages/pi-lattices/index.mjs
@@ -1,0 +1,388 @@
+import { daemonCall, daemonConfig, isDaemonUnavailable } from "./daemon-client.mjs";
+
+const TOOL_PREFIX = "lattices_";
+const DEFAULT_SOURCE = "pi-lattices";
+
+const string = (description) => ({ type: "string", description });
+const boolean = (description) => ({ type: "boolean", description });
+const number = (description) => ({ type: "number", description });
+const integer = (description) => ({ type: "integer", minimum: 1, description });
+const optionalEnum = (values, description) => ({ type: "string", enum: values, description });
+const object = (properties = {}, required = []) => ({
+  type: "object",
+  additionalProperties: false,
+  properties,
+  ...(required.length > 0 ? { required } : {}),
+});
+
+const treatment = optionalEnum(
+  ["observe", "stage", "present", "execute"],
+  "Lattices computer-use treatment. Pi tools default to stage where that avoids mutation."
+);
+
+const source = string("Calling surface label recorded in Lattices runs/traces. Defaults to pi-lattices.");
+const dryRun = boolean("Legacy alias for treatment=stage where supported by the daemon.");
+const capture = boolean("Whether Lattices should capture before/after artifacts when supported.");
+const wid = integer("CGWindowID / kCGWindowNumber.");
+const session = string("Lattices tmux/session name, such as myapp-a1b2c3.");
+const app = string("macOS application name, such as Finder, Notes, Terminal, iTerm2, or Scout.");
+const title = string("Optional window title substring for target selection.");
+const x = number("Absolute screen X coordinate.");
+const y = number("Absolute screen Y coordinate.");
+const ratio = (description) => ({ type: "number", minimum: 0, maximum: 1, description });
+const text = string("Text payload. Pass treatment=execute to actually insert it.");
+const windowStateMode = optionalEnum(
+  ["ax", "both", "screenshot"],
+  "Snapshot mode. ax avoids Screen Recording; both includes AX plus screenshot capture; screenshot skips AX."
+);
+
+const emptyParams = object();
+const runSourceParams = {
+  source,
+};
+const targetParams = {
+  wid,
+  session,
+  app,
+  title,
+};
+const windowPointParams = {
+  x,
+  y,
+  xRatio: ratio("Window-relative X ratio, where 0 is the left edge and 1 is the right edge."),
+  yRatio: ratio("Window-relative Y ratio, where 0 is the top edge and 1 is the bottom edge."),
+};
+const computerBaseParams = {
+  treatment,
+  dryRun,
+  capture,
+  source,
+};
+
+export const LATTICES_TOOLS = [
+  {
+    name: `${TOOL_PREFIX}status`,
+    method: "daemon.status",
+    description: "Return Lattices daemon health, uptime, tracked windows, and tmux session counts.",
+    parameters: emptyParams,
+  },
+  {
+    name: `${TOOL_PREFIX}api_schema`,
+    method: "api.schema",
+    description: "Return the live Lattices daemon API schema for self-discovery.",
+    parameters: emptyParams,
+  },
+  {
+    name: `${TOOL_PREFIX}windows_list`,
+    method: "windows.list",
+    description: "List visible windows tracked by Lattices, including app/title/frame/session metadata.",
+    parameters: emptyParams,
+  },
+  {
+    name: `${TOOL_PREFIX}windows_search`,
+    method: "windows.search",
+    description: "Search windows by title, app, Lattices session tag, and optionally OCR text.",
+    parameters: object({
+      query: string("Search query."),
+      ocr: boolean("Include OCR text in search. Defaults to true in the daemon."),
+      limit: integer("Maximum results to return."),
+    }, ["query"]),
+  },
+  {
+    name: `${TOOL_PREFIX}window_get`,
+    method: "windows.get",
+    description: "Get one tracked window by CGWindowID.",
+    parameters: object({ wid }, ["wid"]),
+  },
+  {
+    name: `${TOOL_PREFIX}runs_list`,
+    method: "runs.list",
+    description: "List recent Lattices runs from the local run store.",
+    parameters: object({
+      limit: integer("Maximum runs to return. Daemon default is 20."),
+    }),
+  },
+  {
+    name: `${TOOL_PREFIX}runs_get`,
+    method: "runs.get",
+    description: "Inspect one Lattices run, including artifacts and trace events.",
+    parameters: object({
+      id: string("Run id, such as run_20260617-120000_a1b2c3."),
+    }, ["id"]),
+  },
+  {
+    name: `${TOOL_PREFIX}ocr_snapshot`,
+    method: "ocr.snapshot",
+    description: "Return current in-memory OCR results for visible windows.",
+    parameters: emptyParams,
+  },
+  {
+    name: `${TOOL_PREFIX}ocr_search`,
+    method: "ocr.search",
+    description: "Search Lattices OCR history or the live OCR snapshot.",
+    parameters: object({
+      query: string("FTS5 search query."),
+      app: string("Optional application-name filter."),
+      limit: integer("Maximum results to return. Daemon default is 50."),
+      live: boolean("Search the live OCR snapshot instead of history."),
+    }, ["query"]),
+  },
+  {
+    name: `${TOOL_PREFIX}computer_window_state`,
+    method: "computer.windowState",
+    description: "Inspect a target window's Accessibility tree and return snapshot-local element ids for semantic computer use.",
+    parameters: object({
+      ...targetParams,
+      mode: windowStateMode,
+      capture: boolean("Capture a screenshot artifact. Defaults true for both/screenshot and false for ax."),
+      maxDepth: integer("Maximum AX tree depth to traverse. Daemon default is 8."),
+      maxElements: integer("Maximum elements to return. Daemon default is 250."),
+      timeoutMs: integer("Traversal timeout in milliseconds. Daemon default is 1200."),
+      source,
+    }),
+    defaultSource: DEFAULT_SOURCE,
+  },
+  {
+    name: `${TOOL_PREFIX}window_focus`,
+    method: "computer.focusWindow",
+    description: "Resolve and focus/present a target window through Lattices computer-use runs. Defaults to treatment=stage; pass present or execute to focus.",
+    parameters: object({
+      ...targetParams,
+      ...computerBaseParams,
+    }),
+    defaultTreatment: "stage",
+    defaultSource: DEFAULT_SOURCE,
+  },
+  {
+    name: `${TOOL_PREFIX}window_place`,
+    method: "window.place",
+    description: "Place a target window/session using Lattices' typed placement runtime and return the action receipt.",
+    parameters: object({
+      ...targetParams,
+      display: integer("Target display index."),
+      placement: {
+        description: "Placement shorthand (left, right, maximize, grid:3x2:0,0, etc.) or typed placement object.",
+        anyOf: [
+          { type: "string" },
+          { type: "object", additionalProperties: true },
+        ],
+      },
+    }, ["placement"]),
+  },
+  {
+    name: `${TOOL_PREFIX}capture_window`,
+    method: "capture.screenshotWindow",
+    description: "Capture a target window as a Lattices run artifact. Defaults to frontmost non-Lattices window if no target is provided.",
+    parameters: object({
+      ...targetParams,
+      runId: string("Existing run id to append to."),
+      filename: string("Optional artifact filename."),
+      ...runSourceParams,
+    }),
+    defaultSource: DEFAULT_SOURCE,
+  },
+  {
+    name: `${TOOL_PREFIX}computer_prepare`,
+    method: "computer.prepare",
+    description: "Resolve and stage/observe a safe terminal target for later computer-use actions without typing by default.",
+    parameters: object({
+      wid,
+      tty: string("Specific terminal TTY."),
+      app: string("Preferred terminal app, such as Terminal or iTerm2."),
+      text: string("Optional text to stage in the run trace."),
+      ...computerBaseParams,
+    }),
+    defaultTreatment: "stage",
+    defaultSource: DEFAULT_SOURCE,
+  },
+  {
+    name: `${TOOL_PREFIX}computer_launch_app`,
+    method: "computer.launchApp",
+    description: "Launch or focus a normal macOS app through a Lattices run. Defaults to treatment=stage; pass present or execute to launch/focus.",
+    parameters: object({
+      app,
+      bundleId: string("Bundle identifier fallback for precise launch."),
+      path: string("Explicit .app bundle path."),
+      title,
+      ...computerBaseParams,
+    }, ["app"]),
+    defaultTreatment: "stage",
+    defaultSource: DEFAULT_SOURCE,
+  },
+  {
+    name: `${TOOL_PREFIX}computer_click`,
+    method: "computer.click",
+    description: "Stage, present, or execute a window-relative click. Defaults to treatment=stage; pass execute to click.",
+    parameters: object({
+      ...targetParams,
+      ...windowPointParams,
+      button: optionalEnum(["left", "right", "secondary", "context"], "Mouse button. Defaults to left."),
+      transport: optionalEnum(["auto", "ax", "accessibility", "pointer", "mouse", "hardware"], "Click transport. auto prefers AXPress when possible."),
+      axLabel: string("Optional AX title/label hint, such as Send."),
+      targetText: string("Optional visible target text hint."),
+      noFocus: boolean("Require no-focus AX execution and disable pointer fallback."),
+      label: string("Optional label recorded with the click/cursor target."),
+      ...computerBaseParams,
+    }),
+    defaultTreatment: "stage",
+    defaultSource: DEFAULT_SOURCE,
+  },
+  {
+    name: `${TOOL_PREFIX}computer_type_window_text`,
+    method: "computer.typeWindowText",
+    description: "Type into a normal app window, optionally after a click. Defaults to treatment=stage; pass execute to insert text.",
+    parameters: object({
+      wid,
+      app,
+      title,
+      text,
+      enter: boolean("Press Enter after typing. Defaults to false."),
+      send: boolean("Alias for enter in chat-style demos."),
+      ...windowPointParams,
+      ...computerBaseParams,
+    }, ["text"]),
+    defaultTreatment: "stage",
+    defaultSource: DEFAULT_SOURCE,
+  },
+  {
+    name: `${TOOL_PREFIX}computer_type_text`,
+    method: "computer.typeText",
+    description: "Insert text into a safe terminal through Lattices transports. Defaults to treatment=stage; pass execute to type.",
+    parameters: object({
+      wid,
+      tty: string("Specific terminal TTY."),
+      app: string("Preferred terminal app, such as Terminal or iTerm2."),
+      text,
+      enter: boolean("Press Enter after typing. Defaults to false."),
+      transport: optionalEnum(["auto", "tmux", "pasteboard"], "Terminal text transport. Defaults to auto."),
+      ...computerBaseParams,
+    }, ["text"]),
+    defaultTreatment: "stage",
+    defaultSource: DEFAULT_SOURCE,
+  },
+  {
+    name: `${TOOL_PREFIX}call`,
+    method: null,
+    description: "Escape hatch for calling any Lattices daemon method by name. Prefer typed lattices_* tools when available.",
+    parameters: object({
+      method: string("Daemon method name, such as windows.list or computer.prepare."),
+      params: {
+        type: "object",
+        additionalProperties: true,
+        description: "Method-specific JSON params.",
+      },
+      timeoutMs: {
+        type: "integer",
+        minimum: 1,
+        description: "Optional per-call timeout in milliseconds.",
+      },
+    }, ["method"]),
+    escapeHatch: true,
+  },
+];
+
+export default function latticesPiExtension(pi) {
+  pi.on("session_start", async (_event, ctx) => {
+    for (const tool of LATTICES_TOOLS) {
+      pi.registerTool(createPiTool(tool, ctx));
+    }
+  });
+}
+
+function createPiTool(definition, sessionContext) {
+  return {
+    name: definition.name,
+    label: definition.name,
+    description: definition.description,
+    parameters: definition.parameters,
+    async execute(_toolCallId, params = {}, _signal, _onUpdate, ctx) {
+      const executionContext = ctx ?? sessionContext;
+      const call = daemonRequestForTool(definition, params ?? {});
+
+      try {
+        const result = await daemonCall(call.method, call.params, call.options);
+        return formatSuccess(result);
+      } catch (error) {
+        notifyError(executionContext, definition.name, error);
+        return formatError(definition.name, error);
+      }
+    },
+  };
+}
+
+function daemonRequestForTool(definition, params) {
+  if (definition.escapeHatch) {
+    const { method, params: callParams = null, timeoutMs } = params;
+    return {
+      method,
+      params: callParams,
+      options: timeoutMs ? { timeoutMs } : {},
+    };
+  }
+
+  const callParams = { ...params };
+  if (definition.defaultSource && callParams.source === undefined) {
+    callParams.source = definition.defaultSource;
+  }
+  if (definition.defaultTreatment
+    && callParams.treatment === undefined
+    && callParams.dryRun === undefined) {
+    callParams.treatment = definition.defaultTreatment;
+  }
+
+  return {
+    method: definition.method,
+    params: Object.keys(callParams).length === 0 ? null : callParams,
+    options: {},
+  };
+}
+
+function formatSuccess(result) {
+  return {
+    content: [{ type: "text", text: stringifyResult(result) }],
+    details: result,
+  };
+}
+
+function formatError(toolName, error) {
+  const config = daemonConfig();
+  const original = error instanceof Error ? error.message : String(error);
+  const text = isDaemonUnavailable(error)
+    ? [
+        `Lattices daemon is not reachable at ws://${config.host}:${config.port}.`,
+        "Start Lattices with: lattices app",
+        "Then retry the Pi tool.",
+        `Tool: ${toolName}`,
+        `Original error: ${original}`,
+      ].join("\n")
+    : [
+        `Lattices daemon returned an error for ${toolName}:`,
+        original,
+      ].join("\n");
+
+  return {
+    content: [{ type: "text", text }],
+    details: {
+      tool: toolName,
+      daemon: `ws://${config.host}:${config.port}`,
+      error: original,
+      daemonUnavailable: isDaemonUnavailable(error),
+    },
+    isError: true,
+  };
+}
+
+function notifyError(ctx, toolName, error) {
+  if (!isDaemonUnavailable(error)) return;
+  try {
+    ctx?.ui?.notify?.(`pi-lattices: ${toolName} cannot reach the Lattices daemon. Start it with: lattices app`, "warning");
+  } catch {
+    // Notification is best-effort; tool output remains the source of truth.
+  }
+}
+
+function stringifyResult(result) {
+  if (result === undefined) return "undefined";
+  if (typeof result === "string") return result;
+  return JSON.stringify(result, null, 2);
+}

--- a/packages/pi-lattices/package.json
+++ b/packages/pi-lattices/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@arach/pi-lattices",
+  "version": "0.1.0",
+  "description": "Pi extension exposing the Lattices macOS daemon as typed, receipt-aware tools",
+  "keywords": [
+    "pi-package",
+    "pi",
+    "extension",
+    "lattices",
+    "macos",
+    "daemon",
+    "computer-use",
+    "workspace"
+  ],
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./index.mjs",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "index.mjs",
+    "index.d.ts",
+    "daemon-client.mjs",
+    "README.md",
+    "test/smoke.mjs"
+  ],
+  "pi": {
+    "extensions": [
+      "./index.mjs"
+    ]
+  },
+  "scripts": {
+    "smoke": "node test/smoke.mjs",
+    "smoke:no-daemon": "LATTICES_DAEMON_PORT=1 node test/smoke.mjs --no-daemon",
+    "smoke:live": "node test/smoke.mjs --live"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.74.0"
+  },
+  "peerDependenciesMeta": {
+    "@earendil-works/pi-coding-agent": {
+      "optional": true
+    }
+  }
+}

--- a/packages/pi-lattices/test/smoke.mjs
+++ b/packages/pi-lattices/test/smoke.mjs
@@ -46,6 +46,13 @@ for (const required of [
 }
 assert.equal(names.length, LATTICES_TOOLS.length, "registered tool count matches metadata");
 
+const windowPlaceSchema = LATTICES_TOOLS.find((entry) => entry.name === "lattices_window_place")?.parameters;
+assert.equal(
+  windowPlaceSchema?.properties?.display?.minimum,
+  0,
+  "window_place display accepts zero-based display index"
+);
+
 if (!live && !noDaemon) {
   console.log(`Registered ${names.length} pi-lattices tools.`);
   console.log("Use --no-daemon to verify graceful daemon errors, or --live with `lattices app` running.");

--- a/packages/pi-lattices/test/smoke.mjs
+++ b/packages/pi-lattices/test/smoke.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+
+import latticesPiExtension, { LATTICES_TOOLS } from "../index.mjs";
+
+const args = new Set(process.argv.slice(2));
+const live = args.has("--live");
+const noDaemon = args.has("--no-daemon");
+
+const registeredTools = [];
+const handlers = new Map();
+const notifications = [];
+const ctx = {
+  cwd: process.cwd(),
+  ui: {
+    notify(message, level) {
+      notifications.push({ message, level });
+    },
+  },
+};
+
+const pi = {
+  registerTool(tool) {
+    registeredTools.push(tool);
+  },
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+};
+
+latticesPiExtension(pi);
+assert.equal(typeof handlers.get("session_start"), "function", "extension registers a session_start hook");
+await handlers.get("session_start")({}, ctx);
+
+const names = registeredTools.map((tool) => tool.name).sort();
+for (const required of [
+  "lattices_status",
+  "lattices_api_schema",
+  "lattices_windows_list",
+  "lattices_window_place",
+  "lattices_computer_window_state",
+  "lattices_computer_launch_app",
+  "lattices_computer_click",
+  "lattices_call",
+]) {
+  assert.ok(names.includes(required), `registered ${required}`);
+}
+assert.equal(names.length, LATTICES_TOOLS.length, "registered tool count matches metadata");
+
+if (!live && !noDaemon) {
+  console.log(`Registered ${names.length} pi-lattices tools.`);
+  console.log("Use --no-daemon to verify graceful daemon errors, or --live with `lattices app` running.");
+  process.exit(0);
+}
+
+function tool(name) {
+  const found = registeredTools.find((entry) => entry.name === name);
+  assert.ok(found, `missing tool ${name}`);
+  return found;
+}
+
+async function execute(name, params = {}) {
+  return tool(name).execute(`smoke-${name}`, params, undefined, undefined, ctx);
+}
+
+if (noDaemon) {
+  const result = await execute("lattices_status");
+  assert.equal(result.isError, true, "daemon-down status returns isError");
+  assert.match(result.content[0].text, /Start Lattices with: lattices app/);
+  assert.ok(notifications.some((entry) => entry.level === "warning"), "warning notification emitted");
+  console.log("No-daemon smoke passed: lattices_status returned friendly guidance instead of throwing.");
+  process.exit(0);
+}
+
+const status = await execute("lattices_status");
+if (status.isError) {
+  console.error(status.content[0].text);
+  process.exit(1);
+}
+console.log("lattices_status OK");
+
+const staged = await execute("lattices_computer_launch_app", {
+  app: "Finder",
+  treatment: "stage",
+  capture: false,
+  source: "pi-lattices-smoke",
+});
+if (staged.isError) {
+  console.error(staged.content[0].text);
+  process.exit(1);
+}
+console.log("lattices_computer_launch_app staged OK");
+console.log("Live smoke passed.");


### PR DESCRIPTION
## What changed

- Added `computer.windowState`, a read-only daemon endpoint that resolves a window and returns a bounded AX tree snapshot with snapshot-local element ids, compact tree markdown, warnings, and optional screenshot/run artifacts.
- Registered `AXElement` and `ComputerWindowState` in `api.schema`.
- Added the `@arach/pi-lattices` Pi extension with typed `lattices_*` tools, including `lattices_computer_window_state`, plus smoke checks and docs.
- Updated API/Pi docs and LAT-008 to reflect Phase 1 and the first Phase 2 endpoint.

## Why

This moves the safe computer-use plan past coordinate-only actions by giving agents a semantic read layer before future element-id mutations like `computer.elementAction`, `computer.typeElement`, and `computer.setValue`.

## Validation

- `bun run check:app`
- `bun run check:types`
- `node packages/pi-lattices/test/smoke.mjs`
- `bun run --cwd packages/pi-lattices smoke:no-daemon`
- `bun run --cwd packages/pi-lattices smoke:live`
- Live `api.schema` confirmed `computer.windowState`
- Live Finder AX snapshot returned `ok: true`
- Live `mode: screenshot` returned a completed run with an artifact

## Notes

The local app restart updated `apps/mac/Lattices.app/Contents/Info.plist` version metadata, but that generated bundle plist change is not included in this PR.