### PR TITLE
Improve window placement and background-safe automation

### DIFF
--- a/apps/mac/Sources/AppShell/FrontWindowPlacement.swift
+++ b/apps/mac/Sources/AppShell/FrontWindowPlacement.swift
@@ -30,6 +30,81 @@ enum FrontWindowPlacer {
         WindowTiler.tileFrontmostViaAX(to: position)
         DiagnosticLog.shared.success("Placed front window → \(position.label) (\(source))")
     }
+
+    static func fillOpenGridCell(columns: Int = 3, rows: Int = 2, source: String = "hotkey") {
+        guard canPlace() else {
+            NSSound.beep()
+            return
+        }
+
+        DesktopModel.shared.forcePoll()
+
+        guard let target = DesktopModel.shared.frontmostWindow(),
+              target.app != "Lattices" else {
+            NSSound.beep()
+            DiagnosticLog.shared.warn("Fill open cell: no frontmost target window")
+            return
+        }
+
+        let screen = WindowTiler.screenForWindowFrame(target.frame)
+        guard let placement = bestOpenGridCell(columns: columns, rows: rows, target: target, screen: screen) else {
+            NSSound.beep()
+            DiagnosticLog.shared.warn("Fill open cell: no valid \(columns)x\(rows) placement")
+            return
+        }
+
+        AppFeedback.shared.commitTactile()
+        WindowTiler.tileWindowById(wid: target.wid, pid: target.pid, to: placement, on: screen)
+        WindowTiler.highlightWindowById(wid: target.wid)
+        DiagnosticLog.shared.success("Filled open \(columns)x\(rows) cell → \(placement.wireValue) (\(source))")
+    }
+
+    private static func bestOpenGridCell(columns: Int, rows: Int, target: WindowEntry, screen: NSScreen) -> PlacementSpec? {
+        let windows = DesktopModel.shared.allWindows().filter { entry in
+            entry.wid != target.wid &&
+            entry.isOnScreen &&
+            entry.app != "Lattices" &&
+            entry.frame.w > 50 &&
+            entry.frame.h > 50 &&
+            WindowTiler.screenForWindowFrame(entry.frame) === screen
+        }
+        let targetRect = rect(for: target.frame)
+        let targetCenter = CGPoint(x: targetRect.midX, y: targetRect.midY)
+
+        var best: (placement: PlacementSpec, occupied: CGFloat, distance: CGFloat, order: Int)?
+        for row in 0..<rows {
+            for column in 0..<columns {
+                guard let grid = GridPlacement(columns: columns, rows: rows, column: column, row: row) else { continue }
+                let placement = PlacementSpec.grid(grid)
+                let cellFrame = WindowTiler.tileFrame(for: placement, on: screen)
+                let occupied = windows.reduce(CGFloat.zero) { total, entry in
+                    total + overlapRatio(rect(for: entry.frame), cellFrame)
+                }
+                let distance = hypot(targetCenter.x - cellFrame.midX, targetCenter.y - cellFrame.midY)
+                let candidate = (placement: placement, occupied: occupied, distance: distance, order: row * columns + column)
+                if let current = best {
+                    if candidate.occupied < current.occupied - 0.01 ||
+                        (abs(candidate.occupied - current.occupied) <= 0.01 && candidate.distance < current.distance - 1) ||
+                        (abs(candidate.occupied - current.occupied) <= 0.01 && abs(candidate.distance - current.distance) <= 1 && candidate.order < current.order) {
+                        best = candidate
+                    }
+                } else {
+                    best = candidate
+                }
+            }
+        }
+        return best?.placement
+    }
+
+    private static func rect(for frame: WindowFrame) -> CGRect {
+        CGRect(x: frame.x, y: frame.y, width: frame.w, height: frame.h)
+    }
+
+    private static func overlapRatio(_ lhs: CGRect, _ rhs: CGRect) -> CGFloat {
+        let intersection = lhs.intersection(rhs)
+        guard !intersection.isNull, rhs.width > 0, rhs.height > 0 else { return 0 }
+        return max(0, intersection.width * intersection.height) / (rhs.width * rhs.height)
+    }
 }
 
 /// Compact 3×3 grid — tap a cell to snap the frontmost window there.

--- a/apps/mac/Sources/AppShell/HotkeyBootstrap.swift
+++ b/apps/mac/Sources/AppShell/HotkeyBootstrap.swift
@@ -11,7 +11,7 @@ enum HotkeyBootstrap {
         store.register(action: .unifiedWindow) { ScreenMapWindowController.shared.toggle() }
         store.register(action: .screenMap) { ScreenMapWindowController.shared.showPage(.screenMap) }
         store.register(action: .bezel) { WorkspaceInspectorPresenter.show() }
-        store.register(action: .cheatSheet) { SettingsWindowController.shared.show() }
+        store.register(action: .cheatSheet) { SettingsWindowController.shared.show(section: "shortcuts") }
         store.register(action: .desktopInventory) {
             DiagnosticLog.shared.info("Hotkey: desktopInventory triggered")
             ScreenMapWindowController.shared.showPage(.desktopInventory)
@@ -91,11 +91,17 @@ enum HotkeyBootstrap {
                 ?? NSWorkspace.shared.frontmostApplication?.localizedName
             CommandModeWindow.shared.show(launchMode: .organize(appName: appName))
         }
+        store.register(action: .tileOpenCell) {
+            FrontWindowPlacer.fillOpenGridCell()
+        }
         store.register(action: .motionMode) {
             WindowMotionMode.shared.toggleHyperspace()
         }
         store.register(action: .inPlaceMode) {
             WindowMotionMode.shared.toggleInPlace()
+        }
+        store.register(action: .chordHints) {
+            InPlaceChordHintOverlay.shared.toggle()
         }
     }
 }

--- a/apps/mac/Sources/AppShell/SettingsView.swift
+++ b/apps/mac/Sources/AppShell/SettingsView.swift
@@ -4055,7 +4055,7 @@ struct SettingsContentView: View {
             VStack(alignment: .leading, spacing: 8) {
                 ForEach([
                     HotkeyAction.tileLeftThird, .tileCenterThird, .tileRightThird,
-                    .tileCenter, .tileMaximize, .tileDistribute, .tileTypeGrid
+                    .tileCenter, .tileMaximize, .tileOpenCell, .tileDistribute, .tileTypeGrid
                 ], id: \.rawValue) { action in
                     compactKeyRecorder(action: action)
                 }

--- a/apps/mac/Sources/Core/Actions/ComputerUseController.swift
+++ b/apps/mac/Sources/Core/Actions/ComputerUseController.swift
@@ -42,6 +42,29 @@ enum ComputerTreatment: String {
     }
 }
 
+private struct ComputerBackgroundSafetyReceipt {
+    let route: String
+    let lane: String
+    let session: String
+    let backgroundSafe: Bool
+    let cursorMoved: Bool
+    let foregroundChanged: Bool
+
+    var json: JSON {
+        .object([
+            "route": .string(route),
+            "lane": .string(lane),
+            "session": .string(session),
+            "background_safe": .bool(backgroundSafe),
+            "backgroundSafe": .bool(backgroundSafe),
+            "cursor_moved": .bool(cursorMoved),
+            "cursorMoved": .bool(cursorMoved),
+            "foreground_changed": .bool(foregroundChanged),
+            "foregroundChanged": .bool(foregroundChanged),
+        ])
+    }
+}
+
 private struct AXTextInsertionResult {
     let role: String
     let roleDescription: String?
@@ -395,6 +418,7 @@ final class ComputerUseController {
         let source = params?["source"]?.stringValue ?? "daemon"
         let treatment = ComputerTreatment.resolve(params: params, defaultValue: .stage)
         let shouldCapture = params?["capture"]?.boolValue ?? true
+        let wantsBackgroundSafe = backgroundSafeRequested(params)
         let snapshotId = try requiredString(params, keys: ["snapshotId", "snapshot-id", "snapshot"])
         let elementId = try requiredString(params, keys: ["elementId", "element-id", "id"])
         let requestedAction = try elementActionName(params)
@@ -420,6 +444,7 @@ final class ComputerUseController {
                     "snapshotId": .string(snapshotId),
                     "elementId": .string(elementId),
                     "requestedAction": .string(requestedAction),
+                    "backgroundSafe": .bool(wantsBackgroundSafe),
                     "wid": .int(Int(snapshot.window.wid)),
                     "app": .string(snapshot.window.app),
                 ]
@@ -436,7 +461,7 @@ final class ComputerUseController {
             var performed = false
             var focused = false
             var axAction: String?
-            if treatment.focusesWindow {
+            if treatment.focusesWindow && !wantsBackgroundSafe {
                 focused = try focus(window: snapshot.window)
                 _ = try RunStore.shared.appendTrace(
                     id: run.id,
@@ -447,6 +472,9 @@ final class ComputerUseController {
             }
 
             if requestedAction == "focus" {
+                if wantsBackgroundSafe && treatment.focusesWindow {
+                    throw RouterError.custom("AX focus is not background-safe; omit backgroundSafe/noFocus to focus the element")
+                }
                 if treatment.focusesWindow {
                     try focusAXElement(element)
                     performed = true
@@ -495,6 +523,7 @@ final class ComputerUseController {
                     "requestedAction": .string(requestedAction),
                     "performed": .bool(performed),
                     "focused": .bool(focused),
+                    "backgroundSafe": .bool(wantsBackgroundSafe),
                 ]
             )
 
@@ -554,6 +583,7 @@ final class ComputerUseController {
         let source = params?["source"]?.stringValue ?? "daemon"
         let treatment = ComputerTreatment.resolve(params: params, defaultValue: .stage)
         let shouldCapture = params?["capture"]?.boolValue ?? true
+        let wantsBackgroundSafe = backgroundSafeRequested(params)
         let append = params?["append"]?.boolValue ?? false
         let typeIntervalMs = axTypeIntervalMs(params: params)
         let snapshotId = try requiredString(params, keys: ["snapshotId", "snapshot-id", "snapshot"])
@@ -582,6 +612,7 @@ final class ComputerUseController {
                     "elementId": .string(elementId),
                     "characters": .int(text.count),
                     "append": .bool(append),
+                    "backgroundSafe": .bool(wantsBackgroundSafe),
                     "wid": .int(Int(snapshot.window.wid)),
                     "app": .string(snapshot.window.app),
                 ]
@@ -597,7 +628,7 @@ final class ComputerUseController {
 
             var focused = false
             var result: AXTextInsertionResult?
-            if treatment.focusesWindow {
+            if treatment.focusesWindow && !wantsBackgroundSafe {
                 focused = try focus(window: snapshot.window)
                 _ = try RunStore.shared.appendTrace(
                     id: run.id,
@@ -647,6 +678,7 @@ final class ComputerUseController {
                     "typed": .bool(result != nil),
                     "focused": .bool(focused),
                     "append": .bool(append),
+                    "backgroundSafe": .bool(wantsBackgroundSafe),
                 ]
             )
 
@@ -1119,7 +1151,7 @@ final class ComputerUseController {
                 ]
             )
 
-            return .object([
+            var object: [String: JSON] = [
                 "ok": .bool(true),
                 "action": .string("showCursor"),
                 "treatment": .string(treatment.rawValue),
@@ -1127,7 +1159,15 @@ final class ComputerUseController {
                 "run": completed.json,
                 "cursor": cursorJSON(point),
                 "appearance": appearance.json,
-            ])
+            ]
+            attachBackgroundSafety(
+                backgroundSafetyReceipt(
+                    route: shouldShow ? "overlay.cursor" : stagedRoute(for: treatment),
+                    backgroundEligible: true
+                ),
+                to: &object
+            )
+            return .object(object)
         } catch {
             _ = try? RunStore.shared.fail(
                 id: run.id,
@@ -1256,6 +1296,16 @@ final class ComputerUseController {
             if let axResult {
                 object["ax"] = axResult.json
             }
+            let route = typedText == nil
+                ? (shouldShow ? "overlay.cursor" : stagedRoute(for: treatment))
+                : "ax.setValue"
+            attachBackgroundSafety(
+                backgroundSafetyReceipt(
+                    route: route,
+                    backgroundEligible: true
+                ),
+                to: &object
+            )
             return .object(object)
         } catch {
             _ = try? RunStore.shared.fail(
@@ -4315,6 +4365,50 @@ final class ComputerUseController {
         return CGRect(origin: point, size: size)
     }
 
+    private func attachBackgroundSafety(
+        _ receipt: ComputerBackgroundSafetyReceipt,
+        to object: inout [String: JSON]
+    ) {
+        object["backgroundSafety"] = receipt.json
+        object["background_safe"] = .bool(receipt.backgroundSafe)
+        object["backgroundSafe"] = .bool(receipt.backgroundSafe)
+        object["route"] = .string(receipt.route)
+        object["lane"] = .string(receipt.lane)
+        object["session"] = .string(receipt.session)
+        object["cursor_moved"] = .bool(receipt.cursorMoved)
+        object["cursorMoved"] = .bool(receipt.cursorMoved)
+        object["foreground_changed"] = .bool(receipt.foregroundChanged)
+        object["foregroundChanged"] = .bool(receipt.foregroundChanged)
+    }
+
+    private func backgroundSafetyReceipt(
+        route: String,
+        cursorMoved: Bool = false,
+        foregroundChanged: Bool = false,
+        backgroundEligible: Bool
+    ) -> ComputerBackgroundSafetyReceipt {
+        ComputerBackgroundSafetyReceipt(
+            route: route,
+            lane: "same_session",
+            session: "parent",
+            backgroundSafe: backgroundEligible && !cursorMoved && !foregroundChanged,
+            cursorMoved: cursorMoved,
+            foregroundChanged: foregroundChanged
+        )
+    }
+
+    private func stagedRoute(for treatment: ComputerTreatment) -> String {
+        treatment == .observe ? "observe" : "stage"
+    }
+
+    private func backgroundSafeRequested(_ params: JSON?) -> Bool {
+        params?["backgroundSafe"]?.boolValue == true
+            || params?["background-safe"]?.boolValue == true
+            || params?["background"]?.boolValue == true
+            || params?["noFocus"]?.boolValue == true
+            || params?["no-focus"]?.boolValue == true
+    }
+
     private func appResponse(
         action: String,
         run: RunSession,
@@ -4342,6 +4436,38 @@ final class ComputerUseController {
         if let after { object["afterArtifact"] = after }
         if let typedText { object["typedText"] = .string(typedText) }
         if let clicked { object["clicked"] = .bool(clicked) }
+        let route: String
+        let cursorMoved = clicked == true && treatment.performsPointerAction
+        let foregroundChanged = launched || focused
+        let backgroundEligible: Bool
+        if treatment == .observe || treatment == .stage {
+            route = stagedRoute(for: treatment)
+            backgroundEligible = true
+        } else if launched {
+            route = "app.launch"
+            backgroundEligible = false
+        } else if cursorMoved {
+            route = "pointer.click"
+            backgroundEligible = false
+        } else if typedText != nil && treatment.insertsText {
+            route = "keyboard.typeText"
+            backgroundEligible = false
+        } else if focused {
+            route = "window.focus"
+            backgroundEligible = false
+        } else {
+            route = "app.\(action)"
+            backgroundEligible = false
+        }
+        attachBackgroundSafety(
+            backgroundSafetyReceipt(
+                route: route,
+                cursorMoved: cursorMoved,
+                foregroundChanged: foregroundChanged,
+                backgroundEligible: backgroundEligible
+            ),
+            to: &object
+        )
         return .object(object)
     }
 
@@ -4376,6 +4502,19 @@ final class ComputerUseController {
         if let before { object["beforeArtifact"] = before }
         if let after { object["afterArtifact"] = after }
         if let axResult { object["ax"] = axResult.json }
+        let isStaged = !clicked || treatment == .observe || treatment == .stage
+        let route = isStaged
+            ? stagedRoute(for: treatment)
+            : (transport == "ax" ? "ax.press" : "pointer.click")
+        attachBackgroundSafety(
+            backgroundSafetyReceipt(
+                route: route,
+                cursorMoved: clicked && transport == "pointer",
+                foregroundChanged: focused,
+                backgroundEligible: isStaged || transport == "ax"
+            ),
+            to: &object
+        )
         return .object(object)
     }
 
@@ -4415,6 +4554,16 @@ final class ComputerUseController {
         if let delta { object["delta"] = scrollJSON(delta) }
         if let button { object["button"] = .string(normalizedMouseButton(button)) }
         if let count { object["count"] = .int(count) }
+        let isStaged = !performed || treatment == .observe || treatment == .stage
+        attachBackgroundSafety(
+            backgroundSafetyReceipt(
+                route: isStaged ? stagedRoute(for: treatment) : "pointer.\(action)",
+                cursorMoved: performed && transport == "pointer",
+                foregroundChanged: focused,
+                backgroundEligible: isStaged
+            ),
+            to: &object
+        )
         return .object(object)
     }
 
@@ -4451,6 +4600,18 @@ final class ComputerUseController {
         if let target { object["target"] = Encoders.window(target) }
         if let before { object["beforeArtifact"] = before }
         if let after { object["afterArtifact"] = after }
+        let isStaged = !sent || treatment == .observe || treatment == .stage
+        let route = isStaged
+            ? stagedRoute(for: treatment)
+            : (global ? "keyboard.global" : "keyboard.target")
+        attachBackgroundSafety(
+            backgroundSafetyReceipt(
+                route: route,
+                foregroundChanged: focused,
+                backgroundEligible: isStaged
+            ),
+            to: &object
+        )
         return .object(object)
     }
 
@@ -4482,6 +4643,15 @@ final class ComputerUseController {
         if let axAction { object["axAction"] = .string(axAction) }
         if let before { object["beforeArtifact"] = before }
         if let after { object["afterArtifact"] = after }
+        let isStaged = !performed || treatment == .observe || treatment == .stage
+        attachBackgroundSafety(
+            backgroundSafetyReceipt(
+                route: isStaged ? stagedRoute(for: treatment) : "ax.\(axAction ?? requestedAction)",
+                foregroundChanged: focused,
+                backgroundEligible: true
+            ),
+            to: &object
+        )
         return .object(object)
     }
 
@@ -4518,6 +4688,16 @@ final class ComputerUseController {
         }
         if let before { object["beforeArtifact"] = before }
         if let after { object["afterArtifact"] = after }
+        let typed = result != nil
+        let isStaged = !typed || treatment == .observe || treatment == .stage
+        attachBackgroundSafety(
+            backgroundSafetyReceipt(
+                route: isStaged ? stagedRoute(for: treatment) : "ax.setValue",
+                foregroundChanged: focused,
+                backgroundEligible: true
+            ),
+            to: &object
+        )
         return .object(object)
     }
 
@@ -4680,6 +4860,14 @@ final class ComputerUseController {
         ]
         if let before { object["beforeArtifact"] = before["artifact"] ?? before }
         if let after { object["afterArtifact"] = after["artifact"] ?? after }
+        attachBackgroundSafety(
+            backgroundSafetyReceipt(
+                route: focused ? "window.focus" : stagedRoute(for: treatment),
+                foregroundChanged: focused,
+                backgroundEligible: !focused
+            ),
+            to: &object
+        )
         return .object(object)
     }
 
@@ -4711,6 +4899,26 @@ final class ComputerUseController {
         }
         if let before { object["beforeArtifact"] = before }
         if let after { object["afterArtifact"] = after }
+        let route: String
+        let backgroundEligible: Bool
+        if !treatment.insertsText {
+            route = stagedRoute(for: treatment)
+            backgroundEligible = true
+        } else if let transport {
+            route = "terminal.\(transport)"
+            backgroundEligible = transport == "tmux" || transport == "iterm-session"
+        } else {
+            route = "terminal.focused"
+            backgroundEligible = false
+        }
+        attachBackgroundSafety(
+            backgroundSafetyReceipt(
+                route: route,
+                foregroundChanged: treatment.focusesWindow && !backgroundEligible,
+                backgroundEligible: backgroundEligible
+            ),
+            to: &object
+        )
         return .object(object)
     }
 

--- a/apps/mac/Sources/Core/Actions/HotkeyStore.swift
+++ b/apps/mac/Sources/Core/Actions/HotkeyStore.swift
@@ -38,8 +38,10 @@ enum HotkeyAction: String, CaseIterable, Codable {
     case tileTopLeft, tileTopRight, tileBottomLeft, tileBottomRight
     case tileTop, tileBottom, tileDistribute, tileTypeGrid, tileOrganize
     case tileLeftThird, tileCenterThird, tileRightThird
+    case tileOpenCell
     case motionMode
     case inPlaceMode
+    case chordHints
 
     var label: String {
         switch self {
@@ -87,14 +89,16 @@ enum HotkeyAction: String, CaseIterable, Codable {
         case .tileLeftThird:   return "Left Third"
         case .tileCenterThird: return "Center Third"
         case .tileRightThird:  return "Right Third"
+        case .tileOpenCell:    return "Fill Open Cell"
         case .motionMode:      return "Hyperspace"
         case .inPlaceMode:     return "In-Place Tools"
+        case .chordHints:      return "Window Nav Hints"
         }
     }
 
     var group: HotkeyGroup {
         switch self {
-        case .palette, .screenMap, .bezel, .cheatSheet, .desktopInventory, .omniSearch, .voiceCommand, .handsOff, .unifiedWindow, .hud, .mouseFinder, .overlayActors, .workspaceAssistant, .activityLog, .gridPlacement, .commandBar, .inPlaceMode: return .app
+        case .palette, .screenMap, .bezel, .cheatSheet, .desktopInventory, .omniSearch, .voiceCommand, .handsOff, .unifiedWindow, .hud, .mouseFinder, .overlayActors, .workspaceAssistant, .activityLog, .gridPlacement, .commandBar, .inPlaceMode, .chordHints: return .app
         case .layer1, .layer2, .layer3, .layer4, .layer5,
              .layer6, .layer7, .layer8, .layer9,
              .layerNext, .layerPrev, .layerTag: return .layers
@@ -150,6 +154,8 @@ enum HotkeyAction: String, CaseIterable, Codable {
         case .tileOrganize:    return 315
         case .motionMode:      return 316
         case .inPlaceMode:     return 317
+        case .tileOpenCell:    return 318
+        case .chordHints:      return 319
         }
     }
 
@@ -316,8 +322,10 @@ class HotkeyStore: ObservableObject {
         bind(.tileCenterThird,  19, ctrlOpt)  // Ctrl+Opt+2
         bind(.tileRightThird,   20, ctrlOpt)  // Ctrl+Opt+3
         bind(.tileOrganize,     31, ctrlOpt)  // Ctrl+Opt+O
+        bind(.tileOpenCell,      9, ctrlOpt)  // Ctrl+Opt+V
         bind(.motionMode,       49, hyper)    // Hyper+Space — Hyperspace (full survey)
         bind(.inPlaceMode,       5, hyper)    // Hyper+G — in-place window tools
+        bind(.chordHints,        4, hyper)    // Hyper+H — jump-letter badges on windows
 
         return d
     }()

--- a/apps/mac/Sources/Core/Daemon/DaemonServer.swift
+++ b/apps/mac/Sources/Core/Daemon/DaemonServer.swift
@@ -15,6 +15,11 @@ final class DaemonServer: ObservableObject {
     private var clients: [UUID: WebSocketClient] = [:]
     private let lock = NSLock()
     private let queue = DispatchQueue(label: "lattices.daemon", qos: .userInitiated)
+    private let blockingRequestQueue = DispatchQueue(
+        label: "lattices.daemon.blocking-requests",
+        qos: .userInitiated,
+        attributes: .concurrent
+    )
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
     private var acceptSource: DispatchSourceRead?
@@ -325,8 +330,28 @@ final class DaemonServer: ObservableObject {
             return
         }
 
+        // Interactive window picking can wait for user input for up to five
+        // minutes. Keep that wait off the daemon's serial socket queue so other
+        // clients, events, handshakes, and RPCs continue flowing.
+        if request.method == "window.pick.start" {
+            blockingRequestQueue.async { [weak self] in
+                let response = LatticesApi.shared.handle(request)
+                self?.queue.async { [weak self] in
+                    guard let self, self.isConnected(client) else { return }
+                    self.sendResponse(response, to: client)
+                }
+            }
+            return
+        }
+
         let response = LatticesApi.shared.handle(request)
         sendResponse(response, to: client)
+    }
+
+    private func isConnected(_ client: WebSocketClient) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return clients[client.id] === client
     }
 
     private func sendResponse(_ response: DaemonResponse, to client: WebSocketClient) {

--- a/apps/mac/Sources/Core/Daemon/LatticesApi.swift
+++ b/apps/mac/Sources/Core/Daemon/LatticesApi.swift
@@ -161,6 +161,24 @@ final class LatticesApi {
             Field(name: "latticesSession", type: "string", required: false, description: "Associated lattices session name"),
         ]))
 
+        api.model(ApiModel(name: "WindowPreview", fields: [
+            Field(name: "ok", type: "bool", required: true, description: "Whether preview image data is included"),
+            Field(name: "wid", type: "int", required: true, description: "CGWindowID"),
+            Field(name: "cached", type: "bool", required: true, description: "Whether the image came from the warm preview cache"),
+            Field(name: "loading", type: "bool", required: true, description: "Whether Lattices is currently warming this preview"),
+            Field(name: "mimeType", type: "string", required: false, description: "Image MIME type when data is present"),
+            Field(name: "base64", type: "string", required: false, description: "Base64-encoded PNG preview"),
+            Field(name: "width", type: "int", required: false, description: "Preview pixel width"),
+            Field(name: "height", type: "int", required: false, description: "Preview pixel height"),
+        ]))
+
+        api.model(ApiModel(name: "WindowPickResult", fields: [
+            Field(name: "ok", type: "bool", required: true, description: "Whether a window was selected"),
+            Field(name: "status", type: "string", required: true, description: "selected, cancelled, timeout, or unavailable"),
+            Field(name: "window", type: "Window", required: false, description: "Selected window when status is selected"),
+            Field(name: "error", type: "string", required: false, description: "Error detail when unavailable"),
+        ]))
+
         api.model(ApiModel(name: "TmuxSession", fields: [
             Field(name: "name", type: "string", required: true, description: "Session name"),
             Field(name: "windowCount", type: "int", required: true, description: "Number of tmux windows"),
@@ -427,6 +445,20 @@ final class LatticesApi {
                     throw RouterError.notFound("window \(wid)")
                 }
                 return Encoders.window(entry)
+            }
+        ))
+
+        api.register(Endpoint(
+            method: "windows.preview",
+            description: "Return a cached Lattices window preview image, optionally triggering cache warmup.",
+            access: .read,
+            params: [
+                Param(name: "wid", type: "uint32", required: true, description: "Window ID"),
+                Param(name: "load", type: "bool", required: false, description: "Trigger preview warmup when missing (default true)"),
+            ],
+            returns: .object(model: "WindowPreview"),
+            handler: { params in
+                try Self.windowPreview(params)
             }
         ))
 
@@ -2442,6 +2474,25 @@ final class LatticesApi {
         ))
 
         api.register(Endpoint(
+            method: "window.pick.start",
+            description: "Open Lattices Hyperspace in read-only single-window grab mode and return the selected window",
+            access: .read,
+            params: [
+                Param(name: "client", type: "string", required: false, description: "Calling client, e.g. scope"),
+                Param(name: "requestId", type: "string", required: false, description: "Client-provided correlation id"),
+                Param(name: "prompt", type: "string", required: false, description: "User-visible prompt for the grab"),
+                Param(name: "mode", type: "string", required: false, description: "single-window (default)"),
+                Param(name: "allowOffscreen", type: "bool", required: false, description: "Reserved; current implementation selects onscreen windows"),
+                Param(name: "currentWid", type: "uint32", required: false, description: "Currently bound window to preselect when visible"),
+                Param(name: "timeoutMs", type: "int", required: false, description: "How long to wait for user selection, default 120000"),
+            ],
+            returns: .object(model: "WindowPickResult"),
+            handler: { params in
+                try Self.windowPickStart(params)
+            }
+        ))
+
+        api.register(Endpoint(
             method: "window.move",
             description: "Move a session's window to a different space",
             access: .mutate,
@@ -4047,6 +4098,117 @@ private extension LatticesApi {
             return nil
         }
         return (UInt32(wid), app.processIdentifier)
+    }
+
+    static func windowPreview(_ params: JSON?) throws -> JSON {
+        guard let wid = params?["wid"]?.uint32Value else {
+            throw RouterError.missingParam("wid")
+        }
+        let shouldLoad = params?["load"]?.boolValue ?? true
+        guard let entry = DesktopModel.shared.windows[wid] else {
+            throw RouterError.notFound("window \(wid)")
+        }
+
+        return syncOnMain {
+            let store = WindowPreviewStore.shared
+            if let image = store.image(for: wid),
+               let preview = pngPreviewPayload(image: image) {
+                return .object([
+                    "ok": .bool(true),
+                    "wid": .int(Int(wid)),
+                    "cached": .bool(true),
+                    "loading": .bool(false),
+                    "mimeType": .string("image/png"),
+                    "base64": .string(preview.base64),
+                    "width": .int(preview.width),
+                    "height": .int(preview.height),
+                ])
+            }
+
+            if shouldLoad {
+                store.load(window: entry)
+            }
+
+            return .object([
+                "ok": .bool(false),
+                "wid": .int(Int(wid)),
+                "cached": .bool(false),
+                "loading": .bool(store.isLoading(wid)),
+            ])
+        }
+    }
+
+    static func pngPreviewPayload(image: NSImage) -> (base64: String, width: Int, height: Int)? {
+        guard let tiff = image.tiffRepresentation,
+              let rep = NSBitmapImageRep(data: tiff),
+              let png = rep.representation(using: .png, properties: [:]) else {
+            return nil
+        }
+        return (png.base64EncodedString(), rep.pixelsWide, rep.pixelsHigh)
+    }
+
+    static func windowPickStart(_ params: JSON?) throws -> JSON {
+        let mode = params?["mode"]?.stringValue ?? "single-window"
+        guard mode == "single-window" else {
+            throw RouterError.custom("Unsupported window pick mode: \(mode)")
+        }
+        let prompt = params?["prompt"]?.stringValue
+        let currentWid = params?["currentWid"]?.uint32Value
+        let timeoutMs = max(5_000, min(params?["timeoutMs"]?.intValue ?? 120_000, 300_000))
+
+        let semaphore = DispatchSemaphore(value: 0)
+        let lock = NSLock()
+        var outcome: WindowMotionMode.PickOutcome?
+
+        WindowMotionMode.shared.startWindowPick(prompt: prompt, currentWid: currentWid) { result in
+            lock.lock()
+            outcome = result
+            lock.unlock()
+            semaphore.signal()
+        }
+
+        let timeout = DispatchTime.now() + .milliseconds(timeoutMs)
+        guard semaphore.wait(timeout: timeout) == .success else {
+            DispatchQueue.main.async {
+                WindowMotionMode.shared.deactivate()
+            }
+            return .object([
+                "ok": .bool(false),
+                "status": .string("timeout"),
+                "error": .string("window pick timed out"),
+            ])
+        }
+
+        lock.lock()
+        let result = outcome
+        lock.unlock()
+
+        guard let result else {
+            return .object([
+                "ok": .bool(false),
+                "status": .string("unavailable"),
+                "error": .string("window pick returned no result"),
+            ])
+        }
+
+        var response: [String: JSON] = [
+            "ok": .bool(result.status == "selected"),
+            "status": .string(result.status),
+        ]
+        if let window = result.window {
+            response["window"] = Encoders.window(window)
+        }
+        if let error = result.error {
+            response["error"] = .string(error)
+        }
+        return .object(response)
+    }
+
+    static func syncOnMain<T>(_ work: () throws -> T) rethrows -> T {
+        if Thread.isMainThread {
+            return try work()
+        }
+        return try DispatchQueue.main.sync(execute: work)
     }
 
     static func windowEntry(forSession session: String) -> WindowEntry? {

--- a/apps/mac/Sources/Core/Desktop/WindowTiler.swift
+++ b/apps/mac/Sources/Core/Desktop/WindowTiler.swift
@@ -1727,6 +1727,96 @@ enum WindowTiler {
         diag.success("batchMoveWindows: moved \(moved)/\(moves.count) windows")
     }
 
+    /// Move windows one at a time so the UI can show placement progress. AX targets are
+    /// resolved off the main thread; each step is separated by a short yield.
+    static func batchMoveWindowsProgressive(
+        moves: [(wid: UInt32, pid: Int32, frame: CGRect)],
+        stepDelay: TimeInterval = 0.028,
+        onReady: (() -> Void)? = nil,
+        onStep: @escaping (_ index: Int, _ wid: UInt32) -> Void,
+        onComplete: @escaping (_ moved: Int, _ failed: Int) -> Void
+    ) {
+        guard !moves.isEmpty else {
+            onComplete(0, 0)
+            return
+        }
+
+        let diag = DiagnosticLog.shared
+        let queue = DispatchQueue(label: "dev.lattices.app.window-move-progressive", qos: .userInitiated)
+
+        queue.async {
+            let resolved = resolveBatchMoveTargets(moves)
+            diag.info("batchMoveWindowsProgressive: \(resolved.count) windows")
+
+            func runStep(_ index: Int, moved: Int, failed: Int) {
+                guard index < resolved.count else {
+                    diag.success("batchMoveWindowsProgressive: moved \(moved)/\(resolved.count) windows")
+                    DispatchQueue.main.async {
+                        onComplete(moved, failed)
+                    }
+                    return
+                }
+
+                let item = resolved[index]
+                DispatchQueue.main.async {
+                    onStep(index, item.wid)
+                }
+
+                if let axWin = item.axWindow {
+                    applyFrameToAXWindow(axWin, wid: item.wid, target: item.frame)
+                }
+
+                let nextMoved = moved + (item.axWindow != nil ? 1 : 0)
+                let nextFailed = failed + (item.axWindow == nil ? 1 : 0)
+                queue.asyncAfter(deadline: .now() + stepDelay) {
+                    runStep(index + 1, moved: nextMoved, failed: nextFailed)
+                }
+            }
+
+            DispatchQueue.main.async {
+                onReady?()
+            }
+            runStep(0, moved: 0, failed: 0)
+        }
+    }
+
+    private struct ProgressiveBatchTarget {
+        let wid: UInt32
+        let pid: Int32
+        let frame: CGRect
+        let axWindow: AXUIElement?
+    }
+
+    private static func resolveBatchMoveTargets(
+        _ moves: [(wid: UInt32, pid: Int32, frame: CGRect)]
+    ) -> [ProgressiveBatchTarget] {
+        var byPid: Set<Int32> = []
+        for move in moves { byPid.insert(move.pid) }
+
+        var axByWid: [UInt32: AXUIElement] = [:]
+        for pid in byPid {
+            let appRef = AXUIElementCreateApplication(pid)
+            var windowsRef: CFTypeRef?
+            let err = AXUIElementCopyAttributeValue(appRef, kAXWindowsAttribute as CFString, &windowsRef)
+            guard err == .success, let axWindows = windowsRef as? [AXUIElement] else { continue }
+            for axWin in axWindows {
+                var windowId: CGWindowID = 0
+                if _AXUIElementGetWindow(axWin, &windowId) == .success {
+                    axByWid[windowId] = axWin
+                }
+            }
+        }
+
+        return moves.map {
+            ProgressiveBatchTarget(
+                wid: $0.wid,
+                pid: $0.pid,
+                frame: $0.frame,
+                axWindow: axByWid[$0.wid]
+            )
+        }
+    }
+
     /// Apply position+size to a single AX window. No delays, no retries — just set and go.
     private static func applyFrameToAXWindow(_ axWin: AXUIElement, wid: UInt32, target: CGRect) {
         var newPos = CGPoint(x: target.origin.x, y: target.origin.y)

--- a/apps/mac/Sources/Core/Overlays/HUD/CheatSheetHUD.swift
+++ b/apps/mac/Sources/Core/Overlays/HUD/CheatSheetHUD.swift
@@ -253,6 +253,7 @@ struct CheatSheetView: View {
 
             // Center + Distribute
             shortcutRow(action: .tileCenter)
+            shortcutRow(action: .tileOpenCell)
             shortcutRow(action: .tileDistribute)
             shortcutRow(action: .tileTypeGrid)
             shortcutRow(action: .tileOrganize)
@@ -375,6 +376,7 @@ struct CheatSheetView: View {
             columnHeader("Workspace")
             shortcutRow(action: .motionMode)
             shortcutRow(action: .inPlaceMode)
+            shortcutRow(action: .chordHints)
             shortcutRow(action: .desktopInventory)
         }
     }

--- a/apps/mac/Sources/Core/Overlays/Motion/InPlaceChordHints.swift
+++ b/apps/mac/Sources/Core/Overlays/Motion/InPlaceChordHints.swift
@@ -1,0 +1,334 @@
+import AppKit
+import SwiftUI
+
+// MARK: - Hint assignment
+
+/// Home-row jump letters for the nav-hint overlay (reading order on screen).
+enum InPlaceWindowHintAssigner {
+    static let reservedKeys: Set<Character> = ["e", "g"]
+    private static let alphabet: [String] = Array("asdfghjklqwertyuiopzxcvbnm")
+        .filter { !reservedKeys.contains($0) }
+        .map(String.init)
+
+    /// Assign one letter per window in display reading order (top→bottom, left→right).
+    static func assign(windows: [WindowEntry]) -> [UInt32: String] {
+        let ordered = windows
+            .filter(\.isOnScreen)
+            .sorted { a, b in
+                if a.frame.y != b.frame.y { return a.frame.y < b.frame.y }
+                return a.frame.x < b.frame.x
+            }
+        var map: [UInt32: String] = [:]
+        for (index, window) in ordered.enumerated() where index < alphabet.count {
+            map[window.wid] = alphabet[index]
+        }
+        return map
+    }
+
+    static func reverse(_ hints: [UInt32: String]) -> [String: UInt32] {
+        var map: [String: UInt32] = [:]
+        for (wid, letter) in hints { map[letter] = wid }
+        return map
+    }
+}
+
+// MARK: - Badge
+
+/// Top-right jump letter — same chrome as the HUD badges, no modifier prefix.
+struct WindowNavHintBadge: View {
+    let letter: String
+
+    static let glowMargin: CGFloat = 7
+
+    var body: some View {
+        Text(letter.uppercased())
+            .font(.system(size: 13, weight: .bold, design: .monospaced))
+            .foregroundColor(HUDChrome.cyan)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 4)
+            .background(
+                RoundedRectangle(cornerRadius: 7, style: .continuous)
+                    .fill(
+                        LinearGradient(
+                            colors: [HUDChrome.baseTop, HUDChrome.baseBottom],
+                            startPoint: .top, endPoint: .bottom
+                        )
+                    )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 7, style: .continuous)
+                    .strokeBorder(HUDChrome.cyan.opacity(0.55), lineWidth: 1)
+            )
+            .shadow(color: HUDChrome.cyan.opacity(0.30), radius: 6, y: 1)
+            .shadow(color: Color.black.opacity(0.45), radius: 5, y: 2)
+            .padding(Self.glowMargin)
+            .fixedSize()
+    }
+}
+
+// MARK: - Overlay controller
+
+/// Toggle with Hyper+H: every visible window wears a jump letter. Press the letter
+/// to focus that window; Esc or click dismisses. Does not enter in-place or Hyperspace.
+final class InPlaceChordHintOverlay {
+    static let shared = InPlaceChordHintOverlay()
+
+    private struct Bezel {
+        let panel: NSPanel
+        let hosting: NSHostingView<WindowNavHintBadge>
+    }
+
+    private static let cornerGap: CGFloat = 3
+
+    private var bezels: [UInt32: Bezel] = [:]
+    private var hints: [UInt32: String] = [:]
+    private var hintMap: [String: UInt32] = [:]
+    private var hiddenWids: Set<UInt32> = []
+    private var keyEventTap: CFMachPort?
+    private var keyRunLoopSource: CFRunLoopSource?
+    private var clickMonitor: Any?
+    private var pollTimer: Timer?
+
+    private(set) var isVisible = false
+
+    func toggle() {
+        if isVisible { dismiss() } else { show() }
+    }
+
+    func show() {
+        DesktopModel.shared.forcePoll()
+        isVisible = true
+        refreshHints()
+        guard installMonitors() else {
+            DiagnosticLog.shared.warn("Window nav hints: unable to capture navigation keys")
+            NSSound.beep()
+            dismiss()
+            return
+        }
+        startPolling()
+        applyVisibility()
+    }
+
+    func dismiss() {
+        isVisible = false
+        removeMonitors()
+        pollTimer?.invalidate()
+        pollTimer = nil
+        for bezel in bezels.values { bezel.panel.orderOut(nil) }
+        bezels.removeAll()
+        hiddenWids.removeAll()
+        hints.removeAll()
+        hintMap.removeAll()
+    }
+
+    // MARK: - Direct access
+
+    private func jump(to letter: String) {
+        guard let wid = hintMap[letter.lowercased()],
+              let window = DesktopModel.shared.windows[wid] else { NSSound.beep(); return }
+        dismiss()
+        _ = WindowTiler.focusWindow(wid: window.wid, pid: window.pid)
+        let primaryHeight = NSScreen.screens.first?.frame.height ?? 900
+        let frame = appKitRect(for: window.frame, primaryHeight: primaryHeight)
+        WindowHighlight.shared.flash(frame: frame)
+    }
+
+    // MARK: - Layout
+
+    private func refreshHints() {
+        let myPid = ProcessInfo.processInfo.processIdentifier
+        let eligible = DesktopModel.shared.allWindows()
+            .filter { $0.pid != myPid && $0.isOnScreen && !$0.title.isEmpty }
+        hints = InPlaceWindowHintAssigner.assign(windows: eligible)
+        hintMap = InPlaceWindowHintAssigner.reverse(hints)
+        updateBezels()
+    }
+
+    private func updateBezels() {
+        let windows = DesktopModel.shared.windows
+        let primaryHeight = NSScreen.screens.first?.frame.height ?? 900
+        let screenFrames = NSScreen.screens.map(\.frame)
+        let allWindows = Array(windows.values)
+
+        for wid in Array(bezels.keys) where hints[wid] == nil { drop(wid) }
+
+        var nextHidden: Set<UInt32> = []
+        for (wid, letter) in hints {
+            guard let window = windows[wid], window.isOnScreen else { drop(wid); continue }
+            let frame = appKitRect(for: window.frame, primaryHeight: primaryHeight)
+            guard screenFrames.contains(where: { $0.intersects(frame) }) else { drop(wid); continue }
+
+            let bezel = bezels[wid] ?? makeBezel()
+            bezel.hosting.rootView = WindowNavHintBadge(letter: letter)
+            let size = bezel.hosting.fittingSize
+            bezel.panel.setContentSize(size)
+
+            let originX = frame.maxX - Self.cornerGap - size.width
+            let originY = frame.maxY - Self.cornerGap - size.height
+            bezel.panel.setFrameOrigin(NSPoint(x: originX, y: originY))
+            bezels[wid] = bezel
+
+            let centerAppKit = NSPoint(x: originX + size.width / 2, y: originY + size.height / 2)
+            let centerCG = CGPoint(x: centerAppKit.x, y: primaryHeight - centerAppKit.y)
+            let occluded = allWindows.contains { other in
+                other.wid != wid && other.isOnScreen && other.zIndex < window.zIndex &&
+                cgRect(other.frame).contains(centerCG)
+            }
+            if occluded { nextHidden.insert(wid) }
+        }
+
+        hiddenWids = nextHidden
+        if isVisible { applyVisibility() }
+    }
+
+    private func applyVisibility() {
+        for (wid, bezel) in bezels {
+            let shouldShow = isVisible && !hiddenWids.contains(wid)
+            bezel.panel.alphaValue = shouldShow ? 1 : 0
+            if shouldShow { bezel.panel.orderFrontRegardless() }
+        }
+    }
+
+    private func drop(_ wid: UInt32) {
+        bezels[wid]?.panel.orderOut(nil)
+        bezels.removeValue(forKey: wid)
+    }
+
+    private func makeBezel() -> Bezel {
+        let hosting = NSHostingView(rootView: WindowNavHintBadge(letter: ""))
+        hosting.sizingOptions = []
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 64, height: 36),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.level = .floating
+        panel.hasShadow = false
+        panel.hidesOnDeactivate = false
+        panel.isReleasedWhenClosed = false
+        panel.ignoresMouseEvents = true
+        panel.alphaValue = 0
+        panel.sharingType = .readOnly
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+        panel.contentView = hosting
+        return Bezel(panel: panel, hosting: hosting)
+    }
+
+    // MARK: - Monitors
+
+    private func installMonitors() -> Bool {
+        guard installKeyEventTap() else { return false }
+        clickMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] _ in
+            self?.dismiss()
+        }
+        return true
+    }
+
+    private func removeMonitors() {
+        if let source = keyRunLoopSource {
+            EventTapThread.shared.remove(source: source)
+        }
+        keyRunLoopSource = nil
+        if let tap = keyEventTap {
+            CFMachPortInvalidate(tap)
+        }
+        keyEventTap = nil
+        if let m = clickMonitor { NSEvent.removeMonitor(m); clickMonitor = nil }
+    }
+
+    /// A global NSEvent monitor can observe a hint letter but cannot consume it,
+    /// which would also type that letter into the foreground app. A short-lived
+    /// session event tap makes the hint overlay a true keyboard mode: handled
+    /// letters and Escape are swallowed, while unrelated shortcuts pass through.
+    private func installKeyEventTap() -> Bool {
+        var mask = CGEventMask(0)
+        mask |= CGEventMask(1) << CGEventType.keyDown.rawValue
+        mask |= CGEventMask(1) << CGEventType.keyUp.rawValue
+
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: mask,
+            callback: Self.keyEventTapCallback,
+            userInfo: UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
+        ) else {
+            return false
+        }
+
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        keyEventTap = tap
+        keyRunLoopSource = source
+        if let source {
+            EventTapThread.shared.add(source: source)
+        }
+        CGEvent.tapEnable(tap: tap, enable: true)
+        return true
+    }
+
+    private static let keyEventTapCallback: CGEventTapCallBack = { _, type, event, userInfo in
+        guard let userInfo else { return Unmanaged.passUnretained(event) }
+        let overlay = Unmanaged<InPlaceChordHintOverlay>.fromOpaque(userInfo).takeUnretainedValue()
+        return overlay.handleKeyEvent(type: type, event: event)
+    }
+
+    private func handleKeyEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            if let keyEventTap { CGEvent.tapEnable(tap: keyEventTap, enable: true) }
+            return Unmanaged.passUnretained(event)
+        }
+        guard isVisible, type == .keyDown || type == .keyUp,
+              let nsEvent = NSEvent(cgEvent: event) else {
+            return Unmanaged.passUnretained(event)
+        }
+
+        let flags = nsEvent.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        guard flags.isEmpty || flags == .capsLock else {
+            return Unmanaged.passUnretained(event)
+        }
+
+        if nsEvent.keyCode == 53 {
+            if type == .keyDown {
+                DispatchQueue.main.async { [weak self] in self?.dismiss() }
+            }
+            return nil
+        }
+
+        guard let key = nsEvent.charactersIgnoringModifiers?.lowercased(),
+              key.count == 1,
+              key.first?.isLetter == true else {
+            return Unmanaged.passUnretained(event)
+        }
+        if type == .keyDown {
+            DispatchQueue.main.async { [weak self] in self?.jump(to: key) }
+        }
+        return nil
+    }
+
+    private func startPolling() {
+        pollTimer?.invalidate()
+        pollTimer = Timer.scheduledTimer(withTimeInterval: 0.35, repeats: true) { [weak self] _ in
+            guard let self, self.isVisible else { return }
+            DesktopModel.shared.poll()
+            self.updateBezels()
+        }
+    }
+
+    // MARK: - Geometry
+
+    private func cgRect(_ frame: WindowFrame) -> CGRect {
+        CGRect(x: frame.x, y: frame.y, width: frame.w, height: frame.h)
+    }
+
+    private func appKitRect(for frame: WindowFrame, primaryHeight: CGFloat) -> NSRect {
+        NSRect(
+            x: frame.x,
+            y: primaryHeight - frame.y - frame.h,
+            width: frame.w,
+            height: frame.h
+        )
+    }
+}

--- a/apps/mac/Sources/Core/Overlays/Motion/WindowMotionMode.swift
+++ b/apps/mac/Sources/Core/Overlays/Motion/WindowMotionMode.swift
@@ -14,14 +14,60 @@ final class WindowMotionMode {
 
     enum Entry { case hyperspace, inPlace }
 
+    struct PickOutcome {
+        let status: String
+        let window: WindowEntry?
+        let error: String?
+
+        static func selected(_ window: WindowEntry) -> PickOutcome {
+            PickOutcome(status: "selected", window: window, error: nil)
+        }
+
+        static func cancelled() -> PickOutcome {
+            PickOutcome(status: "cancelled", window: nil, error: nil)
+        }
+
+        static func unavailable(_ error: String) -> PickOutcome {
+            PickOutcome(status: "unavailable", window: nil, error: error)
+        }
+    }
+
     private var panel: MotionPanel?
     private var activeEntry: Entry?
     private var lastToggle: CFTimeInterval = 0
+    private var pickCompletion: ((PickOutcome) -> Void)?
+    private var pickCompleted = false
 
     var isActive: Bool { panel != nil }
 
     func toggleHyperspace() { toggle(entry: .hyperspace) }
     func toggleInPlace() { toggle(entry: .inPlace) }
+
+    func startWindowPick(prompt: String? = nil,
+                         currentWid: UInt32? = nil,
+                         completion: @escaping (PickOutcome) -> Void) {
+        DispatchQueue.main.async {
+            guard self.pickCompletion == nil else {
+                completion(.unavailable("window pick already active"))
+                return
+            }
+            if self.isActive { self.deactivate() }
+            self.pickCompletion = completion
+            self.pickCompleted = false
+            self.activate(entry: .hyperspace,
+                          selectionPrompt: prompt,
+                          selectionCurrentWid: currentWid)
+        }
+    }
+
+    private var isPickingWindow: Bool { pickCompletion != nil }
+
+    private func finishWindowPick(_ outcome: PickOutcome) {
+        guard let completion = pickCompletion, !pickCompleted else { return }
+        pickCompleted = true
+        pickCompletion = nil
+        completion(outcome)
+    }
 
     private func toggle(entry: Entry) {
         // Debounce machine-gun re-fire. The Hyper trigger rides the Caps Lock
@@ -39,7 +85,9 @@ final class WindowMotionMode {
         }
     }
 
-    private func activate(entry: Entry = .hyperspace) {
+    private func activate(entry: Entry = .hyperspace,
+                          selectionPrompt: String? = nil,
+                          selectionCurrentWid: UInt32? = nil) {
         guard panel == nil else { return }
         // Defensive: clear any overlay panels orphaned by a prior race before we
         // open a fresh one, so we never stack a new survey on top of a stuck one.
@@ -50,21 +98,34 @@ final class WindowMotionMode {
         // Eligible = real app windows (never our own), frontmost first.
         let myPid = ProcessInfo.processInfo.processIdentifier
         let eligible = DesktopModel.shared.allWindows()
-            .filter { $0.pid != myPid && $0.isOnScreen && !$0.title.isEmpty }
+            .filter { $0.pid != myPid && $0.isOnScreen && (isPickingWindow || !$0.title.isEmpty) }
             .sorted { $0.zIndex < $1.zIndex }
         guard !eligible.isEmpty else {
             DiagnosticLog.shared.warn("MotionMode: no eligible app window to act on")
             NSSound.beep()
+            if isPickingWindow { finishWindowPick(.unavailable("no eligible app window to pick")) }
             return
         }
         let tEligible = CACurrentMediaTime()
         let inPlace = entry == .inPlace
+        let selectingWindow = isPickingWindow
         AppFeedback.shared.warmUp()
-        let p = MotionPanel(eligible: eligible, inPlace: inPlace)
+        let p = MotionPanel(eligible: eligible,
+                            inPlace: inPlace,
+                            selectionPrompt: selectionPrompt,
+                            selectionCurrentWid: selectionCurrentWid)
         p.loadStart = t0
         p.beginLoadTrace()
         let tInit = CACurrentMediaTime()
-        p.onExit = { [weak self] in self?.deactivate() }
+        p.onSelection = { [weak self] entry in
+            self?.finishWindowPick(.selected(entry))
+            self?.deactivate()
+        }
+        p.onExit = { [weak self] in
+            guard let self else { return }
+            if selectingWindow { self.finishWindowPick(.cancelled()) }
+            self.deactivate()
+        }
         panel = p
         activeEntry = entry
         p.present()
@@ -83,6 +144,7 @@ final class WindowMotionMode {
         panel?.dismiss()
         panel = nil
         activeEntry = nil
+        if pickCompletion != nil { finishWindowPick(.cancelled()) }
         // Belt-and-suspenders: sweep up any Hyperspace overlay panel still on screen
         // even if we lost the reference to it. Guarantees the toggle hotkey always
         // clears the spread — the recovery path for the "stuck on top" trap.
@@ -340,6 +402,7 @@ final class HyperspaceDrag: ObservableObject {
 
 private final class MotionPanel: NSPanel {
     var onExit: (() -> Void)?
+    var onSelection: ((WindowEntry) -> Void)?
     var loadStart: CFTimeInterval = 0          // set by activate(); base for load-profile marks
     private var loadTrace: HyperspaceLoadTrace?
 
@@ -387,6 +450,8 @@ private final class MotionPanel: NSPanel {
     /// In-place tools (Hyper+G): float Current View + inventory over the live desktop.
     /// Hyperspace (Hyper+Space) keeps the full scrim + screenshot survey.
     private let inPlaceMode: Bool
+    private let selectionPrompt: String?
+    private let selectionCurrentWid: UInt32?
     private var scrollMonitor: Any?
     private var mouseUpMonitor: Any?    // re-claims key focus after a survey click/drag
     private var keyMonitor: Any?        // catches Enter/Esc even when a survey panel holds key
@@ -446,6 +511,7 @@ private final class MotionPanel: NSPanel {
     private var exposeFrames: [UInt32: CGRect] = [:]   // tile wid → laid-out frame (survey space)
     private lazy var handKeysMode = UserDefaults.standard.bool(forKey: "hyperspace.handKeys")
 
+    private var selectionOnly: Bool { onSelection != nil }
     private var activeEntry: WindowEntry { eligible[reticle] }
     private var activeSurveyScreen: NSScreen? {
         if let activeScreenID,
@@ -460,9 +526,14 @@ private final class MotionPanel: NSPanel {
         return eligible.filter { entry($0, isOn: screen) }
     }
 
-    init(eligible: [WindowEntry], inPlace: Bool = false) {
+    init(eligible: [WindowEntry],
+         inPlace: Bool = false,
+         selectionPrompt: String? = nil,
+         selectionCurrentWid: UInt32? = nil) {
         self.eligible = eligible
         self.inPlaceMode = inPlace
+        self.selectionPrompt = selectionPrompt
+        self.selectionCurrentWid = selectionCurrentWid
 
         let union = MotionPanel.screensUnion()
         super.init(contentRect: union, styleMask: [.borderless, .nonactivatingPanel], backing: .buffered, defer: false)
@@ -527,6 +598,11 @@ private final class MotionPanel: NSPanel {
             reticle = bestIdx
             fillAimWid = eligible[bestIdx].wid
             resolved[eligible[bestIdx].wid] = focused
+        }
+        if let selectionCurrentWid,
+           let idx = eligible.firstIndex(where: { $0.wid == selectionCurrentWid }) {
+            reticle = idx
+            fillAimWid = selectionCurrentWid
         }
     }
 
@@ -775,7 +851,12 @@ private final class MotionPanel: NSPanel {
             undoAndExit(); return
         }
         if code == 36 || code == 76 {                       // Return / keypad Enter — confirm: keep + leave
-            if exposed && inPlaceMode {
+            if selectionOnly {
+                let screen = validSurveyScreen(screenForPointer())
+                    ?? validSurveyScreen(screenForEvent(event))
+                    ?? activeSurveyScreen
+                completeWindowPickFromAim(on: screen)
+            } else if exposed && inPlaceMode {
                 let screen = validSurveyScreen(screenForPointer())
                     ?? validSurveyScreen(screenForEvent(event))
                     ?? activeSurveyScreen
@@ -811,6 +892,21 @@ private final class MotionPanel: NSPanel {
         }
         let mods = event.modifierFlags
 
+        // A daemon window pick is a read-only selection session. `expose()` can
+        // legitimately stay collapsed when only one window is eligible, so gate
+        // the plain motion key map as well as the survey actions below.
+        if selectionOnly && !exposed {
+            switch code {
+            case 48:
+                moveReticle(mods.contains(.shift) ? -1 : 1)
+            case 49:
+                completeWindowPick(activeEntry.wid)
+            default:
+                NSSound.beep()
+            }
+            return
+        }
+
         // In the screenshot Exposé survey the keyboard drives a clustered lattice:
         // Tab/Space move & pluck the highlighted tile, a–z pluck by hint letter,
         // G gathers in place, E collapses back. Nothing here moves a real window
@@ -831,11 +927,18 @@ private final class MotionPanel: NSPanel {
             case 49:                                                         // Space — pluck highlighted
                 if let eventScreen, let id = screenID {
                     let aim = exposeAimByScreen[id] ?? 0
-                    if let wid = exposeOrderByScreen[id]?[safe: aim] { exposeToggle(wid, on: eventScreen) }
+                    if let wid = exposeOrderByScreen[id]?[safe: aim] {
+                        if selectionOnly { completeWindowPick(wid) }
+                        else { exposeToggle(wid, on: eventScreen) }
+                    }
                 }
                 return
-            case 14 where !mods.contains(.shift) && !inPlaceMode: collapseExpose(); return  // E — collapse survey
+            case 14 where !mods.contains(.shift) && !inPlaceMode:             // E — collapse survey
+                if selectionOnly { NSSound.beep() }
+                else { collapseExpose() }
+                return
             case 5  where !mods.contains(.shift):                            // G — grid selection (stay in mode)
+                if selectionOnly { NSSound.beep(); return }
                 AppFeedback.shared.commitTactile()
                 if let eventScreen { gatherInPlace(on: eventScreen) }
                 return
@@ -855,16 +958,19 @@ private final class MotionPanel: NSPanel {
                 if let eventScreen { canvasForScreen(eventScreen).reset() }  // 0      — reset to fit
                 return
             case 44:                                                         // / — curated command bar
-                if let eventScreen { presentCommandBar(on: eventScreen) }
+                if selectionOnly { NSSound.beep() }
+                else if let eventScreen { presentCommandBar(on: eventScreen) }
                 return
             default:
                 let ch = event.charactersIgnoringModifiers?.lowercased()
                 if let eventScreen, let id = screenID,
                    mods.contains(.shift), let ch, let cid = clusterHintMapByScreen[id]?[ch] {
-                    exposeToggleCluster(cid, on: eventScreen)                // ⇧a–z — pluck a whole group
+                    if selectionOnly { NSSound.beep() }
+                    else { exposeToggleCluster(cid, on: eventScreen) }        // ⇧a–z — pluck a whole group
                 } else if let eventScreen, let id = screenID,
                           let ch, let wid = hintMapByScreen[id]?[ch] {
-                    exposeToggle(wid, on: eventScreen)                       // a–z — pluck by hint
+                    if selectionOnly { completeWindowPick(wid) }
+                    else { exposeToggle(wid, on: eventScreen) }              // a–z — pluck by hint
                 } else {
                     NSSound.beep()
                 }
@@ -907,6 +1013,7 @@ private final class MotionPanel: NSPanel {
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
         if event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
            event.keyCode == 37 {                                // ⌘L — save the pluck as a layer
+            guard !selectionOnly else { NSSound.beep(); return true }
             saveGroupAsLayer()
             return true
         }
@@ -914,6 +1021,30 @@ private final class MotionPanel: NSPanel {
     }
 
     // MARK: - Selection
+
+    private func completeWindowPick(_ wid: UInt32) {
+        guard let entry = eligible.first(where: { $0.wid == wid }) else {
+            NSSound.beep()
+            return
+        }
+        DiagnosticLog.shared.info("Window pick — selected \(entry.app) #\(entry.wid)")
+        AppFeedback.shared.commitTactile()
+        onSelection?(entry)
+    }
+
+    private func completeWindowPickFromAim(on screen: NSScreen?) {
+        guard let screen else {
+            completeWindowPick(activeEntry.wid)
+            return
+        }
+        let id = MotionPanel.screenID(screen)
+        let aim = exposeAimByScreen[id] ?? 0
+        if let wid = exposeOrderByScreen[id]?[safe: aim] {
+            completeWindowPick(wid)
+        } else {
+            completeWindowPick(activeEntry.wid)
+        }
+    }
 
     private func moveReticle(_ delta: Int) {
         let members = activeSurveyMembers
@@ -2291,26 +2422,63 @@ private final class MotionPanel: NSPanel {
                 inPlace: inPlaceMode,
                 screenAspect: screen.visibleFrame.width / max(1, screen.visibleFrame.height),
                 usableInset: MotionPanel.usableInset(of: screen),
-                onPick: { [weak self] wid in self?.exposeToggle(wid, on: screen) },
-                onDrop: { [weak self] wid, spec in self?.handleDrop(wid, spec) },
-                onDropGridGroup: { [weak self] wids, res, anchor in
-                    self?.handleGridGroupDrop(wids, res: res, anchor: anchor)
+                onPick: { [weak self] wid in
+                    guard let self else { return }
+                    if self.selectionOnly { self.completeWindowPick(wid) }
+                    else { self.exposeToggle(wid, on: screen) }
                 },
-                onDropLayer: { [weak self] wid, key in self?.handleLayerDrop(wid, key) },
-                onDropLayers: { [weak self] wids, key in self?.handleLayerDrops(wids, key) },
-                onSwap: { [weak self] a, b in self?.swapWindows(widA: a, widB: b, on: screen) },
-                onGridSelection: { [weak self] in self?.gatherInPlace(on: screen) },
+                onDrop: { [weak self] wid, spec in
+                    guard let self, !self.selectionOnly else { return }
+                    self.handleDrop(wid, spec)
+                },
+                onDropGridGroup: { [weak self] wids, res, anchor in
+                    guard let self, !self.selectionOnly else { return }
+                    self.handleGridGroupDrop(wids, res: res, anchor: anchor)
+                },
+                onDropLayer: { [weak self] wid, key in
+                    guard let self, !self.selectionOnly else { return }
+                    self.handleLayerDrop(wid, key)
+                },
+                onDropLayers: { [weak self] wids, key in
+                    guard let self, !self.selectionOnly else { return }
+                    self.handleLayerDrops(wids, key)
+                },
+                onSwap: { [weak self] a, b in
+                    guard let self, !self.selectionOnly else { return }
+                    self.swapWindows(widA: a, widB: b, on: screen)
+                },
+                onGridSelection: { [weak self] in
+                    guard let self, !self.selectionOnly else { return }
+                    self.gatherInPlace(on: screen)
+                },
                 onSwapFirstTwo: { [weak self] in
-                    guard let self, let a = self.pickOrderByScreen[id]?[safe: 0],
+                    guard let self, !self.selectionOnly, let a = self.pickOrderByScreen[id]?[safe: 0],
                           let b = self.pickOrderByScreen[id]?[safe: 1] else { NSSound.beep(); return }
                     self.swapWindows(widA: a, widB: b, on: screen)
                 },
-                onSwapWith: { [weak self] a, b in self?.swapWindows(widA: a, widB: b, on: screen) },
-                onFocusWindow: { [weak self] wid in self?.focusWindow(wid, on: screen) },
-                onClearSelection: { [weak self] in self?.clearPicks(on: screen) },
-                onApplyPlacement: { [weak self] wid, spec in self?.applyPlacementNow(wid, spec, on: screen) },
-                onFillAvailable: { [weak self] wid in self?.fillAvailableSpace(for: wid) },
-                onOpenHyperspace: {
+                onSwapWith: { [weak self] a, b in
+                    guard let self, !self.selectionOnly else { return }
+                    self.swapWindows(widA: a, widB: b, on: screen)
+                },
+                onFocusWindow: { [weak self] wid in
+                    guard let self else { return }
+                    if self.selectionOnly { self.completeWindowPick(wid) }
+                    else { self.focusWindow(wid, on: screen) }
+                },
+                onClearSelection: { [weak self] in
+                    guard let self, !self.selectionOnly else { return }
+                    self.clearPicks(on: screen)
+                },
+                onApplyPlacement: { [weak self] wid, spec in
+                    guard let self, !self.selectionOnly else { return }
+                    self.applyPlacementNow(wid, spec, on: screen)
+                },
+                onFillAvailable: { [weak self] wid in
+                    guard let self, !self.selectionOnly else { return }
+                    self.fillAvailableSpace(for: wid)
+                },
+                onOpenHyperspace: { [weak self] in
+                    guard self?.selectionOnly != true else { NSSound.beep(); return }
                     WindowMotionMode.shared.deactivate()
                     WindowMotionMode.shared.toggleHyperspace()
                 },
@@ -2329,7 +2497,7 @@ private final class MotionPanel: NSPanel {
                     }
                 },
                 onHandKeys: { [weak self] on in
-                    guard let self else { return }
+                    guard let self, !self.selectionOnly else { NSSound.beep(); return }
                     self.handKeysMode = on
                     let changed = self.surveyScreens().filter {
                         self.reassignHandHints(on: $0, rebuild: false)
@@ -2342,13 +2510,25 @@ private final class MotionPanel: NSPanel {
                     }
                 },
                 onExit: { [weak self] in self?.onExit?() },   // ✕ — leave, keep what's on screen
-                onNewLayer: { [weak self] in self?.presentNewLayer() },
+                onNewLayer: { [weak self] in
+                    guard let self, !self.selectionOnly else { NSSound.beep(); return }
+                    self.presentNewLayer()
+                },
                 onRecallLayer: { [weak self] id in self?.pluckLayer(id, on: screen) },
                 onBeginClusterSearch: { [weak self] cid in self?.activateClusterSearch(cid, on: screen) },
                 onClearClusterSearch: { [weak self] cid in self?.clearClusterSearch(cid, on: screen) },
-                onEditClause: { [weak self] id, idx, clause in self?.presentLayerRuleEditor(id, idx, clause, on: screen) },
-                onRemoveClause: { [weak self] id, idx in self?.removeLayerClause(id, idx) },
-                onDeleteLayer: { [weak self] id in self?.deleteLayer(id) },
+                onEditClause: { [weak self] id, idx, clause in
+                    guard let self, !self.selectionOnly else { NSSound.beep(); return }
+                    self.presentLayerRuleEditor(id, idx, clause, on: screen)
+                },
+                onRemoveClause: { [weak self] id, idx in
+                    guard let self, !self.selectionOnly else { NSSound.beep(); return }
+                    self.removeLayerClause(id, idx)
+                },
+                onDeleteLayer: { [weak self] id in
+                    guard let self, !self.selectionOnly else { NSSound.beep(); return }
+                    self.deleteLayer(id)
+                },
                 loadSummary: loadSummaryText())
     }
 
@@ -3223,11 +3403,21 @@ private final class MotionPanel: NSPanel {
     }
 
     private func legendModel() -> MotionLegend {
-        MotionLegend(app: activeEntry.app,
+        let prompt = selectionPrompt?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let title: String
+        if selectionOnly, let prompt, !prompt.isEmpty {
+            title = String(prompt.prefix(64))
+        } else if selectionOnly {
+            title = "Choose a window"
+        } else {
+            title = activeEntry.app
+        }
+        return MotionLegend(app: title,
                      tint: Color(nsColor: MotionPanel.tint(for: activeEntry.app)),
                      groupCount: group.count,
                      exposed: exposed,
                      inPlace: inPlaceMode,
+                     selectionOnly: selectionOnly,
                      displayCount: surveyScreens().count)
     }
 
@@ -3386,6 +3576,7 @@ private struct MotionLegend: View {
     let groupCount: Int
     var exposed: Bool = false
     var inPlace: Bool = false
+    var selectionOnly: Bool = false
     var displayCount: Int = 1
 
     var body: some View {
@@ -3405,7 +3596,12 @@ private struct MotionLegend: View {
 
             Rectangle().fill(Palette.border).frame(width: 1, height: 13)
 
-            if exposed {
+            if selectionOnly {
+                keyHint("a–z", "choose")
+                keyHint("Tab", "aim")
+                keyHint("⏎", "choose")
+                keyHint("esc", "cancel")
+            } else if exposed {
                 if inPlace {
                     keyHint("click", "select")
                     keyHint("a–z", "select")

--- a/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapApplySequence.swift
+++ b/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapApplySequence.swift
@@ -1,0 +1,196 @@
+import SwiftUI
+
+// MARK: - Apply sequence (progressive grid placement)
+
+enum ScreenMapApplyStepStatus: Equatable {
+    case pending
+    case active
+    case done
+}
+
+struct ScreenMapApplyStep: Identifiable, Equatable {
+    let id: UInt32
+    let app: String
+    let title: String
+    var status: ScreenMapApplyStepStatus
+}
+
+/// Live state for a multi-window apply — drives the action rail and per-tile shimmer.
+final class ScreenMapApplySequence: ObservableObject {
+    @Published private(set) var steps: [ScreenMapApplyStep]
+    @Published private(set) var phaseLabel: String
+    let label: String
+
+    init(label: String, windows: [(wid: UInt32, app: String, title: String)]) {
+        self.label = label
+        self.phaseLabel = "Preparing…"
+        self.steps = windows.map {
+            ScreenMapApplyStep(id: $0.wid, app: $0.app, title: $0.title, status: .pending)
+        }
+    }
+
+    func setPhase(_ text: String) {
+        phaseLabel = text
+    }
+
+    var total: Int { steps.count }
+    var completedCount: Int { steps.filter { $0.status == .done }.count }
+    var isFinished: Bool { completedCount == total }
+
+    func status(for wid: UInt32) -> ScreenMapApplyStepStatus? {
+        steps.first(where: { $0.id == wid })?.status
+    }
+
+    func begin(wid: UInt32) {
+        phaseLabel = "Placing…"
+        for i in steps.indices where steps[i].status == .active {
+            steps[i].status = .done
+        }
+        guard let idx = steps.firstIndex(where: { $0.id == wid }) else { return }
+        steps[idx].status = .active
+    }
+
+    func finishAll() {
+        phaseLabel = "Done"
+        for i in steps.indices {
+            steps[i].status = .done
+        }
+    }
+
+    func complete(wid: UInt32) {
+        guard let idx = steps.firstIndex(where: { $0.id == wid }) else { return }
+        steps[idx].status = .done
+    }
+
+    /// The tail of the queue — what's left plus the active step.
+    var trail: [ScreenMapApplyStep] {
+        let active = steps.filter { $0.status == .active }
+        let pending = steps.filter { $0.status == .pending }
+        return active + pending.prefix(5)
+    }
+}
+
+// MARK: - Tile overlay
+
+struct ScreenMapApplyTileOverlay: View {
+    let status: ScreenMapApplyStepStatus
+
+    var body: some View {
+        GeometryReader { geo in
+            let shape = RoundedRectangle(cornerRadius: 2)
+            ZStack {
+                switch status {
+                case .pending:
+                    shape
+                        .strokeBorder(Palette.running.opacity(0.35), lineWidth: 1)
+                        .background(shape.fill(Palette.running.opacity(0.06)))
+                case .active:
+                    shape
+                        .fill(Palette.running.opacity(0.12))
+                    TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { timeline in
+                        let t = timeline.date.timeIntervalSinceReferenceDate
+                        let phase = CGFloat(t.truncatingRemainder(dividingBy: 1.1) / 1.1)
+                        LinearGradient(
+                            colors: [
+                                Color.clear,
+                                Palette.running.opacity(0.45),
+                                Color.clear,
+                            ],
+                            startPoint: UnitPoint(x: phase - 0.35, y: 0),
+                            endPoint: UnitPoint(x: phase + 0.35, y: 1)
+                        )
+                        .mask(shape)
+                    }
+                    shape.strokeBorder(Palette.running.opacity(0.85), lineWidth: 1.25)
+                case .done:
+                    shape
+                        .fill(Palette.running.opacity(0.22))
+                        .overlay(
+                            shape.strokeBorder(Palette.running.opacity(0.55), lineWidth: 0.75)
+                        )
+                }
+            }
+        }
+        .allowsHitTesting(false)
+    }
+}
+
+// MARK: - Action rail
+
+struct ScreenMapApplySequenceRail: View {
+    @ObservedObject var sequence: ScreenMapApplySequence
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Image(systemName: "rectangle.split.3x3")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(Palette.running)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(sequence.label)
+                        .font(Typo.monoBold(10))
+                        .foregroundColor(Palette.text)
+                    Text(sequence.phaseLabel)
+                        .font(Typo.mono(8))
+                        .foregroundColor(Palette.textMuted)
+                }
+                Spacer(minLength: 8)
+                Text("\(sequence.completedCount)/\(sequence.total)")
+                    .font(Typo.monoBold(10))
+                    .foregroundColor(Palette.running)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(sequence.trail) { step in
+                    HStack(spacing: 6) {
+                        stepIcon(step.status)
+                        Text(step.app)
+                            .font(Typo.mono(9))
+                            .foregroundColor(step.status == .pending ? Palette.textDim : Palette.text)
+                            .lineLimit(1)
+                        if !step.title.isEmpty {
+                            Text(step.title)
+                                .font(Typo.mono(8))
+                                .foregroundColor(Palette.textMuted)
+                                .lineLimit(1)
+                        }
+                        Spacer(minLength: 0)
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color.black.opacity(0.62))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .strokeBorder(Palette.running.opacity(0.28), lineWidth: 1)
+                )
+        )
+        .shadow(color: .black.opacity(0.35), radius: 10, y: 4)
+        .frame(maxWidth: 320, alignment: .leading)
+        .allowsHitTesting(false)
+    }
+
+    @ViewBuilder
+    private func stepIcon(_ status: ScreenMapApplyStepStatus) -> some View {
+        switch status {
+        case .pending:
+            Circle()
+                .strokeBorder(Color.white.opacity(0.22), lineWidth: 1)
+                .frame(width: 7, height: 7)
+        case .active:
+            Circle()
+                .fill(Palette.running)
+                .frame(width: 7, height: 7)
+                .shadow(color: Palette.running.opacity(0.6), radius: 3)
+        case .done:
+            Image(systemName: "checkmark")
+                .font(.system(size: 7, weight: .bold))
+                .foregroundColor(Palette.running)
+                .frame(width: 7, height: 7)
+        }
+    }
+}

--- a/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapState.swift
+++ b/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapState.swift
@@ -1399,12 +1399,17 @@ final class ScreenMapController: ObservableObject {
     @Published var savedPositions: [UInt32: (pid: Int32, frame: WindowFrame)]? = nil
     @Published var isSearchActive: Bool = false
     @Published var searchHighlightIndex: Int = 0
+    @Published var applySequence: ScreenMapApplySequence?
+    @Published var isApplyingEdits: Bool = false
+
+    private static let progressiveApplyThreshold = 4
 
     enum DisplayTransitionDirection {
         case left, right, none
     }
     @Published var displayTransition: DisplayTransitionDirection = .none
     private var editorObserver: AnyCancellable?
+    private var applySequenceObserver: AnyCancellable?
 
     var previewWindow: NSWindow? = nil
     private var previewGlobalMonitor: Any? = nil
@@ -2346,6 +2351,7 @@ final class ScreenMapController: ObservableObject {
 
     func applyEdits(showFlash: Bool = true) {
         guard let ed = editor else { return }
+        guard !isApplyingEdits else { return }
         let pendingEdits = ed.windows.filter(\.hasEdits)
         guard !pendingEdits.isEmpty else {
             if showFlash { flash("No changes to apply") }
@@ -2365,32 +2371,115 @@ final class ScreenMapController: ObservableObject {
         let allMoves = sorted.map { (wid: $0.id, pid: $0.pid, frame: $0.editedFrame) }
         NSLog("[ScreenMap] Applying %d edits", allMoves.count)
 
+        if allMoves.count >= Self.progressiveApplyThreshold {
+            applyEditsProgressively(
+                pendingEdits: pendingEdits,
+                allMoves: allMoves,
+                showFlash: showFlash
+            )
+            return
+        }
+
+        finishApplyEdits(allMoves: allMoves, pendingCount: pendingEdits.count, showFlash: showFlash)
+    }
+
+    private func applyEditsProgressively(
+        pendingEdits: [ScreenMapWindowEntry],
+        allMoves: [(wid: UInt32, pid: Int32, frame: CGRect)],
+        showFlash: Bool
+    ) {
+        guard let ed = editor else { return }
         let actionLog = ed.actionLog
+        let label = "Placing \(allMoves.count) windows"
+        let sequence = ScreenMapApplySequence(
+            label: label,
+            windows: pendingEdits.map { (wid: $0.id, app: $0.app, title: $0.title) }
+        )
 
-        // Apply AX changes (no hide/show — Screen Map stays visible)
+        isApplyingEdits = true
+        applySequence = sequence
+        applySequenceObserver = sequence.objectWillChange.sink { [weak self] _ in
+            self?.objectWillChange.send()
+        }
+
+        // Paint the rail before any AX work so the UI responds immediately.
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            WindowTiler.batchMoveWindowsProgressive(
+                moves: allMoves,
+                onReady: { [weak self] in
+                    self?.applySequence?.setPhase("Connecting to windows…")
+                },
+                onStep: { [weak self] _, wid in
+                    self?.applySequence?.begin(wid: wid)
+                },
+                onComplete: { [weak self] _, _ in
+                    guard let self, let ed = self.editor else { return }
+                    self.applySequence?.finishAll()
+                    self.commitAppliedFrames(in: ed)
+                    self.objectWillChange.send()
+
+                    let moves = allMoves
+                    DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.2) {
+                        let drifted = WindowTiler.verifyMoves(moves)
+                        if !drifted.isEmpty {
+                            NSLog("[ScreenMap] %d/%d windows drifted, retrying", drifted.count, moves.count)
+                            WindowTiler.batchMoveWindows(drifted)
+                        }
+                        DispatchQueue.main.async {
+                            actionLog.verify()
+                        }
+                    }
+
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
+                        self.applySequenceObserver = nil
+                        self.applySequence = nil
+                        self.isApplyingEdits = false
+                    }
+
+                    if showFlash {
+                        let noun = pendingEdits.count == 1 ? "window" : "windows"
+                        self.flash("Placed \(pendingEdits.count) \(noun)")
+                    }
+                }
+            )
+        }
+    }
+
+    private func finishApplyEdits(
+        allMoves: [(wid: UInt32, pid: Int32, frame: CGRect)],
+        pendingCount: Int,
+        showFlash: Bool
+    ) {
+        guard let ed = editor else { return }
+        let actionLog = ed.actionLog
         WindowTiler.batchMoveWindows(allMoves)
+        commitAppliedFrames(in: ed)
+        objectWillChange.send()
 
-        // Commit edited frames as new originals so the map doesn't reload
+        let moves = allMoves
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.2) {
+            let drifted = WindowTiler.verifyMoves(moves)
+            if !drifted.isEmpty {
+                NSLog("[ScreenMap] %d/%d windows drifted, retrying", drifted.count, moves.count)
+                WindowTiler.batchMoveWindows(drifted)
+            }
+            DispatchQueue.main.async {
+                actionLog.verify()
+            }
+        }
+
+        if showFlash {
+            let noun = pendingCount == 1 ? "edit" : "edits"
+            flash("Applied \(pendingCount) \(noun)")
+        }
+    }
+
+    private func commitAppliedFrames(in ed: ScreenMapEditorState) {
         for i in ed.windows.indices {
             ed.windows[i].originalFrame = ed.windows[i].editedFrame
         }
         ed.objectWillChange.send()
-        objectWillChange.send()
-
-        // Verify in background — if anything drifted, retry once then refresh
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-            let drifted = WindowTiler.verifyMoves(allMoves)
-            if !drifted.isEmpty {
-                NSLog("[ScreenMap] %d/%d windows drifted, retrying", drifted.count, allMoves.count)
-                WindowTiler.batchMoveWindows(drifted)
-            }
-            actionLog.verify()
-        }
-
-        if showFlash {
-            let noun = pendingEdits.count == 1 ? "edit" : "edits"
-            flash("Applied \(pendingEdits.count) \(noun)")
-        }
     }
 
     func applyEditsFromButton() {

--- a/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapView.swift
+++ b/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapView.swift
@@ -2453,6 +2453,11 @@ struct ScreenMapView: View {
                                             .strokeBorder(stroke, lineWidth: isSelected ? 0.9 : 0.7)
                                     )
                                     .overlay {
+                                        if let status = controller.applySequence?.status(for: win.id) {
+                                            ScreenMapApplyTileOverlay(status: status)
+                                        }
+                                    }
+                                    .overlay {
                                         if projectionLabelIds.contains(win.id) {
                                             projectionWindowLabel(win: win, rect: rect, isSelected: isSelected)
                                         }
@@ -2512,6 +2517,21 @@ struct ScreenMapView: View {
             canvasContextBadge
                 .padding(.leading, 12)
                 .padding(.bottom, 12)
+        }
+        .overlay(alignment: .bottomTrailing) {
+            if let sequence = controller.applySequence {
+                ScreenMapApplySequenceRail(sequence: sequence)
+                    .padding(.trailing, 12)
+                    .padding(.bottom, 12)
+                    .transition(.move(edge: .trailing).combined(with: .opacity))
+            }
+        }
+        .overlay {
+            if controller.isApplyingEdits {
+                canvasShape
+                    .fill(Palette.running.opacity(0.04))
+                    .allowsHitTesting(true)
+            }
         }
         .overlay(
             GeometryReader { geo in
@@ -2748,6 +2768,11 @@ struct ScreenMapView: View {
                 RoundedRectangle(cornerRadius: 2)
                     .strokeBorder(borderColor, lineWidth: isSearchHighlighted ? 2 : isSelected ? 1.5 : 0.5)
             )
+            .overlay {
+                if let status = controller.applySequence?.status(for: win.id) {
+                    ScreenMapApplyTileOverlay(status: status)
+                }
+            }
             .overlay(alignment: .leading) {
                 if !usesFlatStyle {
                     Rectangle()

--- a/apps/mac/Sources/Core/Pi/WorkspaceAssistantSession.swift
+++ b/apps/mac/Sources/Core/Pi/WorkspaceAssistantSession.swift
@@ -1327,11 +1327,48 @@ final class WorkspaceAssistantSession: ObservableObject {
     private func buildProcessEnvironment(for provider: PiProvider) -> [String: String] {
         var env = ProcessInfo.processInfo.environment
         env.removeValue(forKey: "CLAUDECODE")
+        hydrateProviderRuntimePath(in: &env)
         if provider.id == "github-copilot", storedCredentialKinds[provider.id] == nil {
             env.removeValue(forKey: "COPILOT_GITHUB_TOKEN")
         }
         Self.sanitizeEnvironment(&env, for: provider.id, hasStoredCredential: storedCredentialKinds[provider.id] != nil)
         return env
+    }
+
+    private func hydrateProviderRuntimePath(in env: inout [String: String]) {
+        let home = NSHomeDirectory()
+        var pathEntries: [String] = []
+        var seen: Set<String> = []
+
+        func appendDirectory(_ path: String?) {
+            guard let rawPath = path?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !rawPath.isEmpty else {
+                return
+            }
+            let path = (rawPath as NSString).expandingTildeInPath
+            guard seen.insert(path).inserted else { return }
+            pathEntries.append(path)
+        }
+
+        appendDirectory(nodeBinaryPath.map { URL(fileURLWithPath: $0).deletingLastPathComponent().path })
+        appendDirectory(piBinaryPath.map { URL(fileURLWithPath: $0).deletingLastPathComponent().path })
+        appendDirectory("\(home)/.local/bin")
+        appendDirectory("\(home)/.bun/bin")
+        appendDirectory("\(home)/.npm-global/bin")
+        appendDirectory("\(home)/Library/pnpm")
+        appendDirectory("/opt/homebrew/bin")
+        appendDirectory("/usr/local/bin")
+
+        for entry in (env["PATH"] ?? "").split(separator: ":") {
+            appendDirectory(String(entry))
+        }
+
+        appendDirectory("/usr/bin")
+        appendDirectory("/bin")
+        appendDirectory("/usr/sbin")
+        appendDirectory("/sbin")
+
+        env["PATH"] = pathEntries.joined(separator: ":")
     }
 
     func startSelectedAuthFlow() {

--- a/docs/agent/cua-implementation.md
+++ b/docs/agent/cua-implementation.md
@@ -58,6 +58,13 @@ this guide must all expose the same supported surface.
 - Preserve Lattices' treatment model: read-only calls observe, risky actions
   default to `treatment: "stage"`, and mutation requires explicit
   `treatment: "execute"` unless the endpoint documents a different safe mode.
+- Every computer-use action response should expose `backgroundSafety` plus the
+  compatibility fields `background_safe`, `cursor_moved`, and
+  `foreground_changed`. Agents must rely on `background_safe: true`, not just
+  `ok: true`, before assuming a call did not disturb the foreground session.
+- For semantic AX execution, support `backgroundSafe: true` / `noFocus: true`
+  where the action can run without focus; never treat focus actions, pointer
+  events, or global keyboard input as background-safe.
 - Keep mutating actions receipt-backed through runs or action receipts whenever
   practical. Include `source` in traceable calls.
 - Prefer semantic targets (`snapshotId` + `elementId`, AX path, `wid`, `app`,

--- a/docs/api.md
+++ b/docs/api.md
@@ -389,6 +389,31 @@ the action may be:
 
 The legacy `dryRun: true` flag maps to `stage`.
 
+#### Background-Safety Receipts
+
+Computer-use action responses include a `backgroundSafety` receipt plus
+top-level compatibility fields:
+
+```json
+{
+  "backgroundSafety": {
+    "route": "ax.press",
+    "lane": "same_session",
+    "session": "parent",
+    "background_safe": true,
+    "backgroundSafe": true,
+    "cursor_moved": false,
+    "foreground_changed": false
+  }
+}
+```
+
+Agents should treat `background_safe: true` as the signal that the call stayed
+out of the user's foreground session. AX, tmux, iTerm session, overlay, staged,
+and observe routes can be background-safe. Pointer input, app activation,
+window focus, global keyboard input, and foreground typing report
+`background_safe: false`.
+
 #### `computer.prepare`
 
 Resolve and score terminal candidates for a future computer-use action. This is
@@ -466,6 +491,7 @@ daemon process and expire from the in-memory cache after a short window.
 | `elementId` | string | yes | Snapshot-local element id, such as `e4` |
 | `action` | string | no | `press` (default), `showMenu`, or `focus` |
 | `treatment` | string | no | `stage`, `present`, or `execute`. Defaults to `stage` |
+| `backgroundSafe` / `noFocus` | bool | no | With `execute`, perform AX actions without focusing the app when the requested action can run in the background |
 | `dryRun` | bool | no | Stage without performing the action |
 | `capture` | bool | no | Capture before/after artifacts. Defaults to `true` |
 | `source` | string | no | Calling surface label |
@@ -480,7 +506,8 @@ await daemonCall('computer.elementAction', {
   snapshotId: state.snapshotId,
   elementId: 'e7',
   action: 'press',
-  treatment: 'execute'
+  treatment: 'execute',
+  backgroundSafe: true
 })
 ```
 
@@ -502,6 +529,7 @@ Stage or execute text/value insertion against an element returned by a recent
 | `append` | bool | no | Append to current `AXValue` instead of replacing it |
 | `typeIntervalMs` | double | no | Per-character interval for typewriter-style AXValue updates |
 | `treatment` | string | no | `stage`, `present`, or `execute`. Defaults to `stage` |
+| `backgroundSafe` / `noFocus` | bool | no | With `execute`, set `AXValue` without focusing the app or AX element |
 | `dryRun` | bool | no | Stage without setting `AXValue` |
 | `capture` | bool | no | Capture before/after artifacts. Defaults to `true` |
 | `source` | string | no | Calling surface label |
@@ -516,7 +544,8 @@ await daemonCall('computer.typeElement', {
   snapshotId: state.snapshotId,
   elementId: 'e12',
   text: 'Draft note',
-  treatment: 'execute'
+  treatment: 'execute',
+  backgroundSafe: true
 })
 ```
 
@@ -1394,8 +1423,10 @@ Supported action types:
 |--------|------|-------------|
 | `windows.list` | read | All visible windows |
 | `windows.get` | read | Single window by ID |
+| `windows.preview` | read | Cached PNG preview for a window |
 | `windows.search` | read | Search windows by query |
 | `spaces.list` | read | macOS display spaces |
+| `window.pick.start` | read | Ask the user to choose one visible window in a read-only Hyperspace survey |
 | `window.place` | write | Place a window or session using a typed placement spec |
 | `window.tile` | write | Compatibility wrapper for session tiling |
 | `window.focus` | write | Focus a window / switch Spaces |
@@ -1499,6 +1530,19 @@ lattices search vox --json
 lattices place vox right
 ```
 
+#### `windows.preview`
+
+Return a cached PNG preview for a tracked window. When the cache is cold,
+`load` starts an asynchronous warmup and the caller can poll until `ok` is true.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `wid` | number | yes | CGWindowID from `windows.list` |
+| `load` | boolean | no | Warm the cache when missing; defaults to `true` |
+
+The response includes `cached` and `loading`. A ready preview also includes
+`mimeType: "image/png"`, base64 image data, and pixel dimensions.
+
 #### `spaces.list`
 
 List macOS display spaces (virtual desktops).
@@ -1555,6 +1599,25 @@ compact `CxR:C,R`. The canonical `grid:` form is 0-indexed; the compact form is
 ```
 
 **Returns**: execution receipt including resolved target, placement, and trace.
+
+#### `window.pick.start`
+
+Open Hyperspace in a read-only selection mode and wait for the user to choose
+one visible window. Letter hints, Tab/Return, and clicking a survey tile select;
+Escape cancels. Placement, layer editing, and normal motion commands are disabled
+for the duration of the pick.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `client` | string | no | Calling client label |
+| `requestId` | string | no | Caller correlation id |
+| `prompt` | string | no | Prompt shown in the selection HUD |
+| `mode` | string | no | `single-window` (default and currently supported mode) |
+| `currentWid` | number | no | Visible window to preselect |
+| `timeoutMs` | number | no | Wait time, clamped to 5–300 seconds; default 120 seconds |
+
+Returns `status: "selected"` with a window, or `cancelled`, `timeout`, or
+`unavailable` without one.
 
 #### `window.tile`
 

--- a/docs/app.md
+++ b/docs/app.md
@@ -239,19 +239,27 @@ authentication state.
 
 ### Shortcuts
 
-Shows keyboard shortcut reference:
+Shows keyboard shortcut reference. These are defaults; you can change them
+from Settings > Shortcuts.
 
 | Shortcut          | Action              |
 |-------------------|----------------------|
 | Cmd+Shift+M       | Open command palette |
-| Hyper+1            | Screen map           |
+| Hyper+1            | Workspace home       |
+| Hyper+L            | Studio / screen map  |
 | Hyper+2            | Window bezel         |
 | Hyper+3            | HUD                  |
-| Hyper+D            | Voice commands       |
-| Hyper+G            | Desktop inventory    |
+| Ctrl+Cmd+M         | Hands-off mode       |
+| Hyper+Space        | Hyperspace window survey |
+| Hyper+G            | In-place window tools |
+| Hyper+H            | Window navigation hints |
 | Hyper+5            | Omni search          |
 | Hyper+6            | Cheat sheet          |
-| Hyper+B            | Hide/show persistent overlay actors |
+| Ctrl+Option+Space  | Command bar          |
+| Ctrl+Option+G      | 4x4 grid placement   |
+| Ctrl+Option+V      | Fill open 3x2 cell   |
+| Ctrl+Option+arrows | Tile halves          |
+| Ctrl+Option+1/2/3  | Tile thirds          |
 | Cmd+Option+1/2/3  | Switch workspace layer |
 | Ctrl+B  D         | Detach from session  |
 | Ctrl+B  X         | Kill current pane    |

--- a/docs/assistant-knowledge.md
+++ b/docs/assistant-knowledge.md
@@ -82,12 +82,16 @@ subscribe to events (`windows.changed`, `tmux.changed`, `layer.switched`).
 | Shortcut | Action |
 |----------|--------|
 | **Cmd+Shift+M** | Open the command palette |
+| **Ctrl+Option+Space** | Open the command bar for captured-front-window actions |
+| **Ctrl+Option+G** | Show the 4x4 grid placement target |
+| **Ctrl+Option+V** | Fill the least-occupied 3x2 grid cell with the frontmost window |
 | `lattices tile <position>` | Tile the focused window (CLI) |
 | `lattices layer [name\|index]` | Switch workspace layer (CLI) |
 | **Ctrl+B** then `D` / `Z` / arrows | tmux: detach / zoom / move pane (inside a session) |
 
 Tiling and grid hotkeys are user-configurable — for the live set, point the user to
-Settings or the [Tiling reference](/docs/tiling-reference) rather than asserting one.
+Settings or the [Tiling reference](/docs/tiling-reference) rather than treating
+the defaults as guaranteed.
 
 ## CLI quick reference
 

--- a/docs/hudson-overlay-alignment.md
+++ b/docs/hudson-overlay-alignment.md
@@ -1,0 +1,144 @@
+# Lattices ↔ Hudson Overlay: Alignment Guidance
+
+Guidance from the Lattices side for Hudson Overlay (`/Users/art/dev/hudson-notch`):
+notch notifications + Scout-style agent tail + a Lattices-like screen overlay where
+agents get stable placements, quick show/hide/toggle, and small action shortcuts.
+
+Written in response to a Scout consult. TL;DR at the bottom.
+
+## First, a correction on sources
+
+- **`LatticesOverlayChrome.swift` does not exist in the Lattices repo.** The real
+  files to read are:
+  - `apps/mac/Sources/Core/Overlays/ScreenOverlayCanvasController.swift` — the
+    click-through per-screen canvas substrate (LAT-002).
+  - `apps/mac/Sources/Core/Overlays/ScreenOverlayActorHUDController.swift` — actor
+    hover HUD (WKWebView) plumbing.
+  - `apps/mac/Sources/Core/Daemon/LatticesApi.swift` (~line 988+) — the
+    `overlay.actor.*` daemon methods.
+  - `docs/api.md` (§ Overlay UI, ~line 972+) — the shipped agent-facing contract.
+  - `docs/proposals/LAT-002-shared-overlay-canvas.md`, `docs/proposals/LAT-004-interactive-overlay-actors.md`.
+
+## The key mental model: Lattices has TWO separate "placement" systems
+
+They are intentionally decoupled. Choosing the wrong one is the main pitfall.
+
+### System A — Window tiling / layers (moves *real OS windows*)
+
+- **What it is:** arranging foreign application windows (by `wid`) into a grid.
+- **Grammar:** `PlacementSpec` / `GridPlacement` — `left`, `top-right`,
+  `grid:4x4:0,0`, spans like `grid:4x4:0,0-1,1`. Operates in global AppKit/CoreGraphics
+  coordinates and drives windows through the Accessibility API.
+- **Session layers** (`workspace.json`): launch-and-tile contexts. Switching raises,
+  launches-if-absent, and tiles a set of real windows. `layer.switch`, hotkeys ⌥1–9.
+- **Studio layers** (`~/.lattices/layers.json`): rule-backed. A `match` array
+  (app/title/session/space clauses) resolves *which existing desktop windows* belong
+  to a layer, then recalls/scopes them.
+- **Altitude:** heavyweight desktop-window management. AX, CGWindow, Spaces, multi-monitor.
+
+### System B — Overlay canvas + actors (draws *app-owned UI*)
+
+- **What it is:** one transparent, **click-through**, always-on-top window per display.
+  Features publish lightweight visual layers into it. It never owns input semantics or
+  action dispatch (explicit LAT-002 non-goal).
+- **Passive layers** (`overlay.publish`): `toast`, `label`, `highlight`, `pet`. Declarative,
+  value-type snapshots with `id`, `owner`, screen target, `zIndex`, `opacity`, payload
+  enum, optional `ttlMs`. Rendered synchronously; no callbacks into features during draw.
+- **Actors** (`overlay.actor.*`): a small *persistent* desktop object with a stable `id`,
+  renderer (`sprite`), state, screen-local position, app-owned easing, and **selective
+  hit-testing** (only actor/surface/button bounds capture input; everything else passes
+  through). Persistent by default (`ttlMs: 0`, `dismissible: false`).
+- **Altitude:** ambient, contextual, app-owned visuals in screen-local coordinates. No AX.
+
+## Which one should Hudson's agent-placement model mirror?
+
+**Mirror System B (overlay canvas + actor semantics). Do NOT mirror System A
+(tile values / session layers).**
+
+Hudson agents are notch notifications, an agent tail, and overlay chips — they are
+*app-owned visual objects*, not foreign OS windows you're tiling. So:
+
+- **"stable placements"** → actor `id` + anchored/pinned `position`, persistent
+  (`ttlMs: 0`). This is exactly `overlay.actor.publish`. It is **not** a tile value.
+- **"quick show/hide/toggle"** → this is `overlay.actor.visibility`
+  (`show` / `hide` / `toggle` / `status`), the daemon twin of the app's **Hyper+B**
+  park shortcut. This is the single closest existing primitive to what Hudson wants —
+  it toggles the whole actor *layer's visibility without destroying actor ids/state*.
+- **"small action shortcuts"** → actor click-activation (`targetApp` / `targetBundleId` /
+  `targetAppPath`) is shipped; richer **action surfaces / click callbacks are still
+  *planned* (LAT-004 phase 4), not shipped.** Don't build on them as if they exist.
+
+Only reach into System A if Hudson genuinely needs to move *real* application windows
+(e.g. "tile these three app windows around the notch"). Reusing the `grid:CxR:c,r`
+grammar there would be sensible — but that's a different feature from agent placement.
+
+## What to reuse conceptually vs. how to couple
+
+**Reuse the *designs*, keep your own *contract*, bridge later.**
+
+- **ScreenOverlayCanvas substrate — reuse the design.** One per-screen click-through
+  window; features publish declarative, `Equatable` value snapshots (stable id, owner,
+  screen target, z-index, opacity, payload enum, expiry); centralized coordinate/Y-flip
+  handling; passive-by-default; boring failure. This is the correct substrate for a notch
+  overlay. Adopt the shape; you don't need our code.
+- **Actor semantics — reuse the model.** Stable-id desktop object, persistent by default,
+  app-owned motion, selective hit-testing, visibility-toggle (park, don't destroy),
+  dismiss-surface-not-actor. This is *the* model for "represent an agent on the desktop."
+- **Coupling posture — small product-facing contract now, bridge adapter later.** Do not
+  hard-depend on the Lattices daemon API yet, because:
+  - action surfaces / event callbacks aren't shipped;
+  - the contract is still evolving — actor scoping (global vs per-Space), pinned-position
+    persistence (per-display vs per-Space vs global), and event routing (broadcast vs
+    caller-routed) are literally **open questions** in LAT-004;
+  - Hudson has product-specific needs (notch geometry, agent tail) Lattices doesn't model.
+
+  Define Hudson's own thin contract whose verbs line up with ours
+  (`publish` / `moveTo` / `visibility` / `clear` + `state`), so a later adapter can map
+  Hudson → `overlay.actor.*` (or vice-versa) without reshaping either side.
+
+## Pitfalls to avoid duplicating (hard-won here)
+
+1. **Don't conflate the two coordinate/ownership worlds.** Tiling = foreign windows,
+   `wid`, AX, global coords. Canvas = app-owned sprites, screen-local coords, no AX.
+   Keep agent placement entirely in the canvas/actor world.
+2. **Passive by default; input capture must be surgical.** The canvas is click-through;
+   only actor/surface/button *bounds* hit-test, return `nil` everywhere else so desktop
+   clicks pass through. Input capture must never cover the whole screen, and the app
+   should not *activate* for a mere hover/click. Get this wrong and the overlay becomes a
+   click-eating menace — it's the #1 thing to nail.
+3. **Never let actions depend on rendering.** Overlay failure is boring: if the canvas
+   can't draw, notification/agent logic still runs. Decouple semantics from visuals — your
+   notch notifications must fire even if overlay rendering fails.
+4. **Don't API-spam motion/position.** We learned WebSocket per-frame position updates are
+   too chunky. Callers send *target + durationMs + easing*; the renderer owns interpolation
+   at display cadence. Same for the agent tail: publish state *transitions*, not per-pixel
+   updates.
+5. **Dismiss ≠ delete; hide ≠ destroy.** Dismissal clears the *surface/message*, not the
+   actor. Park/hide preserves ids and positions. Model show/hide/toggle as *visibility* so
+   "stable placements" actually survive a toggle.
+6. **Declarative value snapshots, not live view refs.** Layers/actors are plain Equatable
+   payloads the canvas renders synchronously — no calling back into feature controllers
+   during draw; coalesce rapid updates per run loop.
+7. **"Layers" is overloaded — pick your meaning.** In Lattices it means three different
+   things: `workspace.json` launch-and-tile layers, Studio rule-backed layers
+   (`layers.json`), and ScreenOverlayCanvas *visual* layer snapshots. For Hudson agent
+   placement you want the **third**. Don't import the word without disambiguating.
+8. **Don't assume the unsettled parts are settled.** Spaces scoping, pinned-position
+   persistence, and event routing are open on our side. If Hudson needs answers, decide
+   independently rather than coupling to a contract that may still move.
+
+## TL;DR
+
+- **Mirror the overlay canvas + `overlay.actor.*` model, not tile values / session layers.**
+  Agents are app-owned overlay objects, not tiled OS windows.
+- Your "stable placement / show-hide-toggle / actions" map to
+  `overlay.actor.publish` + `overlay.actor.visibility` + actor click-activation
+  (action *surfaces* are planned, not shipped).
+- **Align conceptually, keep a thin Hudson-owned contract, bridge to `overlay.actor.*`
+  later.** The API is still evolving (open questions on Spaces scoping, pinned position,
+  event routing) — don't hard-depend yet.
+- Biggest pitfalls: conflating the tiling world with the canvas world; letting input
+  capture or the app-activation escape the actor's bounds; and letting actions depend on
+  rendering.
+- Read `ScreenOverlayCanvasController.swift`, `LatticesApi.swift` (`overlay.actor.*`),
+  and `docs/api.md` § Overlay UI — not `LatticesOverlayChrome.swift`, which doesn't exist.

--- a/docs/hudson-overlay-next-steps.md
+++ b/docs/hudson-overlay-next-steps.md
@@ -1,0 +1,181 @@
+# Hudson Overlay: Recommended Next Steps (from the Lattices side)
+
+Follow-up to `docs/hudson-overlay-alignment.md`. Hudson Overlay is becoming a small
+standalone **paid** local desktop layer. Three surfaces: notch notifications, a
+Scout-style agent tail/status view, and a Lattices-like screen overlay for agent
+placements. Any app/agent sends local events via a small socket/CLI contract. First
+paid wedge: **tail all agents** — status, notifications, lightweight talkback/action
+shortcuts, stable per-agent placements. Calm, not goofy moving mascots.
+
+Current Hudson state: SwiftPM accessory app; Unix socket event server + CLI; surfaces
+`notch` / `agentTail` / `overlay`; agent context `id/name/workspace/service/placement/
+visibility/shortcuts`; placement is a 3×3 enum (`topLeading`…`bottomTrailing`).
+
+What I'd do if I held the Hudson side.
+
+---
+
+## Answers to the four questions
+
+### 1. Vocabulary — keep your own; borrow the *actor placement* primitive, not tile/session vocab
+
+**Keep your human product vocabulary (named slots). Do not mirror tile values or
+session-layer vocabulary.** They solve a different problem:
+
+- Lattices **tile** vocab (`left`, `grid:4x4:0,0`) describes *proportional rectangles a
+  real window fills*. Your agents are small overlay objects that *dock at an anchor* —
+  points, not rects. Wrong abstraction.
+- **Session/Studio layers** are launch-and-tile / rule-match over *foreign OS windows by
+  `wid`*. Irrelevant to overlay chips.
+
+Your 3×3 enum is actually closer to Lattices **actor placement** (`placement: point|top|
+bottom|center` + anchor + offset) than to tiling. So: keep the enum, but formalize it as a
+resolver `slot → (anchor, normalizedPoint)`. That normalized anchor+point is your
+**bridge unit** — it maps directly onto `overlay.actor.publish`'s anchor/x/y and onto
+`GridPlacement.fractions` if you ever need rects. Vocabulary stays yours; geometry
+contract lines up with Lattices for free.
+
+One upgrade the wedge forces: a slot must hold **multiple** agents (many agents tail at
+once). So evolve placement from "3×3 position" to **"slot (anchor lane) + order within
+lane."** Dedicated slots = an agent *pinned* to a lane; everyone else flows into a default
+lane the app packs calmly. This is the single most important placement change to make now.
+
+### 2. Canvas — build your own; define an adapter seam; do NOT depend on Lattices at runtime
+
+**Own your passive per-screen canvas. Put a `OverlaySink` protocol at the seam so a
+Lattices backend can slot in later. Never a hard runtime dependency.**
+
+- You're selling this. Coupling your core loop to another app's daemon lifecycle and an
+  evolving API (`overlay.actor.*` still has open questions on Spaces scoping, pinned-
+  position persistence, event routing) is unacceptable for a paid product.
+- The canvas isn't much code: one click-through `NSPanel` per `NSScreen` + a value-snapshot
+  renderer. You want control over notch geometry, calm packing, and your visual language.
+- Define the seam both ways so the bridge is symmetric and opt-in:
+  - `OverlaySink` (default = Hudson's own canvas; future `LatticesOverlaySink` maps
+    publish/place/visibility → `overlay.actor.*`), and
+  - because you already expose a socket/CLI, Lattices can equally be a *client* that feeds
+    agent events into Hudson's tail.
+  Default: Hudson hosts. Bridge is an adapter, never a dependency.
+
+### 3. First implementation — contract first, then the tail (wedge), then calm placements
+
+The wedge is the **agent tail**, not the fancy overlay. Ship the tail as a real
+interactive panel; keep the click-through canvas for phase 2. (Lattices' own lesson:
+interactive stuff lives in a real panel; only passive visuals go on the click-through
+canvas.)
+
+Design so Lattices-compat is a later adapter, not a rewrite. Compat comes from three
+things, all cheap to establish now: **(a) verb-aligned contract, (b) normalized
+anchor+point geometry, (c) the `OverlaySink` seam.**
+
+### 4. Mistakes / overbuilds to avoid right now
+
+- **No mascots / sprite animation system.** You said calm — skip motion, easing, an
+  animator entirely. Static chips. (Drop Lattices' `OverlayActorAnimator` idea outright.)
+- **Don't build the interactive hit-testing canvas first.** The tail (a normal panel)
+  delivers the wedge with zero click-through-canvas complexity. Add the passive canvas
+  second; make it interactive only if chip-level actions are truly needed — and even then
+  prefer putting actions in the tail row.
+- **Don't leak rendering into the contract.** Callers send *intent* (agent state, slot,
+  notification, action list). The app owns pixels, z-order, packing. This is the #1
+  discipline — the same "don't API-spam frames/positions" lesson Lattices learned.
+- **Don't hard-depend on Lattices**, and don't adopt its tile grammar as your public
+  vocabulary.
+- **Don't overmodel geometry.** No `grid:CxR` spans, fractional rects, or multi-monitor
+  span logic. Named slots + lanes is enough; the grid grammar is System A's job (real
+  windows), not yours.
+- **One source of truth.** A single `AgentStore` keyed by id feeds all three surfaces;
+  notch/tail/overlay are pure projections. Two stores = drift.
+- **Surfaces degrade independently.** Notch notifications must fire even if the overlay
+  canvas is down; actions must never depend on rendering.
+- **No Spaces/multi-Space machinery now.** Current-Space, all-displays. Pick simple
+  defaults (placement persisted per display) and move on — Lattices left these as open
+  questions; you don't need to solve them to ship.
+- **Don't design licensing into the core yet.** Ship the wedge.
+
+---
+
+## The contract (sharpen this first — it's your real product API)
+
+Newline-delimited JSON over the Unix socket, versioned envelope. Verbs deliberately
+line up with `overlay.actor.*` so a bridge is a rename, not a redesign:
+
+| Hudson event            | Meaning                                  | Lattices analog             |
+|-------------------------|------------------------------------------|-----------------------------|
+| `agent.upsert`          | register/update an agent (full context)  | `overlay.actor.publish`     |
+| `agent.status`          | status + last line transition            | `overlay.actor.setState`    |
+| `agent.notify`          | a notification (severity, actions)       | actor message / `overlay.publish` |
+| `agent.place`           | assign agent to a slot/lane              | `overlay.actor.moveTo`      |
+| `overlay.visibility`    | show/hide/toggle the whole layer         | `overlay.actor.visibility`  |
+| `agent.clear`           | remove an agent                          | `overlay.actor.clear`       |
+| `agent.action` (→ out)  | user clicked a declared shortcut         | `overlay.actor.actionSelected` |
+
+```jsonc
+// inbound
+{"v":1,"type":"agent.upsert","agent":{"id":"scout-1","name":"Scout","workspace":"lattices",
+  "service":"claude-code","status":"working","slot":"topTrailing","pinned":true,"visible":true,
+  "shortcuts":[{"id":"open","label":"Open PR"},{"id":"approve","label":"Approve","style":"primary"}]}}
+{"v":1,"type":"agent.status","id":"scout-1","status":"waiting","line":"Needs review on #31"}
+{"v":1,"type":"agent.notify","id":"scout-1","surface":"notch","title":"Review?","body":"PR #31",
+  "severity":"decision","actions":[{"id":"open","label":"Open PR"}]}
+{"v":1,"type":"agent.place","id":"scout-1","slot":"topTrailing"}
+{"v":1,"type":"overlay.visibility","action":"toggle"}
+{"v":1,"type":"agent.clear","id":"scout-1"}
+// outbound (emitted back to the caller that owns the agent)
+{"v":1,"type":"agent.action","id":"scout-1","actionId":"approve"}
+```
+
+Status is a small closed set: `idle | working | waiting | blocked | done | failed`.
+CLI is a thin wrapper (`hudson agent upsert|status|place|clear`, `hudson notify`,
+`hudson overlay toggle`) plus a language-agnostic escape hatch
+(`hudson emit '<json>'` / `nc -U ~/.hudson/hudson.sock`).
+
+---
+
+## Phased plan
+
+### Phase 0 — Contract & core (do first; cheapest, unblocks integrators)
+- Version the envelope (`v:1`). Single `AgentStore` keyed by id = source of truth;
+  surfaces are projections.
+- Lock the verb set above. Status enum closed. Document socket + CLI. This is the hardest
+  thing to change once agents integrate — get it right before the UI.
+- Add the `OverlaySink` protocol seam (default impl no-op/logging) even before the canvas.
+
+### Phase 1 — Agent tail (the paid wedge)
+- Interactive panel: every known agent with status dot, name, workspace/service, last
+  line, "waiting-for-you" badge; keyboard nav; click focuses the agent's target app.
+- Declared `shortcuts` render as row actions; click emits `agent.action` back over the
+  socket (routed to the owning caller, not broadcast).
+- Notch notifications driven by `agent.notify` (severity → style); notch + tail share the
+  `AgentStore`.
+- Global show/hide/toggle for the whole Hudson layer (hotkey + `overlay.visibility`).
+- Sellable on its own: "one calm place to see and talk back to all your agents."
+
+### Phase 2 — Overlay placements (calm, static)
+- Your own passive per-screen click-through canvas. Small **static** agent chips docked to
+  named slots; slots are lanes that stack calmly.
+- `slot → (anchor, normalizedPoint)` resolver = the bridge unit. Persist per-agent slot +
+  pin per display.
+- Show/hide/toggle parks chips (visibility), never destroys agent state.
+- No motion, no mascots, no whole-screen input capture.
+
+### Phase 3 — Selective interaction + Lattices bridge (only if needed)
+- If chips need direct actions: selective hit-testing — only chip/button bounds capture
+  input, return `nil` everywhere else, don't activate the app on hover. Copy LAT-004's
+  discipline exactly.
+- Ship `LatticesOverlaySink`: map upsert/place/visibility/clear → `overlay.actor.*` so
+  Hudson chips can optionally render through Lattices' canvas, and/or Lattices agents can
+  appear in Hudson's tail. Opt-in, symmetric, still not a hard dependency.
+
+---
+
+## TL;DR
+1. **Keep your slot vocabulary**; formalize `slot → (anchor, normalizedPoint)` as the
+   bridge unit; evolve placement to **slot + lane order** so a slot holds many agents.
+2. **Build your own canvas**, hide it behind an `OverlaySink` seam; no runtime Lattices
+   dependency.
+3. **Contract first → agent tail (wedge) as a real panel → calm static overlay chips →
+   optional Lattices bridge.** Compat = verb-aligned contract + normalized geometry +
+   the sink seam.
+4. Avoid: mascots/animation, interactive canvas before the tail, rendering concerns in the
+   contract, two agent stores, surfaces that can't degrade independently, Spaces machinery.

--- a/docs/tiling-reference.md
+++ b/docs/tiling-reference.md
@@ -72,6 +72,17 @@ For arbitrary grids: compact `CxR:C,R` or canonical `grid:CxR:C,R`
 
 Parsed by `PlacementSpec` / `parseGridString()` into fractional `(x, y, w, h)`.
 
+### App Shortcut Defaults
+
+The menu bar app exposes tiling shortcuts in Settings > Shortcuts. Useful
+defaults include:
+
+- `Ctrl+Option+G`: show the 4x4 grid placement target for the frontmost window.
+- `Ctrl+Option+V`: move the frontmost window into the least-occupied cell of a
+  3x2 grid on its current screen.
+- `Ctrl+Option+Space`: open the command bar; type `/tile 3x2:3,2` or another
+  placement string to place the captured frontmost window precisely.
+
 ### Placement Contract
 
 Placement strings are convenient at the boundary, but the daemon uses a


### PR DESCRIPTION
## Summary

- add fill-open-cell placement, progressive Screen Map apply feedback, and global window navigation hints
- expose cached window previews and a read-only interactive window picker through the daemon API
- add computer-use background-safety receipts and no-focus AX execution
- hydrate the embedded assistant runtime PATH and document the API, shortcuts, tiling behavior, and Hudson overlay guidance

## Review fixes included

- keep window-pick selection mode strictly read-only by blocking motion, placement, command-bar, and layer-editing paths
- move the blocking picker wait off the daemon socket queue so other RPCs and events remain responsive
- allow picker selection when macOS exposes visible windows without titles
- consume jump-letter keystrokes so they do not leak into the foreground app

## Validation

- `bun run check`
- `bun run test`
- `bun run test:e2e`
- `lattices app restart` (signed production app bundle)
- live picker timeout smoke test while `lattices daemon status` completed concurrently in 0.03s
- `windows.preview` cold-cache/warmup response smoke test
