### PR TITLE
Companion deck builder and dependency-free CLI release

### DIFF
--- a/.github/workflows/release-package-npm.yml
+++ b/.github/workflows/release-package-npm.yml
@@ -11,6 +11,11 @@ on:
         required: false
         default: false
         type: boolean
+      build_app:
+        description: 'Rebuild the bundled macOS app before publishing'
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   publish:
@@ -87,11 +92,18 @@ jobs:
         if: ${{ github.event_name == 'push' || inputs.publish }}
         run: |
           set -euo pipefail
+          # Build once for normal releases. CLI-only releases may deliberately
+          # reuse the committed app bundle, avoiding an unrelated Swift rebuild.
+          if [[ "${{ github.event_name }}" == "push" || "${{ inputs.build_app }}" == "true" ]]; then
+            npm run prepack
+          else
+            echo "Reusing committed apps/mac/Lattices.app for this CLI-only release."
+          fi
           # Primary package (@arach/lattices) — updates the public npm page.
-          npm publish --provenance --access public
+          npm publish --ignore-scripts --provenance --access public
           # Back-compat alias for existing @lattices/cli installs/imports.
           npm pkg set name=@lattices/cli
-          npm publish --provenance --access public
+          npm publish --ignore-scripts --provenance --access public
           npm pkg set name=@arach/lattices
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/bin/infer.ts
+++ b/bin/infer.ts
@@ -1,18 +1,13 @@
 /**
- * Lattices inference wrapper — thin layer over Vercel AI SDK.
+ * Lattices inference wrapper — dependency-free HTTP clients for text models.
  *
  * Features:
- *  - Multi-provider: groq, openai, anthropic, google, xai
+ *  - Multi-provider: groq, openai, anthropic, google, xai, minimax
  *  - Credential loading: env vars → .env.local/.env → ~/.lattices/inference.json → macOS Keychain
  *  - Instrumented: every call logged with timing, model, token usage
  *  - Simple API: `await infer("do something", { provider: "groq" })`
  */
 
-import { generateText, type ModelMessage } from "ai";
-import { createOpenAI } from "@ai-sdk/openai";
-import { createAnthropic } from "@ai-sdk/anthropic";
-import { createGoogleGenerativeAI } from "@ai-sdk/google";
-import { createXai } from "@ai-sdk/xai";
 import { readFileSync, existsSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
@@ -22,11 +17,16 @@ import { getKeychainSecret } from "./keychain";
 
 export type ProviderName = "groq" | "openai" | "anthropic" | "google" | "xai" | "minimax";
 
+export interface InferenceMessage {
+  role: "system" | "user" | "assistant";
+  content: string | Array<{ type?: string; text?: string }>;
+}
+
 export interface InferOptions {
   provider?: ProviderName;
   model?: string;
   system?: string;
-  messages?: ModelMessage[];
+  messages?: InferenceMessage[];
   temperature?: number;
   maxTokens?: number;
   /** Tag for logging — e.g. "hands-off", "voice-fallback" */
@@ -245,44 +245,218 @@ export function resolveVoiceInferenceOptions(): { provider: ProviderName; model:
   return { provider, model };
 }
 
-// ── Provider factory ───────────────────────────────────────────────
+// ── Provider HTTP clients ─────────────────────────────────────────
 
-function getModel(provider: ProviderName, modelId: string) {
-  const creds = loadCredentials();
+interface ProviderResponse {
+  text: string;
+  usage?: InferResult["usage"];
+}
 
-  switch (provider) {
-    case "groq": {
-      const groq = createOpenAI({
-        baseURL: "https://api.groq.com/openai/v1",
-        apiKey: creds.groq,
-      });
-      return groq(modelId);
-    }
-    case "openai": {
-      const openai = createOpenAI({ apiKey: creds.openai });
-      return openai(modelId);
-    }
-    case "anthropic": {
-      const anthropic = createAnthropic({ apiKey: creds.anthropic });
-      return anthropic(modelId);
-    }
-    case "google": {
-      const google = createGoogleGenerativeAI({ apiKey: creds.google });
-      return google(modelId);
-    }
-    case "xai": {
-      const xai = createXai({ apiKey: creds.xai });
-      return xai(modelId);
-    }
-    case "minimax": {
-      // MiniMax uses OpenAI-compatible chat completions API
-      const minimax = createOpenAI({
-        baseURL: "https://api.minimax.io/v1",
-        apiKey: creds.minimax,
-      });
-      return minimax.chat(modelId);
-    }
+interface NormalizedMessage {
+  role: InferenceMessage["role"];
+  content: string;
+}
+
+function contentText(content: InferenceMessage["content"]): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return String(content ?? "");
+  return content
+    .map((part) => typeof part?.text === "string" ? part.text : "")
+    .filter(Boolean)
+    .join("\n");
+}
+
+function normalizeMessages(
+  prompt: string,
+  messages: InferenceMessage[] = []
+): NormalizedMessage[] {
+  return [
+    ...messages.map((message) => ({
+      role: message.role,
+      content: contentText(message.content),
+    })),
+    { role: "user" as const, content: prompt },
+  ];
+}
+
+async function postJSON(
+  url: string,
+  headers: Record<string, string>,
+  body: Record<string, unknown>,
+  abortSignal?: AbortSignal
+): Promise<any> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+    signal: abortSignal,
+  });
+  const raw = await response.text();
+  let data: any;
+  try {
+    data = raw ? JSON.parse(raw) : {};
+  } catch {
+    data = { message: raw };
   }
+
+  if (!response.ok) {
+    const detail = data?.error?.message ?? data?.error ?? data?.message ?? raw;
+    throw new Error(`HTTP ${response.status}: ${String(detail || response.statusText)}`);
+  }
+  return data;
+}
+
+function responseText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => typeof part === "string" ? part : part?.text ?? "")
+      .filter(Boolean)
+      .join("\n");
+  }
+  return "";
+}
+
+async function inferOpenAICompatible(
+  provider: "groq" | "openai" | "xai" | "minimax",
+  apiKey: string,
+  model: string,
+  messages: NormalizedMessage[],
+  options: InferOptions
+): Promise<ProviderResponse> {
+  const baseURLs = {
+    groq: "https://api.groq.com/openai/v1",
+    openai: "https://api.openai.com/v1",
+    xai: "https://api.x.ai/v1",
+    minimax: "https://api.minimax.io/v1",
+  } as const;
+  const maxTokens = options.maxTokens ?? 1024;
+  const data = await postJSON(
+    `${baseURLs[provider]}/chat/completions`,
+    { authorization: `Bearer ${apiKey}` },
+    {
+      model,
+      messages: [
+        ...(options.system ? [{ role: "system", content: options.system }] : []),
+        ...messages,
+      ],
+      temperature: options.temperature ?? 0.3,
+      ...(provider === "xai"
+        ? { max_tokens: maxTokens }
+        : { max_completion_tokens: maxTokens }),
+    },
+    options.abortSignal
+  );
+  const usage = data?.usage;
+  const text = responseText(data?.choices?.[0]?.message?.content);
+  if (!text) throw new Error(`${provider} returned no text`);
+  return {
+    text,
+    usage: usage ? {
+      promptTokens: usage.prompt_tokens,
+      completionTokens: usage.completion_tokens,
+      totalTokens: usage.total_tokens,
+    } : undefined,
+  };
+}
+
+async function inferAnthropic(
+  apiKey: string,
+  model: string,
+  messages: NormalizedMessage[],
+  options: InferOptions
+): Promise<ProviderResponse> {
+  const systemMessages = messages.filter((message) => message.role === "system");
+  const system = [options.system, ...systemMessages.map((message) => message.content)]
+    .filter(Boolean)
+    .join("\n\n");
+  const data = await postJSON(
+    "https://api.anthropic.com/v1/messages",
+    {
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    {
+      model,
+      max_tokens: options.maxTokens ?? 1024,
+      temperature: options.temperature ?? 0.3,
+      ...(system ? { system } : {}),
+      messages: messages.filter((message) => message.role !== "system"),
+    },
+    options.abortSignal
+  );
+  const text = responseText(data?.content);
+  if (!text) throw new Error("anthropic returned no text");
+  const promptTokens = data?.usage?.input_tokens;
+  const completionTokens = data?.usage?.output_tokens;
+  return {
+    text,
+    usage: data?.usage ? {
+      promptTokens,
+      completionTokens,
+      totalTokens: typeof promptTokens === "number" && typeof completionTokens === "number"
+        ? promptTokens + completionTokens
+        : undefined,
+    } : undefined,
+  };
+}
+
+async function inferGoogle(
+  apiKey: string,
+  model: string,
+  messages: NormalizedMessage[],
+  options: InferOptions
+): Promise<ProviderResponse> {
+  const modelId = model.replace(/^models\//, "");
+  const systemMessages = messages.filter((message) => message.role === "system");
+  const system = [options.system, ...systemMessages.map((message) => message.content)]
+    .filter(Boolean)
+    .join("\n\n");
+  const data = await postJSON(
+    `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(modelId)}:generateContent`,
+    { "x-goog-api-key": apiKey },
+    {
+      ...(system ? { systemInstruction: { parts: [{ text: system }] } } : {}),
+      contents: messages
+        .filter((message) => message.role !== "system")
+        .map((message) => ({
+          role: message.role === "assistant" ? "model" : "user",
+          parts: [{ text: message.content }],
+        })),
+      generationConfig: {
+        temperature: options.temperature ?? 0.3,
+        maxOutputTokens: options.maxTokens ?? 1024,
+      },
+    },
+    options.abortSignal
+  );
+  const text = responseText(data?.candidates?.[0]?.content?.parts);
+  if (!text) throw new Error("google returned no text");
+  const usage = data?.usageMetadata;
+  return {
+    text,
+    usage: usage ? {
+      promptTokens: usage.promptTokenCount,
+      completionTokens: usage.candidatesTokenCount,
+      totalTokens: usage.totalTokenCount,
+    } : undefined,
+  };
+}
+
+async function callProvider(
+  provider: ProviderName,
+  apiKey: string,
+  model: string,
+  messages: NormalizedMessage[],
+  options: InferOptions
+): Promise<ProviderResponse> {
+  if (provider === "anthropic") {
+    return inferAnthropic(apiKey, model, messages, options);
+  }
+  if (provider === "google") {
+    return inferGoogle(apiKey, model, messages, options);
+  }
+  return inferOpenAICompatible(provider, apiKey, model, messages, options);
 }
 
 // ── Logging ────────────────────────────────────────────────────────
@@ -333,36 +507,18 @@ export async function infer(
     );
   }
 
-  const model = getModel(provider, modelId);
-
-  // Build messages
-  const messages: ModelMessage[] = [
-    ...(options.messages ?? []),
-    { role: "user", content: prompt },
-  ];
+  const apiKey = creds[provider];
+  const messages = normalizeMessages(prompt, options.messages);
 
   log(tag, `→ ${provider}/${modelId} (${prompt.length} chars)`);
   const start = performance.now();
 
   try {
-    const result = await generateText({
-      model,
-      system: options.system,
-      messages,
-      temperature: options.temperature ?? 0.3,
-      maxOutputTokens: options.maxTokens ?? 1024,
-      abortSignal: options.abortSignal,
-    });
+    const result = await callProvider(provider, apiKey, modelId, messages, options);
 
     const durationMs = Math.round(performance.now() - start);
 
-    const usage = result.usage
-      ? {
-          promptTokens: result.usage.inputTokens,
-          completionTokens: result.usage.outputTokens,
-          totalTokens: result.usage.totalTokens,
-        }
-      : undefined;
+    const usage = result.usage;
 
     log(
       tag,

--- a/bun.lock
+++ b/bun.lock
@@ -4,14 +4,6 @@
   "workspaces": {
     "": {
       "name": "@arach/lattices",
-      "dependencies": {
-        "@ai-sdk/anthropic": "^3.0.58",
-        "@ai-sdk/google": "^3.0.43",
-        "@ai-sdk/openai": "^3.0.41",
-        "@ai-sdk/xai": "^3.0.67",
-        "ai": "^6.0.116",
-        "zod": "^3.25.76",
-      },
       "devDependencies": {
         "bun-types": "^1.3.10",
         "typescript": "^5.9.3",
@@ -19,42 +11,12 @@
     },
   },
   "packages": {
-    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.58", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-/53SACgmVukO4bkms4dpxpRlYhW8Ct6QZRe6sj1Pi5H00hYhxIrqfiLbZBGxkdRvjsBQeP/4TVGsXgH5rQeb8Q=="],
-
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.66", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-SIQ0YY0iMuv+07HLsZ+bB990zUJ6S4ujORAh+Jv1V2KGNn73qQKnGO0JBk+w+Res8YqOFSycwDoWcFlQrVxS4A=="],
-
-    "@ai-sdk/google": ["@ai-sdk/google@3.0.43", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-NGCgP5g8HBxrNdxvF8Dhww+UKfqAkZAmyYBvbu9YLoBkzAmGKDBGhVptN/oXPB5Vm0jggMdoLycZ8JReQM8Zqg=="],
-
-    "@ai-sdk/openai": ["@ai-sdk/openai@3.0.41", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-IZ42A+FO+vuEQCVNqlnAPYQnnUpUfdJIwn1BEDOBywiEHa23fw7PahxVtlX9zm3/zMvTW4JKPzWyvAgDu+SQ2A=="],
-
-    "@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@2.0.35", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-g3wA57IAQFb+3j4YuFndgkUdXyRETZVvbfAWM+UX7bZSxA3xjes0v3XKgIdKdekPtDGsh4ZX2byHD0gJIMPfiA=="],
-
-    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
-
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.19", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg=="],
-
-    "@ai-sdk/xai": ["@ai-sdk/xai@3.0.67", "", { "dependencies": { "@ai-sdk/openai-compatible": "2.0.35", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-KQQIDc91dUA5IGFMnXBuvPBeraYNTdpDC1qUS+JG8vE+/299//5sZFafI1kKYUu3f3p7LaZrKXYgZ1Ni7QIRbw=="],
-
-    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
-
-    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
-    "@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
-
-    "ai": ["ai@6.0.116", "", { "dependencies": { "@ai-sdk/gateway": "3.0.66", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA=="],
-
     "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
-
-    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
-
-    "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
   }
 }

--- a/design/studio/app/embed/deck-builder/page.tsx
+++ b/design/studio/app/embed/deck-builder/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+/**
+ * Chrome-free deck builder for embedding in the Mac app's WKWebView.
+ *
+ * Bridge contract (JS ↔ Swift):
+ *  - Init — the host injects `window.__DECK_INIT__` (Deck[]) before the page
+ *    loads (a WKUserScript at documentStart), or posts a
+ *    `{ type: "deck-init", decks }` window message afterwards.
+ *  - Save — every layout change is posted to the host via
+ *    `window.webkit.messageHandlers.deck.postMessage({ type: "deck-change", decks })`.
+ *    In a plain browser (no bridge) it logs to the console instead, so the
+ *    contract is fully testable without the Mac.
+ */
+
+import { useEffect, useState } from "react";
+import { DeckBuilder, type Deck } from "@/studio/studies/DeckBuilder";
+
+declare global {
+  interface Window {
+    __DECK_INIT__?: Deck[];
+    webkit?: { messageHandlers?: Record<string, { postMessage: (msg: unknown) => void }> };
+  }
+}
+
+export default function DeckBuilderEmbed() {
+  const [initial, setInitial] = useState<Deck[] | undefined>(undefined);
+  const [ver, setVer] = useState(0); // bump → remount DeckBuilder with fresh initialDecks
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && Array.isArray(window.__DECK_INIT__)) {
+      setInitial(window.__DECK_INIT__);
+      setVer((v) => v + 1);
+    }
+    const onMsg = (e: MessageEvent) => {
+      const d = e.data as { type?: string; decks?: Deck[] } | null;
+      if (d && d.type === "deck-init" && Array.isArray(d.decks)) {
+        setInitial(d.decks);
+        setVer((v) => v + 1);
+      }
+    };
+    window.addEventListener("message", onMsg);
+    setReady(true);
+    return () => window.removeEventListener("message", onMsg);
+  }, []);
+
+  const onChange = (decks: Deck[]) => {
+    const bridge = typeof window !== "undefined" ? window.webkit?.messageHandlers?.deck : undefined;
+    if (bridge) bridge.postMessage({ type: "deck-change", decks });
+    else console.log("[deck-change]", JSON.stringify(decks));
+  };
+
+  if (!ready) return null;
+
+  return (
+    <div style={{ minHeight: "100vh", background: "#060607", color: "#e2e2df" }}>
+      <DeckBuilder key={ver} initialDecks={initial} onChange={onChange} className="p-6" />
+    </div>
+  );
+}

--- a/design/studio/src/studio/StudioPages.tsx
+++ b/design/studio/src/studio/StudioPages.tsx
@@ -3,6 +3,7 @@
 import { ArrowRight, Command } from "lucide-react";
 import type { StudioHudsonRenderContext } from "studio/app-shell";
 import { useStudioRouter } from "studio/router";
+import { DeckBuilderStudy } from "@/studio/studies/DeckBuilder";
 import {
   HOME_HREF,
   pages,
@@ -17,6 +18,7 @@ type RenderContext = StudioHudsonRenderContext<Bucket, Surface, Status>;
 export function renderStudioPage({ pathname, page }: RenderContext) {
   if (pathname === HOME_HREF) return <HomePage />;
   if (page?.href === "/studio/studies/nexus") return <NexusStudy page={page} />;
+  if (page?.href === "/studio/studies/deck-builder") return <DeckBuilderStudy page={page} />;
   if (page) return <PlaceholderPage page={page} />;
   return <NotFoundPage />;
 }

--- a/design/studio/src/studio/studies/DeckBuilder.tsx
+++ b/design/studio/src/studio/studies/DeckBuilder.tsx
@@ -11,7 +11,7 @@
  * real editor is built on the Mac (see docs/companion-deck-builder-spec.md).
  */
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Mic, X, CornerDownLeft, ArrowLeft, ArrowRight, ArrowUp, ArrowDown,
   ChevronLeft, ChevronRight, Search, Command, LayoutGrid, Crosshair,
@@ -107,11 +107,11 @@ const CATALOG: { group: string; items: CatalogItem[] }[] = [
 const CATALOG_BY_ID = new Map(CATALOG.flatMap((g) => g.items).map((i) => [i.id, i]));
 
 // ── model ────────────────────────────────────────────────────────────────
-type Key = {
+export type Key = {
   id: string; label: string; icon: IconName; tint: Tint; category: string;
   actionID: string; col: number; row: number; colSpan: number; rowSpan: number;
 };
-type Deck = { id: string; name: string; tint: Tint; columns: number; rows: number; keys: Key[] };
+export type Deck = { id: string; name: string; tint: Tint; columns: number; rows: number; keys: Key[] };
 
 let uid = 0;
 const nid = () => `k${++uid}`;
@@ -247,14 +247,32 @@ type Drag =
   | { mode: "move"; id: string; col: number; row: number; ok: boolean; preview: Key[] | null }
   | { mode: "resize"; id: string; colSpan: number; rowSpan: number; ok: boolean; preview: Key[] | null };
 
-export function DeckBuilderStudy({ page }: { page: LatticesPage }) {
-  const [decks, setDecks] = useState<Deck[]>(SEED);
-  const [activeId, setActiveId] = useState("command");
+/**
+ * Reusable deck editor core. In the studio it's wrapped by `DeckBuilderStudy`;
+ * in the Mac app it's loaded chrome-free at `/embed/deck-builder`, seeded with
+ * `initialDecks` (the Mac's current layout) and reporting every change through
+ * `onChange` → the JS↔Swift bridge, which persists to `companionCockpitLayout`.
+ */
+export function DeckBuilder({ initialDecks, onChange, className }: {
+  initialDecks?: Deck[];
+  onChange?: (decks: Deck[]) => void;
+  className?: string;
+}) {
+  const [decks, setDecks] = useState<Deck[]>(initialDecks && initialDecks.length ? initialDecks : SEED);
+  const [activeId, setActiveId] = useState(() => (initialDecks?.[0]?.id ?? "command"));
   const [selId, setSelId] = useState<string | null>(null);
   const [drag, setDrag] = useState<Drag | null>(null);
   const canvasRef = useRef<HTMLDivElement>(null);
 
-  const deck = decks.find((d) => d.id === activeId)!;
+  // Report layout changes to the host bridge; skip the initial mount so we don't
+  // echo the seed/injected layout straight back to the Mac.
+  const firstEmit = useRef(true);
+  useEffect(() => {
+    if (firstEmit.current) { firstEmit.current = false; return; }
+    onChange?.(decks);
+  }, [decks, onChange]);
+
+  const deck = decks.find((d) => d.id === activeId) ?? decks[0];
   const sel = deck.keys.find((k) => k.id === selId) ?? null;
 
   const patchDeck = useCallback((fn: (d: Deck) => Deck) => {
@@ -371,11 +389,9 @@ export function DeckBuilderStudy({ page }: { page: LatticesPage }) {
   const keyCount = deck.keys.length;
 
   return (
-    <main className="w-full px-6 py-9 lg:px-7">
-      <PageHeader page={page} />
-
+    <div className={className}>
       {/* deck tabs + grid shape */}
-      <div className="mt-6 flex flex-wrap items-center gap-3">
+      <div className="flex flex-wrap items-center gap-3">
         <div className="flex items-center gap-1.5">
           {decks.map((d) => (
             <button
@@ -502,6 +518,16 @@ export function DeckBuilderStudy({ page }: { page: LatticesPage }) {
         material, and reticle framing match the live Lats deck so this doubles as the visual spec.
         See <code>docs/companion-deck-builder-spec.md</code>.
       </p>
+    </div>
+  );
+}
+
+/** Studio wrapper — the deck builder under the studio page chrome. */
+export function DeckBuilderStudy({ page }: { page: LatticesPage }) {
+  return (
+    <main className="w-full px-6 py-9 lg:px-7">
+      <PageHeader page={page} />
+      <DeckBuilder className="mt-6" />
     </main>
   );
 }

--- a/design/studio/src/studio/studies/DeckBuilder.tsx
+++ b/design/studio/src/studio/studies/DeckBuilder.tsx
@@ -1,0 +1,736 @@
+"use client";
+
+/**
+ * Deck Builder — interactive study for the companion cockpit editor.
+ *
+ * A span-aware grid editor in the Lats keycap / reticle visual language:
+ * tap an empty cell to add a key, drag to move (cell-snapped, valid/invalid
+ * ghost), drag the corner handle to span multiple cells, and edit the selected
+ * key in the inspector (label / icon / tint / action / size). Grid shape is
+ * 2–5 columns × 1–4 rows, ≤ 16 keys, gaps allowed. Pure design prototype — the
+ * real editor is built on the Mac (see docs/companion-deck-builder-spec.md).
+ */
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import {
+  Mic, X, CornerDownLeft, ArrowLeft, ArrowRight, ArrowUp, ArrowDown,
+  ChevronLeft, ChevronRight, Search, Command, LayoutGrid, Crosshair,
+  MousePointer2, Space as SpaceIcon, PanelLeft, PanelRight,
+  SquareDashed, Maximize2, Monitor, Terminal, Play, Hammer, GitBranch,
+  Volume2, Sun, Camera, Sparkles, Home, Clock, Plus, Trash2, Rows3, Columns3,
+} from "lucide-react";
+import type { LatticesPage } from "@/studio/studioRegistry";
+
+// ── palette (Lats design tokens) ─────────────────────────────────────────
+const TINTS = {
+  red: "#E1726B", amber: "#E8BC6B", green: "#81DD86", blue: "#7EAFE2",
+  teal: "#6ECFCF", violet: "#BD97FC", pink: "#F593CE",
+} as const;
+type Tint = keyof typeof TINTS;
+const TINT_KEYS = Object.keys(TINTS) as Tint[];
+
+const INK = {
+  pad: "#060607", well0: "#0a0b0d", well1: "#08090b", card: "#0c0c0e",
+  brk: "#202024", fg: "#e2e2df", fg2: "#a0a09b", fg3: "#71716c", fg4: "#4a4a4d",
+};
+
+// ── icon registry ────────────────────────────────────────────────────────
+const ICONS = {
+  Mic, X, CornerDownLeft, ArrowLeft, ArrowRight, ArrowUp, ArrowDown,
+  ChevronLeft, ChevronRight, Search, Command, LayoutGrid, Crosshair,
+  MousePointer2, SpaceIcon, PanelLeft, PanelRight, SquareDashed, Maximize2,
+  Monitor, Terminal, Play, Hammer, GitBranch, Volume2, Sun, Camera, Sparkles,
+  Home, Clock,
+} as const;
+type IconName = keyof typeof ICONS;
+const ICON_PICKER: IconName[] = [
+  "Mic", "X", "CornerDownLeft", "ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown",
+  "ChevronLeft", "ChevronRight", "Search", "Command", "LayoutGrid", "Crosshair",
+  "MousePointer2", "SpaceIcon", "PanelLeft", "PanelRight", "Maximize2", "Monitor",
+  "Terminal", "Play", "Hammer", "GitBranch", "Volume2", "Sun", "Camera",
+  "Sparkles", "Home", "Clock", "SquareDashed",
+];
+function Icon({ name, size = 15, color }: { name: IconName; size?: number; color?: string }) {
+  const C = ICONS[name] ?? SquareDashed;
+  return <C size={size} color={color} strokeWidth={1.7} />;
+}
+
+// ── action catalog (mirrors the Mac shortcut catalog) ────────────────────
+type CatalogItem = { id: string; label: string; icon: IconName; tint: Tint; category: string };
+const CATALOG: { group: string; items: CatalogItem[] }[] = [
+  { group: "Voice", items: [
+    { id: "voice.toggle", label: "Start Voice", icon: "Mic", tint: "red", category: "voice" },
+    { id: "voice.cancel", label: "Cancel Voice", icon: "X", tint: "red", category: "voice" },
+  ]},
+  { group: "System", items: [
+    { id: "key.escape", label: "Escape", icon: "CornerDownLeft", tint: "amber", category: "system" },
+    { id: "key.enter", label: "Enter", icon: "CornerDownLeft", tint: "amber", category: "system" },
+    { id: "key.space", label: "Space", icon: "SpaceIcon", tint: "amber", category: "system" },
+  ]},
+  { group: "Switching", items: [
+    { id: "switch.appPrev", label: "Prev App", icon: "ChevronLeft", tint: "blue", category: "system" },
+    { id: "switch.appNext", label: "Next App", icon: "ChevronRight", tint: "blue", category: "system" },
+    { id: "switch.winPrev", label: "Prev Window", icon: "ArrowLeft", tint: "blue", category: "window" },
+    { id: "switch.winNext", label: "Next Window", icon: "ArrowRight", tint: "blue", category: "window" },
+  ]},
+  { group: "Layout", items: [
+    { id: "layout.optimize", label: "Optimize", icon: "LayoutGrid", tint: "blue", category: "window" },
+    { id: "layout.left", label: "Left", icon: "PanelLeft", tint: "blue", category: "window" },
+    { id: "layout.right", label: "Right", icon: "PanelRight", tint: "blue", category: "window" },
+    { id: "layout.center", label: "Center", icon: "SquareDashed", tint: "blue", category: "window" },
+    { id: "layout.maximize", label: "Maximize", icon: "Maximize2", tint: "blue", category: "window" },
+    { id: "layout.monitorL", label: "L Monitor", icon: "Monitor", tint: "teal", category: "window" },
+    { id: "layout.monitorR", label: "R Monitor", icon: "Monitor", tint: "teal", category: "window" },
+  ]},
+  { group: "Mouse", items: [
+    { id: "mouse.find", label: "Find Mouse", icon: "Crosshair", tint: "green", category: "system" },
+    { id: "mouse.summon", label: "Summon Mouse", icon: "MousePointer2", tint: "green", category: "system" },
+  ]},
+  { group: "Dev", items: [
+    { id: "dev.terminal", label: "Terminal", icon: "Terminal", tint: "green", category: "dev" },
+    { id: "dev.run", label: "Run", icon: "Play", tint: "green", category: "dev" },
+    { id: "dev.build", label: "Build", icon: "Hammer", tint: "amber", category: "dev" },
+    { id: "dev.git", label: "Git", icon: "GitBranch", tint: "amber", category: "dev" },
+  ]},
+  { group: "Media", items: [
+    { id: "media.play", label: "Play", icon: "Play", tint: "violet", category: "system" },
+    { id: "media.vol", label: "Volume", icon: "Volume2", tint: "teal", category: "system" },
+    { id: "media.bright", label: "Brightness", icon: "Sun", tint: "amber", category: "system" },
+    { id: "media.shot", label: "Screenshot", icon: "Camera", tint: "pink", category: "system" },
+  ]},
+  { group: "Agent", items: [
+    { id: "agent.claude", label: "Claude", icon: "Sparkles", tint: "violet", category: "agent" },
+    { id: "agent.home", label: "Home", icon: "Home", tint: "pink", category: "system" },
+    { id: "agent.recents", label: "Recents", icon: "Clock", tint: "violet", category: "system" },
+  ]},
+];
+const CATALOG_BY_ID = new Map(CATALOG.flatMap((g) => g.items).map((i) => [i.id, i]));
+
+// ── model ────────────────────────────────────────────────────────────────
+type Key = {
+  id: string; label: string; icon: IconName; tint: Tint; category: string;
+  actionID: string; col: number; row: number; colSpan: number; rowSpan: number;
+};
+type Deck = { id: string; name: string; tint: Tint; columns: number; rows: number; keys: Key[] };
+
+let uid = 0;
+const nid = () => `k${++uid}`;
+function keyFrom(item: CatalogItem, col: number, row: number, colSpan = 1, rowSpan = 1): Key {
+  return { id: nid(), label: item.label, icon: item.icon, tint: item.tint,
+    category: item.category, actionID: item.id, col, row, colSpan, rowSpan };
+}
+const c = (id: string) => CATALOG_BY_ID.get(id)!;
+
+const SEED: Deck[] = [
+  { id: "command", name: "Command", tint: "green", columns: 4, rows: 4, keys: [
+    { ...keyFrom(c("voice.toggle"), 0, 0, 2, 2) },
+    keyFrom(c("key.escape"), 2, 0), keyFrom(c("key.enter"), 3, 0),
+    keyFrom(c("voice.cancel"), 2, 1), keyFrom(c("key.space"), 3, 1),
+    { ...keyFrom(c("layout.optimize"), 0, 2, 2, 1) },
+    keyFrom(c("mouse.find"), 2, 2), keyFrom(c("mouse.summon"), 3, 2),
+    keyFrom(c("layout.left"), 0, 3), keyFrom(c("layout.right"), 1, 3),
+    keyFrom(c("layout.center"), 2, 3), keyFrom(c("layout.maximize"), 3, 3),
+  ]},
+  { id: "windows", name: "Windows", tint: "blue", columns: 4, rows: 3, keys: [
+    { ...keyFrom(c("layout.optimize"), 0, 0, 4, 1) },
+    keyFrom(c("layout.left"), 0, 1), keyFrom(c("layout.right"), 1, 1),
+    keyFrom(c("layout.center"), 2, 1), keyFrom(c("layout.maximize"), 3, 1),
+    { ...keyFrom(c("layout.monitorL"), 0, 2, 2, 1) },
+    { ...keyFrom(c("layout.monitorR"), 2, 2, 2, 1) },
+  ]},
+  { id: "dev", name: "Dev", tint: "green", columns: 4, rows: 2, keys: [
+    keyFrom(c("dev.terminal"), 0, 0), keyFrom(c("dev.run"), 1, 0),
+    keyFrom(c("dev.build"), 2, 0), keyFrom(c("dev.git"), 3, 0),
+    { ...keyFrom(c("layout.optimize"), 0, 1, 2, 1) },
+    keyFrom(c("switch.winPrev"), 2, 1), keyFrom(c("switch.winNext"), 3, 1),
+  ]},
+  { id: "media", name: "Media", tint: "violet", columns: 3, rows: 2, keys: [
+    { ...keyFrom(c("media.play"), 0, 0, 1, 2) },
+    keyFrom(c("media.vol"), 1, 0), keyFrom(c("media.bright"), 2, 0),
+    keyFrom(c("media.shot"), 1, 1), keyFrom(c("agent.home"), 2, 1),
+  ]},
+  { id: "voice", name: "Voice", tint: "red", columns: 3, rows: 2, keys: [
+    { ...keyFrom(c("voice.toggle"), 0, 0, 2, 1) },
+    keyFrom(c("voice.cancel"), 2, 0),
+    keyFrom(c("agent.claude"), 0, 1), keyFrom(c("agent.recents"), 1, 1),
+    keyFrom(c("mouse.summon"), 2, 1),
+  ]},
+];
+
+const SIZE_PRESETS: { label: string; cs: number; rs: number }[] = [
+  { label: "1×1", cs: 1, rs: 1 }, { label: "2×1", cs: 2, rs: 1 },
+  { label: "1×2", cs: 1, rs: 2 }, { label: "2×2", cs: 2, rs: 2 },
+];
+
+// ── geometry + validation ────────────────────────────────────────────────
+const CELL = 108;
+const GAP = 10;
+const canvasSize = (n: number) => n * CELL + (n - 1) * GAP;
+const cellRect = (k: { col: number; row: number; colSpan: number; rowSpan: number }) => ({
+  left: k.col * (CELL + GAP),
+  top: k.row * (CELL + GAP),
+  width: k.colSpan * CELL + (k.colSpan - 1) * GAP,
+  height: k.rowSpan * CELL + (k.rowSpan - 1) * GAP,
+});
+const inBounds = (k: Key, cols: number, rows: number) =>
+  k.col >= 0 && k.row >= 0 && k.col + k.colSpan <= cols && k.row + k.rowSpan <= rows;
+
+const intersects = (
+  a: Pick<Key, "col" | "row" | "colSpan" | "rowSpan">,
+  b: Pick<Key, "col" | "row" | "colSpan" | "rowSpan">,
+) =>
+  a.col < b.col + b.colSpan && a.col + a.colSpan > b.col &&
+  a.row < b.row + b.rowSpan && a.row + a.rowSpan > b.row;
+
+function findFreeSpot(
+  m: Key, occ: boolean[][], cols: number, rows: number, prefer: { col: number; row: number }[],
+): { col: number; row: number } | null {
+  const fits = (col: number, row: number) => {
+    if (col < 0 || row < 0 || col + m.colSpan > cols || row + m.rowSpan > rows) return false;
+    for (let r = 0; r < m.rowSpan; r++) for (let c = 0; c < m.colSpan; c++) if (occ[row + r][col + c]) return false;
+    return true;
+  };
+  for (const p of prefer) if (fits(p.col, p.row)) return p;         // fill the vacated space first → swap feel
+  for (let row = 0; row < rows; row++) for (let col = 0; col < cols; col++) if (fits(col, row)) return { col, row };
+  return null;
+}
+
+/**
+ * Resolve a move/resize: drop the dragged key at its new footprint and push any
+ * keys it now overlaps into free cells — preferring the cells the dragged key
+ * just vacated, so a same-size drop reads as a straight swap and a bigger move
+ * shuffles the smaller keys into the freed space. Returns the full new layout,
+ * or null when there genuinely isn't room.
+ */
+function resolve(
+  keys: Key[],
+  dragId: string,
+  next: Partial<Pick<Key, "col" | "row" | "colSpan" | "rowSpan">>,
+  cols: number,
+  rows: number,
+): Key[] | null {
+  const dragged = keys.find((k) => k.id === dragId);
+  if (!dragged) return null;
+  const K: Key = { ...dragged, ...next };
+  if (!inBounds(K, cols, rows)) return null;
+
+  const originCells: { col: number; row: number }[] = [];
+  for (let r = 0; r < dragged.rowSpan; r++)
+    for (let c = 0; c < dragged.colSpan; c++) originCells.push({ col: dragged.col + c, row: dragged.row + r });
+
+  const others = keys.filter((k) => k.id !== dragId);
+  const displaced = others
+    .filter((k) => intersects(K, k))
+    .sort((a, b) => b.colSpan * b.rowSpan - a.colSpan * a.rowSpan); // place larger keys first
+  const fixed = others.filter((k) => !intersects(K, k));
+
+  const occ = Array.from({ length: rows }, () => Array<boolean>(cols).fill(false));
+  const paint = (k: Key) => {
+    for (let r = 0; r < k.rowSpan; r++) for (let c = 0; c < k.colSpan; c++) occ[k.row + r][k.col + c] = true;
+  };
+  fixed.forEach(paint);
+  paint(K);
+
+  const placed: Key[] = [];
+  for (const m of displaced) {
+    const spot = findFreeSpot(m, occ, cols, rows, originCells);
+    if (!spot) return null; // no room to make space → invalid drop
+    const m2 = { ...m, col: spot.col, row: spot.row };
+    paint(m2);
+    placed.push(m2);
+  }
+  return [...fixed, K, ...placed];
+}
+
+// ── component ──────────────────────────────────────────────────────────────
+type Drag =
+  | { mode: "move"; id: string; col: number; row: number; ok: boolean; preview: Key[] | null }
+  | { mode: "resize"; id: string; colSpan: number; rowSpan: number; ok: boolean; preview: Key[] | null };
+
+export function DeckBuilderStudy({ page }: { page: LatticesPage }) {
+  const [decks, setDecks] = useState<Deck[]>(SEED);
+  const [activeId, setActiveId] = useState("command");
+  const [selId, setSelId] = useState<string | null>(null);
+  const [drag, setDrag] = useState<Drag | null>(null);
+  const canvasRef = useRef<HTMLDivElement>(null);
+
+  const deck = decks.find((d) => d.id === activeId)!;
+  const sel = deck.keys.find((k) => k.id === selId) ?? null;
+
+  const patchDeck = useCallback((fn: (d: Deck) => Deck) => {
+    setDecks((ds) => ds.map((d) => (d.id === activeId ? fn(d) : d)));
+  }, [activeId]);
+  const patchKey = useCallback((id: string, fn: (k: Key) => Key) => {
+    patchDeck((d) => ({ ...d, keys: d.keys.map((k) => (k.id === id ? fn(k) : k)) }));
+  }, [patchDeck]);
+
+  const pointerCell = useCallback((e: React.PointerEvent | PointerEvent) => {
+    const rect = canvasRef.current!.getBoundingClientRect();
+    const col = Math.floor((e.clientX - rect.left) / (CELL + GAP));
+    const row = Math.floor((e.clientY - rect.top) / (CELL + GAP));
+    return {
+      col: Math.max(0, Math.min(deck.columns - 1, col)),
+      row: Math.max(0, Math.min(deck.rows - 1, row)),
+    };
+  }, [deck.columns, deck.rows]);
+
+  // occupancy grid for empty-cell affordances
+  const occupied = useMemo(() => {
+    const g = Array.from({ length: deck.rows }, () => Array<boolean>(deck.columns).fill(false));
+    for (const k of deck.keys)
+      for (let r = 0; r < k.rowSpan; r++)
+        for (let cc = 0; cc < k.colSpan; cc++)
+          if (g[k.row + r]) g[k.row + r][k.col + cc] = true;
+    return g;
+  }, [deck]);
+
+  // ── drag / resize ────────────────────────────────────────────────────
+  const startMove = (e: React.PointerEvent, k: Key) => {
+    e.stopPropagation();
+    const start = pointerCell(e);
+    const grabCol = start.col - k.col, grabRow = start.row - k.row;
+    const dragState: Drag = { mode: "move", id: k.id, col: k.col, row: k.row, ok: true, preview: null };
+    setSelId(k.id);
+    setDrag(dragState);
+    const move = (ev: PointerEvent) => {
+      const p = pointerCell(ev);
+      const nc = Math.max(0, Math.min(deck.columns - k.colSpan, p.col - grabCol));
+      const nr = Math.max(0, Math.min(deck.rows - k.rowSpan, p.row - grabRow));
+      dragState.col = nc; dragState.row = nr;
+      const layout = resolve(deck.keys, k.id, { col: nc, row: nr }, deck.columns, deck.rows);
+      dragState.ok = !!layout; dragState.preview = layout;
+      setDrag({ ...dragState });
+    };
+    const up = () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+      const layout = dragState.preview;
+      if (dragState.ok && layout) patchDeck((d) => ({ ...d, keys: layout }));
+      setDrag(null);
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+  };
+
+  const startResize = (e: React.PointerEvent, k: Key) => {
+    e.stopPropagation();
+    const dragState: Drag = { mode: "resize", id: k.id, colSpan: k.colSpan, rowSpan: k.rowSpan, ok: true, preview: null };
+    setSelId(k.id);
+    setDrag(dragState);
+    const move = (ev: PointerEvent) => {
+      const p = pointerCell(ev);
+      const cs = Math.max(1, Math.min(deck.columns - k.col, p.col - k.col + 1));
+      const rs = Math.max(1, Math.min(deck.rows - k.row, p.row - k.row + 1));
+      dragState.colSpan = cs; dragState.rowSpan = rs;
+      const layout = resolve(deck.keys, k.id, { colSpan: cs, rowSpan: rs }, deck.columns, deck.rows);
+      dragState.ok = !!layout; dragState.preview = layout;
+      setDrag({ ...dragState });
+    };
+    const up = () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+      const layout = dragState.preview;
+      if (dragState.ok && layout) patchDeck((d) => ({ ...d, keys: layout }));
+      setDrag(null);
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+  };
+
+  const addAt = (col: number, row: number) => {
+    if (deck.keys.length >= 16) return;
+    const item = c("layout.optimize");
+    const k = keyFrom(item, col, row);
+    patchDeck((d) => ({ ...d, keys: [...d.keys, k] }));
+    setSelId(k.id);
+  };
+
+  const setGrid = (cols: number, rows: number) => {
+    patchDeck((d) => ({
+      ...d, columns: cols, rows,
+      // drop keys that no longer fit within the new bounds
+      keys: d.keys.filter((k) => k.col + k.colSpan <= cols && k.row + k.rowSpan <= rows),
+    }));
+  };
+
+  const applySize = (cs: number, rs: number) => {
+    if (!sel) return;
+    const layout = resolve(
+      deck.keys, sel.id,
+      { colSpan: Math.min(cs, deck.columns - sel.col), rowSpan: Math.min(rs, deck.rows - sel.row) },
+      deck.columns, deck.rows,
+    );
+    if (layout) patchDeck((d) => ({ ...d, keys: layout }));
+  };
+
+  const chooseAction = (item: CatalogItem) => {
+    if (!sel) return;
+    patchKey(sel.id, (k) => ({ ...k, actionID: item.id, label: item.label, icon: item.icon, tint: item.tint, category: item.category }));
+  };
+
+  const keyCount = deck.keys.length;
+
+  return (
+    <main className="w-full px-6 py-9 lg:px-7">
+      <PageHeader page={page} />
+
+      {/* deck tabs + grid shape */}
+      <div className="mt-6 flex flex-wrap items-center gap-3">
+        <div className="flex items-center gap-1.5">
+          {decks.map((d) => (
+            <button
+              key={d.id}
+              onClick={() => { setActiveId(d.id); setSelId(null); }}
+              className="rounded-md px-3 py-1.5 font-mono text-[11px] tracking-wide transition-colors"
+              style={{
+                color: d.id === activeId ? INK.fg : INK.fg3,
+                background: d.id === activeId ? "rgba(126,175,226,0.10)" : "transparent",
+                border: `0.5px solid ${d.id === activeId ? "rgba(126,175,226,0.30)" : INK.brk}`,
+              }}
+            >
+              {d.name.toLowerCase()}
+            </button>
+          ))}
+        </div>
+        <div className="ml-auto flex items-center gap-4">
+          <Stepper icon={<Columns3 size={13} />} label="cols" value={deck.columns} min={2} max={5}
+            onChange={(v) => setGrid(v, deck.rows)} />
+          <Stepper icon={<Rows3 size={13} />} label="rows" value={deck.rows} min={1} max={4}
+            onChange={(v) => setGrid(deck.columns, v)} />
+          <span className="font-mono text-[11px]" style={{ color: keyCount >= 16 ? TINTS.amber : INK.fg3 }}>
+            {keyCount}/16 keys
+          </span>
+        </div>
+      </div>
+
+      {/* builder: canvas + inspector */}
+      <div className="mt-5 flex flex-wrap items-start gap-6">
+        {/* canvas */}
+        <div
+          className="relative shrink-0 rounded-[14px] p-5"
+          style={{
+            background: `linear-gradient(160deg, ${INK.well0}, ${INK.well1} 60%, #090a0c)`,
+            border: `1px solid rgba(255,255,255,0.07)`,
+            boxShadow: "0 22px 60px -30px rgba(0,0,0,0.9)",
+          }}
+          onClick={() => setSelId(null)}
+        >
+          <Reticle />
+          <div
+            ref={canvasRef}
+            className="relative"
+            style={{ width: canvasSize(deck.columns), height: canvasSize(deck.rows) }}
+          >
+            {/* empty-cell add affordances (hidden while dragging) */}
+            {!drag && occupied.map((rowArr, r) =>
+              rowArr.map((occ, cc) =>
+                occ ? null : (
+                  <button
+                    key={`e${r}-${cc}`}
+                    onClick={(e) => { e.stopPropagation(); addAt(cc, r); }}
+                    className="absolute flex items-center justify-center rounded-[10px] transition-colors"
+                    style={{
+                      left: cc * (CELL + GAP), top: r * (CELL + GAP), width: CELL, height: CELL,
+                      border: `1px dashed ${INK.brk}`, color: INK.fg4,
+                    }}
+                  >
+                    <Plus size={16} />
+                  </button>
+                )
+              )
+            )}
+
+            {/* keys — during a drag every key lays out at its resolved position so
+                the displaced keys visibly make room; the dragged one follows the cursor. */}
+            {deck.keys.map((k) => {
+              const dragging = drag?.id === k.id;
+              const previewKey = drag?.preview?.find((p) => p.id === k.id);
+              let rect;
+              if (dragging && drag) {
+                rect = drag.mode === "move"
+                  ? cellRect({ ...k, col: drag.col, row: drag.row })
+                  : cellRect({ ...k, colSpan: drag.colSpan, rowSpan: drag.rowSpan });
+              } else if (previewKey) {
+                rect = cellRect(previewKey);
+              } else {
+                rect = cellRect(k);
+              }
+              return (
+                <KeyBlock
+                  key={k.id}
+                  k={k}
+                  rect={rect}
+                  selected={selId === k.id}
+                  dragging={!!dragging}
+                  dragOk={dragging ? drag!.ok : true}
+                  animate={!!drag && !dragging}
+                  onPointerDownMove={(e) => startMove(e, k)}
+                  onPointerDownResize={(e) => startResize(e, k)}
+                  onSelect={() => setSelId(k.id)}
+                />
+              );
+            })}
+          </div>
+          <div className="mt-3 font-mono text-[10px]" style={{ color: INK.fg4 }}>
+            tap empty cell to add · drag to move · pull the corner to span
+          </div>
+        </div>
+
+        {/* inspector */}
+        <div
+          className="min-w-[300px] flex-1 rounded-[10px] p-4"
+          style={{ background: INK.card, border: `1px solid ${INK.brk}` }}
+        >
+          {sel ? (
+            <KeyInspector
+              k={sel}
+              onLabel={(v) => patchKey(sel.id, (k) => ({ ...k, label: v }))}
+              onTint={(t) => patchKey(sel.id, (k) => ({ ...k, tint: t }))}
+              onIcon={(ic) => patchKey(sel.id, (k) => ({ ...k, icon: ic }))}
+              onSize={applySize}
+              onAction={chooseAction}
+              onDelete={() => { patchDeck((d) => ({ ...d, keys: d.keys.filter((x) => x.id !== sel.id) })); setSelId(null); }}
+            />
+          ) : (
+            <DeckInspector deck={deck} onName={(v) => patchDeck((d) => ({ ...d, name: v }))} />
+          )}
+        </div>
+      </div>
+
+      <p className="mt-6 max-w-[70ch] font-mono text-[11px] leading-relaxed" style={{ color: INK.fg3 }}>
+        Interactive prototype for the Mac-side companion deck builder. The grid, spans, keycap
+        material, and reticle framing match the live Lats deck so this doubles as the visual spec.
+        See <code>docs/companion-deck-builder-spec.md</code>.
+      </p>
+    </main>
+  );
+}
+
+// ── key block ──────────────────────────────────────────────────────────────
+function KeyBlock({ k, rect, selected, dragging, dragOk, animate, onPointerDownMove, onPointerDownResize, onSelect }: {
+  k: Key; rect: { left: number; top: number; width: number; height: number };
+  selected: boolean; dragging: boolean; dragOk: boolean; animate: boolean;
+  onPointerDownMove: (e: React.PointerEvent) => void;
+  onPointerDownResize: (e: React.PointerEvent) => void;
+  onSelect: () => void;
+}) {
+  const tint = TINTS[k.tint];
+  const ring = dragging ? (dragOk ? TINTS.green : TINTS.red) : selected ? tint : "rgba(0,0,0,0.85)";
+  return (
+    <div
+      onPointerDown={onPointerDownMove}
+      onClick={(e) => { e.stopPropagation(); onSelect(); }}
+      className="absolute flex select-none flex-col rounded-[11px] p-3"
+      style={{
+        left: rect.left, top: rect.top, width: rect.width, height: rect.height,
+        background: "linear-gradient(180deg, #1a1a1e, #0f0f11 74%, #0c0c0e)",
+        border: `${selected || dragging ? 1.5 : 0.5}px solid ${ring}`,
+        boxShadow: dragging
+          ? "0 18px 34px -12px rgba(0,0,0,0.85)"
+          : "inset 0 1px 0 rgba(255,255,255,0.08), inset 0 -1px 1px rgba(0,0,0,0.6), 0 5px 12px -6px rgba(0,0,0,0.6)",
+        cursor: dragging ? "grabbing" : "grab",
+        opacity: dragging && !dragOk ? 0.7 : 1,
+        zIndex: dragging ? 20 : selected ? 10 : 1,
+        // displaced keys glide as they make room during a drag
+        transition: animate ? "left 0.14s ease, top 0.14s ease, width 0.14s ease, height 0.14s ease" : undefined,
+      }}
+    >
+      <span
+        className="flex items-center justify-center rounded-[7px]"
+        style={{ width: 26, height: 26, color: tint, background: `${tint}22`, border: `0.5px solid ${tint}66` }}
+      >
+        <Icon name={k.icon} />
+      </span>
+      <div className="mt-auto">
+        <div className="text-[14px] font-medium" style={{ color: INK.fg }}>{k.label}</div>
+        <div className="mt-1 flex items-center gap-1.5 font-mono text-[10px]" style={{ color: INK.fg4 }}>
+          <span style={{ width: 5, height: 5, borderRadius: 999, background: tint, display: "inline-block" }} />
+          {k.colSpan}×{k.rowSpan} · {k.category}
+        </div>
+      </div>
+      {/* resize handle */}
+      <span
+        onPointerDown={onPointerDownResize}
+        className="absolute bottom-0 right-0 cursor-nwse-resize"
+        style={{ width: 18, height: 18 }}
+      >
+        <span className="absolute bottom-1.5 right-1.5 block" style={{
+          width: 7, height: 7, borderRight: `1.5px solid ${INK.fg3}`, borderBottom: `1.5px solid ${INK.fg3}`,
+        }} />
+      </span>
+    </div>
+  );
+}
+
+// ── inspectors ───────────────────────────────────────────────────────────
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mb-2 font-mono text-[9px] font-bold uppercase tracking-[0.18em]" style={{ color: TINTS.amber }}>
+      {children}
+    </div>
+  );
+}
+
+function KeyInspector({ k, onLabel, onTint, onIcon, onSize, onAction, onDelete }: {
+  k: Key;
+  onLabel: (v: string) => void; onTint: (t: Tint) => void; onIcon: (i: IconName) => void;
+  onSize: (cs: number, rs: number) => void; onAction: (i: CatalogItem) => void; onDelete: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <SectionLabel>key</SectionLabel>
+        <input
+          value={k.label}
+          onChange={(e) => onLabel(e.target.value)}
+          className="w-full rounded-[6px] px-3 py-2 font-mono text-[12px] outline-none"
+          style={{ background: "rgba(0,0,0,0.25)", border: `1px solid ${INK.brk}`, color: INK.fg }}
+        />
+      </div>
+
+      <div>
+        <SectionLabel>size</SectionLabel>
+        <div className="flex flex-wrap gap-1.5">
+          {SIZE_PRESETS.map((p) => {
+            const on = k.colSpan === p.cs && k.rowSpan === p.rs;
+            return (
+              <button key={p.label} onClick={() => onSize(p.cs, p.rs)}
+                className="rounded-[5px] px-2.5 py-1 font-mono text-[11px]"
+                style={{ color: on ? INK.pad : INK.fg2, background: on ? TINTS.green : "rgba(255,255,255,0.04)", border: `1px solid ${on ? TINTS.green : INK.brk}` }}>
+                {p.label}
+              </button>
+            );
+          })}
+          <button onClick={() => onSize(99, k.rowSpan)}
+            className="rounded-[5px] px-2.5 py-1 font-mono text-[11px]"
+            style={{ color: INK.fg2, background: "rgba(255,255,255,0.04)", border: `1px solid ${INK.brk}` }}>
+            full row
+          </button>
+        </div>
+      </div>
+
+      <div>
+        <SectionLabel>tint</SectionLabel>
+        <div className="flex gap-2">
+          {TINT_KEYS.map((t) => (
+            <button key={t} onClick={() => onTint(t)}
+              style={{ width: 22, height: 22, borderRadius: 6, background: TINTS[t],
+                outline: k.tint === t ? `2px solid ${INK.fg}` : "none", outlineOffset: 1 }} />
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <SectionLabel>icon</SectionLabel>
+        <div className="grid grid-cols-8 gap-1.5">
+          {ICON_PICKER.map((ic) => {
+            const on = k.icon === ic;
+            return (
+              <button key={ic} onClick={() => onIcon(ic)}
+                className="flex items-center justify-center rounded-[6px] py-1.5"
+                style={{ background: on ? `${TINTS[k.tint]}22` : "rgba(255,255,255,0.03)",
+                  border: `0.5px solid ${on ? TINTS[k.tint] : INK.brk}`, color: on ? TINTS[k.tint] : INK.fg2 }}>
+                <Icon name={ic} size={14} />
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div>
+        <SectionLabel>action</SectionLabel>
+        <div className="max-h-[220px] overflow-y-auto rounded-[6px]" style={{ border: `1px solid ${INK.brk}` }}>
+          {CATALOG.map((grp) => (
+            <div key={grp.group}>
+              <div className="px-3 py-1.5 font-mono text-[9px] uppercase tracking-wider" style={{ color: INK.fg4, background: "rgba(255,255,255,0.02)" }}>
+                {grp.group}
+              </div>
+              {grp.items.map((it) => {
+                const on = k.actionID === it.id;
+                return (
+                  <button key={it.id} onClick={() => onAction(it)}
+                    className="flex w-full items-center gap-2.5 px-3 py-1.5 text-left"
+                    style={{ background: on ? "rgba(126,175,226,0.10)" : "transparent" }}>
+                    <span style={{ color: TINTS[it.tint] }}><Icon name={it.icon} size={13} /></span>
+                    <span className="font-mono text-[11px]" style={{ color: on ? INK.fg : INK.fg2 }}>{it.label}</span>
+                    <span className="ml-auto font-mono text-[9px]" style={{ color: INK.fg4 }}>{it.id}</span>
+                  </button>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <button onClick={onDelete}
+        className="flex items-center justify-center gap-2 rounded-[6px] py-2 font-mono text-[11px]"
+        style={{ color: TINTS.red, background: "rgba(225,114,107,0.08)", border: `1px solid rgba(225,114,107,0.3)` }}>
+        <Trash2 size={13} /> delete key
+      </button>
+    </div>
+  );
+}
+
+function DeckInspector({ deck, onName }: { deck: Deck; onName: (v: string) => void }) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <SectionLabel>deck</SectionLabel>
+        <input value={deck.name} onChange={(e) => onName(e.target.value)}
+          className="w-full rounded-[6px] px-3 py-2 font-mono text-[12px] outline-none"
+          style={{ background: "rgba(0,0,0,0.25)", border: `1px solid ${INK.brk}`, color: INK.fg }} />
+      </div>
+      <div className="font-mono text-[11px] leading-relaxed" style={{ color: INK.fg3 }}>
+        {deck.columns}×{deck.rows} grid · {deck.keys.length} keys.
+        <br />Select a key to edit it, or tap an empty cell to add one. Drag to move, pull the
+        corner handle to make a key span multiple cells.
+      </div>
+      <div className="rounded-[6px] p-3 font-mono text-[10px]" style={{ background: "rgba(255,255,255,0.02)", border: `1px solid ${INK.brk}`, color: INK.fg4 }}>
+        Empty cells stay as gaps — a deck doesn&apos;t have to fully tile.
+      </div>
+    </div>
+  );
+}
+
+// ── small bits ─────────────────────────────────────────────────────────────
+function Stepper({ icon, label, value, min, max, onChange }: {
+  icon: React.ReactNode; label: string; value: number; min: number; max: number; onChange: (v: number) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 font-mono text-[11px]" style={{ color: INK.fg3 }}>
+      <span className="flex items-center gap-1">{icon}{label}</span>
+      <div className="flex items-center overflow-hidden rounded-[5px]" style={{ border: `1px solid ${INK.brk}` }}>
+        <button onClick={() => onChange(Math.max(min, value - 1))} className="px-2 py-0.5" style={{ color: INK.fg2 }}>−</button>
+        <span className="min-w-[18px] text-center" style={{ color: INK.fg }}>{value}</span>
+        <button onClick={() => onChange(Math.min(max, value + 1))} className="px-2 py-0.5" style={{ color: INK.fg2 }}>+</button>
+      </div>
+    </div>
+  );
+}
+
+function Reticle() {
+  const L = 11, T = 1, o = 10, col = "rgba(255,255,255,0.34)";
+  const bar = (s: React.CSSProperties) => <span className="pointer-events-none absolute" style={{ background: col, ...s }} />;
+  return (
+    <>
+      {bar({ left: o, top: o, width: L, height: T })} {bar({ left: o, top: o, width: T, height: L })}
+      {bar({ right: o, top: o, width: L, height: T })} {bar({ right: o, top: o, width: T, height: L })}
+      {bar({ left: o, bottom: o, width: L, height: T })} {bar({ left: o, bottom: o, width: T, height: L })}
+      {bar({ right: o, bottom: o, width: L, height: T })} {bar({ right: o, bottom: o, width: T, height: L })}
+    </>
+  );
+}
+
+function PageHeader({ page }: { page: LatticesPage }) {
+  return (
+    <header className="max-w-[980px] border-b border-studio-rule pb-7">
+      <div className="font-mono text-[10px] uppercase tracking-eyebrow text-studio-ink-faint">
+        {page.bucket} / {page.surface}
+      </div>
+      <h1 className="mt-4 text-[36px] font-medium leading-tight text-studio-ink-strong">{page.label}</h1>
+      {page.blurb ? (
+        <p className="mt-4 max-w-[66ch] text-[15px] leading-[1.7] text-studio-ink">{page.blurb}</p>
+      ) : null}
+    </header>
+  );
+}

--- a/design/studio/src/studio/studioRegistry.ts
+++ b/design/studio/src/studio/studioRegistry.ts
@@ -33,6 +33,19 @@ export const pages: readonly LatticesPage[] = [
       "One slim bar: search · /commands · voice → act inline or hand off to the assistant. Six states on the registration grid.",
     source: ["apps/mac/Sources/Core/Overlays/Nexus/"],
   },
+  {
+    href: "/studio/studies/deck-builder",
+    label: "Deck Builder — companion cockpit",
+    bucket: "studies",
+    surface: "macos",
+    status: "in-flight",
+    blurb:
+      "Span-aware grid editor for the companion deck: tap an empty cell to add, drag to move, pull the corner to span 2×1 / 2×2. Interactive prototype for the Mac-side builder — the iPad just receives the layout and renders it.",
+    source: [
+      "docs/companion-deck-builder-spec.md",
+      "apps/mac/Sources/Core/Companion/LatticesCompanionCockpit.swift",
+    ],
+  },
 ];
 
 const defined = defineStudio({

--- a/docs/api.md
+++ b/docs/api.md
@@ -141,8 +141,8 @@ Returns `true` if `daemon.status` responds within 1 second.
 ## TypeScript SDK facade
 
 The CLI is a human/debug surface. Product code and agents should prefer the
-typed SDK facade, which validates params with Zod and calls the same daemon
-methods directly.
+typed SDK facade, which validates params with dependency-free schemas and calls
+the same daemon methods directly.
 
 ```ts
 import { cua } from '@lattices/sdk'

--- a/docs/companion-deck-builder-spec.md
+++ b/docs/companion-deck-builder-spec.md
@@ -1,0 +1,220 @@
+# Companion Deck Builder — implementation spec
+
+**Status:** proposed / for review — implementation on hold (owner is reviewing this doc first).
+**Architecture owner decisions (confirmed):**
+- **The builder lives on the Mac.** The Mac owns the cockpit layout + the shortcut catalog and is the source of truth.
+- **The iPad just receives the layout and renders it.** The only iPad change is a span-capable renderer; no iOS editor, no on-device deck store.
+- **Mac-defined shortcuts are the standard model.** ("The Mac defining its shortcuts is a somewhat standard idea.") The iPad defining *its own* decks is a possible future bonus — explicitly **out of scope** for this work.
+
+This is an **upgrade of the existing Mac cockpit editor**, not a greenfield build. The Mac already ships a functional-but-basic editor and a positional layout model; this spec extends both to support variable grid shapes and spanning keys, and replaces the per-slot dropdown UI with a real visual grid builder.
+
+---
+
+## 0. What already exists (ground truth)
+
+- **Layout model** — `apps/mac/Sources/Core/Companion/LatticesCompanionCockpit.swift`
+  - `LatticesCompanionCockpitLayout { pages: [Page] }`; `Page { id, title, subtitle, columns: Int = 4, slotIDs: [String] }` (Codable/Equatable).
+  - Positional flat slots: exactly `slotCount = 16` per page; slot index *i* ⇒ row `i / columns`, col `i % columns`; `""` = empty slot (gap). `normalizedSlots` pads/trims to 16.
+  - `LatticesCompanionCockpitCatalog`: `defaultLayout` (blueprint pages: `command`, `talkie`, …), a static shortcut catalog (`shortcuts`, `definition(for:)`), 9 categories (`LatticesCompanionShortcutCategory`) with tint tokens, and per-shortcut `actionID`+`payload` templates (keyboard / placement / resize / voice / mouse / switching / media).
+  - `normalized(_:)` maps the persisted layout onto the blueprint pages — **it currently drops any non-blueprint page id** and clamps `columns >= 2`.
+  - `renderedState(layout:voice:desktop:layoutState:talkie:) -> DeckCockpitState` builds the `DeckCockpitPage`/`DeckCockpitTile` payload sent to the iPad, hydrating live state (e.g. voice-toggle → "Stop Voice"/`isActive`).
+- **Persistence** — `apps/mac/Sources/AppShell/Preferences.swift`
+  - `companionCockpitLayout` (`didSet → persistCompanionCockpitLayout()`, UserDefaults JSON); `resetCompanionCockpitLayout()`; `updateCompanionCockpitSlot(pageID:index:shortcutID:)`.
+- **Editor UI (basic)** — `apps/mac/Sources/AppShell/SettingsView.swift`
+  - `companionCockpitCard` (line ~3820): page `Picker` + a 16-slot grid where each slot is a `companionCockpitSlotMenu` (a dropdown to assign a catalog shortcut or clear the slot), plus a reset button. `@State selectedCompanionCockpitPageID`.
+- **Serving** — `apps/mac/Sources/Core/Companion/LatticesDeckHost.swift` `manifest()` / snapshot path serves `DeckCockpitState` over the secure bridge.
+- **iPad renderer** — `apps/ios/Sources/LatsDeckScreen.swift`
+  - `LatsShortcutGrid` renders a flat `[LatsShortcut]` into equal rows of `columns` (fill-vs-scroll via GeometryReader, spacing 9, minRowHeight 96). `liveShortcuts()` maps `DeckCockpitTile` → `LatsShortcut`. `LatsShortcutTile` = keycap. No span/position support anywhere yet.
+- **Shared package** — `swift/Sources/DeckKit/DeckCockpit.swift`: `DeckCockpitPage { columns, tiles }`, `DeckCockpitTile { …, no layout fields }`. Compiled by **both** the Mac app and the iOS app.
+
+---
+
+## 1. Summary
+
+Extend the Mac's cockpit layout so each key can be a rectangular block with explicit position and span (`col,row,colSpan,rowSpan`), grow the grid to a variable shape (2–5 columns × 1–4 rows, ≤16 keys, gaps allowed), and replace the dropdown editor with a **visual grid builder** in Mac Settings (tap-to-add, drag-to-move, resize-to-span, catalog-backed action picker, deck management). The layout continues to render through `renderedState()` into `DeckCockpitState`; `DeckCockpitTile` gains **optional** layout fields so the span/position rides the existing bridge to the iPad. The iPad's only change is generalizing `LatsShortcutGrid` into a span-aware renderer. No new endpoint is required — the layout already flows Mac → iPad through the manifest/snapshot.
+
+---
+
+## 2. Data model
+
+### 2a. DeckKit (shared — `swift/Sources/DeckKit/DeckCockpit.swift`)
+
+Add **optional** layout fields (nil-default ⇒ Codable back-compat; both builds recompile with no source changes elsewhere):
+
+```swift
+// DeckCockpitTile
+public var col: Int?      // 0-based anchor column
+public var row: Int?      // 0-based anchor row
+public var colSpan: Int?  // nil ⇒ 1
+public var rowSpan: Int?  // nil ⇒ 1
+
+// DeckCockpitPage
+public var rows: Int?     // nil ⇒ legacy behavior (derive rows from tiles/columns)
+```
+
+Rebuild **both** targets after this change (`cd apps/mac && swift build -c release`, plus the iOS scheme). Any non-optional addition or init-parameter reorder breaks the Mac build.
+
+### 2b. Mac layout model (`LatticesCompanionCockpit.swift`)
+
+Replace the flat `slotIDs: [String]` with a positional slot list that carries span, while keeping a lossless migration from the old format:
+
+```swift
+struct Slot: Codable, Equatable {
+    var shortcutID: String   // "" ⇒ empty
+    var col: Int
+    var row: Int
+    var colSpan: Int = 1
+    var rowSpan: Int = 1
+}
+struct Page: Codable, Equatable, Identifiable {
+    var id: String
+    var title: String
+    var subtitle: String?
+    var columns: Int         // 2...5
+    var rows: Int            // 1...4  (NEW; default 4)
+    var slots: [Slot]        // replaces slotIDs
+}
+```
+
+**Migration:** implement a custom `Page` decoder that reads legacy `slotIDs: [String]` (16 entries) when `slots` is absent, mapping slot index *i* ⇒ `Slot(shortcutID: id, col: i % columns, row: i / columns, 1×1)` and dropping `""` entries. Bump a `schemaVersion` on the layout for headroom. This keeps every persisted UserDefaults blob and the `defaultLayout` blueprint valid.
+
+`normalized(_:)` must be updated to (a) validate/repair spans (clamp into bounds, resolve overlaps deterministically by dropping the later slot), and (b) **stop dropping non-blueprint pages** if deck add/remove is in scope (see Phasing P3) — today it hard-maps to blueprint ids.
+
+`renderedState()` / `renderedTile()` set the new `DeckCockpitTile.col/row/colSpan/rowSpan` from each slot; `DeckCockpitPage.rows` from the page. `slotCount = 16` becomes a max-keys cap, not a fixed length.
+
+---
+
+## 3. Layout engine
+
+**Placement model: explicit anchors, gaps allowed.** Grid is ≤ 5×4 = 20 cells, so an explicit canvas is trivially editable and matches the existing positional slot model; no auto-flow reflow (surprising on resize). Legacy flat pages already map by slot index (§2b).
+
+**Validation** (pure functions, shared by the Mac store + editor):
+1. `2 ≤ columns ≤ 5`, `1 ≤ rows ≤ 4`.
+2. `keys.count ≤ 16` (non-empty slots).
+3. Per key: `colSpan ≥ 1`, `rowSpan ≥ 1`, `col ≥ 0`, `row ≥ 0`, `col + colSpan ≤ columns`, `row + rowSpan ≤ rows`.
+4. No overlap: paint each key's rect into a `rows × columns` occupancy grid; any double-paint is an error naming both keys.
+5. Gaps are legal (render as empty pad) — full tiling not required.
+
+**Rendering geometry (shared iPad + Mac canvas): pure cell-rect math + absolute positioning**, not a `Layout` conformance (the editor reuses the same rects for hit-testing, drag ghosts, drop validation):
+
+```
+cellW = (width  - (columns-1)*spacing) / columns
+rowH  = fill ? (height - (rows-1)*spacing) / rows : minRowHeight
+rect(key) = (x: col*(cellW+spacing), y: row*(rowH+spacing),
+             w: colSpan*cellW + (colSpan-1)*spacing,
+             h: rowSpan*rowH + (rowSpan-1)*spacing)
+```
+
+Implement once as `DeckGridGeometry` (candidate for DeckKit so Mac + iPad share it; if kept per-platform, keep the two copies identical). Keep the iPad's existing fill-vs-scroll rule (spacing 9, minRowHeight 96) and point→cell inverse for editor hit-testing.
+
+---
+
+## 4. iPad renderer (the only iPad change)
+
+- `LatsShortcut` (`LatsDeckScreen.swift`) gains `var placement: DeckGridPlacement? = nil` (small Equatable struct: col/row/colSpan/rowSpan).
+- `liveShortcuts()` copies the tile's `col/row/colSpan/rowSpan` into `placement`.
+- `LatsShortcutGrid` gains `var rows: Int? = nil` and branches: if **any** shortcut has a placement → new positioned path (`ZStack` + `DeckGridGeometry`, reusing `LatsShortcutTile` verbatim; compute `act.NN` index by `(row, col)` order); else the **existing chunked flow path unchanged** (mocks, legacy live pages, and the App Store screenshot harness in `LatticesCompanionApp.swift` render byte-identically).
+- In `gridColumns` (`LatsDeckScreen.swift`), the compact clamp `min(3, columns)` **must not** apply to placed pages — explicit placement depends on the true column count; compact devices get smaller cells / scroll instead of reflow.
+- No iOS editor, no `CompanionDeckStore`, no source-mode toggle. The iPad renders whatever `DeckCockpitState` the Mac sends.
+
+---
+
+## 5. Mac editor UX (the builder)
+
+Rebuild `companionCockpitCard` (`SettingsView.swift:3820`) from a per-slot dropdown list into a visual grid builder. Keep it inside the existing Settings surface (a card that can expand, or a dedicated sheet/tab if it needs room).
+
+- **Deck selector:** the current page `Picker` → a segmented/list selector over the layout's pages; add rename + (P3) add/reorder/delete. `columns` stepper (2–5) and `rows` stepper (1–4) with an inline guard when shrinking would orphan keys (block + "remove N affected keys" confirmation).
+- **Canvas:** render the deck exactly as the iPad would (the same `DeckGridGeometry` cell math) so the editor preview *is* the renderer. Empty cells show a dashed add-affordance; keys show icon + label + tint.
+  - Tap empty cell → create a slot there → open the inspector (action-first; a slot with no action is inert).
+  - Tap key → select (ring in the key's tint); resize handle → change span (snap to cells, reject overlap/out-of-bounds); drag → move (cell-snapped ghost, green valid / red invalid).
+  - Delete key (context menu / inspector).
+- **Inspector** (selected key): label, icon (SF Symbol picker over the catalog's icons + free-form field), tint (category tokens), size presets (1×1 / 2×1 / 1×2 / 2×2 / full-row) + span steppers, and **action** — a browser over `LatticesCompanionCockpitCatalog.shortcuts` grouped by `LatticesCompanionShortcutCategory`; choosing one fills actionID/payload/title/icon/tint. An "advanced" disclosure exposes raw `actionID` + a payload editor (round-trip through `DeckValue`), plus a key-combo sub-builder emitting `keys.send` payloads.
+- Reuse the existing `prefs.updateCompanionCockpitSlot`-style mutation surface, extended to span/position (`updateSlot(pageID:slotID:…)`, `addSlot`, `removeSlot`, `setGridShape`). Keep `resetCompanionCockpitLayout()`.
+
+AppKit/SwiftUI: this is the Mac app's existing SwiftUI settings stack — build with its current components; a drag/resize canvas is the main new UI work.
+
+---
+
+## 5b. Editor implementation — embed the web builder (recommended)
+
+Rather than reimplement the span grid, drag/move, resize, make-room displacement, inspector, and catalog in SwiftUI, **host the already-built React `DeckBuilder` (`design/studio/src/studio/studies/DeckBuilder.tsx`) in a `WKWebView`** inside Mac Settings. The interactive editor is done and proven; a native rebuild would re-solve drag/drop, span geometry, and the displacement algorithm from scratch. This turns the prototype into the product and collapses most of the editor phases into "wire the bridge + persist."
+
+- **Stays native, unchanged by this choice:** the DeckKit span extension (§2), `renderedState()` carrying spans (§6), persistence in `Preferences` (§0/§9), and the iPad spanning renderer (§4). The web view only replaces the *editor UI*.
+- **Packaging:** build the builder into a small static bundle (extract it into a standalone Vite `index.html`, or a Next static export of the single route) and embed it in the app bundle; load via `WKWebView.loadFileURL`. A tiny build step keeps the embedded bundle in sync with the studio study (one source of UI).
+- **JS ↔ Swift bridge:**
+  - *Init* — Swift injects the current layout (`Preferences.companionCockpitLayout`, normalized) + the shortcut catalog (`LatticesCompanionCockpitCatalog` → JSON) into the page, so the catalog stays single-source on the Mac and the builder drops its hardcoded `CATALOG`/`SEED`.
+  - *Save* — the page posts changes via `window.webkit.messageHandlers.deck.postMessage(layout)`; a `WKScriptMessageHandler` decodes them into the layout model and writes `companionCockpitLayout` (→ `renderedState()` → bridge → iPad, live).
+  - *Theme/size* — pass the dark theme + a content size; the study already renders dark.
+- **Trade-offs:** ➕ reuse the finished editor, ship fast, iterate in the browser, web is ideal for canvas/drag UI. ➖ a `WKWebView` island in native Settings (sizing/focus/theming polish), a build-and-embed step to keep in sync, and the JS↔Swift bridge for persistence + catalog. The native SwiftUI editor (§5) stays the fallback if the embed feels wrong.
+- **Recommendation:** start with the embedded web view. The `DeckBuilder` study is the editor; the remaining work is the DeckKit/render span plumbing (needed either way) plus a thin persistence bridge.
+
+---
+
+## 6. Serving / data flow
+
+No new endpoint. Mac layout (persisted) → `renderedState()` (now carrying spans) → `DeckCockpitState` → existing `LatticesDeckHost.manifest()`/snapshot → bridge → iPad `liveSnapshot.cockpit.pages` → `liveShortcuts()` → span-aware `LatsShortcutGrid`. Because `DeckCockpitTile` layout fields are optional, older iPad builds ignore them (flat render) and newer builds honor them — forward/backward compatible.
+
+---
+
+## 7. Action catalog
+
+Already exists Mac-side (`LatticesCompanionCockpitCatalog.shortcuts`, 9 categories, actionID/payload templates). The builder's action picker reads it directly; no port needed (unlike the earlier iOS-first plan). Free-form actionID/payload stays available for power users. Talkie category behavior is Mac-state-dependent (`talkieShortcut`) — keep as-is.
+
+---
+
+## 8. Phasing
+
+- **P1 — model + spanning render end-to-end.** DeckKit optional layout fields; Mac `Page.slots` + migration + `normalized()`/`renderedState()` carrying spans; iPad `DeckGridGeometry` + positioned path in `LatsShortcutGrid`. *Accept:* hand-author a page with a 2×2 and a 2×1 slot (even via the existing/temporary editing surface), and the iPad renders the spans correctly; legacy pages and the screenshot harness render unchanged; both targets build.
+- **P2 — visual builder.** Replace `companionCockpitCard` with the canvas + inspector: tap-add, tap-select, drag-move, resize-span, catalog action picker, grid-shape steppers. *Accept:* build a deck visually on the Mac, it persists, and it appears on a connected iPad.
+- **P3 — deck management + polish.** Add/rename/reorder/delete pages (update `normalized()` to preserve non-blueprint pages); free-form payload + key-combo builder; icon picker polish; validation UX. *Accept:* create a 6th deck; iPad deck pill/swipe cycling follows it.
+- **P4 (later / bonus) — iPad-authored decks.** Only if the owner wants the "iPad defines its own too" bonus: an on-device layer + a signed `/deck/layout` write endpoint. Out of scope now.
+
+---
+
+## 9. Decisions table
+
+| Question | Decision |
+|---|---|
+| Where does the builder live? | **Mac app** (extends the existing `companionCockpitCard` + layout model + catalog). |
+| iPad role | **Receives `DeckCockpitState` and renders it**; only change is a span-aware `LatsShortcutGrid`. No editor/store. |
+| Placement model | **Explicit `(col,row,colSpan,rowSpan)` anchors, gaps allowed.** Grid ≤ 5×4; matches existing positional slots; legacy flat pages migrate by index. |
+| Model change shape | Replace `Page.slotIDs: [String]` with `Page.slots: [Slot]` (+`rows`) with a legacy decoder; add **optional** `col/row/colSpan/rowSpan` to `DeckCockpitTile` and `rows` to `DeckCockpitPage` (Codable back-compat). |
+| Spanning render | Shared `DeckGridGeometry` cell-rect math + absolute positioning; keep iPad fill-vs-scroll (spacing 9, minRowHeight 96). |
+| Action catalog | Reuse the existing Mac `LatticesCompanionCockpitCatalog` + free-form advanced. |
+| Persistence | Existing `Preferences.companionCockpitLayout` (UserDefaults JSON), extended + `schemaVersion` + migration. |
+| Bounds | Decks (P3) up to ~8; columns 2–5 (default 4); rows 1–4 (default 4); ≤16 keys; any in-bounds rectangle (UI presets 1×1/2×1/1×2/2×2/full-row); gaps allowed. |
+| iPad-authored decks | Deferred bonus (P4), not now. |
+
+---
+
+## 10. Risks / verify before starting
+
+1. **DeckKit is shared by both apps** — rebuild the Mac app *and* the iOS scheme after the model change; keep additions optional / append-only to avoid breaking the Mac build.
+2. **Legacy migration** — every persisted `companionCockpitLayout` and the `defaultLayout` blueprint use the old flat `slotIDs`; the custom decoder must decode them losslessly (write a test in `swift/Tests/DeckKitTests` and a Mac-side layout test).
+3. **`normalized()` drops non-blueprint pages** today — fine until P3, but deck add/remove requires rewriting it to preserve custom pages while still repairing spans.
+4. **`gridColumns` compact clamp** (`LatsDeckScreen.swift`) reflowing to 3 columns would corrupt explicit placement — bypass for placed pages; verify iPhone falls back to scroll acceptably.
+5. **Screenshot harness** (`LatticesCompanionApp.swift`, `--app-store-deck=`) builds `LatsDeckScreen(deckID:)` with no live snapshot — must keep rendering mocks via the flat path.
+6. **Perform routing** — the Mac's `/deck/perform` handler routes on `actionID`; confirm span/position changes don't affect action dispatch (they shouldn't — layout is presentation only).
+7. **Dirty tree** — `apps/ios/Sources/*` currently has an open PR (`ipad-cockpit-redesign`); land or coordinate before touching `LatsDeckScreen.swift` to avoid conflicts. This feature is a **new, separate branch**.
+8. **Owner confirmations still open:** deck cap (8?), whether P3 deck add/remove is in the first delivery or later, and whether the builder stays an expandable Settings card vs a dedicated window/sheet.
+
+---
+
+## 11. Prior art — Talkie's deck editor (`~/dev/talkie`)
+
+Talkie has a mature deck configurator that independently arrived at the **same architecture we chose**, which is a strong validation signal — but it is a **fixed-grid, per-slot editor with no spans**, so it's a reference for the *inspector/UX*, not the *layout engine*.
+
+**What it is**
+- `apps/ios/Talkie iOS/Views/Configurator/KeyboardGridView.swift` — a WYSIWYG grid (3×4 + a dictate row) where each cell is a `SlotButtonPreview`; tap a slot → open the editor. The **editor preview is the real render** (the pattern we want). Its only "span" is a hardcoded 2×-wide DICTATE button — not user-editable.
+- `apps/ios/Talkie iOS/Views/Configurator/SlotEditorSheet.swift` (604 lines) — the rich per-slot editor: a **kind selector** (`text / snippet / action / space / empty`), per-kind dynamic fields, an action picker, a default-vs-custom summary, live keyboard-context preview, and Save/Cancel → `buildConfig()`. This is the most borrowable piece.
+- Model `apps/ios/Talkie iOS/Models/DeckBoardSnapshot.swift`: `DeckBoardSnapshot → [DeckSpace] → tiles: [DeckTile]` ("16 entries for the canonical 4×4"). `DeckTile { id, slotID?, label, icon, hint? }` — **no position/span/size**. `DeckMirrorStore` renders the Mac's board and fires `slotID` back to the Mac.
+
+**Architecture (identical to Lattices, validates the Mac-side decision)**
+> "iOS-side mirror of the macOS Command Deck … Mac resolves [label] from its shortcut catalog; iOS just renders it." A `DeckBoardSnapshot` ships Mac→iOS over the bridge; iOS renders and fires `slotID`; the Mac dispatches. This is exactly `DeckCockpitState` + `store.perform` in Lattices, and exactly the owner's "Mac owns, iPad renders" call.
+
+**Borrow for our Mac builder**
+1. The `SlotEditorSheet` structure for our key inspector — a **kind selector** is nicer than "pick one catalog shortcut": e.g. `action (catalog) / key-combo / advanced`, with per-kind fields + live preview.
+2. The **override + "customized" + reset-to-default** slot model (maps onto Lattices' existing `updateCompanionCockpitSlot` / `resetCompanionCockpitLayout`).
+3. **Editor preview = the renderer** (WYSIWYG), already in §5.
+
+**What Talkie does NOT solve (our net-new work):** user-defined **spans + variable grid shape**. Both Talkie and today's Lattices editor are fixed 16-slot 4×4. The spanning/variable-shape layer (§2–§3) is the genuinely new contribution — we design it; we can't lift it from Talkie.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arach/lattices",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Tile windows, search your screen, keep tmux sessions alive, and let AI agents control your Mac — CLI + daemon API",
   "homepage": "https://lattices.dev",
   "bugs": {
@@ -54,8 +54,9 @@
     "check": "bun run check:types && bun run check:app",
     "check:types": "tsc --noEmit",
     "check:app": "env CLANG_MODULE_CACHE_PATH=/tmp/lattices-clang-cache SWIFTPM_TESTS_MODULECACHE=/tmp/lattices-swiftpm-cache swift build --package-path apps/mac",
-    "test": "node --experimental-strip-types --test tests/cli.test.mjs",
+    "test": "node --experimental-strip-types --test tests/cli.test.mjs && bun test tests/dependency-free.test.ts",
     "test:cli": "node --experimental-strip-types --test tests/cli.test.mjs",
+    "test:dependencies": "bun test tests/dependency-free.test.ts",
     "test:e2e": "node --experimental-strip-types --test tests/e2e-daemon.test.mjs",
     "test:e2e:voice": "node --experimental-strip-types tests/eval-voice.js",
     "typecheck": "bun run check:types",
@@ -82,13 +83,5 @@
   "devDependencies": {
     "bun-types": "^1.3.10",
     "typescript": "^5.9.3"
-  },
-  "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.58",
-    "@ai-sdk/google": "^3.0.43",
-    "@ai-sdk/openai": "^3.0.41",
-    "@ai-sdk/xai": "^3.0.67",
-    "ai": "^6.0.116",
-    "zod": "^3.25.76"
   }
 }

--- a/packages/npm/sdk/cua.d.ts
+++ b/packages/npm/sdk/cua.d.ts
@@ -1,4 +1,9 @@
-import type { z } from "zod";
+export interface Schema<T> {
+  parse(value: unknown): T;
+  safeParse(value: unknown):
+    | { success: true; data: T }
+    | { success: false; error: Error & { issues?: Array<{ path: Array<string | number>; message: string }> } };
+}
 
 export type ComputerTreatment = "observe" | "stage" | "present" | "execute";
 export type ComputerClickTransport =
@@ -376,44 +381,44 @@ export interface CuaClient {
   magicCursor(params: ComputerMagicCursorParams): Promise<unknown>;
 }
 
-export declare const computerTreatmentSchema: z.ZodType<ComputerTreatment>;
-export declare const computerClickTransportSchema: z.ZodType<ComputerClickTransport>;
-export declare const cursorStyleSchema: z.ZodType<CursorStyle>;
-export declare const cursorShapeSchema: z.ZodType<CursorShape>;
-export declare const cursorSizeSchema: z.ZodType<CursorSize>;
-export declare const cursorTrailSchema: z.ZodType<CursorTrail>;
-export declare const cursorMotionSchema: z.ZodType<CursorMotion>;
-export declare const cursorTrajectorySchema: z.ZodType<CursorTrajectory>;
-export declare const cursorGlowSchema: z.ZodType<CursorGlow>;
-export declare const cursorIdleSchema: z.ZodType<CursorIdle>;
-export declare const cursorEdgeSchema: z.ZodType<CursorEdge>;
-export declare const cursorSoundSchema: z.ZodType<CursorSound>;
-export declare const captionPlacementSchema: z.ZodType<CaptionPlacement>;
-export declare const computerWindowStateParamsSchema: z.ZodType<ComputerWindowStateParams>;
-export declare const computerElementActionParamsSchema: z.ZodType<ComputerElementActionParams>;
-export declare const computerTypeElementParamsSchema: z.ZodType<ComputerTypeElementParams>;
-export declare const computerSetValueParamsSchema: z.ZodType<ComputerSetValueParams>;
-export declare const computerPressKeyParamsSchema: z.ZodType<ComputerPressKeyParams>;
-export declare const computerHotkeyParamsSchema: z.ZodType<ComputerHotkeyParams>;
-export declare const computerFocusWindowParamsSchema: z.ZodType<ComputerFocusWindowParams>;
-export declare const computerLaunchAppParamsSchema: z.ZodType<ComputerLaunchAppParams>;
-export declare const computerTypeWindowTextParamsSchema: z.ZodType<ComputerTypeWindowTextParams>;
-export declare const computerTypeTextParamsSchema: z.ZodType<ComputerTypeTextParams>;
-export declare const computerClickParamsSchema: z.ZodType<ComputerClickParams>;
-export declare const computerDoubleClickParamsSchema: z.ZodType<ComputerDoubleClickParams>;
-export declare const computerRightClickParamsSchema: z.ZodType<ComputerRightClickParams>;
-export declare const computerScrollParamsSchema: z.ZodType<ComputerScrollParams>;
-export declare const computerDragParamsSchema: z.ZodType<ComputerDragParams>;
-export declare const computerVerifyParamsSchema: z.ZodType<ComputerVerifyParams>;
-export declare const captureWindowParamsSchema: z.ZodType<CaptureWindowParams>;
-export declare const captureRegionParamsSchema: z.ZodType<CaptureRegionParams>;
-export declare const zoomArtifactParamsSchema: z.ZodType<ZoomArtifactParams>;
-export declare const visionAnalyzeWindowParamsSchema: z.ZodType<VisionAnalyzeWindowParams>;
-export declare const visionAnalyzeArtifactParamsSchema: z.ZodType<VisionAnalyzeArtifactParams>;
-export declare const browserGetTextParamsSchema: z.ZodType<BrowserGetTextParams>;
-export declare const browserQueryDomParamsSchema: z.ZodType<BrowserQueryDomParams>;
-export declare const browserExecuteJavascriptParamsSchema: z.ZodType<BrowserExecuteJavascriptParams>;
-export declare const computerMagicCursorParamsSchema: z.ZodType<ComputerMagicCursorParams>;
+export declare const computerTreatmentSchema: Schema<ComputerTreatment>;
+export declare const computerClickTransportSchema: Schema<ComputerClickTransport>;
+export declare const cursorStyleSchema: Schema<CursorStyle>;
+export declare const cursorShapeSchema: Schema<CursorShape>;
+export declare const cursorSizeSchema: Schema<CursorSize>;
+export declare const cursorTrailSchema: Schema<CursorTrail>;
+export declare const cursorMotionSchema: Schema<CursorMotion>;
+export declare const cursorTrajectorySchema: Schema<CursorTrajectory>;
+export declare const cursorGlowSchema: Schema<CursorGlow>;
+export declare const cursorIdleSchema: Schema<CursorIdle>;
+export declare const cursorEdgeSchema: Schema<CursorEdge>;
+export declare const cursorSoundSchema: Schema<CursorSound>;
+export declare const captionPlacementSchema: Schema<CaptionPlacement>;
+export declare const computerWindowStateParamsSchema: Schema<ComputerWindowStateParams>;
+export declare const computerElementActionParamsSchema: Schema<ComputerElementActionParams>;
+export declare const computerTypeElementParamsSchema: Schema<ComputerTypeElementParams>;
+export declare const computerSetValueParamsSchema: Schema<ComputerSetValueParams>;
+export declare const computerPressKeyParamsSchema: Schema<ComputerPressKeyParams>;
+export declare const computerHotkeyParamsSchema: Schema<ComputerHotkeyParams>;
+export declare const computerFocusWindowParamsSchema: Schema<ComputerFocusWindowParams>;
+export declare const computerLaunchAppParamsSchema: Schema<ComputerLaunchAppParams>;
+export declare const computerTypeWindowTextParamsSchema: Schema<ComputerTypeWindowTextParams>;
+export declare const computerTypeTextParamsSchema: Schema<ComputerTypeTextParams>;
+export declare const computerClickParamsSchema: Schema<ComputerClickParams>;
+export declare const computerDoubleClickParamsSchema: Schema<ComputerDoubleClickParams>;
+export declare const computerRightClickParamsSchema: Schema<ComputerRightClickParams>;
+export declare const computerScrollParamsSchema: Schema<ComputerScrollParams>;
+export declare const computerDragParamsSchema: Schema<ComputerDragParams>;
+export declare const computerVerifyParamsSchema: Schema<ComputerVerifyParams>;
+export declare const captureWindowParamsSchema: Schema<CaptureWindowParams>;
+export declare const captureRegionParamsSchema: Schema<CaptureRegionParams>;
+export declare const zoomArtifactParamsSchema: Schema<ZoomArtifactParams>;
+export declare const visionAnalyzeWindowParamsSchema: Schema<VisionAnalyzeWindowParams>;
+export declare const visionAnalyzeArtifactParamsSchema: Schema<VisionAnalyzeArtifactParams>;
+export declare const browserGetTextParamsSchema: Schema<BrowserGetTextParams>;
+export declare const browserQueryDomParamsSchema: Schema<BrowserQueryDomParams>;
+export declare const browserExecuteJavascriptParamsSchema: Schema<BrowserExecuteJavascriptParams>;
+export declare const computerMagicCursorParamsSchema: Schema<ComputerMagicCursorParams>;
 
 export declare function createCuaClient(options?: CuaClientOptions): CuaClient;
 export declare const cua: CuaClient;

--- a/packages/npm/sdk/cua.mjs
+++ b/packages/npm/sdk/cua.mjs
@@ -1,7 +1,134 @@
 import { randomBytes } from "node:crypto";
 import { createConnection } from "node:net";
 
-import { z } from "zod";
+// This SDK only needs a small, synchronous subset of Zod. Keeping that subset
+// here avoids making every CLI install pull in a general-purpose schema library
+// while preserving the public schemas' parse/safeParse interface.
+function validationError(path, message) {
+  const location = path.length ? ` at ${path.join(".")}` : "";
+  const error = new Error(`${message}${location}`);
+  error.name = "ValidationError";
+  error.issues = [{ path, message }];
+  return error;
+}
+
+function schema(parser) {
+  const value = {
+    _parse: parser,
+    parse(input) {
+      return parser(input, []);
+    },
+    safeParse(input) {
+      try {
+        return { success: true, data: value.parse(input) };
+      } catch (error) {
+        return { success: false, error };
+      }
+    },
+    optional() {
+      const optionalSchema = schema((input, path) =>
+        input === undefined ? undefined : parser(input, path)
+      );
+      optionalSchema._optional = true;
+      return optionalSchema;
+    },
+    refine(check, message = "Invalid value") {
+      return schema((input, path) => {
+        const parsed = parser(input, path);
+        if (!check(parsed)) throw validationError(path, message);
+        return parsed;
+      });
+    },
+  };
+  return value;
+}
+
+function withChecks(kind, initialChecks = []) {
+  const build = (checks) => {
+    const value = schema((input, path) => {
+      if (typeof input !== kind) {
+        throw validationError(path, `Expected ${kind}`);
+      }
+      for (const { check, message } of checks) {
+        if (!check(input)) throw validationError(path, message);
+      }
+      return input;
+    });
+    const add = (check, message) => build([...checks, { check, message }]);
+    if (kind === "string") {
+      value.min = (minimum) => add(
+        (input) => input.length >= minimum,
+        `Expected string length to be at least ${minimum}`
+      );
+    } else {
+      value.min = (minimum) => add(
+        (input) => input >= minimum,
+        `Expected number to be at least ${minimum}`
+      );
+      value.max = (maximum) => add(
+        (input) => input <= maximum,
+        `Expected number to be at most ${maximum}`
+      );
+      value.int = () => add(Number.isInteger, "Expected integer");
+      value.finite = () => add(Number.isFinite, "Expected finite number");
+      value.positive = () => add((input) => input > 0, "Expected positive number");
+      value.nonnegative = () => add((input) => input >= 0, "Expected nonnegative number");
+    }
+    return value;
+  };
+  return build(initialChecks);
+}
+
+function objectSchema(shape) {
+  const value = schema((input, path) => {
+    if (!input || typeof input !== "object" || Array.isArray(input)) {
+      throw validationError(path, "Expected object");
+    }
+    const output = {};
+    for (const [key, child] of Object.entries(shape)) {
+      const parsed = child._parse(input[key], [...path, key]);
+      if (parsed !== undefined || Object.hasOwn(input, key)) output[key] = parsed;
+    }
+    return output;
+  });
+  value._shape = shape;
+  value.extend = (extension) => objectSchema({ ...shape, ...extension });
+  value.merge = (other) => objectSchema({ ...shape, ...other._shape });
+  value.pick = (selection) => objectSchema(Object.fromEntries(
+    Object.keys(selection)
+      .filter((key) => selection[key] && key in shape)
+      .map((key) => [key, shape[key]])
+  ));
+  return value;
+}
+
+const z = {
+  string: () => withChecks("string"),
+  number: () => withChecks("number"),
+  boolean: () => schema((input, path) => {
+    if (typeof input !== "boolean") throw validationError(path, "Expected boolean");
+    return input;
+  }),
+  enum: (values) => schema((input, path) => {
+    if (!values.includes(input)) {
+      throw validationError(path, `Expected one of: ${values.join(", ")}`);
+    }
+    return input;
+  }),
+  array: (item) => schema((input, path) => {
+    if (!Array.isArray(input)) throw validationError(path, "Expected array");
+    return input.map((entry, index) => item._parse(entry, [...path, index]));
+  }),
+  union: (schemas) => schema((input, path) => {
+    for (const candidate of schemas) {
+      try {
+        return candidate._parse(input, path);
+      } catch {}
+    }
+    throw validationError(path, "Value did not match any allowed type");
+  }),
+  object: objectSchema,
+};
 
 const DAEMON_HOST = "127.0.0.1";
 const DAEMON_PORT = 9399;

--- a/packages/npm/sdk/package.json
+++ b/packages/npm/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lattices/sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Typed SDK modules for Lattices desktop automation",
   "type": "module",
   "exports": {
@@ -38,8 +38,5 @@
   "homepage": "https://github.com/arach/lattices",
   "engines": {
     "node": ">=18"
-  },
-  "dependencies": {
-    "zod": "^3.25.76"
   }
 }

--- a/tests/dependency-free.test.ts
+++ b/tests/dependency-free.test.ts
@@ -1,0 +1,105 @@
+import { afterAll, expect, test } from "bun:test";
+
+import {
+  clearCredentialCache,
+  infer,
+  type ProviderName,
+} from "../bin/infer.ts";
+import {
+  browserQueryDomParamsSchema,
+  computerClickParamsSchema,
+  computerHotkeyParamsSchema,
+} from "../packages/npm/sdk/cua.mjs";
+
+const originalFetch = globalThis.fetch;
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test("CUA schemas validate without Zod", () => {
+  expect(computerClickParamsSchema.parse({
+    xRatio: 0.5,
+    button: "left",
+    count: 2,
+    ignored: true,
+  })).toEqual({ xRatio: 0.5, button: "left", count: 2 });
+  expect(computerClickParamsSchema.safeParse({ xRatio: 2 }).success).toBe(false);
+  expect(computerHotkeyParamsSchema.safeParse({}).success).toBe(false);
+  expect(browserQueryDomParamsSchema.safeParse({
+    selector: "main",
+    allowAutomation: true,
+  }).success).toBe(true);
+});
+
+test("inference providers use their dependency-free HTTP contracts", async () => {
+  process.env.GROQ_API_KEY = "test-groq";
+  process.env.OPENAI_API_KEY = "test-openai";
+  process.env.ANTHROPIC_API_KEY = "test-anthropic";
+  process.env.GOOGLE_GENERATIVE_AI_API_KEY = "test-google";
+  process.env.XAI_API_KEY = "test-xai";
+  process.env.MINIMAX_API_KEY = "test-minimax";
+  clearCredentialCache();
+
+  const requests: Array<{ url: string; init: RequestInit; body: any }> = [];
+  globalThis.fetch = (async (input: string | URL | Request, init: RequestInit = {}) => {
+    const url = String(input);
+    const body = JSON.parse(String(init.body));
+    requests.push({ url, init, body });
+
+    if (url.includes("anthropic.com")) {
+      return Response.json({
+        content: [{ type: "text", text: "anthropic ok" }],
+        usage: { input_tokens: 2, output_tokens: 1 },
+      });
+    }
+    if (url.includes("googleapis.com")) {
+      return Response.json({
+        candidates: [{ content: { parts: [{ text: "google ok" }] } }],
+        usageMetadata: {
+          promptTokenCount: 2,
+          candidatesTokenCount: 1,
+          totalTokenCount: 3,
+        },
+      });
+    }
+    return Response.json({
+      choices: [{ message: { content: "openai compatible ok" } }],
+      usage: { prompt_tokens: 2, completion_tokens: 1, total_tokens: 3 },
+    });
+  }) as typeof fetch;
+
+  const expectedHosts: Record<ProviderName, string> = {
+    groq: "api.groq.com",
+    openai: "api.openai.com",
+    anthropic: "api.anthropic.com",
+    google: "generativelanguage.googleapis.com",
+    xai: "api.x.ai",
+    minimax: "api.minimax.io",
+  };
+
+  for (const provider of Object.keys(expectedHosts) as ProviderName[]) {
+    const result = await infer("hello", {
+      provider,
+      model: `${provider}-test`,
+      system: "Be concise",
+      maxTokens: 64,
+    });
+    const request = requests.at(-1)!;
+    expect(request.url).toContain(expectedHosts[provider]);
+    expect(result.usage?.totalTokens).toBe(3);
+    if (provider === "google") {
+      expect(request.url).toContain("google-test:generateContent");
+    } else {
+      expect(request.body.model).toBe(`${provider}-test`);
+    }
+  }
+
+  const anthropic = requests.find((request) => request.url.includes("anthropic.com"))!;
+  expect(anthropic.body.system).toBe("Be concise");
+  expect(anthropic.body.max_tokens).toBe(64);
+
+  const google = requests.find((request) => request.url.includes("googleapis.com"))!;
+  expect(google.body.systemInstruction.parts[0].text).toBe("Be concise");
+  expect(google.body.generationConfig.maxOutputTokens).toBe(64);
+});


### PR DESCRIPTION
Adds an interactive **deck builder** as a design-studio study, plus the implementation spec for building it on the Mac.

## Studio study — `design/studio`

A new **Deck Builder** study (`src/studio/studies/DeckBuilder.tsx`, registered in the registry + page renderer), in the real Lats keycap / reticle language so it doubles as the visual spec:

- Span-aware grid canvas — 2–5 cols × 1–4 rows, ≤ 16 keys, gaps allowed.
- **Tap** an empty cell to add · **drag** to move · **pull the corner** to span (1×1 / 2×1 / 1×2 / 2×2 / full-row).
- Dropping onto occupied cells **pushes the overlapped keys into the freed space** (same-size = swap), with the displaced keys gliding out of the way live; only rejected when there's genuinely no room.
- Inspector (label / icon / tint / action from catalog), deck switcher, grid-shape steppers, live validation.

Run: `next dev` in `design/studio` → `/studio/studies/deck-builder`.

## Spec — `docs/companion-deck-builder-spec.md`

Mac-side implementation plan: the **Mac owns the layout + catalog, the iPad receives and renders it**. Covers the DeckKit span extension (back-compat), the layout engine + displacement, persistence via `Preferences`, phasing, Talkie prior art, and the recommended **embedded-`WKWebView`** path — host this very study in the Mac app rather than reimplement drag/resize/span in SwiftUI.

## Dependency-free CLI/npm release

- Removes all runtime npm dependencies from the CLI and embedded CUA SDK.
- Replaces the AI SDK stack with direct HTTP clients for all six existing providers.
- Preserves CUA schema `.parse()` / `.safeParse()` behavior with local validators.
- Adds mocked provider-contract and schema regression tests.
- Adds an explicit CLI-only npm release mode that can reuse the committed app bundle when unrelated Swift dependencies are unavailable.
- Publishes `@arach/lattices@0.6.4` and `@lattices/cli@0.6.4`.

## Verification

- `bun run test`
- `bun run check:types`
- Root and SDK package dry-runs
- npm registry verification for both public CLI package names