### PR TITLE
[codex] Add computer input primitives

### DIFF
--- a/apps/mac/Sources/Core/Actions/ComputerUseController.swift
+++ b/apps/mac/Sources/Core/Actions/ComputerUseController.swift
@@ -1373,10 +1373,30 @@ final class ComputerUseController {
     }
 
     func click(params: JSON?) throws -> JSON {
+        try clickAction(params: params, actionName: "click", buttonOverride: nil, countOverride: nil)
+    }
+
+    func doubleClick(params: JSON?) throws -> JSON {
+        try clickAction(params: params, actionName: "doubleClick", buttonOverride: nil, countOverride: 2)
+    }
+
+    func rightClick(params: JSON?) throws -> JSON {
+        try clickAction(params: params, actionName: "rightClick", buttonOverride: "right", countOverride: nil)
+    }
+
+    private func clickAction(
+        params: JSON?,
+        actionName: String,
+        buttonOverride: String?,
+        countOverride: Int?
+    ) throws -> JSON {
         let source = params?["source"]?.stringValue ?? "daemon"
         let treatment = ComputerTreatment.resolve(params: params, defaultValue: .stage)
         let shouldCapture = params?["capture"]?.boolValue ?? true
         let requestedTransport = clickTransport(params)
+        let buttonName = buttonOverride ?? params?["button"]?.stringValue
+        let clickCount = clickCount(params: params, defaultValue: countOverride ?? 1)
+        let delayMs = pointerDelayMs(params: params, defaultValue: 90)
         let noFocus = params?["noFocus"]?.boolValue == true
             || params?["no-focus"]?.boolValue == true
             || requestedTransport == "ax"
@@ -1384,7 +1404,7 @@ final class ComputerUseController {
         let window = try? CaptureController.shared.resolveWindow(params: params)
         let point = clickPoint(params: params, window: window) ?? cursorPoint(params: params)
         let run = try RunStore.shared.createRun(
-            title: "Click",
+            title: actionName == "doubleClick" ? "Double click" : actionName == "rightClick" ? "Right click" : "Click",
             source: source,
             surfaces: window.map { [.window($0), .cursor(point)] } ?? [.cursor(point)]
         )
@@ -1394,10 +1414,11 @@ final class ComputerUseController {
                 id: run.id,
                 summary: "Resolved click target",
                 data: [
-                    "action": .string("click"),
+                    "action": .string(actionName),
                     "treatment": .string(treatment.rawValue),
                     "point": cursorJSON(point),
-                    "button": .string(normalizedMouseButton(params?["button"]?.stringValue)),
+                    "button": .string(normalizedMouseButton(buttonName)),
+                    "count": .int(clickCount),
                     "transport": .string(requestedTransport),
                     "noFocus": .bool(noFocus),
                 ]
@@ -1419,7 +1440,8 @@ final class ComputerUseController {
             var axResult: AXPressResult?
             if treatment.performsPointerAction {
                 let canTryAX = window != nil
-                    && normalizedMouseButton(params?["button"]?.stringValue) == "left"
+                    && normalizedMouseButton(buttonName) == "left"
+                    && clickCount == 1
                     && requestedTransport != "pointer"
                     && requestedTransport != "mouse"
 
@@ -1468,14 +1490,14 @@ final class ComputerUseController {
                             data: ["wid": .int(Int(window.wid)), "focused": .bool(focused)]
                         )
                     }
-                    try postMouseClick(at: point, rawButton: params?["button"]?.stringValue)
+                    try postMouseClick(at: point, rawButton: buttonName, count: clickCount, delayMs: delayMs)
                     clicked = true
                     transportUsed = "pointer"
                     _ = try RunStore.shared.appendTrace(
                         id: run.id,
                         kind: "computer.clicked",
                         summary: "Posted mouse click",
-                        data: clickJSON(point, button: params?["button"]?.stringValue)
+                        data: clickJSON(point, button: buttonName, count: clickCount)
                     )
                     usleep(180_000)
                 }
@@ -1498,9 +1520,12 @@ final class ComputerUseController {
                     "point": cursorJSON(point),
                     "focused": .bool(focused),
                     "transport": .string(transportUsed),
+                    "button": .string(normalizedMouseButton(buttonName)),
+                    "count": .int(clickCount),
                 ]
             )
             return clickResponse(
+                action: actionName,
                 run: completed,
                 target: window,
                 point: point,
@@ -1508,7 +1533,8 @@ final class ComputerUseController {
                 after: after?["artifact"],
                 treatment: treatment,
                 clicked: clicked,
-                button: params?["button"]?.stringValue,
+                button: buttonName,
+                count: clickCount,
                 transport: transportUsed,
                 focused: focused,
                 axResult: axResult
@@ -1517,6 +1543,247 @@ final class ComputerUseController {
             _ = try? RunStore.shared.fail(
                 id: run.id,
                 summary: "Click action failed",
+                data: ["error": .string(error.localizedDescription)]
+            )
+            throw error
+        }
+    }
+
+    func scroll(params: JSON?) throws -> JSON {
+        let source = params?["source"]?.stringValue ?? "daemon"
+        let treatment = ComputerTreatment.resolve(params: params, defaultValue: .stage)
+        let shouldCapture = params?["capture"]?.boolValue ?? true
+        let window = try? CaptureController.shared.resolveWindow(params: params)
+        let point = clickPoint(params: params, window: window) ?? cursorPoint(params: params)
+        let delta = scrollDelta(params: params)
+        let count = pointerCount(params: params, defaultValue: 1, maxValue: 30)
+        let delayMs = pointerDelayMs(params: params, defaultValue: 80)
+        let run = try RunStore.shared.createRun(
+            title: "Scroll",
+            source: source,
+            surfaces: window.map { [.window($0), .cursor(point)] } ?? [.cursor(point)]
+        )
+
+        do {
+            _ = try RunStore.shared.markRunning(
+                id: run.id,
+                summary: "Resolved scroll target",
+                data: [
+                    "action": .string("scroll"),
+                    "treatment": .string(treatment.rawValue),
+                    "point": cursorJSON(point),
+                    "delta": scrollJSON(delta),
+                    "count": .int(count),
+                ]
+            )
+
+            let before = try window.flatMap { target in
+                try maybeCaptureWindow(
+                    shouldCapture: shouldCapture,
+                    runId: run.id,
+                    source: source,
+                    wid: target.wid,
+                    prefix: "scroll-before"
+                )
+            }
+
+            var focused = false
+            var scrolled = false
+            if treatment.focusesWindow, let window {
+                focused = try focus(window: window)
+                _ = try RunStore.shared.appendTrace(
+                    id: run.id,
+                    kind: "computer.focused",
+                    summary: "Focused window before scroll",
+                    data: ["wid": .int(Int(window.wid)), "focused": .bool(focused)]
+                )
+            }
+
+            if treatment.performsPointerAction {
+                try postMouseScroll(at: point, deltaX: delta.x, deltaY: delta.y, count: count, delayMs: delayMs)
+                scrolled = true
+                _ = try RunStore.shared.appendTrace(
+                    id: run.id,
+                    kind: "computer.scrolled",
+                    summary: "Posted scroll wheel events",
+                    data: [
+                        "point": cursorJSON(point),
+                        "delta": scrollJSON(delta),
+                        "count": .int(count),
+                    ]
+                )
+                usleep(160_000)
+            }
+
+            let after = try window.flatMap { target in
+                try maybeCaptureWindow(
+                    shouldCapture: shouldCapture,
+                    runId: run.id,
+                    source: source,
+                    wid: target.wid,
+                    prefix: "scroll-after"
+                )
+            }
+            let completed = try RunStore.shared.complete(
+                id: run.id,
+                summary: scrolled ? "Completed scroll action" : "Staged scroll without posting",
+                data: [
+                    "scrolled": .bool(scrolled),
+                    "point": cursorJSON(point),
+                    "delta": scrollJSON(delta),
+                    "focused": .bool(focused),
+                    "count": .int(count),
+                ]
+            )
+
+            return pointerActionResponse(
+                action: "scroll",
+                run: completed,
+                target: window,
+                before: before?["artifact"],
+                after: after?["artifact"],
+                treatment: treatment,
+                focused: focused,
+                performedKey: "scrolled",
+                performed: scrolled,
+                point: point,
+                from: nil,
+                to: nil,
+                delta: delta,
+                button: nil,
+                count: count,
+                transport: "pointer"
+            )
+        } catch {
+            _ = try? RunStore.shared.fail(
+                id: run.id,
+                summary: "Scroll action failed",
+                data: ["error": .string(error.localizedDescription)]
+            )
+            throw error
+        }
+    }
+
+    func drag(params: JSON?) throws -> JSON {
+        let source = params?["source"]?.stringValue ?? "daemon"
+        let treatment = ComputerTreatment.resolve(params: params, defaultValue: .stage)
+        let shouldCapture = params?["capture"]?.boolValue ?? true
+        let window = try? CaptureController.shared.resolveWindow(params: params)
+        let toPoint = dragEndPoint(params: params, window: window)
+        let fromPoint = dragStartPoint(params: params, window: window, fallback: toPoint)
+        let buttonName = params?["button"]?.stringValue
+        let durationMs = dragDurationMs(params: params)
+        let steps = dragSteps(params: params)
+        let run = try RunStore.shared.createRun(
+            title: "Drag",
+            source: source,
+            surfaces: window.map { [.window($0), .cursor(fromPoint), .cursor(toPoint)] } ?? [.cursor(fromPoint), .cursor(toPoint)]
+        )
+
+        do {
+            _ = try RunStore.shared.markRunning(
+                id: run.id,
+                summary: "Resolved drag target",
+                data: [
+                    "action": .string("drag"),
+                    "treatment": .string(treatment.rawValue),
+                    "from": cursorJSON(fromPoint),
+                    "to": cursorJSON(toPoint),
+                    "button": .string(normalizedMouseButton(buttonName)),
+                    "durationMs": .double(durationMs),
+                    "steps": .int(steps),
+                ]
+            )
+
+            let before = try window.flatMap { target in
+                try maybeCaptureWindow(
+                    shouldCapture: shouldCapture,
+                    runId: run.id,
+                    source: source,
+                    wid: target.wid,
+                    prefix: "drag-before"
+                )
+            }
+
+            var focused = false
+            var dragged = false
+            if treatment.focusesWindow, let window {
+                focused = try focus(window: window)
+                _ = try RunStore.shared.appendTrace(
+                    id: run.id,
+                    kind: "computer.focused",
+                    summary: "Focused window before drag",
+                    data: ["wid": .int(Int(window.wid)), "focused": .bool(focused)]
+                )
+            }
+
+            if treatment.performsPointerAction {
+                try postMouseDrag(
+                    from: fromPoint,
+                    to: toPoint,
+                    rawButton: buttonName,
+                    durationMs: durationMs,
+                    steps: steps
+                )
+                dragged = true
+                _ = try RunStore.shared.appendTrace(
+                    id: run.id,
+                    kind: "computer.dragged",
+                    summary: "Posted mouse drag",
+                    data: [
+                        "from": cursorJSON(fromPoint),
+                        "to": cursorJSON(toPoint),
+                        "button": .string(normalizedMouseButton(buttonName)),
+                        "durationMs": .double(durationMs),
+                        "steps": .int(steps),
+                    ]
+                )
+                usleep(180_000)
+            }
+
+            let after = try window.flatMap { target in
+                try maybeCaptureWindow(
+                    shouldCapture: shouldCapture,
+                    runId: run.id,
+                    source: source,
+                    wid: target.wid,
+                    prefix: "drag-after"
+                )
+            }
+            let completed = try RunStore.shared.complete(
+                id: run.id,
+                summary: dragged ? "Completed drag action" : "Staged drag without posting",
+                data: [
+                    "dragged": .bool(dragged),
+                    "from": cursorJSON(fromPoint),
+                    "to": cursorJSON(toPoint),
+                    "focused": .bool(focused),
+                    "button": .string(normalizedMouseButton(buttonName)),
+                ]
+            )
+
+            return pointerActionResponse(
+                action: "drag",
+                run: completed,
+                target: window,
+                before: before?["artifact"],
+                after: after?["artifact"],
+                treatment: treatment,
+                focused: focused,
+                performedKey: "dragged",
+                performed: dragged,
+                point: nil,
+                from: fromPoint,
+                to: toPoint,
+                delta: nil,
+                button: buttonName ?? "left",
+                count: nil,
+                transport: "pointer"
+            )
+        } catch {
+            _ = try? RunStore.shared.fail(
+                id: run.id,
+                summary: "Drag action failed",
                 data: ["error": .string(error.localizedDescription)]
             )
             throw error
@@ -2441,6 +2708,76 @@ final class ComputerUseController {
         )
     }
 
+    private func dragEndPoint(params: JSON?, window: WindowEntry?) -> CGPoint {
+        if let x = params?["toX"]?.numericDouble
+            ?? params?["to-x"]?.numericDouble
+            ?? params?["endX"]?.numericDouble
+            ?? params?["end-x"]?.numericDouble,
+           let y = params?["toY"]?.numericDouble
+            ?? params?["to-y"]?.numericDouble
+            ?? params?["endY"]?.numericDouble
+            ?? params?["end-y"]?.numericDouble {
+            return CGPoint(x: x, y: y)
+        }
+
+        if let window {
+            let xRatio = params?["toXRatio"]?.numericDouble
+                ?? params?["to-x-ratio"]?.numericDouble
+                ?? params?["endXRatio"]?.numericDouble
+                ?? params?["end-x-ratio"]?.numericDouble
+            let yRatio = params?["toYRatio"]?.numericDouble
+                ?? params?["to-y-ratio"]?.numericDouble
+                ?? params?["endYRatio"]?.numericDouble
+                ?? params?["end-y-ratio"]?.numericDouble
+            if xRatio != nil || yRatio != nil {
+                return windowRelativePoint(
+                    window,
+                    xRatio: CGFloat(max(0.0, min(1.0, xRatio ?? 0.5))),
+                    yRatio: CGFloat(max(0.0, min(1.0, yRatio ?? 0.5)))
+                )
+            }
+        }
+
+        return clickPoint(params: params, window: window) ?? cursorPoint(params: params)
+    }
+
+    private func dragStartPoint(params: JSON?, window: WindowEntry?, fallback: CGPoint) -> CGPoint {
+        if let x = params?["fromX"]?.numericDouble
+            ?? params?["from-x"]?.numericDouble
+            ?? params?["startX"]?.numericDouble
+            ?? params?["start-x"]?.numericDouble,
+           let y = params?["fromY"]?.numericDouble
+            ?? params?["from-y"]?.numericDouble
+            ?? params?["startY"]?.numericDouble
+            ?? params?["start-y"]?.numericDouble {
+            return CGPoint(x: x, y: y)
+        }
+
+        if let window {
+            let xRatio = params?["fromXRatio"]?.numericDouble
+                ?? params?["from-x-ratio"]?.numericDouble
+                ?? params?["startXRatio"]?.numericDouble
+                ?? params?["start-x-ratio"]?.numericDouble
+            let yRatio = params?["fromYRatio"]?.numericDouble
+                ?? params?["from-y-ratio"]?.numericDouble
+                ?? params?["startYRatio"]?.numericDouble
+                ?? params?["start-y-ratio"]?.numericDouble
+            if xRatio != nil || yRatio != nil {
+                return windowRelativePoint(
+                    window,
+                    xRatio: CGFloat(max(0.0, min(1.0, xRatio ?? 0.5))),
+                    yRatio: CGFloat(max(0.0, min(1.0, yRatio ?? 0.5)))
+                )
+            }
+        }
+
+        let current = cursorPoint(params: nil)
+        if current == fallback {
+            return CGPoint(x: fallback.x - 240, y: fallback.y - 120)
+        }
+        return current
+    }
+
     private func windowRelativePoint(_ window: WindowEntry, xRatio: CGFloat, yRatio: CGFloat) -> CGPoint {
         CGPoint(
             x: window.frame.x + window.frame.w * Double(xRatio),
@@ -2449,32 +2786,142 @@ final class ComputerUseController {
     }
 
     private func postMouseClick(at point: CGPoint, rawButton: String?) throws {
+        try postMouseClick(at: point, rawButton: rawButton, count: 1, delayMs: 90)
+    }
+
+    private func postMouseClick(at point: CGPoint, rawButton: String?, count: Int, delayMs: Double) throws {
         guard AXIsProcessTrusted() else {
             throw RouterError.custom("Accessibility permission is required to click")
         }
         let button = mouseButton(rawButton)
-        guard let source = CGEventSource(stateID: .combinedSessionState),
-              let down = CGEvent(
-                mouseEventSource: source,
-                mouseType: button.downType,
-                mouseCursorPosition: point,
-                mouseButton: button.button
-              ),
-              let up = CGEvent(
-                mouseEventSource: source,
-                mouseType: button.upType,
-                mouseCursorPosition: point,
-                mouseButton: button.button
-              ) else {
+        guard let source = CGEventSource(stateID: .combinedSessionState) else {
             throw RouterError.custom("Unable to create mouse click event")
         }
 
         CGAssociateMouseAndMouseCursorPosition(0)
         CGWarpMouseCursorPosition(point)
         usleep(35_000)
+        for index in 0..<max(1, count) {
+            guard let down = CGEvent(
+                    mouseEventSource: source,
+                    mouseType: button.downType,
+                    mouseCursorPosition: point,
+                    mouseButton: button.button
+                  ),
+                  let up = CGEvent(
+                    mouseEventSource: source,
+                    mouseType: button.upType,
+                    mouseCursorPosition: point,
+                    mouseButton: button.button
+                  ) else {
+                CGAssociateMouseAndMouseCursorPosition(1)
+                throw RouterError.custom("Unable to create mouse click event")
+            }
+
+            let clickState = Int64(index + 1)
+            down.setIntegerValueField(.mouseEventClickState, value: clickState)
+            up.setIntegerValueField(.mouseEventClickState, value: clickState)
+            down.post(tap: .cghidEventTap)
+            usleep(28_000)
+            up.post(tap: .cghidEventTap)
+            if index < count - 1 {
+                usleep(UInt32(max(0, min(delayMs, 1_000)) * 1_000))
+            }
+        }
+        CGAssociateMouseAndMouseCursorPosition(1)
+    }
+
+    private func postMouseScroll(at point: CGPoint, deltaX: Double, deltaY: Double, count: Int, delayMs: Double) throws {
+        guard AXIsProcessTrusted() else {
+            throw RouterError.custom("Accessibility permission is required to scroll")
+        }
+        guard let source = CGEventSource(stateID: .combinedSessionState) else {
+            throw RouterError.custom("Unable to create scroll event source")
+        }
+
+        CGAssociateMouseAndMouseCursorPosition(0)
+        CGWarpMouseCursorPosition(point)
+        usleep(35_000)
+        for index in 0..<max(1, count) {
+            guard let event = CGEvent(
+                scrollWheelEvent2Source: source,
+                units: .pixel,
+                wheelCount: 2,
+                wheel1: Int32(max(-8_000, min(8_000, deltaY)).rounded()),
+                wheel2: Int32(max(-8_000, min(8_000, deltaX)).rounded()),
+                wheel3: 0
+            ) else {
+                CGAssociateMouseAndMouseCursorPosition(1)
+                throw RouterError.custom("Unable to create scroll event")
+            }
+            event.post(tap: .cghidEventTap)
+            if index < count - 1 {
+                usleep(UInt32(max(0, min(delayMs, 1_000)) * 1_000))
+            }
+        }
+        CGAssociateMouseAndMouseCursorPosition(1)
+    }
+
+    private func postMouseDrag(
+        from start: CGPoint,
+        to end: CGPoint,
+        rawButton: String?,
+        durationMs: Double,
+        steps: Int
+    ) throws {
+        guard AXIsProcessTrusted() else {
+            throw RouterError.custom("Accessibility permission is required to drag")
+        }
+        let button = mouseButton(rawButton)
+        let dragType = mouseDragType(button.button)
+        guard let source = CGEventSource(stateID: .combinedSessionState),
+              let down = CGEvent(
+                mouseEventSource: source,
+                mouseType: button.downType,
+                mouseCursorPosition: start,
+                mouseButton: button.button
+              ) else {
+            throw RouterError.custom("Unable to create drag event")
+        }
+
+        let boundedSteps = max(2, min(steps, 120))
+        let stepDelay = UInt32(max(2, min(durationMs / Double(boundedSteps), 120)) * 1_000)
+        CGAssociateMouseAndMouseCursorPosition(0)
+        CGWarpMouseCursorPosition(start)
+        usleep(35_000)
         down.post(tap: .cghidEventTap)
-        usleep(28_000)
+        usleep(stepDelay)
+
+        for index in 1...boundedSteps {
+            let progress = CGFloat(index) / CGFloat(boundedSteps)
+            let point = CGPoint(
+                x: start.x + (end.x - start.x) * progress,
+                y: start.y + (end.y - start.y) * progress
+            )
+            guard let drag = CGEvent(
+                mouseEventSource: source,
+                mouseType: dragType,
+                mouseCursorPosition: point,
+                mouseButton: button.button
+            ) else {
+                CGAssociateMouseAndMouseCursorPosition(1)
+                throw RouterError.custom("Unable to create drag event")
+            }
+            drag.post(tap: .cghidEventTap)
+            usleep(stepDelay)
+        }
+
+        guard let up = CGEvent(
+            mouseEventSource: source,
+            mouseType: button.upType,
+            mouseCursorPosition: end,
+            mouseButton: button.button
+        ) else {
+            CGAssociateMouseAndMouseCursorPosition(1)
+            throw RouterError.custom("Unable to create drag release event")
+        }
         up.post(tap: .cghidEventTap)
+        CGWarpMouseCursorPosition(end)
         CGAssociateMouseAndMouseCursorPosition(1)
     }
 
@@ -2494,6 +2941,113 @@ final class ComputerUseController {
         default:
             return "left"
         }
+    }
+
+    private func mouseDragType(_ button: CGMouseButton) -> CGEventType {
+        switch button {
+        case .right:
+            return .rightMouseDragged
+        default:
+            return .leftMouseDragged
+        }
+    }
+
+    private func clickCount(params: JSON?, defaultValue: Int) -> Int {
+        pointerCount(params: params, defaultValue: defaultValue, maxValue: 8)
+    }
+
+    private func pointerCount(params: JSON?, defaultValue: Int, maxValue: Int) -> Int {
+        let raw = params?["count"]?.intValue
+            ?? params?["clicks"]?.intValue
+            ?? params?["clickCount"]?.intValue
+            ?? params?["click-count"]?.intValue
+            ?? defaultValue
+        return max(1, min(raw, maxValue))
+    }
+
+    private func pointerDelayMs(params: JSON?, defaultValue: Double) -> Double {
+        let raw: Double
+        if let value = params?["delayMs"]?.numericDouble {
+            raw = value
+        } else if let value = params?["delay-ms"]?.numericDouble {
+            raw = value
+        } else if let value = params?["intervalMs"]?.numericDouble {
+            raw = value
+        } else if let value = params?["interval-ms"]?.numericDouble {
+            raw = value
+        } else {
+            raw = defaultValue
+        }
+        return max(0, min(raw, 1_000))
+    }
+
+    private func dragDurationMs(params: JSON?) -> Double {
+        let raw: Double
+        if let value = params?["durationMs"]?.numericDouble {
+            raw = value
+        } else if let value = params?["duration-ms"]?.numericDouble {
+            raw = value
+        } else if let value = params?["dragDurationMs"]?.numericDouble {
+            raw = value
+        } else if let value = params?["drag-duration-ms"]?.numericDouble {
+            raw = value
+        } else {
+            raw = 360
+        }
+        return max(40, min(raw, 3_000))
+    }
+
+    private func dragSteps(params: JSON?) -> Int {
+        let raw = params?["steps"]?.intValue
+            ?? params?["stepCount"]?.intValue
+            ?? params?["step-count"]?.intValue
+            ?? 18
+        return max(2, min(raw, 120))
+    }
+
+    private func scrollDelta(params: JSON?) -> CGPoint {
+        if params?["deltaX"]?.numericDouble != nil
+            || params?["delta-x"]?.numericDouble != nil
+            || params?["dx"]?.numericDouble != nil
+            || params?["deltaY"]?.numericDouble != nil
+            || params?["delta-y"]?.numericDouble != nil
+            || params?["dy"]?.numericDouble != nil {
+            return CGPoint(
+                x: boundedScrollDelta(
+                    params?["deltaX"]?.numericDouble
+                        ?? params?["delta-x"]?.numericDouble
+                        ?? params?["dx"]?.numericDouble
+                        ?? 0
+                ),
+                y: boundedScrollDelta(
+                    params?["deltaY"]?.numericDouble
+                        ?? params?["delta-y"]?.numericDouble
+                        ?? params?["dy"]?.numericDouble
+                        ?? 0
+                )
+            )
+        }
+
+        let amount = boundedScrollDelta(
+            params?["amount"]?.numericDouble
+                ?? params?["distance"]?.numericDouble
+                ?? params?["delta"]?.numericDouble
+                ?? 420
+        )
+        switch params?["direction"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "up", "north":
+            return CGPoint(x: 0, y: amount)
+        case "left", "west":
+            return CGPoint(x: -amount, y: 0)
+        case "right", "east":
+            return CGPoint(x: amount, y: 0)
+        default:
+            return CGPoint(x: 0, y: -amount)
+        }
+    }
+
+    private func boundedScrollDelta(_ value: Double) -> Double {
+        max(-8_000, min(8_000, value))
     }
 
     private func clickTransport(_ params: JSON?) -> String {
@@ -2527,11 +3081,23 @@ final class ComputerUseController {
     }
 
     private func clickJSON(_ point: CGPoint, button: String?) -> [String: JSON] {
+        clickJSON(point, button: button, count: 1)
+    }
+
+    private func clickJSON(_ point: CGPoint, button: String?, count: Int) -> [String: JSON] {
         [
             "x": .double(point.x),
             "y": .double(point.y),
             "button": .string(normalizedMouseButton(button)),
+            "count": .int(count),
         ]
+    }
+
+    private func scrollJSON(_ delta: CGPoint) -> JSON {
+        .object([
+            "x": .double(delta.x),
+            "y": .double(delta.y),
+        ])
     }
 
     private func pressViaAX(
@@ -3623,6 +4189,7 @@ final class ComputerUseController {
     }
 
     private func clickResponse(
+        action: String,
         run: RunSession,
         target: WindowEntry?,
         point: CGPoint,
@@ -3631,13 +4198,14 @@ final class ComputerUseController {
         treatment: ComputerTreatment,
         clicked: Bool,
         button: String?,
+        count: Int,
         transport: String,
         focused: Bool,
         axResult: AXPressResult?
     ) -> JSON {
         var object: [String: JSON] = [
             "ok": .bool(true),
-            "action": .string("click"),
+            "action": .string(action),
             "treatment": .string(treatment.rawValue),
             "clicked": .bool(clicked),
             "focused": .bool(focused),
@@ -3645,11 +4213,51 @@ final class ComputerUseController {
             "run": run.json,
             "cursor": cursorJSON(point),
             "button": .string(normalizedMouseButton(button)),
+            "count": .int(count),
         ]
         if let target { object["target"] = Encoders.window(target) }
         if let before { object["beforeArtifact"] = before }
         if let after { object["afterArtifact"] = after }
         if let axResult { object["ax"] = axResult.json }
+        return .object(object)
+    }
+
+    private func pointerActionResponse(
+        action: String,
+        run: RunSession,
+        target: WindowEntry?,
+        before: JSON?,
+        after: JSON?,
+        treatment: ComputerTreatment,
+        focused: Bool,
+        performedKey: String,
+        performed: Bool,
+        point: CGPoint?,
+        from: CGPoint?,
+        to: CGPoint?,
+        delta: CGPoint?,
+        button: String?,
+        count: Int?,
+        transport: String
+    ) -> JSON {
+        var object: [String: JSON] = [
+            "ok": .bool(true),
+            "action": .string(action),
+            "treatment": .string(treatment.rawValue),
+            performedKey: .bool(performed),
+            "focused": .bool(focused),
+            "transport": .string(transport),
+            "run": run.json,
+        ]
+        if let target { object["target"] = Encoders.window(target) }
+        if let before { object["beforeArtifact"] = before }
+        if let after { object["afterArtifact"] = after }
+        if let point { object["cursor"] = cursorJSON(point) }
+        if let from { object["from"] = cursorJSON(from) }
+        if let to { object["to"] = cursorJSON(to) }
+        if let delta { object["delta"] = scrollJSON(delta) }
+        if let button { object["button"] = .string(normalizedMouseButton(button)) }
+        if let count { object["count"] = .int(count) }
         return .object(object)
     }
 

--- a/apps/mac/Sources/Core/Actions/ComputerUseController.swift
+++ b/apps/mac/Sources/Core/Actions/ComputerUseController.swift
@@ -532,6 +532,14 @@ final class ComputerUseController {
         try typeElement(params: params, actionName: "setValue")
     }
 
+    func pressKey(params: JSON?) throws -> JSON {
+        try keyboardAction(params: params, actionName: "pressKey", requiresModifier: false)
+    }
+
+    func hotkey(params: JSON?) throws -> JSON {
+        try keyboardAction(params: params, actionName: "hotkey", requiresModifier: true)
+    }
+
     private func typeElement(params: JSON?, actionName: String) throws -> JSON {
         let source = params?["source"]?.stringValue ?? "daemon"
         let treatment = ComputerTreatment.resolve(params: params, defaultValue: .stage)
@@ -652,6 +660,146 @@ final class ComputerUseController {
                 data: [
                     "snapshotId": .string(snapshotId),
                     "elementId": .string(elementId),
+                    "error": .string(error.localizedDescription),
+                ]
+            )
+            throw error
+        }
+    }
+
+    private func keyboardAction(params: JSON?, actionName: String, requiresModifier: Bool) throws -> JSON {
+        let source = params?["source"]?.stringValue ?? "daemon"
+        let treatment = ComputerTreatment.resolve(params: params, defaultValue: .stage)
+        let allowGlobal = params?["allowGlobal"]?.boolValue == true
+            || params?["allow-global"]?.boolValue == true
+            || params?["global"]?.boolValue == true
+        let request = try keyboardRequest(params: params, requiresModifier: requiresModifier)
+        let count = max(1, min(params?["count"]?.intValue ?? 1, 20))
+        let delayMs = max(0, min(params?["delayMs"]?.numericDouble ?? params?["delay-ms"]?.numericDouble ?? 80, 1_000))
+        let hasExplicitTarget = hasKeyboardTarget(params)
+        let window = hasExplicitTarget ? try CaptureController.shared.resolveWindow(params: params) : nil
+
+        if treatment.focusesWindow, window == nil, !allowGlobal {
+            throw RouterError.custom("computer.\(actionName) requires wid, app, or session for present/execute; pass allowGlobal true to post to the focused system target")
+        }
+
+        let shouldCapture = params?["capture"]?.boolValue ?? (window != nil)
+        let surfaces: [RunSurface] = window.map { [.window($0)] } ?? []
+        let title = actionName == "hotkey" ? "Send hotkey" : "Press key"
+        let run = try RunStore.shared.createRun(title: title, source: source, surfaces: surfaces)
+
+        do {
+            _ = try RunStore.shared.markRunning(
+                id: run.id,
+                summary: "Resolved keyboard action",
+                data: [
+                    "action": .string(actionName),
+                    "treatment": .string(treatment.rawValue),
+                    "key": .string(request.key),
+                    "modifiers": .array(request.modifiers.map { .string($0) }),
+                    "count": .int(count),
+                    "allowGlobal": .bool(allowGlobal),
+                ]
+            )
+
+            let before = try window.flatMap { target in
+                try maybeCaptureWindow(
+                    shouldCapture: shouldCapture,
+                    runId: run.id,
+                    source: source,
+                    wid: target.wid,
+                    prefix: "key-before"
+                )
+            }
+
+            var focused = false
+            if treatment.focusesWindow, let window {
+                focused = try focus(window: window)
+                _ = try RunStore.shared.appendTrace(
+                    id: run.id,
+                    kind: "computer.focused",
+                    summary: "Focused keyboard target window",
+                    data: ["wid": .int(Int(window.wid)), "focused": .bool(focused)]
+                )
+                if treatment == .execute, !focused {
+                    throw RouterError.custom("failed to focus window \(window.wid)")
+                }
+            }
+
+            var sent = false
+            var displayName = (request.modifiers + [request.key]).joined(separator: "+")
+            if treatment == .execute {
+                for index in 0..<count {
+                    displayName = try CompanionKeyboardController.shared.send(
+                        key: request.key,
+                        modifiers: request.modifiers,
+                        targetPid: window?.pid
+                    )
+                    if index < count - 1, delayMs > 0 {
+                        usleep(UInt32(delayMs * 1_000))
+                    }
+                }
+                sent = true
+                _ = try RunStore.shared.appendTrace(
+                    id: run.id,
+                    kind: "computer.keySent",
+                    summary: "Sent keyboard action",
+                    data: [
+                        "key": .string(request.key),
+                        "modifiers": .array(request.modifiers.map { .string($0) }),
+                        "display": .string(displayName),
+                        "count": .int(count),
+                        "global": .bool(window == nil),
+                    ]
+                )
+                usleep(140_000)
+            }
+
+            let after = try window.flatMap { target in
+                try maybeCaptureWindow(
+                    shouldCapture: shouldCapture,
+                    runId: run.id,
+                    source: source,
+                    wid: target.wid,
+                    prefix: "key-after"
+                )
+            }
+            let completed = try RunStore.shared.complete(
+                id: run.id,
+                summary: sent ? "Completed keyboard action" : "Staged keyboard action without posting",
+                data: [
+                    "sent": .bool(sent),
+                    "focused": .bool(focused),
+                    "key": .string(request.key),
+                    "modifiers": .array(request.modifiers.map { .string($0) }),
+                    "count": .int(count),
+                    "global": .bool(window == nil && allowGlobal),
+                ]
+            )
+
+            return keyboardActionResponse(
+                action: actionName,
+                run: completed,
+                target: window,
+                before: before?["artifact"],
+                after: after?["artifact"],
+                treatment: treatment,
+                key: request.key,
+                modifiers: request.modifiers,
+                displayName: displayName,
+                count: count,
+                delayMs: delayMs,
+                sent: sent,
+                focused: focused,
+                global: window == nil && allowGlobal
+            )
+        } catch {
+            _ = try? RunStore.shared.fail(
+                id: run.id,
+                summary: "Keyboard action failed",
+                data: [
+                    "action": .string(actionName),
+                    "key": .string(request.key),
                     "error": .string(error.localizedDescription),
                 ]
             )
@@ -2566,6 +2714,116 @@ final class ComputerUseController {
         throw RouterError.missingParam(keys.first ?? "value")
     }
 
+    private func hasKeyboardTarget(_ params: JSON?) -> Bool {
+        if params?["wid"]?.uint32Value != nil { return true }
+        if params?["session"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false { return true }
+        if params?["app"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false { return true }
+        return false
+    }
+
+    private func keyboardRequest(params: JSON?, requiresModifier: Bool) throws -> (key: String, modifiers: [String]) {
+        var key = params?["key"]?.stringValue
+            ?? params?["code"]?.stringValue
+            ?? params?["shortcut"]?.stringValue
+        var modifiers = keyboardModifiers(params)
+
+        if let shortcut = params?["shortcut"]?.stringValue, !shortcut.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let parsed = parseKeyboardShortcut(shortcut)
+            if params?["key"]?.stringValue == nil && params?["code"]?.stringValue == nil {
+                key = parsed.key
+            }
+            modifiers.append(contentsOf: parsed.modifiers)
+        } else if let rawKey = key,
+                  rawKey.contains("+")
+                    || rawKey.contains("\u{2318}")
+                    || rawKey.contains("\u{2325}")
+                    || rawKey.contains("\u{2303}")
+                    || rawKey.contains("\u{21E7}") {
+            let parsed = parseKeyboardShortcut(rawKey)
+            key = parsed.key
+            modifiers.append(contentsOf: parsed.modifiers)
+        }
+
+        guard let rawKey = key?.trimmingCharacters(in: .whitespacesAndNewlines), !rawKey.isEmpty else {
+            throw RouterError.missingParam("key")
+        }
+
+        let normalizedModifiers = uniqueKeyboardModifiers(modifiers)
+        if requiresModifier, normalizedModifiers.isEmpty {
+            throw RouterError.custom("computer.hotkey requires at least one modifier or shortcut")
+        }
+
+        return (rawKey, normalizedModifiers)
+    }
+
+    private func keyboardModifiers(_ params: JSON?) -> [String] {
+        var modifiers: [String] = []
+        if let values = params?["modifiers"]?.arrayValue {
+            modifiers.append(contentsOf: values.compactMap(\.stringValue))
+        } else if let raw = params?["modifiers"]?.stringValue {
+            modifiers.append(contentsOf: raw.split { character in
+                character == "," || character == "+" || character == " "
+            }.map(String.init))
+        }
+
+        let boolAliases: [(String, String)] = [
+            ("cmd", "command"),
+            ("command", "command"),
+            ("meta", "command"),
+            ("opt", "option"),
+            ("option", "option"),
+            ("alt", "option"),
+            ("ctrl", "control"),
+            ("control", "control"),
+            ("shift", "shift"),
+        ]
+        for (key, modifier) in boolAliases where params?[key]?.boolValue == true {
+            modifiers.append(modifier)
+        }
+        return modifiers
+    }
+
+    private func parseKeyboardShortcut(_ value: String) -> (key: String, modifiers: [String]) {
+        let expanded = value
+            .replacingOccurrences(of: "\u{2318}", with: "command+")
+            .replacingOccurrences(of: "\u{2325}", with: "option+")
+            .replacingOccurrences(of: "\u{2303}", with: "control+")
+            .replacingOccurrences(of: "\u{21E7}", with: "shift+")
+        let parts = expanded
+            .split(separator: "+")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        guard parts.count > 1 else {
+            return (value.trimmingCharacters(in: .whitespacesAndNewlines), [])
+        }
+
+        return (
+            parts.last ?? value.trimmingCharacters(in: .whitespacesAndNewlines),
+            Array(parts.dropLast())
+        )
+    }
+
+    private func uniqueKeyboardModifiers(_ rawModifiers: [String]) -> [String] {
+        let normalized = Set(rawModifiers.compactMap(normalizeKeyboardModifier))
+        return ["control", "option", "shift", "command"].filter { normalized.contains($0) }
+    }
+
+    private func normalizeKeyboardModifier(_ modifier: String) -> String? {
+        switch modifier.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "cmd", "command", "meta", "\u{2318}":
+            return "command"
+        case "opt", "option", "alt", "\u{2325}":
+            return "option"
+        case "ctrl", "control", "\u{2303}":
+            return "control"
+        case "shift", "\u{21E7}":
+            return "shift"
+        default:
+            return nil
+        }
+    }
+
     private func elementActionName(_ params: JSON?) throws -> String {
         let raw = params?["action"]?.stringValue
             ?? params?["elementAction"]?.stringValue
@@ -3392,6 +3650,42 @@ final class ComputerUseController {
         if let before { object["beforeArtifact"] = before }
         if let after { object["afterArtifact"] = after }
         if let axResult { object["ax"] = axResult.json }
+        return .object(object)
+    }
+
+    private func keyboardActionResponse(
+        action: String,
+        run: RunSession,
+        target: WindowEntry?,
+        before: JSON?,
+        after: JSON?,
+        treatment: ComputerTreatment,
+        key: String,
+        modifiers: [String],
+        displayName: String,
+        count: Int,
+        delayMs: Double,
+        sent: Bool,
+        focused: Bool,
+        global: Bool
+    ) -> JSON {
+        var object: [String: JSON] = [
+            "ok": .bool(true),
+            "action": .string(action),
+            "treatment": .string(treatment.rawValue),
+            "key": .string(key),
+            "modifiers": .array(modifiers.map { .string($0) }),
+            "display": .string(displayName),
+            "count": .int(count),
+            "delayMs": .double(delayMs),
+            "sent": .bool(sent),
+            "focused": .bool(focused),
+            "global": .bool(global),
+            "run": run.json,
+        ]
+        if let target { object["target"] = Encoders.window(target) }
+        if let before { object["beforeArtifact"] = before }
+        if let after { object["afterArtifact"] = after }
         return .object(object)
     }
 

--- a/apps/mac/Sources/Core/Daemon/LatticesApi.swift
+++ b/apps/mac/Sources/Core/Daemon/LatticesApi.swift
@@ -1653,6 +1653,57 @@ final class LatticesApi {
         ))
 
         api.register(Endpoint(
+            method: "computer.pressKey",
+            description: "Stage or execute one keyboard key press against an explicit target window, or globally when allowGlobal is true.",
+            access: .mutate,
+            params: [
+                Param(name: "wid", type: "uint32", required: false, description: "Target window id"),
+                Param(name: "session", type: "string", required: false, description: "Target lattices session"),
+                Param(name: "app", type: "string", required: false, description: "Target app name"),
+                Param(name: "title", type: "string", required: false, description: "Optional title substring for app target"),
+                Param(name: "key", type: "string", required: true, description: "Key name, such as escape, enter, tab, left, right, or a single character"),
+                Param(name: "modifiers", type: "array|string", required: false, description: "Optional modifier names: command, option, control, shift"),
+                Param(name: "count", type: "int", required: false, description: "Number of times to press the key (default 1, max 20)"),
+                Param(name: "delayMs", type: "double", required: false, description: "Delay between repeated presses in milliseconds (default 80)"),
+                Param(name: "allowGlobal", type: "bool", required: false, description: "Allow execute without an explicit target by posting to the focused system target"),
+                Param(name: "treatment", type: "string", required: false, description: "stage, present, or execute; execute is required to post the key"),
+                Param(name: "dryRun", type: "bool", required: false, description: "Stage without pressing the key"),
+                Param(name: "capture", type: "bool", required: false, description: "Capture before/after artifacts when targeting a window (default true)"),
+                Param(name: "source", type: "string", required: false, description: "Calling surface label"),
+            ],
+            returns: .custom("Object with ok, run, key, modifiers, sent, target, and optional artifacts"),
+            handler: { params in
+                try ComputerUseController.shared.pressKey(params: params)
+            }
+        ))
+
+        api.register(Endpoint(
+            method: "computer.hotkey",
+            description: "Stage or execute a keyboard shortcut against an explicit target window, or globally when allowGlobal is true.",
+            access: .mutate,
+            params: [
+                Param(name: "wid", type: "uint32", required: false, description: "Target window id"),
+                Param(name: "session", type: "string", required: false, description: "Target lattices session"),
+                Param(name: "app", type: "string", required: false, description: "Target app name"),
+                Param(name: "title", type: "string", required: false, description: "Optional title substring for app target"),
+                Param(name: "shortcut", type: "string", required: false, description: "Shortcut shorthand such as command+shift+p or cmd+k"),
+                Param(name: "key", type: "string", required: false, description: "Base key when modifiers are supplied separately"),
+                Param(name: "modifiers", type: "array|string", required: false, description: "Modifier names: command, option, control, shift"),
+                Param(name: "count", type: "int", required: false, description: "Number of times to send the shortcut (default 1, max 20)"),
+                Param(name: "delayMs", type: "double", required: false, description: "Delay between repeated sends in milliseconds (default 80)"),
+                Param(name: "allowGlobal", type: "bool", required: false, description: "Allow execute without an explicit target by posting to the focused system target"),
+                Param(name: "treatment", type: "string", required: false, description: "stage, present, or execute; execute is required to post the shortcut"),
+                Param(name: "dryRun", type: "bool", required: false, description: "Stage without pressing the shortcut"),
+                Param(name: "capture", type: "bool", required: false, description: "Capture before/after artifacts when targeting a window (default true)"),
+                Param(name: "source", type: "string", required: false, description: "Calling surface label"),
+            ],
+            returns: .custom("Object with ok, run, key, modifiers, display, sent, target, and optional artifacts"),
+            handler: { params in
+                try ComputerUseController.shared.hotkey(params: params)
+            }
+        ))
+
+        api.register(Endpoint(
             method: "computer.focusWindow",
             description: "Resolve, optionally capture, focus, and verify a target window.",
             access: .mutate,

--- a/apps/mac/Sources/Core/Daemon/LatticesApi.swift
+++ b/apps/mac/Sources/Core/Daemon/LatticesApi.swift
@@ -1870,6 +1870,7 @@ final class LatticesApi {
             access: .mutate,
             params: [
                 Param(name: "wid", type: "uint32", required: false, description: "Target window id"),
+                Param(name: "session", type: "string", required: false, description: "Target lattices session"),
                 Param(name: "app", type: "string", required: false, description: "Target app name"),
                 Param(name: "title", type: "string", required: false, description: "Optional title substring for app target"),
                 Param(name: "x", type: "double", required: false, description: "Absolute click x coordinate"),
@@ -1877,6 +1878,8 @@ final class LatticesApi {
                 Param(name: "xRatio", type: "double", required: false, description: "Window-relative click x ratio, 0 left to 1 right"),
                 Param(name: "yRatio", type: "double", required: false, description: "Window-relative click y ratio, 0 top to 1 bottom"),
                 Param(name: "button", type: "string", required: false, description: "left or right"),
+                Param(name: "count", type: "int", required: false, description: "Number of pointer clicks to post in pointer transport (default 1, max 8)"),
+                Param(name: "delayMs", type: "double", required: false, description: "Delay between repeated pointer clicks in milliseconds (default 90)"),
                 Param(name: "transport", type: "string", required: false, description: "auto, ax, or pointer. auto tries AXPress before pointer fallback"),
                 Param(name: "axLabel", type: "string", required: false, description: "Optional AX title/description text to prefer, such as Send"),
                 Param(name: "noFocus", type: "bool", required: false, description: "Require AX/no-focus execution; do not focus or use pointer fallback"),
@@ -1888,6 +1891,122 @@ final class LatticesApi {
             returns: .custom("Object with ok, run, cursor point, target window, and clicked flag"),
             handler: { params in
                 try ComputerUseController.shared.click(params: params)
+            }
+        ))
+
+        api.register(Endpoint(
+            method: "computer.doubleClick",
+            description: "Stage or execute a double-click target using pointer transport.",
+            access: .mutate,
+            params: [
+                Param(name: "wid", type: "uint32", required: false, description: "Target window id"),
+                Param(name: "session", type: "string", required: false, description: "Target lattices session"),
+                Param(name: "app", type: "string", required: false, description: "Target app name"),
+                Param(name: "title", type: "string", required: false, description: "Optional title substring for app target"),
+                Param(name: "x", type: "double", required: false, description: "Absolute click x coordinate"),
+                Param(name: "y", type: "double", required: false, description: "Absolute click y coordinate"),
+                Param(name: "xRatio", type: "double", required: false, description: "Window-relative click x ratio"),
+                Param(name: "yRatio", type: "double", required: false, description: "Window-relative click y ratio"),
+                Param(name: "delayMs", type: "double", required: false, description: "Delay between the two clicks in milliseconds (default 90)"),
+                Param(name: "treatment", type: "string", required: false, description: "stage, present, or execute; execute is required to post the double-click"),
+                Param(name: "dryRun", type: "bool", required: false, description: "Stage without double-clicking"),
+                Param(name: "capture", type: "bool", required: false, description: "Capture before/after artifacts when targeting a window (default true)"),
+                Param(name: "source", type: "string", required: false, description: "Calling surface label"),
+            ],
+            returns: .custom("Object with ok, run, cursor point, target window, and clicked flag"),
+            handler: { params in
+                try ComputerUseController.shared.doubleClick(params: params)
+            }
+        ))
+
+        api.register(Endpoint(
+            method: "computer.rightClick",
+            description: "Stage or execute a right-click/context-click target using pointer transport.",
+            access: .mutate,
+            params: [
+                Param(name: "wid", type: "uint32", required: false, description: "Target window id"),
+                Param(name: "session", type: "string", required: false, description: "Target lattices session"),
+                Param(name: "app", type: "string", required: false, description: "Target app name"),
+                Param(name: "title", type: "string", required: false, description: "Optional title substring for app target"),
+                Param(name: "x", type: "double", required: false, description: "Absolute click x coordinate"),
+                Param(name: "y", type: "double", required: false, description: "Absolute click y coordinate"),
+                Param(name: "xRatio", type: "double", required: false, description: "Window-relative click x ratio"),
+                Param(name: "yRatio", type: "double", required: false, description: "Window-relative click y ratio"),
+                Param(name: "count", type: "int", required: false, description: "Number of right clicks to post (default 1, max 8)"),
+                Param(name: "delayMs", type: "double", required: false, description: "Delay between repeated clicks in milliseconds (default 90)"),
+                Param(name: "treatment", type: "string", required: false, description: "stage, present, or execute; execute is required to post the right-click"),
+                Param(name: "dryRun", type: "bool", required: false, description: "Stage without right-clicking"),
+                Param(name: "capture", type: "bool", required: false, description: "Capture before/after artifacts when targeting a window (default true)"),
+                Param(name: "source", type: "string", required: false, description: "Calling surface label"),
+            ],
+            returns: .custom("Object with ok, run, cursor point, target window, and clicked flag"),
+            handler: { params in
+                try ComputerUseController.shared.rightClick(params: params)
+            }
+        ))
+
+        api.register(Endpoint(
+            method: "computer.scroll",
+            description: "Stage or execute scroll wheel input at a cursor or window-relative point.",
+            access: .mutate,
+            params: [
+                Param(name: "wid", type: "uint32", required: false, description: "Target window id"),
+                Param(name: "session", type: "string", required: false, description: "Target lattices session"),
+                Param(name: "app", type: "string", required: false, description: "Target app name"),
+                Param(name: "title", type: "string", required: false, description: "Optional title substring for app target"),
+                Param(name: "x", type: "double", required: false, description: "Absolute pointer x coordinate before scrolling"),
+                Param(name: "y", type: "double", required: false, description: "Absolute pointer y coordinate before scrolling"),
+                Param(name: "xRatio", type: "double", required: false, description: "Window-relative pointer x ratio"),
+                Param(name: "yRatio", type: "double", required: false, description: "Window-relative pointer y ratio"),
+                Param(name: "direction", type: "string", required: false, description: "down (default), up, left, or right"),
+                Param(name: "amount", type: "double", required: false, description: "Scroll amount in pixel units when direction is used (default 420)"),
+                Param(name: "deltaX", type: "double", required: false, description: "Horizontal scroll wheel delta override"),
+                Param(name: "deltaY", type: "double", required: false, description: "Vertical scroll wheel delta override"),
+                Param(name: "count", type: "int", required: false, description: "Number of scroll events to post (default 1, max 30)"),
+                Param(name: "delayMs", type: "double", required: false, description: "Delay between repeated scroll events in milliseconds (default 80)"),
+                Param(name: "treatment", type: "string", required: false, description: "stage, present, or execute; execute is required to post scroll events"),
+                Param(name: "dryRun", type: "bool", required: false, description: "Stage without scrolling"),
+                Param(name: "capture", type: "bool", required: false, description: "Capture before/after artifacts when targeting a window (default true)"),
+                Param(name: "source", type: "string", required: false, description: "Calling surface label"),
+            ],
+            returns: .custom("Object with ok, run, cursor point, delta, target window, and scrolled flag"),
+            handler: { params in
+                try ComputerUseController.shared.scroll(params: params)
+            }
+        ))
+
+        api.register(Endpoint(
+            method: "computer.drag",
+            description: "Stage or execute a pointer drag between absolute or window-relative points.",
+            access: .mutate,
+            params: [
+                Param(name: "wid", type: "uint32", required: false, description: "Target window id"),
+                Param(name: "session", type: "string", required: false, description: "Target lattices session"),
+                Param(name: "app", type: "string", required: false, description: "Target app name"),
+                Param(name: "title", type: "string", required: false, description: "Optional title substring for app target"),
+                Param(name: "fromX", type: "double", required: false, description: "Absolute drag start x coordinate"),
+                Param(name: "fromY", type: "double", required: false, description: "Absolute drag start y coordinate"),
+                Param(name: "toX", type: "double", required: false, description: "Absolute drag end x coordinate"),
+                Param(name: "toY", type: "double", required: false, description: "Absolute drag end y coordinate"),
+                Param(name: "x", type: "double", required: false, description: "Alias for absolute drag end x coordinate"),
+                Param(name: "y", type: "double", required: false, description: "Alias for absolute drag end y coordinate"),
+                Param(name: "fromXRatio", type: "double", required: false, description: "Window-relative drag start x ratio"),
+                Param(name: "fromYRatio", type: "double", required: false, description: "Window-relative drag start y ratio"),
+                Param(name: "toXRatio", type: "double", required: false, description: "Window-relative drag end x ratio"),
+                Param(name: "toYRatio", type: "double", required: false, description: "Window-relative drag end y ratio"),
+                Param(name: "xRatio", type: "double", required: false, description: "Alias for window-relative drag end x ratio"),
+                Param(name: "yRatio", type: "double", required: false, description: "Alias for window-relative drag end y ratio"),
+                Param(name: "button", type: "string", required: false, description: "left or right (default left)"),
+                Param(name: "durationMs", type: "double", required: false, description: "Drag duration in milliseconds (default 360)"),
+                Param(name: "steps", type: "int", required: false, description: "Interpolated drag event count (default 18, max 120)"),
+                Param(name: "treatment", type: "string", required: false, description: "stage, present, or execute; execute is required to post drag events"),
+                Param(name: "dryRun", type: "bool", required: false, description: "Stage without dragging"),
+                Param(name: "capture", type: "bool", required: false, description: "Capture before/after artifacts when targeting a window (default true)"),
+                Param(name: "source", type: "string", required: false, description: "Calling surface label"),
+            ],
+            returns: .custom("Object with ok, run, from/to points, target window, and dragged flag"),
+            handler: { params in
+                try ComputerUseController.shared.drag(params: params)
             }
         ))
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -216,6 +216,8 @@ methods write into the Lattices run store under
 | `computer.elementAction` | write | Stage or execute an AX action against a snapshot element id |
 | `computer.typeElement` | write | Stage or execute AXValue text insertion against a snapshot element id |
 | `computer.setValue` | write | Alias for replacing a snapshot element's AXValue |
+| `computer.pressKey` | write | Stage or execute one key press against an explicit target window |
+| `computer.hotkey` | write | Stage or execute a keyboard shortcut against an explicit target window |
 | `computer.focusWindow` | write | Resolve, capture, focus, and verify a target window |
 | `computer.showCursor` | write | Show a visible cursor appearance and record it as a run |
 | `computer.launchApp` | write | Launch or focus a normal macOS app and record the run |
@@ -261,6 +263,8 @@ lattices terminals
 lattices terminals --refresh
 lattices computer prepare --text "# hello" --treatment stage
 lattices call computer.windowState '{"app":"Finder","maxDepth":4}'
+lattices call computer.pressKey '{"app":"Finder","key":"escape","treatment":"stage"}'
+lattices call computer.hotkey '{"app":"Xcode","shortcut":"command+b","treatment":"stage"}'
 lattices computer focus-window --wid 7258 --treatment present
 lattices computer cursor --style marker --shape chevron --angle-deg -8 --label typing
 lattices computer launch-app Scout
@@ -416,6 +420,47 @@ await daemonCall('computer.typeElement', {
   snapshotId: state.snapshotId,
   elementId: 'e12',
   text: 'Draft note',
+  treatment: 'execute'
+})
+```
+
+#### `computer.pressKey` / `computer.hotkey`
+
+Stage or execute keyboard input. `computer.pressKey` sends one key, such as
+`escape`, `enter`, `tab`, an arrow key, or a single character. `computer.hotkey`
+sends a shortcut from either `shortcut: "command+shift+p"` or `key` plus
+`modifiers`. Both default to `stage`; `execute` requires an explicit `wid`,
+`app`, or `session` target unless `allowGlobal: true` is passed.
+
+**Params**:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `wid` | uint32 | no | Target window id |
+| `session` | string | no | Target lattices session |
+| `app` | string | no | Target app name |
+| `title` | string | no | Optional title substring for app target |
+| `key` | string | yes for `pressKey` | Key name or single character |
+| `shortcut` | string | yes for `hotkey` without `key` | Shortcut shorthand, such as `command+shift+p` |
+| `modifiers` | array/string | no | `command`, `option`, `control`, `shift` |
+| `count` | int | no | Repeat count. Defaults to `1`, max `20` |
+| `delayMs` | double | no | Delay between repeats. Defaults to `80` |
+| `allowGlobal` | bool | no | Permit execute without target by posting to the focused system target |
+| `treatment` | string | no | `stage`, `present`, or `execute` |
+| `dryRun` | bool | no | Stage without posting keyboard input |
+| `capture` | bool | no | Capture before/after artifacts when targeting a window |
+| `source` | string | no | Calling surface label |
+
+```js
+await daemonCall('computer.pressKey', {
+  app: 'Finder',
+  key: 'escape',
+  treatment: 'stage'
+})
+
+await daemonCall('computer.hotkey', {
+  app: 'Xcode',
+  shortcut: 'command+b',
   treatment: 'execute'
 })
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -223,6 +223,10 @@ methods write into the Lattices run store under
 | `computer.launchApp` | write | Launch or focus a normal macOS app and record the run |
 | `computer.typeWindowText` | write | Type or paste into a normal app window, optionally after a click |
 | `computer.click` | write | Stage or execute a window-relative click target; prefers no-focus `AXPress` in auto/ax transport |
+| `computer.doubleClick` | write | Stage or execute a pointer double-click target |
+| `computer.rightClick` | write | Stage or execute a right-click/context-click target |
+| `computer.scroll` | write | Stage or execute scroll wheel input |
+| `computer.drag` | write | Stage or execute a pointer drag between two points |
 | `computer.demoScout` | write | Scout warm-up run for memo/demo recording |
 | `computer.typeText` | write | Insert text into a safe terminal using the least intrusive transport |
 | `computer.demoTerminal` | write | Compatibility wrapper for a bounded terminal text action |
@@ -273,6 +277,10 @@ lattices computer scout "Draft memo text" --execute
 lattices computer type-window --app Scout --text "Draft memo text" --x-ratio .5 --y-ratio .86 --execute
 lattices computer click --app Scout --x-ratio .5 --y-ratio .86 --execute
 lattices cua click --app Scout --x-ratio .74 --y-ratio .95 --transport ax --ax-label Send --execute
+lattices call computer.scroll '{"app":"Safari","direction":"down","amount":420,"treatment":"stage"}'
+lattices call computer.drag '{"app":"Finder","fromXRatio":0.2,"fromYRatio":0.2,"toXRatio":0.7,"toYRatio":0.7,"treatment":"stage"}'
+lattices call computer.doubleClick '{"app":"Finder","xRatio":0.5,"yRatio":0.5,"treatment":"stage"}'
+lattices call computer.rightClick '{"app":"Finder","xRatio":0.5,"yRatio":0.5,"treatment":"stage"}'
 lattices computer type-text --text "# hello from lattices"
 lattices computer demo-terminal --dry-run
 ```
@@ -586,24 +594,29 @@ await daemonCall('computer.typeWindowText', {
 })
 ```
 
-#### `computer.click`
+#### `computer.click` / `computer.doubleClick` / `computer.rightClick`
 
 Stage or execute a click target. `stage` records the target without clicking.
 In `execute`, `transport: "auto"` prefers `AXPress` on the resolved accessibility
 button/control before falling back to a pointer click. Use `transport: "ax"` or
 `noFocus: true` when the action must not focus the app or move the hardware
-pointer. When a window target is provided, ratios are relative to that window.
+pointer. `computer.doubleClick` forces two pointer clicks; `computer.rightClick`
+forces the right button. When a window target is provided, ratios are relative to
+that window.
 
 **Params**:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `wid` | uint32 | no | Target window id |
+| `session` | string | no | Target lattices session |
 | `app` | string | no | Target app name |
 | `title` | string | no | Optional title substring for app target |
 | `x`, `y` | double | no | Absolute click point |
 | `xRatio`, `yRatio` | double | no | Window-relative click point |
 | `button` | string | no | `left` or `right`; defaults to `left` |
+| `count` | int | no | Pointer click count. Defaults to `1`, max `8` |
+| `delayMs` | double | no | Delay between repeated pointer clicks |
 | `transport` | string | no | `auto`, `ax`, or `pointer`; defaults to `auto` |
 | `axLabel` | string | no | Optional AX text/title hint, such as `Send` |
 | `noFocus` | bool | no | Require no-focus AX execution; disable pointer fallback |
@@ -628,6 +641,60 @@ await daemonCall('computer.click', {
   axLabel: 'Send',
   noFocus: true,
   treatment: 'execute'
+})
+```
+
+#### `computer.scroll` / `computer.drag`
+
+Stage or execute richer pointer input while keeping the same run/capture model.
+`computer.scroll` posts scroll wheel events at an absolute or window-relative
+point. `computer.drag` interpolates a pointer drag from a start point to an end
+point. Both default to `stage`.
+
+**Scroll params**:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `wid`, `session`, `app`, `title` | target | no | Target window/session/app |
+| `x`, `y` | double | no | Absolute pointer point before scrolling |
+| `xRatio`, `yRatio` | double | no | Window-relative pointer point |
+| `direction` | string | no | `down` (default), `up`, `left`, or `right` |
+| `amount` | double | no | Scroll amount when using `direction`; default `420` |
+| `deltaX`, `deltaY` | double | no | Explicit scroll wheel deltas |
+| `count` | int | no | Number of scroll events; default `1`, max `30` |
+| `delayMs` | double | no | Delay between repeated events |
+| `treatment`, `dryRun`, `capture`, `source` | mixed | no | Standard computer action fields |
+
+**Drag params**:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `wid`, `session`, `app`, `title` | target | no | Target window/session/app |
+| `fromX`, `fromY` | double | no | Absolute drag start point |
+| `toX`, `toY` | double | no | Absolute drag end point |
+| `fromXRatio`, `fromYRatio` | double | no | Window-relative drag start point |
+| `toXRatio`, `toYRatio` | double | no | Window-relative drag end point |
+| `x`, `y`, `xRatio`, `yRatio` | double | no | Aliases for the drag end point |
+| `button` | string | no | `left` or `right`; defaults to `left` |
+| `durationMs` | double | no | Drag duration; default `360` |
+| `steps` | int | no | Interpolated drag event count; default `18` |
+| `treatment`, `dryRun`, `capture`, `source` | mixed | no | Standard computer action fields |
+
+```js
+await daemonCall('computer.scroll', {
+  app: 'Safari',
+  direction: 'down',
+  amount: 420,
+  treatment: 'execute'
+})
+
+await daemonCall('computer.drag', {
+  app: 'Finder',
+  fromXRatio: 0.2,
+  fromYRatio: 0.2,
+  toXRatio: 0.7,
+  toYRatio: 0.7,
+  treatment: 'stage'
 })
 ```
 

--- a/docs/pi-lattices.md
+++ b/docs/pi-lattices.md
@@ -51,6 +51,8 @@ lattices app
 | `lattices_computer_element_action` | `computer.elementAction` |
 | `lattices_computer_type_element` | `computer.typeElement` |
 | `lattices_computer_set_value` | `computer.setValue` |
+| `lattices_computer_press_key` | `computer.pressKey` |
+| `lattices_computer_hotkey` | `computer.hotkey` |
 | `lattices_window_focus` | `computer.focusWindow` |
 | `lattices_window_place` | `window.place` |
 | `lattices_capture_window` | `capture.screenshotWindow` |

--- a/docs/pi-lattices.md
+++ b/docs/pi-lattices.md
@@ -59,6 +59,10 @@ lattices app
 | `lattices_computer_prepare` | `computer.prepare` |
 | `lattices_computer_launch_app` | `computer.launchApp` |
 | `lattices_computer_click` | `computer.click` |
+| `lattices_computer_double_click` | `computer.doubleClick` |
+| `lattices_computer_right_click` | `computer.rightClick` |
+| `lattices_computer_scroll` | `computer.scroll` |
+| `lattices_computer_drag` | `computer.drag` |
 | `lattices_computer_type_window_text` | `computer.typeWindowText` |
 | `lattices_computer_type_text` | `computer.typeText` |
 | `lattices_call` | caller-selected escape hatch |

--- a/docs/proposals/LAT-008-pi-lattices-computer-use.md
+++ b/docs/proposals/LAT-008-pi-lattices-computer-use.md
@@ -137,6 +137,10 @@ Mutations / computer use:
 - `lattices_computer_click` → `computer.click`
 - `lattices_computer_press_key` → `computer.pressKey`
 - `lattices_computer_hotkey` → `computer.hotkey`
+- `lattices_computer_double_click` → `computer.doubleClick`
+- `lattices_computer_right_click` → `computer.rightClick`
+- `lattices_computer_scroll` → `computer.scroll`
+- `lattices_computer_drag` → `computer.drag`
 - `lattices_computer_type_window_text` → `computer.typeWindowText`
 - `lattices_computer_type_text` → `computer.typeText`
 
@@ -253,12 +257,12 @@ primitives. Each endpoint must preserve Lattices' treatment/capture/run model.
 
 Candidate endpoints:
 
-- `computer.pressKey` (first slice)
-- `computer.hotkey` (first slice)
-- `computer.scroll`
-- `computer.drag`
-- `computer.doubleClick`
-- `computer.rightClick` or improved `computer.click` with `count` and button
+- `computer.pressKey` (implemented)
+- `computer.hotkey` (implemented)
+- `computer.scroll` (implemented)
+- `computer.drag` (implemented)
+- `computer.doubleClick` (implemented)
+- `computer.rightClick` and improved `computer.click` with `count` and button (implemented)
 
 Design rules:
 

--- a/docs/proposals/LAT-008-pi-lattices-computer-use.md
+++ b/docs/proposals/LAT-008-pi-lattices-computer-use.md
@@ -135,6 +135,8 @@ Mutations / computer use:
 - `lattices_capture_window` → `capture.screenshotWindow`
 - `lattices_computer_launch_app` → `computer.launchApp`
 - `lattices_computer_click` → `computer.click`
+- `lattices_computer_press_key` → `computer.pressKey`
+- `lattices_computer_hotkey` → `computer.hotkey`
 - `lattices_computer_type_window_text` → `computer.typeWindowText`
 - `lattices_computer_type_text` → `computer.typeText`
 
@@ -251,8 +253,8 @@ primitives. Each endpoint must preserve Lattices' treatment/capture/run model.
 
 Candidate endpoints:
 
-- `computer.pressKey`
-- `computer.hotkey`
+- `computer.pressKey` (first slice)
+- `computer.hotkey` (first slice)
 - `computer.scroll`
 - `computer.drag`
 - `computer.doubleClick`

--- a/packages/pi-lattices/README.md
+++ b/packages/pi-lattices/README.md
@@ -59,6 +59,8 @@ All tools use the `lattices_` prefix.
 | `lattices_computer_element_action` | `computer.elementAction` | Defaults to `treatment: "stage"`; pass `execute` to perform AXPress/showMenu. |
 | `lattices_computer_type_element` | `computer.typeElement` | Defaults to `treatment: "stage"`; pass `execute` to set or append AXValue text. |
 | `lattices_computer_set_value` | `computer.setValue` | Defaults to `treatment: "stage"`; pass `execute` to replace AXValue. |
+| `lattices_computer_press_key` | `computer.pressKey` | Defaults to `treatment: "stage"`; pass `execute` with an explicit target to press. |
+| `lattices_computer_hotkey` | `computer.hotkey` | Defaults to `treatment: "stage"`; pass `execute` with an explicit target to send. |
 | `lattices_window_focus` | `computer.focusWindow` | Defaults to `treatment: "stage"`; pass `present` or `execute` to focus. |
 | `lattices_window_place` | `window.place` | Returns the daemon action receipt. |
 | `lattices_capture_window` | `capture.screenshotWindow` | Creates a run artifact. |

--- a/packages/pi-lattices/README.md
+++ b/packages/pi-lattices/README.md
@@ -67,6 +67,10 @@ All tools use the `lattices_` prefix.
 | `lattices_computer_prepare` | `computer.prepare` | Stages/observes a terminal target. |
 | `lattices_computer_launch_app` | `computer.launchApp` | Defaults to `treatment: "stage"`; pass `present` or `execute` to launch/focus. |
 | `lattices_computer_click` | `computer.click` | Defaults to `treatment: "stage"`; pass `execute` to click. |
+| `lattices_computer_double_click` | `computer.doubleClick` | Defaults to `treatment: "stage"`; pass `execute` to double-click. |
+| `lattices_computer_right_click` | `computer.rightClick` | Defaults to `treatment: "stage"`; pass `execute` to right-click. |
+| `lattices_computer_scroll` | `computer.scroll` | Defaults to `treatment: "stage"`; pass `execute` to scroll. |
+| `lattices_computer_drag` | `computer.drag` | Defaults to `treatment: "stage"`; pass `execute` to drag. |
 | `lattices_computer_type_window_text` | `computer.typeWindowText` | Defaults to `treatment: "stage"`; pass `execute` to insert text. |
 | `lattices_computer_type_text` | `computer.typeText` | Defaults to `treatment: "stage"`; pass `execute` to insert text. |
 | `lattices_call` | caller-selected | Escape hatch; prefer typed tools first. |

--- a/packages/pi-lattices/index.mjs
+++ b/packages/pi-lattices/index.mjs
@@ -40,6 +40,16 @@ const elementAction = optionalEnum(
   ["press", "showMenu", "focus"],
   "Element action. press is the default and maps to AXPress."
 );
+const key = string("Keyboard key name, such as escape, enter, tab, left, right, or a single character.");
+const modifiers = {
+  anyOf: [
+    { type: "array", items: { type: "string" } },
+    { type: "string" },
+  ],
+  description: "Keyboard modifiers: command, option, control, shift. Array or +/comma/space-delimited string.",
+};
+const shortcut = string("Shortcut shorthand, such as command+shift+p, cmd+k, or shift+tab.");
+const allowGlobal = boolean("Allow treatment=execute without an explicit target by posting to the focused system target.");
 
 const emptyParams = object();
 const runSourceParams = {
@@ -198,6 +208,45 @@ export const LATTICES_TOOLS = [
       typeIntervalMs: number("Optional per-character interval for typewriter-style AXValue updates."),
       ...computerBaseParams,
     }, ["snapshotId", "elementId", "value"]),
+    defaultTreatment: "stage",
+    defaultSource: DEFAULT_SOURCE,
+  },
+  {
+    name: `${TOOL_PREFIX}computer_press_key`,
+    method: "computer.pressKey",
+    description: "Stage or execute one keyboard key press against an explicit target window. Defaults to treatment=stage; pass execute to press.",
+    parameters: object({
+      ...targetParams,
+      key,
+      modifiers,
+      count: integer("Number of times to press the key. Daemon default is 1, max 20."),
+      delayMs: number("Delay between repeated presses in milliseconds. Daemon default is 80."),
+      allowGlobal,
+      ...computerBaseParams,
+    }, ["key"]),
+    defaultTreatment: "stage",
+    defaultSource: DEFAULT_SOURCE,
+  },
+  {
+    name: `${TOOL_PREFIX}computer_hotkey`,
+    method: "computer.hotkey",
+    description: "Stage or execute a keyboard shortcut against an explicit target window. Defaults to treatment=stage; pass execute to send.",
+    parameters: {
+      ...object({
+        ...targetParams,
+        shortcut,
+        key,
+        modifiers,
+        count: integer("Number of times to send the shortcut. Daemon default is 1, max 20."),
+        delayMs: number("Delay between repeated sends in milliseconds. Daemon default is 80."),
+        allowGlobal,
+        ...computerBaseParams,
+      }),
+      anyOf: [
+        { required: ["shortcut"] },
+        { required: ["key"] },
+      ],
+    },
     defaultTreatment: "stage",
     defaultSource: DEFAULT_SOURCE,
   },

--- a/packages/pi-lattices/index.mjs
+++ b/packages/pi-lattices/index.mjs
@@ -50,6 +50,9 @@ const modifiers = {
 };
 const shortcut = string("Shortcut shorthand, such as command+shift+p, cmd+k, or shift+tab.");
 const allowGlobal = boolean("Allow treatment=execute without an explicit target by posting to the focused system target.");
+const pointerCount = integer("Repeat count for pointer events.");
+const delayMs = number("Delay between repeated events in milliseconds.");
+const durationMs = number("Pointer action duration in milliseconds.");
 
 const emptyParams = object();
 const runSourceParams = {
@@ -314,11 +317,81 @@ export const LATTICES_TOOLS = [
       ...targetParams,
       ...windowPointParams,
       button: optionalEnum(["left", "right", "secondary", "context"], "Mouse button. Defaults to left."),
+      count: pointerCount,
+      delayMs,
       transport: optionalEnum(["auto", "ax", "accessibility", "pointer", "mouse", "hardware"], "Click transport. auto prefers AXPress when possible."),
       axLabel: string("Optional AX title/label hint, such as Send."),
       targetText: string("Optional visible target text hint."),
       noFocus: boolean("Require no-focus AX execution and disable pointer fallback."),
       label: string("Optional label recorded with the click/cursor target."),
+      ...computerBaseParams,
+    }),
+    defaultTreatment: "stage",
+    defaultSource: DEFAULT_SOURCE,
+  },
+  {
+    name: `${TOOL_PREFIX}computer_double_click`,
+    method: "computer.doubleClick",
+    description: "Stage, present, or execute a window-relative double-click. Defaults to treatment=stage; pass execute to double-click.",
+    parameters: object({
+      ...targetParams,
+      ...windowPointParams,
+      delayMs: number("Delay between the two clicks in milliseconds. Daemon default is 90."),
+      ...computerBaseParams,
+    }),
+    defaultTreatment: "stage",
+    defaultSource: DEFAULT_SOURCE,
+  },
+  {
+    name: `${TOOL_PREFIX}computer_right_click`,
+    method: "computer.rightClick",
+    description: "Stage, present, or execute a window-relative right-click/context-click. Defaults to treatment=stage; pass execute to right-click.",
+    parameters: object({
+      ...targetParams,
+      ...windowPointParams,
+      count: pointerCount,
+      delayMs,
+      ...computerBaseParams,
+    }),
+    defaultTreatment: "stage",
+    defaultSource: DEFAULT_SOURCE,
+  },
+  {
+    name: `${TOOL_PREFIX}computer_scroll`,
+    method: "computer.scroll",
+    description: "Stage, present, or execute scroll wheel input at a cursor or window-relative point. Defaults to treatment=stage; pass execute to scroll.",
+    parameters: object({
+      ...targetParams,
+      ...windowPointParams,
+      direction: optionalEnum(["down", "up", "left", "right"], "High-level scroll direction. Defaults to down."),
+      amount: number("Scroll amount in pixel units when direction is used. Daemon default is 420."),
+      deltaX: number("Horizontal scroll wheel delta override."),
+      deltaY: number("Vertical scroll wheel delta override."),
+      count: integer("Number of scroll events. Daemon default is 1, max 30."),
+      delayMs,
+      ...computerBaseParams,
+    }),
+    defaultTreatment: "stage",
+    defaultSource: DEFAULT_SOURCE,
+  },
+  {
+    name: `${TOOL_PREFIX}computer_drag`,
+    method: "computer.drag",
+    description: "Stage, present, or execute a pointer drag between absolute or window-relative points. Defaults to treatment=stage; pass execute to drag.",
+    parameters: object({
+      ...targetParams,
+      ...windowPointParams,
+      fromX: number("Absolute drag start X coordinate."),
+      fromY: number("Absolute drag start Y coordinate."),
+      toX: number("Absolute drag end X coordinate."),
+      toY: number("Absolute drag end Y coordinate."),
+      fromXRatio: ratio("Window-relative drag start X ratio."),
+      fromYRatio: ratio("Window-relative drag start Y ratio."),
+      toXRatio: ratio("Window-relative drag end X ratio."),
+      toYRatio: ratio("Window-relative drag end Y ratio."),
+      button: optionalEnum(["left", "right", "secondary", "context"], "Mouse button held while dragging. Defaults to left."),
+      durationMs,
+      steps: integer("Interpolated drag event count. Daemon default is 18, max 120."),
       ...computerBaseParams,
     }),
     defaultTreatment: "stage",

--- a/packages/pi-lattices/test/smoke.mjs
+++ b/packages/pi-lattices/test/smoke.mjs
@@ -45,6 +45,10 @@ for (const required of [
   "lattices_computer_hotkey",
   "lattices_computer_launch_app",
   "lattices_computer_click",
+  "lattices_computer_double_click",
+  "lattices_computer_right_click",
+  "lattices_computer_scroll",
+  "lattices_computer_drag",
   "lattices_call",
 ]) {
   assert.ok(names.includes(required), `registered ${required}`);

--- a/packages/pi-lattices/test/smoke.mjs
+++ b/packages/pi-lattices/test/smoke.mjs
@@ -41,6 +41,8 @@ for (const required of [
   "lattices_computer_element_action",
   "lattices_computer_type_element",
   "lattices_computer_set_value",
+  "lattices_computer_press_key",
+  "lattices_computer_hotkey",
   "lattices_computer_launch_app",
   "lattices_computer_click",
   "lattices_call",


### PR DESCRIPTION
## Summary

- complete Phase 3 computer-use primitives across the Swift daemon and Pi tool surface
- add click count/delay support plus double-click, right-click, scroll, and drag endpoints with staged/execute gating and run trace metadata
- update API, Pi, README, and LAT-008 proposal docs so agents can discover the new input actions

## Validation

- `bun run check:app`
- `bun run check:types`
- `node packages/pi-lattices/test/smoke.mjs`
- `bun run --cwd packages/pi-lattices smoke:no-daemon`
- `git diff --check`
- `bun bin/lattices-app.ts restart`
- live staged daemon calls for `computer.scroll`, `computer.drag`, `computer.doubleClick`, and `computer.rightClick`
- `bun run --cwd packages/pi-lattices smoke:live`
