### PR TITLE
[codex] Add AX element actions

### DIFF
--- a/apps/mac/Sources/Core/Actions/ComputerUseController.swift
+++ b/apps/mac/Sources/Core/Actions/ComputerUseController.swift
@@ -223,10 +223,19 @@ private struct AXSnapshotContext {
     let messagingTimeout: Float
     var nextElementIndex = 1
     var elements: [AXSnapshotElement] = []
+    var elementRefsById: [String: AXUIElement] = [:]
     var warnings: [String] = []
     var hitDepthLimit = false
     var hitElementLimit = false
     var hitTimeout = false
+}
+
+private struct AXWindowSnapshot {
+    let id: String
+    let window: WindowEntry
+    let createdAt: Date
+    let elementsById: [String: AXSnapshotElement]
+    let elementRefsById: [String: AXUIElement]
 }
 
 final class ComputerUseController {
@@ -237,6 +246,10 @@ final class ComputerUseController {
         "claude", "codex", "vim", "nvim", "emacs", "nano", "less", "more", "top",
         "ssh", "python", "python3", "node", "bun", "npm", "pnpm", "yarn", "swift",
     ]
+    private let axSnapshotLock = NSLock()
+    private let axSnapshotTTL: TimeInterval = 300
+    private let maxAXSnapshotCacheCount = 30
+    private var axSnapshotsById: [String: AXWindowSnapshot] = [:]
 
     private init() {}
 
@@ -303,6 +316,12 @@ final class ComputerUseController {
                     timeoutMs: timeoutMs
                 )
                 elements = context.elements
+                storeAXSnapshot(
+                    id: snapshotId,
+                    window: window,
+                    elements: context.elements,
+                    elementRefsById: context.elementRefsById
+                )
                 warnings.append(contentsOf: context.warnings)
                 if context.hitDepthLimit {
                     warnings.append("AX traversal reached maxDepth \(maxDepth)")
@@ -368,6 +387,139 @@ final class ComputerUseController {
                     ]
                 )
             }
+            throw error
+        }
+    }
+
+    func elementAction(params: JSON?) throws -> JSON {
+        let source = params?["source"]?.stringValue ?? "daemon"
+        let treatment = ComputerTreatment.resolve(params: params, defaultValue: .stage)
+        let shouldCapture = params?["capture"]?.boolValue ?? true
+        let snapshotId = try requiredString(params, keys: ["snapshotId", "snapshot-id", "snapshot"])
+        let elementId = try requiredString(params, keys: ["elementId", "element-id", "id"])
+        let requestedAction = try elementActionName(params)
+        let snapshot = try axSnapshot(id: snapshotId)
+        guard let element = snapshot.elementRefsById[elementId],
+              let elementInfo = snapshot.elementsById[elementId] else {
+            throw RouterError.notFound("element \(elementId) in snapshot \(snapshotId)")
+        }
+
+        let run = try RunStore.shared.createRun(
+            title: "Element action \(requestedAction)",
+            source: source,
+            surfaces: [.window(snapshot.window)]
+        )
+
+        do {
+            _ = try RunStore.shared.markRunning(
+                id: run.id,
+                summary: "Resolved AX element action",
+                data: [
+                    "action": .string("elementAction"),
+                    "treatment": .string(treatment.rawValue),
+                    "snapshotId": .string(snapshotId),
+                    "elementId": .string(elementId),
+                    "requestedAction": .string(requestedAction),
+                    "wid": .int(Int(snapshot.window.wid)),
+                    "app": .string(snapshot.window.app),
+                ]
+            )
+
+            let before = try maybeCaptureWindow(
+                shouldCapture: shouldCapture,
+                runId: run.id,
+                source: source,
+                wid: snapshot.window.wid,
+                prefix: "element-action-before"
+            )
+
+            var performed = false
+            var focused = false
+            var axAction: String?
+            if treatment.focusesWindow {
+                focused = try focus(window: snapshot.window)
+                _ = try RunStore.shared.appendTrace(
+                    id: run.id,
+                    kind: "computer.focused",
+                    summary: "Focused element target window",
+                    data: ["wid": .int(Int(snapshot.window.wid)), "focused": .bool(focused)]
+                )
+            }
+
+            if requestedAction == "focus" {
+                if treatment.focusesWindow {
+                    try focusAXElement(element)
+                    performed = true
+                    _ = try RunStore.shared.appendTrace(
+                        id: run.id,
+                        kind: "computer.axFocused",
+                        summary: "Focused AX element",
+                        data: [
+                            "snapshotId": .string(snapshotId),
+                            "elementId": .string(elementId),
+                        ]
+                    )
+                }
+            } else if treatment.performsPointerAction {
+                let action = try axActionName(for: requestedAction, elementInfo: elementInfo)
+                axAction = action
+                try performAXAction(element, action: action)
+                performed = true
+                _ = try RunStore.shared.appendTrace(
+                    id: run.id,
+                    kind: "computer.axElementAction",
+                    summary: "Performed AX element action",
+                    data: [
+                        "snapshotId": .string(snapshotId),
+                        "elementId": .string(elementId),
+                        "requestedAction": .string(requestedAction),
+                        "axAction": .string(action),
+                    ]
+                )
+                usleep(180_000)
+            }
+
+            let after = try maybeCaptureWindow(
+                shouldCapture: shouldCapture,
+                runId: run.id,
+                source: source,
+                wid: snapshot.window.wid,
+                prefix: "element-action-after"
+            )
+            let completed = try RunStore.shared.complete(
+                id: run.id,
+                summary: performed ? "Completed AX element action" : "Staged AX element action",
+                data: [
+                    "snapshotId": .string(snapshotId),
+                    "elementId": .string(elementId),
+                    "requestedAction": .string(requestedAction),
+                    "performed": .bool(performed),
+                    "focused": .bool(focused),
+                ]
+            )
+
+            return elementActionResponse(
+                run: completed,
+                snapshot: snapshot,
+                element: elementInfo,
+                before: before?["artifact"],
+                after: after?["artifact"],
+                treatment: treatment,
+                requestedAction: requestedAction,
+                axAction: axAction,
+                performed: performed,
+                focused: focused
+            )
+        } catch {
+            _ = try? RunStore.shared.fail(
+                id: run.id,
+                summary: "AX element action failed",
+                data: [
+                    "snapshotId": .string(snapshotId),
+                    "elementId": .string(elementId),
+                    "error": .string(error.localizedDescription),
+                ]
+            )
             throw error
         }
     }
@@ -2260,6 +2412,112 @@ final class ComputerUseController {
         }
     }
 
+    private func requiredString(_ params: JSON?, keys: [String]) throws -> String {
+        for key in keys {
+            if let value = params?[key]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !value.isEmpty {
+                return value
+            }
+        }
+        throw RouterError.missingParam(keys.first ?? "value")
+    }
+
+    private func elementActionName(_ params: JSON?) throws -> String {
+        let raw = params?["action"]?.stringValue
+            ?? params?["elementAction"]?.stringValue
+            ?? params?["element-action"]?.stringValue
+            ?? params?["axAction"]?.stringValue
+            ?? params?["ax-action"]?.stringValue
+            ?? "press"
+        switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "press", "click", "tap", "open", "confirm", "cancel", "default", "axpress":
+            return "press"
+        case "showmenu", "show-menu", "menu", "context", "contextmenu", "context-menu", "axshowmenu":
+            return "showMenu"
+        case "focus", "focused":
+            return "focus"
+        default:
+            throw RouterError.custom("Unsupported computer.elementAction action '\(raw)'; use press, showMenu, or focus")
+        }
+    }
+
+    private func storeAXSnapshot(
+        id: String,
+        window: WindowEntry,
+        elements: [AXSnapshotElement],
+        elementRefsById: [String: AXUIElement]
+    ) {
+        guard !elements.isEmpty, !elementRefsById.isEmpty else { return }
+        axSnapshotLock.lock()
+        defer { axSnapshotLock.unlock() }
+        pruneAXSnapshotsLocked()
+        axSnapshotsById[id] = AXWindowSnapshot(
+            id: id,
+            window: window,
+            createdAt: Date(),
+            elementsById: Dictionary(uniqueKeysWithValues: elements.map { ($0.id, $0) }),
+            elementRefsById: elementRefsById
+        )
+        if axSnapshotsById.count > maxAXSnapshotCacheCount {
+            let overflow = axSnapshotsById
+                .sorted { $0.value.createdAt < $1.value.createdAt }
+                .prefix(axSnapshotsById.count - maxAXSnapshotCacheCount)
+                .map(\.key)
+            for key in overflow {
+                axSnapshotsById.removeValue(forKey: key)
+            }
+        }
+    }
+
+    private func axSnapshot(id: String) throws -> AXWindowSnapshot {
+        axSnapshotLock.lock()
+        defer { axSnapshotLock.unlock() }
+        pruneAXSnapshotsLocked()
+        guard let snapshot = axSnapshotsById[id] else {
+            throw RouterError.notFound("AX snapshot \(id)")
+        }
+        return snapshot
+    }
+
+    private func pruneAXSnapshotsLocked() {
+        let cutoff = Date().addingTimeInterval(-axSnapshotTTL)
+        axSnapshotsById = axSnapshotsById.filter { $0.value.createdAt >= cutoff }
+    }
+
+    private func axActionName(for requestedAction: String, elementInfo: AXSnapshotElement) throws -> String {
+        let action: String
+        switch requestedAction {
+        case "showMenu":
+            action = kAXShowMenuAction as String
+        default:
+            action = kAXPressAction as String
+        }
+        guard elementInfo.actions.contains(action) else {
+            throw RouterError.custom("Element \(elementInfo.id) does not support \(action)")
+        }
+        return action
+    }
+
+    private func performAXAction(_ element: AXUIElement, action: String) throws {
+        guard AXIsProcessTrusted() else {
+            throw RouterError.custom("Accessibility permission is required for AX element actions")
+        }
+        let err = AXUIElementPerformAction(element, action as CFString)
+        guard err == .success else {
+            throw RouterError.custom("\(action) failed with \(err.rawValue)")
+        }
+    }
+
+    private func focusAXElement(_ element: AXUIElement) throws {
+        guard AXIsProcessTrusted() else {
+            throw RouterError.custom("Accessibility permission is required for AX element focus")
+        }
+        let err = AXUIElementSetAttributeValue(element, kAXFocusedAttribute as CFString, kCFBooleanTrue)
+        guard err == .success else {
+            throw RouterError.custom("AX focus failed with \(err.rawValue)")
+        }
+    }
+
     private func axSnapshot(
         window: WindowEntry,
         maxDepth: Int,
@@ -2346,6 +2604,7 @@ final class ComputerUseController {
             depth: depth,
             childCount: children.count
         ))
+        context.elementRefsById[id] = element
         guard !context.hitTimeout else { return }
 
         guard depth < context.maxDepth else {
@@ -2930,6 +3189,37 @@ final class ComputerUseController {
         if let before { object["beforeArtifact"] = before }
         if let after { object["afterArtifact"] = after }
         if let axResult { object["ax"] = axResult.json }
+        return .object(object)
+    }
+
+    private func elementActionResponse(
+        run: RunSession,
+        snapshot: AXWindowSnapshot,
+        element: AXSnapshotElement,
+        before: JSON?,
+        after: JSON?,
+        treatment: ComputerTreatment,
+        requestedAction: String,
+        axAction: String?,
+        performed: Bool,
+        focused: Bool
+    ) -> JSON {
+        var object: [String: JSON] = [
+            "ok": .bool(true),
+            "action": .string("elementAction"),
+            "treatment": .string(treatment.rawValue),
+            "snapshotId": .string(snapshot.id),
+            "elementId": .string(element.id),
+            "requestedAction": .string(requestedAction),
+            "performed": .bool(performed),
+            "focused": .bool(focused),
+            "target": Encoders.window(snapshot.window),
+            "element": element.json,
+            "run": run.json,
+        ]
+        if let axAction { object["axAction"] = .string(axAction) }
+        if let before { object["beforeArtifact"] = before }
+        if let after { object["afterArtifact"] = after }
         return .object(object)
     }
 

--- a/apps/mac/Sources/Core/Daemon/LatticesApi.swift
+++ b/apps/mac/Sources/Core/Daemon/LatticesApi.swift
@@ -1592,6 +1592,25 @@ final class LatticesApi {
         ))
 
         api.register(Endpoint(
+            method: "computer.elementAction",
+            description: "Stage or execute an Accessibility action against an element from a recent windowState snapshot.",
+            access: .mutate,
+            params: [
+                Param(name: "snapshotId", type: "string", required: true, description: "Snapshot id returned by computer.windowState"),
+                Param(name: "elementId", type: "string", required: true, description: "Snapshot-local element id, such as e4"),
+                Param(name: "action", type: "string", required: false, description: "press (default), showMenu, or focus"),
+                Param(name: "treatment", type: "string", required: false, description: "stage, present, or execute"),
+                Param(name: "dryRun", type: "bool", required: false, description: "Stage without performing the action"),
+                Param(name: "capture", type: "bool", required: false, description: "Capture before/after artifacts (default true)"),
+                Param(name: "source", type: "string", required: false, description: "Calling surface label"),
+            ],
+            returns: .custom("Object with ok, run, target, element, requestedAction, performed, and optional artifacts"),
+            handler: { params in
+                try ComputerUseController.shared.elementAction(params: params)
+            }
+        ))
+
+        api.register(Endpoint(
             method: "computer.focusWindow",
             description: "Resolve, optionally capture, focus, and verify a target window.",
             access: .mutate,

--- a/docs/api.md
+++ b/docs/api.md
@@ -213,6 +213,7 @@ methods write into the Lattices run store under
 | `capture.screenshotWindow` | write | Capture a window screenshot as a run artifact |
 | `computer.prepare` | write | Resolve and optionally capture a terminal target without mutating it |
 | `computer.windowState` | write | Inspect a target window's AX tree and optionally write screenshot/run artifacts |
+| `computer.elementAction` | write | Stage or execute an AX action against a snapshot element id |
 | `computer.focusWindow` | write | Resolve, capture, focus, and verify a target window |
 | `computer.showCursor` | write | Show a visible cursor appearance and record it as a run |
 | `computer.launchApp` | write | Launch or focus a normal macOS app and record the run |
@@ -346,6 +347,38 @@ await daemonCall('computer.windowState', {
   wid: 7258,
   mode: 'both',
   source: 'agent'
+})
+```
+
+#### `computer.elementAction`
+
+Stage or execute an Accessibility action against an element returned by a recent
+`computer.windowState` call. Snapshot element ids are intentionally local to the
+daemon process and expire from the in-memory cache after a short window.
+
+**Params**:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `snapshotId` | string | yes | Snapshot id returned by `computer.windowState` |
+| `elementId` | string | yes | Snapshot-local element id, such as `e4` |
+| `action` | string | no | `press` (default), `showMenu`, or `focus` |
+| `treatment` | string | no | `stage`, `present`, or `execute`. Defaults to `stage` |
+| `dryRun` | bool | no | Stage without performing the action |
+| `capture` | bool | no | Capture before/after artifacts. Defaults to `true` |
+| `source` | string | no | Calling surface label |
+
+```js
+const state = await daemonCall('computer.windowState', {
+  app: 'Calculator',
+  maxDepth: 6
+})
+
+await daemonCall('computer.elementAction', {
+  snapshotId: state.snapshotId,
+  elementId: 'e7',
+  action: 'press',
+  treatment: 'execute'
 })
 ```
 

--- a/docs/pi-lattices.md
+++ b/docs/pi-lattices.md
@@ -48,6 +48,7 @@ lattices app
 | `lattices_ocr_snapshot` | `ocr.snapshot` |
 | `lattices_ocr_search` | `ocr.search` |
 | `lattices_computer_window_state` | `computer.windowState` |
+| `lattices_computer_element_action` | `computer.elementAction` |
 | `lattices_window_focus` | `computer.focusWindow` |
 | `lattices_window_place` | `window.place` |
 | `lattices_capture_window` | `capture.screenshotWindow` |

--- a/docs/proposals/LAT-008-pi-lattices-computer-use.md
+++ b/docs/proposals/LAT-008-pi-lattices-computer-use.md
@@ -69,9 +69,9 @@ Confirmed in `docs/api.md` and
   `lattices_call` escape hatch.
 - `computer.windowState` is now present as the first Phase 2 window-state
   endpoint.
-  Element mutation endpoints such as `computer.elementAction`,
-  `computer.typeElement`, and `computer.setValue` are not yet present as public
-  daemon methods.
+- `computer.elementAction` is present for snapshot element-id press/showMenu/focus
+  actions. Text/value endpoints such as `computer.typeElement` and
+  `computer.setValue` are not yet present as public daemon methods.
 
 MVP wrapper decision: `lattices_window_focus` maps to
 `computer.focusWindow`, not raw `window.focus`, so focus/present calls can stay
@@ -355,6 +355,7 @@ Guardrails:
 1. Build `pi-lattices` MVP around current daemon methods.
 2. Add `computer.windowState` window-state endpoint. **Done.**
 3. Add `computer.elementAction` and element-ID support in click/type/set value.
+   **Partially done:** `computer.elementAction` covers AXPress/showMenu/focus.
 4. Add keyboard/scroll/drag/double-click primitives.
 5. Add vision/zoom/verify.
 6. Add browser primitives.

--- a/packages/pi-lattices/README.md
+++ b/packages/pi-lattices/README.md
@@ -56,6 +56,7 @@ All tools use the `lattices_` prefix.
 | Tool | Daemon method | Safety note |
 | --- | --- | --- |
 | `lattices_computer_window_state` | `computer.windowState` | `mode: "ax"` inspects only; `both`, `screenshot`, or `capture: true` create run artifacts. |
+| `lattices_computer_element_action` | `computer.elementAction` | Defaults to `treatment: "stage"`; pass `execute` to perform AXPress/showMenu. |
 | `lattices_window_focus` | `computer.focusWindow` | Defaults to `treatment: "stage"`; pass `present` or `execute` to focus. |
 | `lattices_window_place` | `window.place` | Returns the daemon action receipt. |
 | `lattices_capture_window` | `capture.screenshotWindow` | Creates a run artifact. |
@@ -112,7 +113,7 @@ export LATTICES_DAEMON_TIMEOUT_MS=3000
 ## Phase 2 direction
 
 `computer.windowState` is now exposed as `lattices_computer_window_state` for
-AX inspection and optional run-backed screenshot artifacts. The next expansion
-should add element-id actions (`computer.elementAction`, `computer.typeElement`,
-`computer.setValue`) while keeping treatment/run/artifact semantics in the
-daemon.
+AX inspection and optional run-backed screenshot artifacts. `computer.elementAction`
+adds the first element-id mutation for AXPress/showMenu/focus. The next expansion
+should add text/value actions (`computer.typeElement`, `computer.setValue`) while
+keeping treatment/run/artifact semantics in the daemon.

--- a/packages/pi-lattices/index.mjs
+++ b/packages/pi-lattices/index.mjs
@@ -36,6 +36,10 @@ const windowStateMode = optionalEnum(
   ["ax", "both", "screenshot"],
   "Snapshot mode. ax avoids Screen Recording; both includes AX plus screenshot capture; screenshot skips AX."
 );
+const elementAction = optionalEnum(
+  ["press", "showMenu", "focus"],
+  "Element action. press is the default and maps to AXPress."
+);
 
 const emptyParams = object();
 const runSourceParams = {
@@ -151,6 +155,19 @@ export const LATTICES_TOOLS = [
       ...targetParams,
       ...computerBaseParams,
     }),
+    defaultTreatment: "stage",
+    defaultSource: DEFAULT_SOURCE,
+  },
+  {
+    name: `${TOOL_PREFIX}computer_element_action`,
+    method: "computer.elementAction",
+    description: "Stage or execute an Accessibility action against an element id from lattices_computer_window_state.",
+    parameters: object({
+      snapshotId: string("Snapshot id returned by lattices_computer_window_state."),
+      elementId: string("Snapshot-local element id, such as e4."),
+      action: elementAction,
+      ...computerBaseParams,
+    }, ["snapshotId", "elementId"]),
     defaultTreatment: "stage",
     defaultSource: DEFAULT_SOURCE,
   },

--- a/packages/pi-lattices/test/smoke.mjs
+++ b/packages/pi-lattices/test/smoke.mjs
@@ -38,6 +38,7 @@ for (const required of [
   "lattices_windows_list",
   "lattices_window_place",
   "lattices_computer_window_state",
+  "lattices_computer_element_action",
   "lattices_computer_launch_app",
   "lattices_computer_click",
   "lattices_call",


### PR DESCRIPTION
## Summary
- add a short-lived AX snapshot cache behind computer.windowState
- add computer.elementAction for staged or executed AXPress/showMenu/focus by snapshot element id
- expose the new endpoint through pi-lattices and update the computer-use plan/docs

## Validation
- node packages/pi-lattices/test/smoke.mjs
- bun run --cwd packages/pi-lattices smoke:no-daemon
- bun run check:types
- bun run check:app
- bun bin/lattices-app.ts restart
- live daemon smoke: Calculator windowState -> computer.elementAction stage with capture:false
- bun run --cwd packages/pi-lattices smoke:live