### PR TITLE
✨ Build the companion deck builder into the Mac app (Phase B)

### DIFF
--- a/apps/ios/Sources/ContentView.swift
+++ b/apps/ios/Sources/ContentView.swift
@@ -5,7 +5,9 @@ import SwiftUI
 
 struct ContentView: View {
     @StateObject private var store = DeckStore()
+    @StateObject private var fleetStore = DeckFleetStore()
     @State private var showLatsDeck = false
+    @State private var requestedMachineID: String?
     @State private var showSettings = false
     @State private var trustedBridges: [StoredBridgeTrust] = []
 
@@ -58,10 +60,22 @@ struct ContentView: View {
                     bottomTelemetry: liveBottomTelemetry,
 
                     onEnterDeck: { machine in
-                        // Only the currently-active machine has a live bridge.
-                        // Tapping an offline / online-but-not-active card must
-                        // not silently open the active machine's deck.
-                        guard machine.status == .active else { return }
+                        guard machine.status != .offline else { return }
+                        if machine.status != .active,
+                           let endpoint = store.discoveredBridges.first(where: { $0.id == machine.id }) {
+                            let isTrusted = endpoint.bridgeFingerprint.map { fingerprint in
+                                DeckBridgeSecurityStore.shared.trustedBridgeList().contains {
+                                    $0.bridgeFingerprint.caseInsensitiveCompare(fingerprint) == .orderedSame
+                                }
+                            } ?? false
+                            if !isTrusted {
+                                // Keep first-time pairing explicit and scoped to
+                                // the Mac the user actually tapped.
+                                store.connect(to: endpoint)
+                            }
+                        }
+                        fleetStore.synchronize(with: store)
+                        requestedMachineID = machine.id
                         showLatsDeck = true
                     },
                     onPair:      { showSettings = true },
@@ -83,20 +97,10 @@ struct ContentView: View {
             .navigationBarHidden(true)
             .toolbar(.hidden, for: .navigationBar)
             .fullScreenCover(isPresented: $showLatsDeck) {
-                LatsDeckScreen(
-                    liveSnapshot: store.snapshot,
-                    connectionLabel: store.connectionLabel,
-                    onAction: { actionID, payload, label in
-                        store.perform(
-                            actionID: actionID,
-                            pageID: "cockpit",
-                            payload: payload,
-                            label: label
-                        )
-                    },
-                    onTrackpadEvent: { event, dx, dy in
-                        store.sendTrackpad(event: event, dx: dx, dy: dy)
-                    }
+                FleetDeckScreen(
+                    primaryStore: store,
+                    fleetStore: fleetStore,
+                    initialMachineID: requestedMachineID
                 )
             }
             .sheet(isPresented: $showSettings) {
@@ -107,12 +111,19 @@ struct ContentView: View {
             // (Deck or settings) — Home alone runs in ambient mode.
             .onChange(of: showLatsDeck) { _, isOpen in
                 store.setUIPriority(isOpen ? .fast : .ambient)
+                fleetStore.setUIPriority(isOpen ? .fast : .ambient, primaryStore: store)
             }
             .onChange(of: showSettings) { _, isOpen in
                 store.setUIPriority(isOpen ? .fast : .ambient)
             }
         }
         .preferredColorScheme(.dark)
+        .onChange(of: store.discoveredBridges) { _, _ in
+            fleetStore.synchronize(with: store)
+        }
+        .onChange(of: store.activeEndpoint) { _, _ in
+            fleetStore.synchronize(with: store)
+        }
     }
 }
 

--- a/apps/ios/Sources/DeckStore.swift
+++ b/apps/ios/Sources/DeckStore.swift
@@ -12,6 +12,8 @@ enum DeckPollPriority {
 
 @MainActor
 final class DeckStore: ObservableObject {
+    let sessionID = UUID()
+
     @Published private(set) var discoveredBridges: [BridgeEndpoint] = []
     @Published private(set) var activeEndpoint: BridgeEndpoint?
     @Published private(set) var health: BridgeHealthResponse?
@@ -89,13 +91,19 @@ final class DeckStore: ObservableObject {
         return s.count >= 16 && s.unicodeScalars.allSatisfy { hex.contains($0) }
     }
 
-    init() {
-        discovery.onUpdate = { [weak self] bridges in
-            Task { @MainActor [weak self] in
-                self?.handleDiscoveryUpdate(bridges)
+    init(endpoint: BridgeEndpoint? = nil, discoversBridges: Bool = true) {
+        if discoversBridges {
+            discovery.onUpdate = { [weak self] bridges in
+                Task { @MainActor [weak self] in
+                    self?.handleDiscoveryUpdate(bridges)
+                }
             }
+            discovery.start()
         }
-        discovery.start()
+
+        if let endpoint {
+            connect(to: endpoint)
+        }
     }
 
     deinit {
@@ -108,7 +116,12 @@ final class DeckStore: ObservableObject {
     }
 
     func connect(to endpoint: BridgeEndpoint) {
+        pollingTask?.cancel()
+        pollingTask = nil
         activeEndpoint = endpoint
+        health = nil
+        manifest = nil
+        snapshot = nil
         manualHost = endpoint.host
         manualPort = String(endpoint.port)
         errorMessage = nil
@@ -391,7 +404,10 @@ private extension DeckStore {
             name: healthName.isEmpty ? endpoint.name : healthName,
             host: endpointHost.isEmpty ? endpoint.host : endpointHost,
             port: Int(health.port),
-            source: endpoint.source
+            source: endpoint.source,
+            bridgeFingerprint: endpoint.bridgeFingerprint ?? health.bridgeFingerprint,
+            securityMode: endpoint.securityMode ?? health.mode,
+            capabilities: endpoint.capabilities.isEmpty ? (health.capabilities ?? []) : endpoint.capabilities
         )
     }
 
@@ -403,7 +419,10 @@ private extension DeckStore {
             name: healthName.isEmpty ? endpoint.name : healthName,
             host: host,
             port: Int(health.port),
-            source: "Health"
+            source: "Health",
+            bridgeFingerprint: endpoint.bridgeFingerprint ?? health.bridgeFingerprint,
+            securityMode: endpoint.securityMode ?? health.mode,
+            capabilities: endpoint.capabilities.isEmpty ? (health.capabilities ?? []) : endpoint.capabilities
         )
     }
 
@@ -468,3 +487,227 @@ private extension DeckStore {
         }
     }
 }
+
+// MARK: - Fleet connections
+
+/// Owns the additional live bridge sessions used by Fleet Deck. The primary
+/// `DeckStore` remains responsible for Bonjour discovery and Home; every other
+/// reachable Mac gets an isolated store so actions can never leak across hosts.
+@MainActor
+final class DeckFleetStore: ObservableObject {
+    @Published private(set) var secondaryStores: [DeckStore] = []
+
+    private var storesByEndpointKey: [String: DeckStore] = [:]
+
+    func synchronize(with primaryStore: DeckStore) {
+        let primaryKey = primaryStore.activeEndpoint.map(Self.endpointKey)
+        var desiredKeys = Set<String>()
+        var orderedStores: [DeckStore] = []
+
+        for endpoint in primaryStore.discoveredBridges {
+            // Secondary sessions are created only for Macs this device has
+            // already paired with. This prevents Fleet Deck from spraying
+            // approval prompts across every Bonjour peer on the network.
+            let isTrusted = endpoint.bridgeFingerprint.map { fingerprint in
+                DeckBridgeSecurityStore.shared.trustedBridgeList().contains {
+                    $0.bridgeFingerprint.caseInsensitiveCompare(fingerprint) == .orderedSame
+                }
+            } ?? false
+            guard isTrusted else { continue }
+
+            let key = Self.endpointKey(endpoint)
+            guard key != primaryKey else { continue }
+            guard desiredKeys.insert(key).inserted else { continue }
+
+            let store: DeckStore
+            if let existing = storesByEndpointKey[key] {
+                store = existing
+                if existing.activeEndpoint != endpoint && existing.health == nil {
+                    existing.connect(to: endpoint)
+                }
+            } else {
+                store = DeckStore(endpoint: endpoint, discoversBridges: false)
+                storesByEndpointKey[key] = store
+            }
+            orderedStores.append(store)
+        }
+
+        let staleKeys = storesByEndpointKey.keys.filter { !desiredKeys.contains($0) }
+        for key in staleKeys {
+            storesByEndpointKey.removeValue(forKey: key)?.disconnect()
+        }
+
+        secondaryStores = orderedStores
+    }
+
+    func stores(including primaryStore: DeckStore) -> [DeckStore] {
+        var result: [DeckStore] = []
+        if primaryStore.activeEndpoint != nil {
+            result.append(primaryStore)
+        }
+        result.append(contentsOf: secondaryStores)
+        return result
+    }
+
+    func setUIPriority(_ priority: DeckPollPriority, primaryStore: DeckStore) {
+        for store in stores(including: primaryStore) {
+            store.setUIPriority(priority)
+        }
+    }
+
+    private static func endpointKey(_ endpoint: BridgeEndpoint) -> String {
+        if let fingerprint = endpoint.bridgeFingerprint, !fingerprint.isEmpty {
+            return "fingerprint:\(fingerprint.lowercased())"
+        }
+        let name = endpoint.name
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        if !name.isEmpty {
+            return "service:\(name):\(endpoint.port)"
+        }
+        return "host:\(endpoint.host.lowercased()):\(endpoint.port)"
+    }
+}
+
+#if DEBUG
+extension DeckStore {
+    /// Deterministic live-looking store for Fleet Deck previews and simulator
+    /// screenshot passes. It never starts discovery or sends network traffic.
+    static func fleetPreview(name: String, index: Int) -> DeckStore {
+        let store = DeckStore(discoversBridges: false)
+        store.activeEndpoint = BridgeEndpoint(
+            name: name,
+            host: "preview-\(index).local",
+            port: 5287,
+            source: "Preview"
+        )
+
+        let accents = ["green", "blue", "violet", "amber"]
+        let apps = ["Xcode", "iTerm2", "Figma", "Safari"]
+        let accent = accents[index % accents.count]
+        let app = apps[index % apps.count]
+
+        func tile(_ id: String, _ title: String, _ icon: String, _ action: String, tint: String? = nil) -> DeckCockpitTile {
+            DeckCockpitTile(
+                id: "\(index)-\(id)",
+                shortcutID: id,
+                title: title,
+                subtitle: nil,
+                iconSystemName: icon,
+                accentToken: tint ?? accent,
+                actionID: action
+            )
+        }
+
+        let command = DeckCockpitPage(
+            id: "command",
+            title: "Command",
+            columns: 3,
+            tiles: [
+                tile("voice", "Voice", "waveform", "voice.command.toggle", tint: "red"),
+                tile("focus", "Focus", "scope", "windows.focusFrontmost"),
+                tile("paste", "Paste", "doc.on.clipboard", "clipboard.pasteFromDevice"),
+                tile("left", "Tile Left", "rectangle.lefthalf.inset.filled", "window.tile.left", tint: "blue"),
+                tile("right", "Tile Right", "rectangle.righthalf.inset.filled", "window.tile.right", tint: "blue"),
+                tile("agent", "Run Agent", "sparkles", "agent.run", tint: "violet")
+            ]
+        )
+        let windows = DeckCockpitPage(
+            id: "windows",
+            title: "Windows",
+            columns: 3,
+            tiles: [
+                tile("maximize", "Maximize", "rectangle.inset.filled", "window.maximize", tint: "blue"),
+                tile("center", "Center", "rectangle.center.inset.filled", "window.center", tint: "blue"),
+                tile("next", "Next Space", "arrow.right.square", "spaces.next", tint: "teal"),
+                tile("prev", "Prev Space", "arrow.left.square", "spaces.previous", tint: "teal")
+            ]
+        )
+
+        store.snapshot = DeckRuntimeSnapshot(
+            cockpit: DeckCockpitState(title: "Fleet", pages: [command, windows]),
+            trackpad: DeckTrackpadState(
+                isEnabled: true,
+                isAvailable: true,
+                statusTitle: "Ready",
+                pointerScale: 1.6
+            ),
+            voice: DeckVoiceState(
+                phase: .idle,
+                transcript: [
+                    "route this Mac to the common deck",
+                    "keep tests visible while the agent runs",
+                    "show the current design pass",
+                    "hold this build in standby"
+                ][index]
+            ),
+            desktop: DeckDesktopSummary(
+                activeLayerName: "Deep Work",
+                activeAppName: app,
+                screenCount: 2,
+                visibleWindowCount: 8 + index,
+                sessionCount: 3,
+                currentSpaceIndex: 1,
+                currentSpaceName: index.isMultiple(of: 2) ? "Code" : "Review"
+            ),
+            layout: DeckLayoutState(
+                frontmostWindow: DeckLayoutFocusWindow(
+                    id: "preview-window-\(index)",
+                    itemID: "preview-item-\(index)",
+                    appName: app,
+                    title: index.isMultiple(of: 2) ? "FleetDeckScreen.swift" : "Design review",
+                    frame: DeckRect(x: 80, y: 70, w: 1100, h: 720)
+                )
+            ),
+            telemetry: DeckSystemTelemetry(
+                cpuLoadPercent: Double(24 + index * 11),
+                memoryUsedPercent: Double(52 + index * 7),
+                gpuLoadPercent: Double(8 + index * 5),
+                windowCount: 8 + index,
+                sessionCount: 3
+            ),
+            cockpitMode: DeckCockpitModeState(
+                mode: index == 3 ? .idle : .agent,
+                elapsedSeconds: Double(42 + index * 19),
+                agentProgress: Double(36 + index * 14) / 100,
+                agentRows: [
+                    DeckAgentPlanRow(
+                        id: "agent-live-\(index)",
+                        state: index == 3 ? .done : .live,
+                        text: ["refining fleet controls", "running iPad checks", "reviewing visual system", "build queue clear"][index]
+                    ),
+                    DeckAgentPlanRow(
+                        id: "agent-next-\(index)",
+                        state: .next,
+                        text: ["verify channel routing", "inspect simulator logs", "prepare design notes", "waiting for work"][index]
+                    )
+                ]
+            ),
+            activityLog: [
+                DeckActivityLogEntry(
+                    id: "activity-primary-\(index)",
+                    createdAt: .now.addingTimeInterval(Double(-18 - index * 12)),
+                    tag: ["CODEX", "TEST", "SCOUT", "BUILD"][index],
+                    tint: ["violet", "green", "blue", "amber"][index],
+                    text: ["polishing common deck", "simulator suite running", "reviewing lane model", "standing by"][index]
+                ),
+                DeckActivityLogEntry(
+                    id: "activity-secondary-\(index)",
+                    createdAt: .now.addingTimeInterval(Double(-86 - index * 21)),
+                    tag: ["SCOUT", "XCODE", "DESIGN", "AGENT"][index],
+                    tint: ["blue", "green", "violet", "amber"][index],
+                    text: ["checked interaction map", "build succeeded", "tuning control lighting", "queue empty"][index]
+                ),
+                DeckActivityLogEntry(
+                    id: "activity-tertiary-\(index)",
+                    createdAt: .now.addingTimeInterval(Double(-154 - index * 27)),
+                    tag: ["BUILD", "CODEX", "REVIEW", "SYSTEM"][index],
+                    tint: ["green", "violet", "blue", "green"][index],
+                    text: ["fixture data refreshed", "checking shared controls", "spacing pass complete", "all services nominal"][index]
+                )
+            ]
+        )
+        return store
+    }
+}
+#endif

--- a/apps/ios/Sources/LatsDeckScreen.swift
+++ b/apps/ios/Sources/LatsDeckScreen.swift
@@ -1,5 +1,6 @@
 import DeckKit
 import SwiftUI
+import UIKit
 
 // MARK: - Design System
 
@@ -117,7 +118,7 @@ extension LatsTelemetry {
 }
 
 struct LatsShortcut: Identifiable {
-    let id = UUID()
+    let id: String
     let label: String
     let icon: String      // SF Symbol name
     let tint: LatsTint
@@ -126,6 +127,46 @@ struct LatsShortcut: Identifiable {
     let sim: SimAction
     var actionID: String? = nil
     var payload: [String: DeckValue] = [:]
+    var controlKind: DeckCockpitControlKind? = nil
+    var col: Int? = nil
+    var row: Int? = nil
+    var colSpan: Int? = nil
+    var rowSpan: Int? = nil
+    var isEnabled = true
+
+    init(
+        id: String = UUID().uuidString,
+        label: String,
+        icon: String,
+        tint: LatsTint,
+        category: ShortcutCategory,
+        hint: String,
+        sim: SimAction,
+        actionID: String? = nil,
+        payload: [String: DeckValue] = [:],
+        controlKind: DeckCockpitControlKind? = nil,
+        col: Int? = nil,
+        row: Int? = nil,
+        colSpan: Int? = nil,
+        rowSpan: Int? = nil,
+        isEnabled: Bool = true
+    ) {
+        self.id = id
+        self.label = label
+        self.icon = icon
+        self.tint = tint
+        self.category = category
+        self.hint = hint
+        self.sim = sim
+        self.actionID = actionID
+        self.payload = payload
+        self.controlKind = controlKind
+        self.col = col
+        self.row = row
+        self.colSpan = colSpan
+        self.rowSpan = rowSpan
+        self.isEnabled = isEnabled
+    }
 }
 
 struct LatsWindow: Identifiable {
@@ -196,6 +237,8 @@ struct LatsTelemetry {
 // MARK: - Top Chrome
 
 struct LatsTopChrome: View {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
     let deckName: String
     let deckNames: [String]
     let accent: Color
@@ -203,6 +246,60 @@ struct LatsTopChrome: View {
     let onClose: () -> Void
 
     var body: some View {
+        Group {
+            if horizontalSizeClass == .compact {
+                compactChrome
+            } else {
+                regularChrome
+            }
+        }
+        .background(Color.black.opacity(0.25))
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(LatsPalette.hairline).frame(height: 1)
+        }
+    }
+
+    private var compactChrome: some View {
+        HStack(spacing: 10) {
+            Text("LATS · DECK")
+                .font(LatsFont.mono(11, weight: .bold))
+                .foregroundStyle(LatsPalette.text)
+                .tracking(1.3)
+                .fixedSize()
+
+            Button(action: onSwitcher) {
+                HStack(spacing: 5) {
+                    Text(deckName)
+                        .font(LatsFont.mono(10, weight: .bold))
+                        .foregroundStyle(accent)
+                        .lineLimit(1)
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 8, weight: .semibold))
+                        .foregroundStyle(LatsPalette.textFaint)
+                }
+                .padding(.horizontal, 9)
+                .frame(height: 30)
+                .background(RoundedRectangle(cornerRadius: 5).fill(accent.opacity(0.10)))
+                .overlay(RoundedRectangle(cornerRadius: 5).stroke(accent.opacity(0.30), lineWidth: 1))
+            }
+            .buttonStyle(.plain)
+
+            Spacer(minLength: 0)
+
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(LatsPalette.textDim)
+                    .frame(width: 36, height: 36)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close deck")
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 46)
+    }
+
+    private var regularChrome: some View {
         HStack(spacing: 0) {
             HStack(spacing: 12) {
                 Text("LATS · DECK")
@@ -244,10 +341,6 @@ struct LatsTopChrome: View {
         }
         .padding(.horizontal, 14)
         .frame(height: 38)
-        .background(Color.black.opacity(0.25))
-        .overlay(alignment: .bottom) {
-            Rectangle().fill(LatsPalette.hairline).frame(height: 1)
-        }
     }
 }
 
@@ -265,13 +358,22 @@ struct LatsCockpitShell<Content: View>: View {
             RoundedRectangle(cornerRadius: 6)
                 .stroke(LatsPalette.hairline2, lineWidth: 1)
         )
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(Color.white.opacity(0.045))
+                .frame(height: 1)
+                .padding(.horizontal, 6)
+        }
         .clipShape(RoundedRectangle(cornerRadius: 6))
+        .shadow(color: Color.black.opacity(0.48), radius: 7, x: 0, y: 4)
     }
 }
 
 // MARK: - Trackpad Surface
 
 struct LatsTrackpadSurface: View {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
     let mode: CockpitMode
     let recTime: Double
     let agentProgress: Double
@@ -336,47 +438,49 @@ struct LatsTrackpadSurface: View {
             )
             .allowsHitTesting(mode == .replay && onReplayUndo != nil)
 
-            // LEFT column — system on top, displays bottom; equal share of vertical space
-            VStack(alignment: .leading, spacing: 8) {
-                LatsInsetSlice {
-                    CompactSystemPanel(hostLabel: hostLabel, telemetry: telemetry)
+            if horizontalSizeClass != .compact {
+                // LEFT column — system on top, displays bottom; equal share of vertical space
+                VStack(alignment: .leading, spacing: 8) {
+                    LatsInsetSlice {
+                        CompactSystemPanel(hostLabel: hostLabel, telemetry: telemetry)
+                    }
+                    .frame(maxHeight: .infinity)
+                    LatsInsetSlice {
+                        CompactDisplaysPanel(
+                            stage: stage,
+                            space: space,
+                            spaceCount: spaceCount,
+                            spaceName: spaceName,
+                            spaceDisplays: spaceDisplays,
+                            onSpaceTap: onSpaceTap,
+                            onMonitorSwipe: onMonitorSwipe
+                        )
+                    }
+                    .frame(maxHeight: .infinity)
                 }
-                .frame(maxHeight: .infinity)
-                LatsInsetSlice {
-                    CompactDisplaysPanel(
-                        stage: stage,
-                        space: space,
-                        spaceCount: spaceCount,
-                        spaceName: spaceName,
-                        spaceDisplays: spaceDisplays,
-                        onSpaceTap: onSpaceTap,
-                        onMonitorSwipe: onMonitorSwipe
-                    )
-                }
-                .frame(maxHeight: .infinity)
-            }
-            .frame(width: 240)
-            .padding(.top, 30)
-            .padding(.bottom, 56)
-            .padding(.leading, 12)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+                .frame(width: 240)
+                .padding(.top, 30)
+                .padding(.bottom, 56)
+                .padding(.leading, 12)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
 
-            // RIGHT column — transcript on top, activity bottom; equal share of vertical space
-            VStack(alignment: .leading, spacing: 8) {
-                LatsInsetSlice {
-                    CompactTranscriptPanel(items: transcript)
+                // RIGHT column — transcript on top, activity bottom; equal share of vertical space
+                VStack(alignment: .leading, spacing: 8) {
+                    LatsInsetSlice {
+                        CompactTranscriptPanel(items: transcript)
+                    }
+                    .frame(maxHeight: .infinity)
+                    LatsInsetSlice {
+                        CompactActivityLogPanel(entries: activityLog)
+                    }
+                    .frame(maxHeight: .infinity)
                 }
-                .frame(maxHeight: .infinity)
-                LatsInsetSlice {
-                    CompactActivityLogPanel(entries: activityLog)
-                }
-                .frame(maxHeight: .infinity)
+                .frame(width: 240)
+                .padding(.top, 30)
+                .padding(.bottom, 56)
+                .padding(.trailing, 12)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
             }
-            .frame(width: 240)
-            .padding(.top, 30)
-            .padding(.bottom, 56)
-            .padding(.trailing, 12)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
 
             // Bottom bezel: keyboard buttons sit on a quiet ledge that mirrors the top bezel.
             VStack(spacing: 0) {
@@ -1058,6 +1162,8 @@ enum LatsModifierState {
 }
 
 struct LatsActionKeyboardRow: View {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
     var onSendKey: ((String, [String]) -> Void)? = nil
 
     /// Source of truth for sticky modifier state. Tapping a chip cycles
@@ -1066,6 +1172,38 @@ struct LatsActionKeyboardRow: View {
     @State private var modifierStates: [LatsModifier: LatsModifierState] = [:]
 
     var body: some View {
+        Group {
+            if horizontalSizeClass == .compact {
+                compactRow
+            } else {
+                regularRow
+            }
+        }
+    }
+
+    private var compactRow: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 4) {
+                ActionKey(label: "esc", width: 30) { send("escape", []) }
+                ActionKey(label: "⌘C", width: 30) { send("c", [.command]) }
+                ActionKey(label: "⌘V", width: 30) { send("v", [.command]) }
+                ActionKey(label: "space", width: 52) { send("space", []) }
+                ArrowCluster(onTap: { dir in send(dir, []) })
+                ForEach(LatsModifier.allCases, id: \.self) { mod in
+                    ModifierKey(
+                        label: mod.glyph,
+                        state: modifierStates[mod] ?? .off,
+                        onSingleTap: { cycleModifier(mod) },
+                        onDoubleTap: { setModifier(mod, .locked) }
+                    )
+                }
+                EnterPill { send("return", []) }
+            }
+            .padding(.horizontal, 4)
+        }
+    }
+
+    private var regularRow: some View {
         HStack(spacing: 12) {
             // Left — utility keys + common combos. Combos fold in any active
             // sticky modifiers so e.g. armed Shift + ⌘C → ⇧⌘C.
@@ -1337,29 +1475,186 @@ struct EnterPill: View {
 struct LatsShortcutGrid: View {
     let shortcuts: [LatsShortcut]
     let columns: Int
+    var rows: Int? = nil
     let onTap: (LatsShortcut) -> Void
+    var onJoystickMove: ((_ dx: Double, _ dy: Double) -> Void)? = nil
+    var onJoystickInteractionChanged: ((Bool) -> Void)? = nil
+    var joystickEnabled = false
+    var joystickScale = 1.6
+    var minimumControlHeight: CGFloat = 80
 
-    @State private var recentlyPressed: UUID?
+    @State private var recentlyPressed: String?
 
     var body: some View {
-        let cols = Array(repeating: GridItem(.flexible(), spacing: 10), count: columns)
-        LazyVGrid(columns: cols, spacing: 10) {
-            ForEach(Array(shortcuts.enumerated()), id: \.element.id) { idx, s in
-                LatsShortcutTile(
-                    shortcut: s,
-                    index: idx + 1,
-                    isRecent: recentlyPressed == s.id
-                ) {
-                    onTap(s)
-                    withAnimation { recentlyPressed = s.id }
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) {
-                        if recentlyPressed == s.id {
-                            withAnimation { recentlyPressed = nil }
-                        }
+        if let rows, shortcuts.contains(where: { $0.col != nil && $0.row != nil }) {
+            positionedGrid(rows: rows)
+        } else {
+            let cols = Array(repeating: GridItem(.flexible(), spacing: 10), count: columns)
+            LazyVGrid(columns: cols, spacing: 10) {
+                ForEach(Array(shortcuts.enumerated()), id: \.element.id) { idx, shortcut in
+                    control(for: shortcut, index: idx + 1)
+                        .frame(minHeight: shortcut.controlKind == .joystick ? max(150, minimumControlHeight) : minimumControlHeight)
+                }
+            }
+        }
+    }
+
+    private func positionedGrid(rows: Int) -> some View {
+        let rowHeight: CGFloat = 96
+        let spacing: CGFloat = 10
+        let totalHeight = CGFloat(rows) * rowHeight + CGFloat(max(0, rows - 1)) * spacing
+        return GeometryReader { proxy in
+            let cellWidth = (proxy.size.width - CGFloat(max(0, columns - 1)) * spacing) / CGFloat(max(1, columns))
+            ZStack(alignment: .topLeading) {
+                ForEach(Array(shortcuts.enumerated()), id: \.element.id) { idx, shortcut in
+                    let col = shortcut.col ?? (idx % max(1, columns))
+                    let row = shortcut.row ?? (idx / max(1, columns))
+                    let colSpan = min(max(1, shortcut.colSpan ?? 1), max(1, columns - col))
+                    let rowSpan = min(max(1, shortcut.rowSpan ?? 1), max(1, rows - row))
+                    control(for: shortcut, index: idx + 1)
+                        .frame(
+                            width: CGFloat(colSpan) * cellWidth + CGFloat(colSpan - 1) * spacing,
+                            height: CGFloat(rowSpan) * rowHeight + CGFloat(rowSpan - 1) * spacing
+                        )
+                        .offset(
+                            x: CGFloat(col) * (cellWidth + spacing),
+                            y: CGFloat(row) * (rowHeight + spacing)
+                        )
+                }
+            }
+        }
+        .frame(height: totalHeight)
+    }
+
+    @ViewBuilder
+    private func control(for shortcut: LatsShortcut, index: Int) -> some View {
+        if shortcut.controlKind == .joystick {
+            LatsJoystickControl(
+                shortcut: shortcut,
+                isEnabled: joystickEnabled && shortcut.isEnabled,
+                pointerScale: joystickScale,
+                onMove: onJoystickMove,
+                onInteractionChanged: onJoystickInteractionChanged
+            )
+        } else {
+            LatsShortcutTile(
+                shortcut: shortcut,
+                index: index,
+                isRecent: recentlyPressed == shortcut.id
+            ) {
+                onTap(shortcut)
+                withAnimation { recentlyPressed = shortcut.id }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) {
+                    if recentlyPressed == shortcut.id {
+                        withAnimation { recentlyPressed = nil }
                     }
                 }
             }
         }
+    }
+}
+
+struct LatsJoystickControl: View {
+    let shortcut: LatsShortcut
+    let isEnabled: Bool
+    let pointerScale: Double
+    let onMove: ((_ dx: Double, _ dy: Double) -> Void)?
+    let onInteractionChanged: ((Bool) -> Void)?
+
+    @State private var knobOffset: CGSize = .zero
+    @State private var driveTimer: Timer?
+
+    var body: some View {
+        GeometryReader { proxy in
+            let diameter = max(54, min(proxy.size.width, proxy.size.height) * 0.72)
+            let knobDiameter = max(30, diameter * 0.38)
+            let radius = max(1, (diameter - knobDiameter) * 0.5)
+
+            ZStack {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.black.opacity(0.22))
+                    .overlay(RoundedRectangle(cornerRadius: 8).stroke(LatsPalette.hairline2, lineWidth: 1))
+
+                VStack(spacing: 3) {
+                    Text(shortcut.label)
+                        .font(LatsFont.ui(12, weight: .semibold))
+                        .foregroundStyle(LatsPalette.text)
+                    Text(isEnabled ? "pointer · hold to steer" : "enable trackpad on Mac")
+                        .font(LatsFont.mono(9))
+                        .foregroundStyle(isEnabled ? LatsPalette.textFaint : LatsPalette.amber)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+                .padding(12)
+
+                ZStack {
+                    Circle()
+                        .fill(shortcut.tint.color.opacity(0.07))
+                        .overlay(Circle().stroke(shortcut.tint.color.opacity(0.30), lineWidth: 1))
+                    Circle()
+                        .stroke(LatsPalette.hairline, style: StrokeStyle(lineWidth: 1, dash: [3, 4]))
+                        .padding(diameter * 0.22)
+                    Circle()
+                        .fill(
+                            RadialGradient(
+                                colors: [shortcut.tint.color, shortcut.tint.color.opacity(0.62), Color.black.opacity(0.88)],
+                                center: .topLeading,
+                                startRadius: 1,
+                                endRadius: knobDiameter * 0.62
+                            )
+                        )
+                        .overlay(Circle().stroke(shortcut.tint.color.opacity(0.58), lineWidth: 1))
+                        .shadow(color: .black.opacity(0.7), radius: 8, y: 5)
+                        .frame(width: knobDiameter, height: knobDiameter)
+                        .offset(knobOffset)
+                }
+                .frame(width: diameter, height: diameter)
+                .opacity(isEnabled ? 1 : 0.45)
+                .highPriorityGesture(joystickGesture(radius: radius))
+            }
+        }
+        .onDisappear(perform: stopDriving)
+    }
+
+    private func joystickGesture(radius: CGFloat) -> some Gesture {
+        DragGesture(minimumDistance: 0)
+            .onChanged { value in
+                guard isEnabled else { return }
+                let length = hypot(value.translation.width, value.translation.height)
+                let scale = length > radius ? radius / length : 1
+                knobOffset = CGSize(
+                    width: value.translation.width * scale,
+                    height: value.translation.height * scale
+                )
+                startDriving(radius: radius)
+            }
+            .onEnded { _ in
+                stopDriving()
+                withAnimation(.spring(response: 0.24, dampingFraction: 0.72)) {
+                    knobOffset = .zero
+                }
+            }
+    }
+
+    private func startDriving(radius: CGFloat) {
+        guard driveTimer == nil else { return }
+        onInteractionChanged?(true)
+        let timer = Timer.scheduledTimer(withTimeInterval: 1.0 / 30.0, repeats: true) { _ in
+            let x = Double(knobOffset.width / radius)
+            let y = Double(knobOffset.height / radius)
+            let magnitude = min(1, hypot(x, y))
+            guard magnitude > 0.08 else { return }
+            let speed = pow((magnitude - 0.08) / 0.92, 1.35) * 8.0 * pointerScale
+            onMove?(x / magnitude * speed, y / magnitude * speed)
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        driveTimer = timer
+    }
+
+    private func stopDriving() {
+        let wasDriving = driveTimer != nil
+        driveTimer?.invalidate()
+        driveTimer = nil
+        if wasDriving { onInteractionChanged?(false) }
     }
 }
 
@@ -1381,11 +1676,13 @@ struct LatsShortcutTile: View {
                         .font(LatsFont.mono(9))
                         .tracking(0.8)
                         .foregroundStyle(LatsPalette.textFaint)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.trailing)
                 }
                 Spacer(minLength: 0)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(shortcut.label)
-                        .font(LatsFont.ui(12, weight: .medium))
+                        .font(LatsFont.mono(12, weight: .medium))
                         .foregroundStyle(LatsPalette.text)
                     Text("act.\(String(format: "%02d", index)) · \(shortcut.category.rawValue)")
                         .font(LatsFont.mono(9))
@@ -1398,6 +1695,12 @@ struct LatsShortcutTile: View {
             .frame(maxWidth: .infinity, minHeight: 80, alignment: .topLeading)
             .background(tileBackground)
             .overlay(tileBorder)
+            .overlay(alignment: .top) {
+                Rectangle()
+                    .fill(Color.white.opacity(isPressed ? 0.035 : 0.065))
+                    .frame(height: 1)
+                    .padding(.horizontal, 7)
+            }
             .overlay(alignment: .topTrailing) {
                 if isRecent {
                     Circle()
@@ -1409,6 +1712,12 @@ struct LatsShortcutTile: View {
             }
             .scaleEffect(isPressed ? 0.985 : 1.0)
             .offset(y: isPressed ? 1 : 0)
+            .shadow(
+                color: Color.black.opacity(isPressed ? 0.28 : 0.62),
+                radius: isPressed ? 2 : 5,
+                x: 0,
+                y: isPressed ? 1 : 3
+            )
         }
         .buttonStyle(.plain)
         .onLongPressGesture(minimumDuration: 0, maximumDistance: .infinity, perform: {}, onPressingChanged: { pressing in
@@ -1418,35 +1727,66 @@ struct LatsShortcutTile: View {
 
     private var iconBadge: some View {
         Image(systemName: shortcut.icon)
-            .font(.system(size: 13, weight: .medium))
+            .font(.system(size: 12, weight: .semibold))
             .foregroundStyle(shortcut.tint.color)
-            .frame(width: 24, height: 24)
+            .frame(width: 25, height: 25)
             .background(
-                RoundedRectangle(cornerRadius: 4)
-                    .fill(shortcut.tint.color.opacity(0.18))
+                Circle()
+                    .fill(
+                        RadialGradient(
+                            colors: [shortcut.tint.color.opacity(0.22), Color.black.opacity(0.34)],
+                            center: .topLeading,
+                            startRadius: 0,
+                            endRadius: 18
+                        )
+                    )
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 4)
-                    .stroke(shortcut.tint.color.opacity(0.28), lineWidth: 1)
+                Circle()
+                    .stroke(Color.white.opacity(0.12), lineWidth: 1)
             )
+            .shadow(color: shortcut.tint.color.opacity(0.16), radius: 4)
     }
 
     @ViewBuilder
     private var tileBackground: some View {
-        let base = RoundedRectangle(cornerRadius: 4)
+        let base = RoundedRectangle(cornerRadius: 7)
         if isPressed {
-            base.fill(Color.white.opacity(0.06))
+            base.fill(
+                LinearGradient(
+                    colors: [LatsPalette.surface, Color.black.opacity(0.34)],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
         } else if isRecent {
             base.fill(shortcut.tint.color.opacity(0.12).blendMode(.plusLighter))
                 .background(base.fill(LatsPalette.surface))
         } else {
-            base.fill(LatsPalette.surface)
+            base.fill(
+                LinearGradient(
+                    colors: [LatsPalette.surface2.opacity(0.74), LatsPalette.surface, Color.black.opacity(0.20)],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
         }
     }
 
     private var tileBorder: some View {
-        RoundedRectangle(cornerRadius: 4)
-            .stroke(isRecent ? shortcut.tint.color : LatsPalette.hairline, lineWidth: 1)
+        RoundedRectangle(cornerRadius: 7)
+            .stroke(
+                isRecent
+                    ? AnyShapeStyle(shortcut.tint.color)
+                    : AnyShapeStyle(
+                        LinearGradient(
+                            colors: [Color.white.opacity(0.11), Color.white.opacity(0.035)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    ),
+                lineWidth: 1
+            )
             .shadow(color: isRecent ? shortcut.tint.color.opacity(0.14) : .clear, radius: 3)
     }
 }
@@ -1454,6 +1794,8 @@ struct LatsShortcutTile: View {
 // MARK: - Cursor-style Status Bar
 
 struct LatsStatusBar: View {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
     let mode: CockpitMode
     let recTime: Double
     let telemetry: LatsTelemetry
@@ -1476,6 +1818,78 @@ struct LatsStatusBar: View {
     }
 
     var body: some View {
+        Group {
+            if horizontalSizeClass == .compact {
+                compactBar
+            } else {
+                regularBar
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, horizontalSizeClass == .compact ? 4 : 14)
+        .padding(.bottom, 4)
+        .background {
+            if #available(iOS 26.0, *) {
+                Color.clear
+                    .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 0))
+            } else {
+                Color.black.opacity(0.32)
+            }
+        }
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(Color.white.opacity(0.08))
+                .frame(height: 0.5)
+        }
+    }
+
+    private var compactBar: some View {
+        HStack(spacing: 8) {
+            Button(action: onModeTap) {
+                HStack(spacing: 6) {
+                    Image(systemName: "mic.fill")
+                    Text(modeLabel)
+                        .font(LatsFont.mono(9, weight: .bold))
+                        .tracking(0.8)
+                }
+                .foregroundStyle(mode.color)
+                .padding(.horizontal, 10)
+                .frame(height: 34)
+                .background(RoundedRectangle(cornerRadius: 6).fill(mode.color.opacity(0.16)))
+                .overlay(RoundedRectangle(cornerRadius: 6).stroke(mode.color.opacity(0.35), lineWidth: 1))
+            }
+            .buttonStyle(.plain)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(shortHostLabel)
+                    .font(LatsFont.mono(9, weight: .semibold))
+                    .foregroundStyle(LatsPalette.green)
+                    .lineLimit(1)
+                Text("space \(space + 1)/\(spaceCount)")
+                    .font(LatsFont.mono(8))
+                    .foregroundStyle(LatsPalette.textFaint)
+            }
+
+            Spacer(minLength: 0)
+
+            Button(action: onSwitcherTap) {
+                HStack(spacing: 5) {
+                    Image(systemName: "square.grid.2x2.fill")
+                    Text("DECKS")
+                        .font(LatsFont.mono(9, weight: .bold))
+                }
+                .foregroundStyle(LatsPalette.text)
+                .padding(.horizontal, 10)
+                .frame(height: 34)
+                .background(RoundedRectangle(cornerRadius: 6).fill(Color.white.opacity(0.055)))
+                .overlay(RoundedRectangle(cornerRadius: 6).stroke(LatsPalette.hairline2, lineWidth: 1))
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 10)
+    }
+
+    private var regularBar: some View {
         HStack(spacing: 0) {
             modePill
             StatusItem(icon: "mic", label: "hold·space", tint: LatsPalette.text, onTap: onModeTap)
@@ -1494,31 +1908,6 @@ struct LatsStatusBar: View {
             StatusItem(label: "●3", tint: LatsPalette.amber)
             StatusItem(label: "⌘K", tint: LatsPalette.text, onTap: onPaletteTap)
             StatusItem(label: "⌘⇧P", tint: LatsPalette.text, onTap: onSwitcherTap)
-        }
-        .frame(maxWidth: .infinity)
-        // Bar is placed via `safeAreaInset(edge: .bottom)` on the parent. With
-        // spacing now under control, narrow it down: ~24pt total. Top padding
-        // gives a touch of breathing room; bottom is a tiny clearance from the
-        // rounded corner / home indicator.
-        .padding(.top, 14)
-        .padding(.bottom, 4)
-        .background {
-            // Liquid Glass — same trick Talkie's BottomTrayBackground uses.
-            // Glass blurs the cockpit content behind it and reflects light, so
-            // the bar reads as a quiet floating ledge instead of a dark slab.
-            // Falls back to the previous flat fill on older iOS.
-            if #available(iOS 26.0, *) {
-                Color.clear
-                    .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 0))
-            } else {
-                Color.black.opacity(0.32)
-            }
-        }
-        .overlay(alignment: .top) {
-            // Hairline gives the glass a defined edge against the cockpit above.
-            Rectangle()
-                .fill(Color.white.opacity(0.08))
-                .frame(height: 0.5)
         }
     }
 
@@ -1623,6 +2012,8 @@ struct LatsDeckScreen: View {
     @State private var recTimer: Timer?
     @State private var agentTimer: Timer?
     @State private var modeAutoReturn: DispatchWorkItem?
+    @State private var isUsingJoystick = false
+    @State private var joystickSwipeSuppressedUntil = Date.distantPast
 
     private var isConnected: Bool { liveSnapshot != nil }
 
@@ -1631,10 +2022,12 @@ struct LatsDeckScreen: View {
     }
 
     private var gridColumns: Int {
+        if hSize == .compact { return 2 }
         if let columns = activeCockpitPage()?.columns {
-            return hSize == .compact ? min(3, columns) : columns
+            if activeCockpitPage()?.rows != nil { return columns }
+            return columns
         }
-        return hSize == .compact ? 3 : 6
+        return 6
     }
 
     // ── Resolved values: prefer live, fall back to mock ──
@@ -1777,7 +2170,9 @@ struct LatsDeckScreen: View {
 
                 GeometryReader { geo in
                     let isPad = geo.size.width > 700 && hSize == .regular
-                    let cockpitH: CGFloat = isPad ? max(380, geo.size.height * 0.50) : max(320, geo.size.height * 0.44)
+                    let cockpitH: CGFloat = hSize == .compact
+                        ? min(250, max(210, geo.size.height * 0.30))
+                        : (isPad ? max(380, geo.size.height * 0.50) : max(320, geo.size.height * 0.44))
 
                     VStack(spacing: 0) {
                         // Cockpit
@@ -1825,7 +2220,19 @@ struct LatsDeckScreen: View {
                             LatsShortcutGrid(
                                 shortcuts: shortcuts,
                                 columns: gridColumns,
-                                onTap: handleTilePress
+                                rows: hSize == .compact ? nil : activeCockpitPage()?.rows,
+                                onTap: handleTilePress,
+                                onJoystickMove: { dx, dy in
+                                    onTrackpadEvent?(.move, dx, dy)
+                                },
+                                onJoystickInteractionChanged: { active in
+                                    isUsingJoystick = active
+                                    if !active {
+                                        joystickSwipeSuppressedUntil = Date().addingTimeInterval(0.25)
+                                    }
+                                },
+                                joystickEnabled: joystickReady,
+                                joystickScale: liveSnapshot?.trackpad?.pointerScale ?? 1.6
                             )
                             .padding(14)
                             .id(effectiveDeckID)
@@ -1878,6 +2285,7 @@ struct LatsDeckScreen: View {
         guard let activePage = activeCockpitPage() else { return nil }
         return activePage.tiles.map { tile in
             LatsShortcut(
+                id: tile.id,
                 label: tile.title,
                 icon: tile.iconSystemName,
                 tint: LatsTint.from(token: tile.categoryTint ?? tile.accentToken),
@@ -1885,9 +2293,21 @@ struct LatsDeckScreen: View {
                 hint: tile.subtitle ?? "",
                 sim: simAction(from: tile.actionID),
                 actionID: tile.actionID,
-                payload: tile.payload
+                payload: tile.payload,
+                controlKind: tile.controlKind,
+                col: tile.col,
+                row: tile.row,
+                colSpan: tile.colSpan,
+                rowSpan: tile.rowSpan,
+                isEnabled: tile.isEnabled
             )
         }
+    }
+
+    private var joystickReady: Bool {
+        guard onTrackpadEvent != nil else { return false }
+        guard let trackpad = liveSnapshot?.trackpad else { return isConnected }
+        return trackpad.isEnabled && trackpad.isAvailable
     }
 
     private func shortcutCategory(for tile: DeckCockpitTile) -> ShortcutCategory {
@@ -1921,7 +2341,14 @@ struct LatsDeckScreen: View {
 
     private func handleTilePress(_ shortcut: LatsShortcut) {
         if let onAction, let actionID = shortcut.actionID {
-            onAction(actionID, shortcut.payload, shortcut.label)
+            var payload = shortcut.payload
+            if actionID == "clipboard.pasteFromDevice",
+               let text = UIPasteboard.general.string,
+               !text.isEmpty {
+                payload["text"] = .string(text)
+                payload["source"] = .string("ios-pasteboard")
+            }
+            onAction(actionID, payload, shortcut.label)
             return
         }
 
@@ -2010,6 +2437,7 @@ struct LatsDeckScreen: View {
     private var deckSwipeGesture: some Gesture {
         DragGesture(minimumDistance: 20)
             .onEnded { value in
+                guard !isUsingJoystick, Date() >= joystickSwipeSuppressedUntil else { return }
                 let dx = value.translation.width
                 let dy = value.translation.height
                 // Require dominantly-horizontal motion so vertical scrolls don't
@@ -2088,6 +2516,1590 @@ struct LatsDeckScreen: View {
     }
 }
 
+// MARK: - Fleet Deck
+
+/// Multi-Mac cockpit. Landscape renders up to four independent decks beside
+/// one another; portrait keeps the same sessions in a swipeable single-deck
+/// pager. Each child observes its own `DeckStore`, preserving host ownership
+/// all the way from visible controls to bridge requests.
+struct FleetDeckScreen: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @ObservedObject var primaryStore: DeckStore
+    @ObservedObject var fleetStore: DeckFleetStore
+    var initialMachineID: String?
+    var previewStores: [DeckStore]? = nil
+
+    @State private var selectedSessionID: UUID?
+
+    private var stores: [DeckStore] {
+        previewStores ?? fleetStore.stores(including: primaryStore)
+    }
+
+    var body: some View {
+        Group {
+            if stores.count == 1, let store = stores.first, store.snapshot != nil {
+                singleDeck(store)
+            } else {
+                fleetLayout
+            }
+        }
+        .preferredColorScheme(.dark)
+        .statusBarHidden(true)
+        .onAppear {
+            if previewStores == nil {
+                fleetStore.synchronize(with: primaryStore)
+                fleetStore.setUIPriority(.fast, primaryStore: primaryStore)
+            }
+            selectInitialSessionIfNeeded()
+        }
+        .onChange(of: primaryStore.discoveredBridges) { _, _ in
+            guard previewStores == nil else { return }
+            fleetStore.synchronize(with: primaryStore)
+            selectInitialSessionIfNeeded()
+        }
+        .onChange(of: fleetStore.secondaryStores.map(\.sessionID)) { _, _ in
+            selectInitialSessionIfNeeded()
+        }
+        .onDisappear {
+            if previewStores == nil {
+                fleetStore.setUIPriority(.ambient, primaryStore: primaryStore)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func singleDeck(_ store: DeckStore) -> some View {
+        LatsDeckScreen(
+            liveSnapshot: store.snapshot,
+            connectionLabel: store.connectionLabel,
+            onAction: { actionID, payload, label in
+                store.perform(actionID: actionID, pageID: "cockpit", payload: payload, label: label)
+            },
+            onTrackpadEvent: { event, dx, dy in
+                store.sendTrackpad(event: event, dx: dx, dy: dy)
+            }
+        )
+    }
+
+    private var fleetLayout: some View {
+        GeometryReader { proxy in
+            let isLandscape = proxy.size.width > proxy.size.height
+
+            LatsBackground(grid: true) {
+                VStack(spacing: 0) {
+                    fleetTopBar(isLandscape: isLandscape)
+                    if stores.isEmpty {
+                        fleetEmptyState
+                    } else if isLandscape {
+                        landscapeDecks(size: proxy.size)
+                    } else {
+                        portraitDecks
+                    }
+                }
+            }
+        }
+    }
+
+    private func fleetTopBar(isLandscape: Bool) -> some View {
+        LatsTopBar(
+            product: "LATS",
+            section: "DECK",
+            trailing: AnyView(
+                HStack(spacing: 8) {
+                    LatsBadge(
+                        text: isLandscape ? "\(stores.count)-UP" : "SWIPE",
+                        tint: LatsPalette.green,
+                        dot: true
+                    )
+                    Text("\(stores.count) MAC\(stores.count == 1 ? "" : "S")")
+                        .font(LatsFont.mono(9, weight: .semibold))
+                        .foregroundStyle(LatsPalette.textFaint)
+                        .tracking(0.8)
+                }
+            ),
+            onClose: { dismiss() }
+        )
+    }
+
+    private func landscapeDecks(size: CGSize) -> some View {
+        VStack(spacing: 10) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 10) {
+                    ForEach(Array(stores.enumerated()), id: \.element.sessionID) { index, store in
+                        FleetLanePicker(
+                            store: store,
+                            laneNumber: index + 1,
+                            accent: fleetAccent(for: index),
+                            isSelected: selectedStore?.sessionID == store.sessionID,
+                            onSelect: {
+                                withAnimation(.easeOut(duration: 0.18)) {
+                                    selectedSessionID = store.sessionID
+                                }
+                            }
+                        )
+                        .frame(width: laneWidth(for: size.width))
+                    }
+                }
+                .padding(.horizontal, 12)
+                .padding(.top, 10)
+            }
+            .frame(height: min(255, max(225, size.height * 0.25)))
+
+            FleetLaneFader(
+                laneCount: stores.count,
+                selectedIndex: selectedLaneIndex,
+                accents: stores.indices.map(fleetAccent(for:)),
+                onSelect: { index in
+                    guard stores.indices.contains(index) else { return }
+                    withAnimation(.easeOut(duration: 0.16)) {
+                        selectedSessionID = stores[index].sessionID
+                    }
+                }
+            )
+            .frame(height: 58)
+            .padding(.horizontal, 12)
+
+            if let selectedStore,
+               let selectedIndex = stores.firstIndex(where: { $0.sessionID == selectedStore.sessionID }) {
+                FleetSharedDeck(
+                    store: selectedStore,
+                    accent: fleetAccent(for: selectedIndex),
+                    laneNumber: selectedIndex + 1
+                )
+                .id(selectedStore.sessionID)
+                .frame(maxHeight: .infinity)
+                .padding(.horizontal, 12)
+                .padding(.bottom, 10)
+                .transition(.opacity)
+            }
+        }
+    }
+
+    private var selectedStore: DeckStore? {
+        if let selectedSessionID,
+           let selected = stores.first(where: { $0.sessionID == selectedSessionID }) {
+            return selected
+        }
+        return stores.first
+    }
+
+    private var selectedLaneIndex: Int {
+        guard let selectedStore else { return 0 }
+        return stores.firstIndex(where: { $0.sessionID == selectedStore.sessionID }) ?? 0
+    }
+
+    private func laneWidth(for availableWidth: CGFloat) -> CGFloat {
+        let visibleCount = min(max(stores.count, 1), 4)
+        let totalSpacing = CGFloat(max(0, visibleCount - 1)) * 10
+        let fitted = (availableWidth - 24 - totalSpacing) / CGFloat(visibleCount)
+        return max(245, fitted)
+    }
+
+    private var portraitDecks: some View {
+        TabView(selection: selectedSessionBinding) {
+            ForEach(Array(stores.enumerated()), id: \.element.sessionID) { index, store in
+                FleetMachineDeck(store: store, accentOverride: fleetAccent(for: index))
+                    .padding(.horizontal, 12)
+                    .padding(.top, 10)
+                    .padding(.bottom, 28)
+                    .tag(store.sessionID)
+            }
+        }
+        .tabViewStyle(.page(indexDisplayMode: .always))
+    }
+
+    private var selectedSessionBinding: Binding<UUID> {
+        Binding(
+            get: { selectedSessionID ?? stores.first?.sessionID ?? primaryStore.sessionID },
+            set: { selectedSessionID = $0 }
+        )
+    }
+
+    private var fleetEmptyState: some View {
+        LatsEmptyState(
+            title: "No reachable Macs",
+            subtitle: "Open Lattices on a paired Mac to add its deck.",
+            icon: "laptopcomputer.slash"
+        )
+        .padding(24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func selectInitialSessionIfNeeded() {
+        if let selectedSessionID,
+           stores.contains(where: { $0.sessionID == selectedSessionID }) {
+            return
+        }
+
+        if let initialMachineID,
+           let requested = stores.first(where: { $0.activeEndpoint?.id == initialMachineID }) {
+            selectedSessionID = requested.sessionID
+        } else {
+            selectedSessionID = stores.first?.sessionID
+        }
+    }
+
+    private func fleetAccent(for index: Int) -> Color {
+        let palette = [
+            LatsPalette.teal,
+            LatsPalette.violet,
+            LatsPalette.green,
+            LatsPalette.amber,
+            LatsPalette.blue,
+            LatsPalette.pink
+        ]
+        return palette[index % palette.count]
+    }
+}
+
+#if DEBUG
+struct FleetDeckPreviewHost: View {
+    @StateObject private var primaryStore: DeckStore
+    @StateObject private var fleetStore = DeckFleetStore()
+    private let previewStores: [DeckStore]
+
+    init(machineCount: Int = 4) {
+        let names = ["Arach MacBook Pro", "Studio", "Mac mini", "Build Mac"]
+        let stores = (0..<max(1, min(machineCount, names.count))).map {
+            DeckStore.fleetPreview(name: names[$0], index: $0)
+        }
+        previewStores = stores
+        _primaryStore = StateObject(wrappedValue: stores[0])
+    }
+
+    var body: some View {
+        FleetDeckScreen(
+            primaryStore: primaryStore,
+            fleetStore: fleetStore,
+            previewStores: previewStores
+        )
+    }
+}
+#endif
+
+private struct FleetLaneFader: View {
+    let laneCount: Int
+    let selectedIndex: Int
+    let accents: [Color]
+    let onSelect: (Int) -> Void
+
+    private var selectedAccent: Color {
+        accents.indices.contains(selectedIndex) ? accents[selectedIndex] : LatsPalette.teal
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            let count = max(1, laneCount)
+            let inset: CGFloat = 28
+            let travel = max(1, proxy.size.width - inset * 2)
+            let step = count > 1 ? travel / CGFloat(count - 1) : 0
+            let knobX = inset + CGFloat(min(max(0, selectedIndex), count - 1)) * step
+
+            ZStack {
+                RoundedRectangle(cornerRadius: 7)
+                    .fill(LatsPalette.surface.opacity(0.72))
+                    .overlay(RoundedRectangle(cornerRadius: 7).stroke(LatsPalette.hairline2, lineWidth: 1))
+
+                Capsule()
+                    .fill(Color.black.opacity(0.72))
+                    .frame(height: 7)
+                    .overlay(Capsule().stroke(Color.white.opacity(0.08), lineWidth: 1))
+                    .padding(.horizontal, inset)
+
+                HStack {
+                    Text("CHANNEL ROUTE")
+                        .font(LatsFont.mono(7, weight: .bold))
+                        .tracking(1.4)
+                        .foregroundStyle(LatsPalette.textFaint)
+                    Spacer()
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(selectedAccent)
+                            .frame(width: 7, height: 7)
+                            .shadow(color: selectedAccent.opacity(0.9), radius: 6)
+                        Text("DECK OUT · CH \(String(format: "%02d", selectedIndex + 1))")
+                            .font(LatsFont.mono(7, weight: .bold))
+                            .tracking(0.8)
+                            .foregroundStyle(selectedAccent)
+                    }
+                }
+                .padding(.horizontal, 12)
+                .frame(maxHeight: .infinity, alignment: .top)
+                .padding(.top, 7)
+
+                ForEach(0..<count, id: \.self) { index in
+                    let x = inset + CGFloat(index) * step
+                    VStack(spacing: 3) {
+                        Circle()
+                            .fill(index == selectedIndex ? selectedAccent : Color.white.opacity(0.12))
+                            .frame(width: index == selectedIndex ? 7 : 5, height: index == selectedIndex ? 7 : 5)
+                        Text("\(index + 1)")
+                            .font(LatsFont.mono(6, weight: .semibold))
+                            .foregroundStyle(index == selectedIndex ? selectedAccent : LatsPalette.textFaint)
+                    }
+                    .position(x: x, y: 37)
+                }
+
+                ZStack {
+                    RoundedRectangle(cornerRadius: 5)
+                        .fill(
+                            LinearGradient(
+                                colors: [Color.white.opacity(0.20), LatsPalette.surface2, Color.black.opacity(0.55)],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                        )
+                    RoundedRectangle(cornerRadius: 5)
+                        .stroke(selectedAccent.opacity(0.70), lineWidth: 1)
+                    Rectangle()
+                        .fill(selectedAccent.opacity(0.88))
+                        .frame(width: 2, height: 18)
+                }
+                .frame(width: 34, height: 24)
+                .shadow(color: Color.black.opacity(0.8), radius: 5, y: 3)
+                .shadow(color: selectedAccent.opacity(0.18), radius: 7)
+                .position(x: knobX, y: 32)
+            }
+            .contentShape(RoundedRectangle(cornerRadius: 7))
+            .gesture(
+                DragGesture(minimumDistance: 0, coordinateSpace: .local)
+                    .onChanged { value in
+                        guard count > 1 else { return }
+                        let normalized = min(1, max(0, (value.location.x - inset) / travel))
+                        let index = Int((normalized * CGFloat(count - 1)).rounded())
+                        if index != selectedIndex { onSelect(index) }
+                    }
+            )
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Computer channel fader")
+            .accessibilityValue("Channel \(selectedIndex + 1) of \(count)")
+            .accessibilityAdjustableAction { direction in
+                switch direction {
+                case .increment: onSelect(min(count - 1, selectedIndex + 1))
+                case .decrement: onSelect(max(0, selectedIndex - 1))
+                @unknown default: break
+                }
+            }
+        }
+    }
+}
+
+private struct FleetAgentTapeEntry: Identifiable {
+    let id: String
+    let label: String
+    let text: String
+    let tint: Color
+    let isLive: Bool
+}
+
+private struct FleetLanePicker: View {
+    @ObservedObject var store: DeckStore
+    let laneNumber: Int
+    let accent: Color
+    let isSelected: Bool
+    let onSelect: () -> Void
+
+    private var statusColor: Color {
+        if store.errorMessage != nil { return LatsPalette.red }
+        if store.snapshot != nil { return LatsPalette.green }
+        return store.isLoading ? LatsPalette.amber : LatsPalette.textFaint
+    }
+
+    private var activeApp: String {
+        store.snapshot?.layout?.frontmostWindow?.appName
+            ?? store.snapshot?.desktop?.activeAppName
+            ?? "No active app"
+    }
+
+    private var activeWindow: String {
+        store.snapshot?.layout?.frontmostWindow?.title
+            ?? store.snapshot?.desktop?.currentSpaceName
+            ?? "Waiting for desktop state"
+    }
+
+    var body: some View {
+        Button(action: onSelect) {
+            VStack(spacing: 0) {
+                laneHeader
+                LatsHairlineDivider()
+                contextStrip
+                LatsHairlineDivider()
+                agentTape
+                LatsHairlineDivider()
+                routeFooter
+            }
+            .background(
+                LinearGradient(
+                    colors: [
+                        isSelected ? accent.opacity(0.075) : Color.white.opacity(0.018),
+                        LatsPalette.bg.opacity(0.98)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 7))
+            .overlay(
+                RoundedRectangle(cornerRadius: 7)
+                    .stroke(isSelected ? accent.opacity(0.62) : LatsPalette.hairline2, lineWidth: 1)
+            )
+            .overlay(alignment: .top) {
+                Rectangle()
+                    .fill(isSelected ? accent.opacity(0.82) : Color.white.opacity(0.055))
+                    .frame(height: isSelected ? 2 : 1)
+                    .padding(.horizontal, 7)
+            }
+            .shadow(
+                color: isSelected ? accent.opacity(0.10) : Color.black.opacity(0.48),
+                radius: isSelected ? 9 : 5,
+                x: 0,
+                y: 4
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Route lane \(laneNumber), \(store.connectionLabel), to common deck")
+    }
+
+    private var laneHeader: some View {
+        HStack(spacing: 8) {
+            Text("CH \(String(format: "%02d", laneNumber))")
+                .font(LatsFont.mono(8, weight: .bold))
+                .tracking(1.2)
+                .foregroundStyle(isSelected ? accent : LatsPalette.textFaint)
+
+            Rectangle()
+                .fill(LatsPalette.hairline2)
+                .frame(width: 1, height: 15)
+
+            Image(systemName: machineIcon)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(isSelected ? accent : LatsPalette.textDim)
+
+            Text(store.connectionLabel)
+                .font(LatsFont.mono(10, weight: .semibold))
+                .foregroundStyle(LatsPalette.text)
+                .lineLimit(1)
+
+            Spacer(minLength: 4)
+
+            Circle().fill(statusColor).frame(width: 5, height: 5)
+            Text(store.snapshot == nil ? "LINK" : "LIVE")
+                .font(LatsFont.mono(7, weight: .bold))
+                .tracking(0.8)
+                .foregroundStyle(statusColor)
+        }
+        .padding(.horizontal, 11)
+        .frame(height: 42)
+    }
+
+    private var contextStrip: some View {
+        ZStack {
+            LatsPalette.bgEdge
+            LatsGridBackground().opacity(isSelected ? 0.48 : 0.30)
+
+            HStack(spacing: 9) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("CONTEXT")
+                        .font(LatsFont.mono(7, weight: .bold))
+                        .tracking(1.3)
+                        .foregroundStyle(isSelected ? accent : LatsPalette.textFaint)
+                    Text(activeApp)
+                        .font(LatsFont.mono(11, weight: .semibold))
+                        .foregroundStyle(LatsPalette.text)
+                        .lineLimit(1)
+                    Text(activeWindow)
+                        .font(LatsFont.mono(7))
+                        .foregroundStyle(LatsPalette.textDim)
+                        .lineLimit(1)
+                }
+
+                Spacer()
+
+                HStack(spacing: 9) {
+                    laneMetric("CPU", value: percent(store.snapshot?.telemetry?.cpuLoadPercent))
+                    laneMetric("MEM", value: percent(store.snapshot?.telemetry?.memoryUsedPercent))
+                    laneMetric("WIN", value: String(store.snapshot?.telemetry?.windowCount ?? 0))
+                }
+            }
+            .padding(12)
+        }
+        .frame(height: 66)
+        .contentShape(Rectangle())
+    }
+
+    private var routeFooter: some View {
+        HStack(spacing: 7) {
+            Circle()
+                .fill(isSelected ? accent : LatsPalette.textFaint)
+                .frame(width: 5, height: 5)
+                .shadow(color: isSelected ? accent.opacity(0.55) : .clear, radius: 4)
+            Text(isSelected ? "ROUTED TO DECK" : "TAP TO ROUTE")
+                .font(LatsFont.mono(8, weight: .bold))
+                .tracking(1)
+                .foregroundStyle(isSelected ? accent : LatsPalette.textFaint)
+            Spacer()
+            Text(isSelected ? "ON DECK" : "STANDBY")
+                .font(LatsFont.mono(7, weight: .semibold))
+                .foregroundStyle(isSelected ? LatsPalette.text : LatsPalette.textFaint)
+        }
+        .padding(.horizontal, 11)
+        .frame(height: 34)
+        .background(Color.black.opacity(isSelected ? 0.26 : 0.16))
+    }
+
+    private var agentTape: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 6) {
+                Text("AGENT TAPE")
+                    .font(LatsFont.mono(7, weight: .bold))
+                    .tracking(1.25)
+                    .foregroundStyle(LatsPalette.violet.opacity(0.82))
+                Spacer()
+                if agentEntries.contains(where: \.isLive) {
+                    Circle()
+                        .fill(LatsPalette.violet)
+                        .frame(width: 5, height: 5)
+                        .shadow(color: LatsPalette.violet.opacity(0.8), radius: 4)
+                    Text("ACTIVE")
+                        .font(LatsFont.mono(6, weight: .bold))
+                        .foregroundStyle(LatsPalette.violet)
+                } else {
+                    Text("IDLE")
+                        .font(LatsFont.mono(6, weight: .bold))
+                        .foregroundStyle(LatsPalette.textFaint)
+                }
+            }
+            .padding(.bottom, 5)
+
+            if agentEntries.isEmpty {
+                Text("no agents on this channel")
+                    .font(LatsFont.mono(7))
+                    .foregroundStyle(LatsPalette.textFaint)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                ForEach(Array(agentEntries.prefix(3))) { entry in
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(entry.tint)
+                            .frame(width: 5, height: 5)
+                            .shadow(color: entry.isLive ? entry.tint.opacity(0.65) : .clear, radius: 3)
+                        Text(entry.label.uppercased())
+                            .font(LatsFont.mono(6, weight: .bold))
+                            .tracking(0.55)
+                            .foregroundStyle(entry.tint.opacity(0.88))
+                            .frame(width: 42, alignment: .leading)
+                        Text(entry.text)
+                            .font(LatsFont.mono(7))
+                            .foregroundStyle(entry.isLive ? LatsPalette.textDim : LatsPalette.textFaint)
+                            .lineLimit(1)
+                        Spacer(minLength: 0)
+                    }
+                    .frame(height: 15)
+                }
+            }
+        }
+        .padding(.horizontal, 11)
+        .padding(.vertical, 7)
+        .frame(maxHeight: .infinity, alignment: .top)
+        .background(Color.black.opacity(0.20))
+    }
+
+    private var agentEntries: [FleetAgentTapeEntry] {
+        let activityEntries = (store.snapshot?.activityLog ?? [])
+            .sorted { $0.createdAt > $1.createdAt }
+            .prefix(3)
+            .map { entry in
+                FleetAgentTapeEntry(
+                    id: entry.id,
+                    label: entry.tag,
+                    text: entry.text,
+                    tint: LatsTint.from(token: entry.tint).color,
+                    isLive: entry.createdAt.timeIntervalSinceNow > -120
+                )
+            }
+        if !activityEntries.isEmpty { return Array(activityEntries) }
+
+        return (store.snapshot?.cockpitMode?.agentRows ?? []).map { row in
+            let tint: Color
+            let live: Bool
+            switch row.state {
+            case .done:
+                tint = LatsPalette.green
+                live = false
+            case .live:
+                tint = LatsPalette.violet
+                live = true
+            case .next:
+                tint = LatsPalette.textFaint
+                live = false
+            }
+            return FleetAgentTapeEntry(id: row.id, label: "agent", text: row.text, tint: tint, isLive: live)
+        }
+    }
+
+    private func laneMetric(_ label: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .font(LatsFont.mono(7, weight: .bold))
+                .foregroundStyle(LatsPalette.textFaint)
+            Text(value)
+                .font(LatsFont.mono(9, weight: .semibold))
+                .foregroundStyle(LatsPalette.textDim)
+        }
+    }
+
+    private func percent(_ value: Double?) -> String {
+        "\(Int((value ?? 0).rounded()))%"
+    }
+
+    private var machineIcon: String {
+        let label = store.connectionLabel.lowercased()
+        if label.contains("mini") { return "macmini" }
+        if label.contains("studio") { return "macstudio" }
+        if label.contains("imac") { return "desktopcomputer" }
+        return "laptopcomputer"
+    }
+}
+
+private struct FleetSharedDeck: View {
+    @ObservedObject var store: DeckStore
+    let accent: Color
+    let laneNumber: Int
+
+    @State private var selectedPageID: String?
+
+    private var pages: [DeckCockpitPage] {
+        store.snapshot?.cockpit?.pages ?? []
+    }
+
+    private var activePage: DeckCockpitPage? {
+        if let selectedPageID,
+           let page = pages.first(where: { $0.id == selectedPageID }) {
+            return page
+        }
+        return pages.first
+    }
+
+    private var shortcuts: [LatsShortcut] {
+        activePage?.tiles.map(shortcut(from:)) ?? []
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            deckHeader
+            LatsHairlineDivider()
+
+            LatsCockpitShell {
+                LatsTrackpadSurface(
+                    mode: cockpitMode,
+                    recTime: store.snapshot?.cockpitMode?.elapsedSeconds ?? 0,
+                    agentProgress: (store.snapshot?.cockpitMode?.agentProgress ?? 0) * 264,
+                    replayMessage: store.snapshot?.cockpitMode?.replayMessage ?? "",
+                    replayUndoLabel: replayUndoLabel,
+                    agentRows: store.snapshot?.cockpitMode?.agentRows ?? [],
+                    telemetry: fleetTelemetry,
+                    stage: fleetStage,
+                    space: fleetSpace,
+                    spaceCount: fleetSpaceCount,
+                    spaceName: store.snapshot?.spaces?.currentSpaceName
+                        ?? store.snapshot?.desktop?.currentSpaceName,
+                    transcript: fleetTranscript,
+                    activityLog: store.snapshot?.activityLog ?? [],
+                    hostLabel: store.connectionLabel,
+                    trackpadState: store.snapshot?.trackpad,
+                    spaceDisplays: store.snapshot?.spaces?.displays ?? [],
+                    frontmostApp: store.snapshot?.layout?.frontmostWindow?.appName
+                        ?? store.snapshot?.desktop?.activeAppName,
+                    frontmostTitle: store.snapshot?.layout?.frontmostWindow?.title,
+                    onSendKey: sendKey,
+                    onReplayUndo: undoReplay,
+                    onTrackpadEvent: { event, dx, dy in
+                        store.sendTrackpad(event: event, dx: dx, dy: dy)
+                    },
+                    onSpaceTap: focusSpace,
+                    onMonitorSwipe: swipeMonitor
+                )
+                .environment(\.horizontalSizeClass, .regular)
+            }
+            .frame(height: 280)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+
+            LatsHairlineDivider()
+
+            GeometryReader { proxy in
+                let columns = max(1, min(3, shortcuts.count))
+                let rows = max(1, Int(ceil(Double(shortcuts.count) / Double(columns))))
+                let availableHeight = max(96, proxy.size.height - 24 - CGFloat(max(0, rows - 1)) * 10)
+                let controlHeight = availableHeight / CGFloat(rows)
+
+                ScrollView {
+                    LatsShortcutGrid(
+                        shortcuts: shortcuts,
+                        columns: columns,
+                        onTap: perform,
+                        onJoystickMove: { dx, dy in store.sendTrackpad(event: .move, dx: dx, dy: dy) },
+                        joystickEnabled: joystickReady,
+                        joystickScale: store.snapshot?.trackpad?.pointerScale ?? 1.6,
+                        minimumControlHeight: controlHeight
+                    )
+                    .padding(12)
+                    .frame(minHeight: proxy.size.height, alignment: .bottom)
+                }
+                .scrollIndicators(.hidden)
+            }
+
+            deckFooter
+        }
+        .background(
+            LinearGradient(
+                colors: [LatsPalette.surface.opacity(0.66), LatsPalette.bg.opacity(0.99)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 7))
+        .overlay(
+            RoundedRectangle(cornerRadius: 7)
+                .stroke(LatsPalette.hairline2, lineWidth: 1)
+        )
+        .overlay(alignment: .top) {
+            LinearGradient(
+                colors: [.clear, accent.opacity(0.78), .clear],
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+            .frame(height: 1)
+            .padding(.horizontal, 8)
+        }
+        .shadow(color: Color.black.opacity(0.60), radius: 9, x: 0, y: 5)
+        .onAppear(perform: selectFirstPageIfNeeded)
+        .onChange(of: pages.map(\.id)) { _, _ in selectFirstPageIfNeeded() }
+    }
+
+    private var deckHeader: some View {
+        HStack(spacing: 10) {
+            Text("COMMON DECK")
+                .font(LatsFont.mono(9, weight: .bold))
+                .tracking(1.5)
+                .foregroundStyle(LatsPalette.text)
+
+            Text("CH \(String(format: "%02d", laneNumber))")
+                .font(LatsFont.mono(8, weight: .bold))
+                .foregroundStyle(accent)
+                .padding(.horizontal, 7)
+                .frame(height: 22)
+                .background(RoundedRectangle(cornerRadius: 4).fill(accent.opacity(0.11)))
+                .overlay(RoundedRectangle(cornerRadius: 4).stroke(accent.opacity(0.30), lineWidth: 1))
+
+            Image(systemName: "arrow.right")
+                .font(.system(size: 8, weight: .semibold))
+                .foregroundStyle(LatsPalette.textFaint)
+
+            Text(store.connectionLabel)
+                .font(LatsFont.mono(9, weight: .semibold))
+                .foregroundStyle(LatsPalette.textDim)
+                .lineLimit(1)
+
+            Spacer(minLength: 12)
+
+            HStack(spacing: 5) {
+                ForEach(pages) { page in
+                    let isSelected = page.id == activePage?.id
+                    Button {
+                        withAnimation(.easeOut(duration: 0.15)) { selectedPageID = page.id }
+                    } label: {
+                        Text(page.title.uppercased())
+                            .font(LatsFont.mono(8, weight: isSelected ? .bold : .regular))
+                            .foregroundStyle(isSelected ? accent : LatsPalette.textFaint)
+                            .padding(.horizontal, 9)
+                            .frame(height: 24)
+                            .background(
+                                RoundedRectangle(cornerRadius: 4)
+                                    .fill(isSelected ? accent.opacity(0.11) : Color.white.opacity(0.025))
+                            )
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 4)
+                                    .stroke(isSelected ? accent.opacity(0.28) : LatsPalette.hairline, lineWidth: 1)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 42)
+        .background(Color.black.opacity(0.22))
+    }
+
+    private var deckFooter: some View {
+        HStack(spacing: 8) {
+            Circle().fill(LatsPalette.green).frame(width: 5, height: 5)
+            Text("OUTPUT")
+                .font(LatsFont.mono(7, weight: .bold))
+                .tracking(1)
+                .foregroundStyle(LatsPalette.textFaint)
+            Text(store.lastActionLabel ?? store.connectionLabel)
+                .font(LatsFont.mono(8))
+                .foregroundStyle(LatsPalette.textDim)
+                .lineLimit(1)
+            Spacer()
+            if let cpu = store.snapshot?.telemetry?.cpuLoadPercent {
+                Text("CPU \(Int(cpu.rounded()))%")
+                    .font(LatsFont.mono(8))
+                    .foregroundStyle(LatsPalette.textFaint)
+            }
+            Text("LANE \(laneNumber) · READY")
+                .font(LatsFont.mono(8, weight: .semibold))
+                .foregroundStyle(accent)
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 28)
+        .background(Color.black.opacity(0.25))
+        .overlay(alignment: .top) {
+            Rectangle().fill(LatsPalette.hairline).frame(height: 1)
+        }
+    }
+
+    private var joystickReady: Bool {
+        guard let state = store.snapshot?.trackpad else { return false }
+        return state.isEnabled && state.isAvailable
+    }
+
+    private var cockpitMode: CockpitMode {
+        guard let mode = store.snapshot?.cockpitMode?.mode else { return .idle }
+        return CockpitMode(from: mode)
+    }
+
+    private var replayUndoLabel: String {
+        guard let expiresAt = store.snapshot?.cockpitMode?.replayUndoExpiresAt else {
+            return "undo within 5s"
+        }
+        let seconds = max(0, Int(ceil(expiresAt.timeIntervalSinceNow)))
+        return seconds > 0 ? "undo within \(seconds)s" : "undo expired"
+    }
+
+    private var fleetTelemetry: LatsTelemetry {
+        guard let telemetry = store.snapshot?.telemetry else { return LatsTelemetry() }
+        return LatsTelemetry(from: telemetry)
+    }
+
+    private var fleetSpace: Int {
+        let index = store.snapshot?.spaces?.currentSpaceIndex
+            ?? store.snapshot?.desktop?.currentSpaceIndex
+            ?? 1
+        return max(0, index - 1)
+    }
+
+    private var fleetSpaceCount: Int {
+        max(1, store.snapshot?.spaces?.displays.first?.spaces.count ?? 1)
+    }
+
+    private var fleetTranscript: [String] {
+        if let lines = store.snapshot?.voice?.transcriptLines, !lines.isEmpty {
+            return Array(lines.sorted { $0.createdAt > $1.createdAt }.prefix(5).map(\.text))
+        }
+        if let transcript = store.snapshot?.voice?.transcript, !transcript.isEmpty {
+            return [transcript]
+        }
+        return []
+    }
+
+    private var fleetStage: [[LatsWindow]] {
+        guard let preview = store.snapshot?.layout?.preview else { return CommandDeck.stage }
+        let displayCount = max(preview.displayCount ?? 1, 1)
+        var buckets = Array(repeating: [LatsWindow](), count: displayCount)
+        for window in preview.windows {
+            let index = window.displayIndex ?? 0
+            guard buckets.indices.contains(index) else { continue }
+            buckets[index].append(
+                LatsWindow(
+                    x: window.normalizedFrame.x * 100,
+                    y: window.normalizedFrame.y * 100,
+                    w: window.normalizedFrame.w * 100,
+                    h: window.normalizedFrame.h * 100,
+                    tint: LatsTint.from(token: window.appCategoryTint),
+                    tag: String(window.title.prefix(4))
+                )
+            )
+        }
+        return buckets
+    }
+
+    private func sendKey(_ key: String, _ modifiers: [String]) {
+        store.perform(
+            actionID: "keys.send",
+            pageID: activePage?.id ?? "cockpit",
+            payload: [
+                "key": .string(key),
+                "modifiers": .array(modifiers.map { .string($0) })
+            ],
+            label: (modifiers + [key.uppercased()]).joined()
+        )
+    }
+
+    private func undoReplay() {
+        let actionID = store.snapshot?.cockpitMode?.replayUndoActionID ?? "history.undoLast"
+        store.perform(actionID: actionID, pageID: activePage?.id ?? "cockpit", label: "Undo last action")
+    }
+
+    private func focusSpace(_ index: Int) {
+        store.perform(
+            actionID: "spaces.focusIndex",
+            pageID: activePage?.id ?? "cockpit",
+            payload: ["index": .int(index)],
+            label: "Switch to space \(index + 1)"
+        )
+    }
+
+    private func swipeMonitor(_ display: Int, _ direction: Int) {
+        let key = direction > 0 ? "right" : "left"
+        store.perform(
+            actionID: "keys.send",
+            pageID: activePage?.id ?? "cockpit",
+            payload: ["key": .string(key), "modifiers": .array([.string("⌃")])],
+            label: direction > 0 ? "Next space" : "Previous space"
+        )
+    }
+
+    private func shortcut(from tile: DeckCockpitTile) -> LatsShortcut {
+        LatsShortcut(
+            id: tile.id,
+            label: tile.title,
+            icon: tile.iconSystemName,
+            tint: LatsTint.from(token: tile.categoryTint ?? tile.accentToken),
+            category: shortcutCategory(for: tile),
+            hint: tile.subtitle ?? "",
+            sim: .none,
+            actionID: tile.actionID,
+            payload: tile.payload,
+            controlKind: tile.controlKind,
+            isEnabled: tile.isEnabled
+        )
+    }
+
+    private func shortcutCategory(for tile: DeckCockpitTile) -> ShortcutCategory {
+        let searchable = [tile.deckID, tile.actionID, tile.title, tile.subtitle]
+            .compactMap { $0?.lowercased() }
+            .joined(separator: " ")
+        if searchable.contains("voice") || searchable.contains("dictate") { return .voice }
+        if searchable.contains("agent") || searchable.contains("claude") { return .agent }
+        if searchable.contains("window") || searchable.contains("tile") { return .window }
+        if searchable.contains("dev") || searchable.contains("terminal") { return .dev }
+        return .system
+    }
+
+    private func perform(_ shortcut: LatsShortcut) {
+        guard shortcut.isEnabled, let actionID = shortcut.actionID else { return }
+        var payload = shortcut.payload
+        if actionID == "clipboard.pasteFromDevice",
+           let text = UIPasteboard.general.string,
+           !text.isEmpty {
+            payload["text"] = .string(text)
+            payload["source"] = .string("ios-pasteboard")
+        }
+        store.perform(
+            actionID: actionID,
+            pageID: activePage?.id ?? "cockpit",
+            payload: payload,
+            label: shortcut.label
+        )
+    }
+
+    private func selectFirstPageIfNeeded() {
+        if let selectedPageID, pages.contains(where: { $0.id == selectedPageID }) { return }
+        selectedPageID = pages.first?.id
+    }
+}
+
+private struct FleetMachineDeck: View {
+    @ObservedObject var store: DeckStore
+    var accentOverride: Color? = nil
+
+    @State private var selectedPageID: String?
+
+    private var pages: [DeckCockpitPage] {
+        store.snapshot?.cockpit?.pages ?? []
+    }
+
+    private var activePage: DeckCockpitPage? {
+        if let selectedPageID,
+           let page = pages.first(where: { $0.id == selectedPageID }) {
+            return page
+        }
+        return pages.first
+    }
+
+    private var shortcuts: [LatsShortcut] {
+        activePage?.tiles.map(shortcut(from:)) ?? []
+    }
+
+    private var accent: Color {
+        if let accentOverride { return accentOverride }
+        // Give each Mac a stable cockpit identity instead of inheriting the
+        // first shortcut's semantic tint (which made voice-first decks all
+        // look red). Individual shortcut icons still keep their action colors.
+        let palette = [
+            LatsPalette.teal,
+            LatsPalette.blue,
+            LatsPalette.violet,
+            LatsPalette.green,
+            LatsPalette.amber,
+            LatsPalette.pink
+        ]
+        let identity = store.activeEndpoint?.bridgeFingerprint
+            ?? store.activeEndpoint?.host
+            ?? store.connectionLabel
+        var hash: UInt64 = 2_166_136_261
+        for byte in identity.utf8 {
+            hash = (hash ^ UInt64(byte)) &* 16_777_619
+        }
+        return palette[Int(hash % UInt64(palette.count))]
+    }
+
+    private var statusColor: Color {
+        if store.errorMessage != nil { return LatsPalette.red }
+        if store.snapshot != nil { return LatsPalette.green }
+        return store.isLoading ? LatsPalette.amber : LatsPalette.textFaint
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            VStack(spacing: 0) {
+                machineHeader
+                LatsCockpitShell {
+                    LatsTrackpadSurface(
+                        mode: cockpitMode,
+                        recTime: store.snapshot?.cockpitMode?.elapsedSeconds ?? 0,
+                        agentProgress: (store.snapshot?.cockpitMode?.agentProgress ?? 0) * 264,
+                        replayMessage: store.snapshot?.cockpitMode?.replayMessage ?? "",
+                        replayUndoLabel: "undo within 5s",
+                        agentRows: store.snapshot?.cockpitMode?.agentRows ?? [],
+                        telemetry: fleetTelemetry,
+                        stage: fleetStage,
+                        space: fleetSpace,
+                        spaceCount: fleetSpaceCount,
+                        spaceName: store.snapshot?.spaces?.currentSpaceName
+                            ?? store.snapshot?.desktop?.currentSpaceName,
+                        transcript: fleetTranscript,
+                        activityLog: store.snapshot?.activityLog ?? [],
+                        hostLabel: store.connectionLabel,
+                        trackpadState: store.snapshot?.trackpad,
+                        spaceDisplays: store.snapshot?.spaces?.displays ?? [],
+                        frontmostApp: store.snapshot?.layout?.frontmostWindow?.appName
+                            ?? store.snapshot?.desktop?.activeAppName,
+                        frontmostTitle: store.snapshot?.layout?.frontmostWindow?.title,
+                        onSendKey: sendKey,
+                        onReplayUndo: undoReplay,
+                        onTrackpadEvent: { event, dx, dy in
+                            store.sendTrackpad(event: event, dx: dx, dy: dy)
+                        },
+                        onSpaceTap: focusSpace,
+                        onMonitorSwipe: swipeMonitor
+                    )
+                    .environment(\.horizontalSizeClass, .compact)
+                }
+                .frame(height: min(240, max(190, proxy.size.height * 0.29)))
+                .padding(.horizontal, 10)
+                .padding(.bottom, 9)
+
+                if pages.count > 1 {
+                    deckPageStrip
+                }
+
+                LatsHairlineDivider()
+
+                Group {
+                    if !shortcuts.isEmpty {
+                        shortcutGrid(width: proxy.size.width)
+                    } else {
+                        connectionState
+                    }
+                }
+                .frame(maxHeight: .infinity)
+
+                machineFooter
+            }
+            .background(
+                LinearGradient(
+                    colors: [accent.opacity(0.045), LatsPalette.bg.opacity(0.98)],
+                    startPoint: .topLeading,
+                    endPoint: .center
+                )
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 5))
+            .overlay(
+                RoundedRectangle(cornerRadius: 5)
+                    .stroke(
+                        store.errorMessage == nil
+                            ? accent.opacity(store.snapshot == nil ? 0.22 : 0.30)
+                            : statusColor.opacity(0.55),
+                        lineWidth: 1
+                    )
+            )
+            .overlay(alignment: .top) {
+                Rectangle()
+                    .fill(accent.opacity(store.snapshot == nil ? 0.26 : 0.50))
+                    .frame(height: 1)
+                    .padding(.horizontal, 5)
+            }
+            .shadow(color: Color.black.opacity(0.50), radius: 6, x: 0, y: 3)
+        }
+        .onAppear(perform: selectFirstPageIfNeeded)
+        .onChange(of: pages.map(\.id)) { _, _ in selectFirstPageIfNeeded() }
+    }
+
+    private var machineHeader: some View {
+        HStack(spacing: 9) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(accent.opacity(0.14))
+                Image(systemName: machineIcon)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(accent)
+            }
+            .frame(width: 30, height: 30)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(store.connectionLabel)
+                    .font(LatsFont.ui(13, weight: .semibold))
+                    .foregroundStyle(LatsPalette.text)
+                    .lineLimit(1)
+                HStack(spacing: 5) {
+                    Circle().fill(statusColor).frame(width: 5, height: 5)
+                    Text(connectionStateLabel)
+                        .font(LatsFont.mono(8, weight: .semibold))
+                        .foregroundStyle(statusColor)
+                        .tracking(0.8)
+                }
+            }
+
+            Spacer(minLength: 4)
+
+            if store.isPerformingAction {
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(accent)
+            } else if let page = activePage {
+                Button(action: cyclePage) {
+                    HStack(spacing: 5) {
+                        Text(page.title.uppercased())
+                            .font(LatsFont.mono(8, weight: .bold))
+                            .lineLimit(1)
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 7, weight: .bold))
+                    }
+                    .foregroundStyle(accent)
+                    .padding(.horizontal, 8)
+                    .frame(height: 28)
+                    .background(RoundedRectangle(cornerRadius: 5).fill(accent.opacity(0.10)))
+                    .overlay(RoundedRectangle(cornerRadius: 5).stroke(accent.opacity(0.25), lineWidth: 1))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 52)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(LatsPalette.hairline).frame(height: 1)
+        }
+    }
+
+    private var deckPageStrip: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 5) {
+                ForEach(pages) { page in
+                    let isSelected = page.id == activePage?.id
+                    Button {
+                        withAnimation(.easeOut(duration: 0.16)) { selectedPageID = page.id }
+                    } label: {
+                        Text(page.title.uppercased())
+                            .font(LatsFont.mono(8, weight: isSelected ? .bold : .regular))
+                            .foregroundStyle(isSelected ? accent : LatsPalette.textFaint)
+                            .padding(.horizontal, 8)
+                            .frame(height: 26)
+                            .background(
+                                RoundedRectangle(cornerRadius: 4)
+                                    .fill(isSelected ? accent.opacity(0.10) : Color.white.opacity(0.025))
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+        }
+    }
+
+    private func shortcutGrid(width: CGFloat) -> some View {
+        GeometryReader { proxy in
+            ScrollView {
+                LatsShortcutGrid(
+                    shortcuts: shortcuts,
+                    columns: width >= 560 ? 3 : 2,
+                    onTap: perform,
+                    onJoystickMove: { dx, dy in store.sendTrackpad(event: .move, dx: dx, dy: dy) },
+                    joystickEnabled: joystickReady,
+                    joystickScale: store.snapshot?.trackpad?.pointerScale ?? 1.6
+                )
+                .padding(10)
+                .frame(minHeight: proxy.size.height, alignment: .bottom)
+                .id(activePage?.id)
+            }
+            .scrollIndicators(.hidden)
+        }
+    }
+
+    private var connectionState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: store.errorMessage == nil ? "dot.radiowaves.left.and.right" : "wifi.exclamationmark")
+                .font(.system(size: 24, weight: .medium))
+                .foregroundStyle(statusColor)
+
+            Text(store.errorMessage == nil ? "CONNECTING TO MAC" : "MAC UNAVAILABLE")
+                .font(LatsFont.mono(10, weight: .bold))
+                .foregroundStyle(LatsPalette.text)
+                .tracking(1)
+
+            if let error = store.errorMessage {
+                Text(error)
+                    .font(LatsFont.mono(9))
+                    .foregroundStyle(LatsPalette.textDim)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(4)
+                    .padding(.horizontal, 16)
+
+                LatsButton(title: "Retry", icon: "arrow.clockwise", style: .ghost) {
+                    if let endpoint = store.activeEndpoint { store.connect(to: endpoint) }
+                }
+            } else {
+                ProgressView().tint(LatsPalette.amber)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var machineFooter: some View {
+        HStack(spacing: 7) {
+            Circle().fill(statusColor).frame(width: 5, height: 5)
+            Text(footerLabel)
+                .font(LatsFont.mono(8))
+                .foregroundStyle(store.lastActionResult?.ok == false ? LatsPalette.red : LatsPalette.textDim)
+                .lineLimit(1)
+            Spacer(minLength: 4)
+            if let cpu = store.snapshot?.telemetry?.cpuLoadPercent {
+                Text("CPU \(Int(cpu.rounded()))%")
+                    .font(LatsFont.mono(8))
+                    .foregroundStyle(LatsPalette.textFaint)
+            }
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 28)
+        .background(Color.black.opacity(0.20))
+        .overlay(alignment: .top) {
+            Rectangle().fill(LatsPalette.hairline).frame(height: 1)
+        }
+    }
+
+    private var connectionStateLabel: String {
+        if store.errorMessage != nil { return "OFFLINE" }
+        if store.snapshot != nil { return "LIVE" }
+        return "LINKING"
+    }
+
+    private var footerLabel: String {
+        if let result = store.lastActionResult { return result.summary }
+        if let label = store.lastActionLabel { return label }
+        if let app = store.snapshot?.layout?.frontmostWindow?.appName
+            ?? store.snapshot?.desktop?.activeAppName {
+            return app
+        }
+        return connectionStateLabel.lowercased()
+    }
+
+    private var machineIcon: String {
+        let label = store.connectionLabel.lowercased()
+        if label.contains("mini") { return "macmini" }
+        if label.contains("studio") { return "macstudio" }
+        if label.contains("imac") { return "desktopcomputer" }
+        return "laptopcomputer"
+    }
+
+    private var joystickReady: Bool {
+        guard let state = store.snapshot?.trackpad else { return false }
+        return state.isEnabled && state.isAvailable
+    }
+
+    private var cockpitMode: CockpitMode {
+        guard let mode = store.snapshot?.cockpitMode?.mode else { return .idle }
+        return CockpitMode(from: mode)
+    }
+
+    private var fleetTelemetry: LatsTelemetry {
+        guard let telemetry = store.snapshot?.telemetry else { return LatsTelemetry() }
+        return LatsTelemetry(from: telemetry)
+    }
+
+    private var fleetSpace: Int {
+        let index = store.snapshot?.spaces?.currentSpaceIndex
+            ?? store.snapshot?.desktop?.currentSpaceIndex
+            ?? 1
+        return max(0, index - 1)
+    }
+
+    private var fleetSpaceCount: Int {
+        max(1, store.snapshot?.spaces?.displays.first?.spaces.count ?? 1)
+    }
+
+    private var fleetTranscript: [String] {
+        if let lines = store.snapshot?.voice?.transcriptLines, !lines.isEmpty {
+            return Array(lines.sorted { $0.createdAt > $1.createdAt }.prefix(5).map(\.text))
+        }
+        if let transcript = store.snapshot?.voice?.transcript, !transcript.isEmpty {
+            return [transcript]
+        }
+        return []
+    }
+
+    private var fleetStage: [[LatsWindow]] {
+        guard let preview = store.snapshot?.layout?.preview else { return CommandDeck.stage }
+        let displayCount = max(preview.displayCount ?? 1, 1)
+        var buckets = Array(repeating: [LatsWindow](), count: displayCount)
+        for window in preview.windows {
+            let index = window.displayIndex ?? 0
+            guard buckets.indices.contains(index) else { continue }
+            buckets[index].append(
+                LatsWindow(
+                    x: window.normalizedFrame.x * 100,
+                    y: window.normalizedFrame.y * 100,
+                    w: window.normalizedFrame.w * 100,
+                    h: window.normalizedFrame.h * 100,
+                    tint: LatsTint.from(token: window.appCategoryTint),
+                    tag: String(window.title.prefix(4))
+                )
+            )
+        }
+        return buckets
+    }
+
+    private func sendKey(_ key: String, _ modifiers: [String]) {
+        store.perform(
+            actionID: "keys.send",
+            pageID: activePage?.id ?? "cockpit",
+            payload: [
+                "key": .string(key),
+                "modifiers": .array(modifiers.map { .string($0) })
+            ],
+            label: (modifiers + [key.uppercased()]).joined()
+        )
+    }
+
+    private func undoReplay() {
+        let actionID = store.snapshot?.cockpitMode?.replayUndoActionID ?? "history.undoLast"
+        store.perform(actionID: actionID, pageID: activePage?.id ?? "cockpit", label: "Undo last action")
+    }
+
+    private func focusSpace(_ index: Int) {
+        store.perform(
+            actionID: "spaces.focusIndex",
+            pageID: activePage?.id ?? "cockpit",
+            payload: ["index": .int(index)],
+            label: "Switch to space \(index + 1)"
+        )
+    }
+
+    private func swipeMonitor(_ display: Int, _ direction: Int) {
+        let key = direction > 0 ? "right" : "left"
+        store.perform(
+            actionID: "keys.send",
+            pageID: activePage?.id ?? "cockpit",
+            payload: ["key": .string(key), "modifiers": .array([.string("⌃")])],
+            label: direction > 0 ? "Next space" : "Previous space"
+        )
+    }
+
+    private func shortcut(from tile: DeckCockpitTile) -> LatsShortcut {
+        LatsShortcut(
+            id: tile.id,
+            label: tile.title,
+            icon: tile.iconSystemName,
+            tint: LatsTint.from(token: tile.categoryTint ?? tile.accentToken),
+            category: shortcutCategory(for: tile),
+            hint: tile.subtitle ?? "",
+            sim: .none,
+            actionID: tile.actionID,
+            payload: tile.payload,
+            controlKind: tile.controlKind,
+            isEnabled: tile.isEnabled
+        )
+    }
+
+    private func shortcutCategory(for tile: DeckCockpitTile) -> ShortcutCategory {
+        let searchable = [tile.deckID, tile.actionID, tile.title, tile.subtitle]
+            .compactMap { $0?.lowercased() }
+            .joined(separator: " ")
+        if searchable.contains("voice") || searchable.contains("dictate") { return .voice }
+        if searchable.contains("agent") || searchable.contains("claude") { return .agent }
+        if searchable.contains("window") || searchable.contains("tile") { return .window }
+        if searchable.contains("dev") || searchable.contains("terminal") { return .dev }
+        return .system
+    }
+
+    private func perform(_ shortcut: LatsShortcut) {
+        guard shortcut.isEnabled, let actionID = shortcut.actionID else { return }
+        var payload = shortcut.payload
+        if actionID == "clipboard.pasteFromDevice",
+           let text = UIPasteboard.general.string,
+           !text.isEmpty {
+            payload["text"] = .string(text)
+            payload["source"] = .string("ios-pasteboard")
+        }
+        store.perform(
+            actionID: actionID,
+            pageID: activePage?.id ?? "cockpit",
+            payload: payload,
+            label: shortcut.label
+        )
+    }
+
+    private func selectFirstPageIfNeeded() {
+        if let selectedPageID, pages.contains(where: { $0.id == selectedPageID }) { return }
+        selectedPageID = pages.first?.id
+    }
+
+    private func cyclePage() {
+        guard pages.count > 1 else { return }
+        let current = pages.firstIndex(where: { $0.id == activePage?.id }) ?? 0
+        selectedPageID = pages[(current + 1) % pages.count].id
+    }
+}
+
+private struct FleetTrackpadSurface: View {
+    let machineLabel: String
+    let activeApp: String?
+    let activeWindow: String?
+    let spaceName: String?
+    let telemetry: DeckSystemTelemetry?
+    let state: DeckTrackpadState?
+    let accent: Color
+    let sendEvent: (DeckTrackpadEvent, Double, Double) -> Void
+
+    @State private var lastLocation: CGPoint?
+
+    private var isEnabled: Bool {
+        state?.isEnabled == true && state?.isAvailable == true
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack {
+                RoundedRectangle(cornerRadius: 7)
+                    .fill(Color.black.opacity(0.28))
+                trackpadGrid(size: proxy.size)
+
+                VStack(alignment: .leading, spacing: 0) {
+                    HStack(alignment: .top) {
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text("CONTROL SURFACE")
+                                .font(LatsFont.mono(8, weight: .bold))
+                                .foregroundStyle(LatsPalette.textFaint)
+                                .tracking(1.2)
+                            Text(activeApp ?? machineLabel)
+                                .font(LatsFont.ui(12, weight: .semibold))
+                                .foregroundStyle(LatsPalette.text)
+                                .lineLimit(1)
+                            Text(activeWindow ?? (isEnabled ? "glide · tap" : state?.statusTitle ?? "trackpad unavailable"))
+                                .font(LatsFont.mono(8))
+                                .foregroundStyle(LatsPalette.textDim)
+                                .lineLimit(1)
+                        }
+
+                        Spacer(minLength: 8)
+
+                        Image(systemName: isEnabled ? "cursorarrow.motionlines" : "cursorarrow.slash")
+                            .font(.system(size: 18, weight: .medium))
+                            .foregroundStyle(isEnabled ? accent : LatsPalette.textFaint)
+                    }
+
+                    Spacer()
+
+                    HStack(spacing: 8) {
+                        if let spaceName, !spaceName.isEmpty {
+                            compactMetric(icon: "square.3.layers.3d", text: spaceName)
+                        }
+                        if let count = telemetry?.windowCount {
+                            compactMetric(icon: "macwindow", text: "\(count)")
+                        }
+                        Spacer(minLength: 0)
+                        Text(isEnabled ? "LIVE INPUT" : "VIEW ONLY")
+                            .font(LatsFont.mono(7, weight: .bold))
+                            .foregroundStyle(isEnabled ? accent : LatsPalette.textFaint)
+                            .tracking(0.8)
+                    }
+                }
+                .padding(11)
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: 7)
+                    .stroke(isEnabled ? accent.opacity(0.30) : LatsPalette.hairline2, lineWidth: 1)
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 7))
+            .gesture(trackpadGesture)
+            .simultaneousGesture(
+                TapGesture().onEnded {
+                    guard isEnabled else { return }
+                    sendEvent(.click, 0, 0)
+                }
+            )
+        }
+        .opacity(isEnabled ? 1 : 0.72)
+    }
+
+    private func trackpadGrid(size: CGSize) -> some View {
+        Path { path in
+            for column in 1..<5 {
+                let x = CGFloat(column) * size.width / 5
+                path.move(to: CGPoint(x: x, y: 0))
+                path.addLine(to: CGPoint(x: x, y: size.height))
+            }
+            for row in 1..<3 {
+                let y = CGFloat(row) * size.height / 3
+                path.move(to: CGPoint(x: 0, y: y))
+                path.addLine(to: CGPoint(x: size.width, y: y))
+            }
+        }
+        .stroke(Color.white.opacity(0.035), style: StrokeStyle(lineWidth: 1, dash: [3, 6]))
+        .padding(8)
+    }
+
+    private var trackpadGesture: some Gesture {
+        DragGesture(minimumDistance: 0, coordinateSpace: .local)
+            .onChanged { value in
+                guard isEnabled else { return }
+                guard let previous = lastLocation else {
+                    lastLocation = value.location
+                    return
+                }
+                let dx = value.location.x - previous.x
+                let dy = value.location.y - previous.y
+                lastLocation = value.location
+                guard abs(dx) > 0.2 || abs(dy) > 0.2 else { return }
+                let scale = state?.pointerScale ?? 1.6
+                sendEvent(.move, Double(dx) * scale, Double(dy) * scale)
+            }
+            .onEnded { _ in lastLocation = nil }
+    }
+
+    private func compactMetric(icon: String, text: String) -> some View {
+        HStack(spacing: 3) {
+            Image(systemName: icon).font(.system(size: 8))
+            Text(text).font(LatsFont.mono(7, weight: .semibold)).lineLimit(1)
+        }
+        .foregroundStyle(LatsPalette.textFaint)
+    }
+}
+
 // MARK: - Preview
 
 #Preview("Lats Deck — iPad landscape") {
@@ -2095,3 +4107,11 @@ struct LatsDeckScreen: View {
         .frame(width: 1180, height: 820)
         .preferredColorScheme(.dark)
 }
+
+#if DEBUG
+#Preview("Fleet Deck — 4-up landscape") {
+    FleetDeckPreviewHost(machineCount: 4)
+        .frame(width: 1366, height: 1024)
+        .preferredColorScheme(.dark)
+}
+#endif

--- a/apps/ios/Sources/LatticesCompanionApp.swift
+++ b/apps/ios/Sources/LatticesCompanionApp.swift
@@ -4,7 +4,15 @@ import SwiftUI
 struct LatticesCompanionApp: App {
     var body: some Scene {
         WindowGroup {
+            #if DEBUG
+            if ProcessInfo.processInfo.arguments.contains("--fleet-preview") {
+                FleetDeckPreviewHost(machineCount: 4)
+            } else {
+                ContentView()
+            }
+            #else
             ContentView()
+            #endif
         }
     }
 }

--- a/apps/mac/Info.plist
+++ b/apps/mac/Info.plist
@@ -39,5 +39,12 @@
     <string>Lattices uses the microphone for Hudson Voice dictation and voice commands.</string>
     <key>NSSupportsAutomaticTermination</key>
     <true/>
+    <!-- Allow the Settings deck-builder WKWebView to load the local studio dev
+         server (http://localhost:3050) over the loopback interface. -->
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsLocalNetworking</key>
+        <true/>
+    </dict>
 </dict>
 </plist>

--- a/apps/mac/Sources/AppShell/SettingsView.swift
+++ b/apps/mac/Sources/AppShell/SettingsView.swift
@@ -1864,9 +1864,9 @@ struct SettingsContentView: View {
     private var companionContent: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
+                companionCockpitCard
                 companionBridgeOverviewCard
                 companionTrustedDevicesCard
-                companionCockpitCard
             }
             .padding(16)
             .frame(maxWidth: 760, alignment: .leading)

--- a/apps/mac/Sources/AppShell/SettingsView.swift
+++ b/apps/mac/Sources/AppShell/SettingsView.swift
@@ -19,6 +19,7 @@ struct SettingsContentView: View {
         case ai
         case search
         case companion
+        case deck
 
         var id: String { rawValue }
 
@@ -33,6 +34,7 @@ struct SettingsContentView: View {
             case .ai: return "AI"
             case .search: return "Search & OCR"
             case .companion: return "Companion"
+            case .deck: return "Command Deck"
             }
         }
 
@@ -47,6 +49,7 @@ struct SettingsContentView: View {
             case .ai: return "sparkles"
             case .search: return "text.viewfinder"
             case .companion: return "ipad.and.iphone"
+            case .deck: return "square.grid.2x2"
             }
         }
 
@@ -61,6 +64,7 @@ struct SettingsContentView: View {
             case .ai: return "Agents"
             case .search: return "Indexing"
             case .companion: return "LATS iOS Bridge"
+            case .deck: return "Companion"
             }
         }
 
@@ -84,6 +88,8 @@ struct SettingsContentView: View {
                 return "OCR cadence, quality, and recent capture visibility."
             case .companion:
                 return "Local-network pairing, trusted iPad devices, and bridge security."
+            case .deck:
+                return "Design the companion command deck — the grid, keys, and spans the iPad renders."
             }
         }
 
@@ -95,7 +101,7 @@ struct SettingsContentView: View {
                 return "Control"
             case .ai, .search:
                 return "Intelligence"
-            case .companion:
+            case .companion, .deck:
                 return "Devices"
             }
         }
@@ -358,7 +364,19 @@ struct SettingsContentView: View {
             searchOcrContent
         case .companion:
             companionContent
+        case .deck:
+            deckContent
         }
+    }
+
+    /// Full-page companion deck builder (its own sidebar page). The WKWebView
+    /// hosts the studio editor; edits persist to the companion draft.
+    private var deckContent: some View {
+        CompanionDeckBuilderView(onChange: { data in
+            persistCompanionDeckDraft(data)
+        })
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(16)
     }
 
     // MARK: - Sticky section header
@@ -1864,9 +1882,9 @@ struct SettingsContentView: View {
     private var companionContent: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
-                companionCockpitCard
                 companionBridgeOverviewCard
                 companionTrustedDevicesCard
+                companionCockpitCard
             }
             .padding(16)
             .frame(maxWidth: 760, alignment: .leading)
@@ -3826,22 +3844,29 @@ struct SettingsContentView: View {
             summary: "Define the Mac-authored command deck here, then let the companion app render it. Trackpad proxy runs through the same bridge."
         ) {
             VStack(alignment: .leading, spacing: 14) {
-                // The deck builder is the headline of this card — embedded web
-                // editor; edits persist to the companion draft.
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Design the deck visually — tap an empty cell to add, drag to move, pull the corner to span. Switch decks with the tabs.")
-                        .font(Typo.caption(10.5))
-                        .foregroundColor(Palette.textMuted)
-
-                    CompanionDeckBuilderView(onChange: { data in
-                        persistCompanionDeckDraft(data)
-                    })
-                    .frame(height: 560)
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
-                    .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(Palette.borderLit, lineWidth: 0.5))
+                // The deck layout lives on its own page now.
+                Button { selectedTab = .deck } label: {
+                    HStack(spacing: 10) {
+                        Image(systemName: "square.grid.2x2")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundColor(Palette.text)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Command Deck")
+                                .font(Typo.monoBold(11))
+                                .foregroundColor(Palette.text)
+                            Text("Design the grid, keys, and spans the companion renders.")
+                                .font(Typo.caption(10.5))
+                                .foregroundColor(Palette.textMuted)
+                        }
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundColor(Palette.textDim)
+                    }
+                    .padding(12)
+                    .background(shortcutsInsetPanel)
                 }
-                .padding(12)
-                .background(shortcutsInsetPanel)
+                .buttonStyle(.plain)
 
                 HStack(alignment: .top, spacing: 12) {
                     VStack(alignment: .leading, spacing: 5) {

--- a/apps/mac/Sources/AppShell/SettingsView.swift
+++ b/apps/mac/Sources/AppShell/SettingsView.swift
@@ -3818,9 +3818,6 @@ struct SettingsContentView: View {
     // MARK: - Shortcuts: Overview
 
     private var companionCockpitCard: some View {
-        let layout = LatticesCompanionCockpitCatalog.normalized(prefs.companionCockpitLayout)
-        let selectedPage = layout.pages.first(where: { $0.id == selectedCompanionCockpitPageID }) ?? layout.pages.first
-        let categories = LatticesCompanionShortcutCategory.allCases
         let trustedDeviceCount = companionTrustedDevices(revision: companionTrustRevision).count
 
         return shortcutSectionCard(
@@ -3829,6 +3826,23 @@ struct SettingsContentView: View {
             summary: "Define the Mac-authored command deck here, then let the companion app render it. Trackpad proxy runs through the same bridge."
         ) {
             VStack(alignment: .leading, spacing: 14) {
+                // The deck builder is the headline of this card — embedded web
+                // editor; edits persist to the companion draft.
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Design the deck visually — tap an empty cell to add, drag to move, pull the corner to span. Switch decks with the tabs.")
+                        .font(Typo.caption(10.5))
+                        .foregroundColor(Palette.textMuted)
+
+                    CompanionDeckBuilderView(onChange: { data in
+                        persistCompanionDeckDraft(data)
+                    })
+                    .frame(height: 560)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(Palette.borderLit, lineWidth: 0.5))
+                }
+                .padding(12)
+                .background(shortcutsInsetPanel)
+
                 HStack(alignment: .top, spacing: 12) {
                     VStack(alignment: .leading, spacing: 5) {
                         Text("Trackpad Proxy")
@@ -3884,43 +3898,6 @@ struct SettingsContentView: View {
                 }
                 .padding(12)
                 .background(shortcutsInsetPanel)
-
-                if let selectedPage {
-                    Picker("Companion page", selection: $selectedCompanionCockpitPageID) {
-                        ForEach(layout.pages) { page in
-                            Text(page.title).tag(page.id)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-
-                    VStack(alignment: .leading, spacing: 8) {
-                        if let subtitle = selectedPage.subtitle, !subtitle.isEmpty {
-                            Text(subtitle)
-                                .font(Typo.caption(10.5))
-                                .foregroundColor(Palette.textMuted)
-                        }
-
-                        LazyVGrid(
-                            columns: Array(
-                                repeating: GridItem(.flexible(minimum: 120, maximum: 220), spacing: 8, alignment: .top),
-                                count: max(2, selectedPage.columns)
-                            ),
-                            alignment: .leading,
-                            spacing: 8
-                        ) {
-                            ForEach(Array(selectedPage.slotIDs.enumerated()), id: \.offset) { index, shortcutID in
-                                companionCockpitSlotMenu(
-                                    pageID: selectedPage.id,
-                                    index: index,
-                                    shortcutID: shortcutID,
-                                    categories: categories
-                                )
-                            }
-                        }
-                    }
-                    .padding(12)
-                    .background(shortcutsInsetPanel)
-                }
 
                 HStack(spacing: 10) {
                     Text("Changes appear in the iPad companion on the next snapshot refresh.")

--- a/apps/mac/Sources/Core/Companion/CompanionDeckBuilderView.swift
+++ b/apps/mac/Sources/Core/Companion/CompanionDeckBuilderView.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+import WebKit
+import Foundation
+
+/// Embeds the web deck builder (`design/studio` → `/embed/deck-builder`) inside
+/// the Mac Settings companion card. In development it loads the studio dev
+/// server; a bundled static export is the eventual production path.
+///
+/// Bridge: the builder posts every layout change to
+/// `window.webkit.messageHandlers.deck` as `{ type: "deck-change", decks }`.
+/// The coordinator forwards the raw `decks` JSON to `onChange`.
+struct CompanionDeckBuilderView: NSViewRepresentable {
+    /// Raw `decks` JSON (the builder's Deck[] shape) on every change.
+    var onChange: (Data) -> Void = { _ in }
+    var url = URL(string: "http://localhost:3050/embed/deck-builder")!
+
+    func makeCoordinator() -> Coordinator { Coordinator(onChange: onChange) }
+
+    func makeNSView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        let controller = WKUserContentController()
+        controller.add(context.coordinator, name: "deck")
+        config.userContentController = controller
+
+        let web = WKWebView(frame: .zero, configuration: config)
+        web.navigationDelegate = context.coordinator
+        context.coordinator.web = web
+        web.load(URLRequest(url: url))
+        return web
+    }
+
+    func updateNSView(_ nsView: WKWebView, context: Context) {}
+
+    final class Coordinator: NSObject, WKScriptMessageHandler, WKNavigationDelegate {
+        let onChange: (Data) -> Void
+        weak var web: WKWebView?
+
+        init(onChange: @escaping (Data) -> Void) {
+            self.onChange = onChange
+        }
+
+        func userContentController(
+            _ controller: WKUserContentController,
+            didReceive message: WKScriptMessage
+        ) {
+            guard message.name == "deck" else { return }
+            guard
+                let dict = message.body as? [String: Any],
+                dict["type"] as? String == "deck-change",
+                let decks = dict["decks"],
+                let data = try? JSONSerialization.data(withJSONObject: decks)
+            else { return }
+            onChange(data)
+        }
+
+        // If the dev server isn't running yet, show a small hint instead of a
+        // blank white error page.
+        func webView(
+            _ webView: WKWebView,
+            didFail navigation: WKNavigation!,
+            withError error: Error
+        ) { showUnavailable(in: webView) }
+
+        func webView(
+            _ webView: WKWebView,
+            didFailProvisionalNavigation navigation: WKNavigation!,
+            withError error: Error
+        ) { showUnavailable(in: webView) }
+
+        private func showUnavailable(in webView: WKWebView) {
+            let html = """
+            <html><body style="margin:0;background:#060607;color:#71716c;\
+            font-family:ui-monospace,Menlo,monospace;font-size:12px;\
+            display:flex;align-items:center;justify-content:center;height:100vh">\
+            deck builder dev server not reachable — run <code style="color:#a0a09b;\
+            margin:0 4px">bun run dev</code> in design/studio (:3050)</body></html>
+            """
+            webView.loadHTMLString(html, baseURL: nil)
+        }
+    }
+}
+
+/// Persist the builder's raw layout JSON so edits survive reopening the pane and
+/// can be inspected end-to-end. v1 stores it as a draft at
+/// `~/.lattices/companion-deck-draft.json`; mapping it into the live cockpit
+/// layout (+ the iPad span render) is the next Phase B step.
+func persistCompanionDeckDraft(_ data: Data) {
+    let dir = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".lattices", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    try? data.write(to: dir.appendingPathComponent("companion-deck-draft.json"), options: .atomic)
+}

--- a/apps/mac/Sources/Core/Companion/CompanionDeckBuilderView.swift
+++ b/apps/mac/Sources/Core/Companion/CompanionDeckBuilderView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import WebKit
+import AppKit
 import Foundation
 
 /// Embeds the web deck builder (`design/studio` → `/embed/deck-builder`) inside
@@ -23,6 +24,14 @@ struct CompanionDeckBuilderView: NSViewRepresentable {
         config.userContentController = controller
 
         let web = WKWebView(frame: .zero, configuration: config)
+        // Dark, non-white background so entering the page doesn't flash white
+        // before the (dark) editor paints. `drawsBackground` is transparent so
+        // the surrounding panel shows through; underPageBackgroundColor kills the
+        // white overscroll/rubber-band edge on macOS 12+.
+        web.setValue(false, forKey: "drawsBackground")
+        if #available(macOS 12.0, *) {
+            web.underPageBackgroundColor = NSColor(red: 6.0 / 255, green: 6.0 / 255, blue: 7.0 / 255, alpha: 1)
+        }
         web.navigationDelegate = context.coordinator
         context.coordinator.web = web
         web.load(URLRequest(url: url))

--- a/apps/mac/Sources/Core/Companion/LatticesCompanionCockpit.swift
+++ b/apps/mac/Sources/Core/Companion/LatticesCompanionCockpit.swift
@@ -2,25 +2,54 @@ import DeckKit
 import Foundation
 
 struct LatticesCompanionCockpitLayout: Codable, Equatable {
+    /// Span-aware placement for a single key. `shortcutID == ""` marks an empty
+    /// cell (a gap).
+    struct Slot: Codable, Equatable {
+        var shortcutID: String
+        var col: Int
+        var row: Int
+        var colSpan: Int
+        var rowSpan: Int
+
+        init(shortcutID: String, col: Int, row: Int, colSpan: Int = 1, rowSpan: Int = 1) {
+            self.shortcutID = shortcutID
+            self.col = col
+            self.row = row
+            self.colSpan = colSpan
+            self.rowSpan = rowSpan
+        }
+    }
+
     struct Page: Codable, Equatable, Identifiable {
         var id: String
         var title: String
         var subtitle: String?
         var columns: Int
+        /// Explicit row count for span-aware pages; `nil` for legacy flat pages.
+        var rows: Int?
+        /// Legacy flat 16-slot layout (row-major into `columns`). Retained for
+        /// back-compat and used as the fallback when `slots` is nil.
         var slotIDs: [String]
+        /// Span-aware placement. When present it is authoritative — the deck
+        /// renders keys by (col,row,colSpan,rowSpan); the web builder writes this.
+        var slots: [Slot]?
 
         init(
             id: String,
             title: String,
             subtitle: String? = nil,
             columns: Int = 4,
-            slotIDs: [String]
+            rows: Int? = nil,
+            slotIDs: [String] = [],
+            slots: [Slot]? = nil
         ) {
             self.id = id
             self.title = title
             self.subtitle = subtitle
             self.columns = columns
+            self.rows = rows
             self.slotIDs = slotIDs
+            self.slots = slots
         }
     }
 
@@ -245,13 +274,15 @@ enum LatticesCompanionCockpitCatalog {
         return LatticesCompanionCockpitLayout(
             pages: blueprintPages.map { blueprint in
                 let current = existing[blueprint.id]
-                let slots = normalizedSlots(current?.slotIDs ?? blueprint.slotIDs)
+                let flatSlots = normalizedSlots(current?.slotIDs ?? blueprint.slotIDs)
                 return .init(
                     id: blueprint.id,
                     title: current?.title ?? blueprint.title,
                     subtitle: current?.subtitle ?? blueprint.subtitle,
                     columns: max(2, current?.columns ?? blueprint.columns),
-                    slotIDs: slots
+                    rows: current?.rows ?? blueprint.rows,
+                    slotIDs: flatSlots,
+                    slots: current?.slots
                 )
             }
         )
@@ -272,12 +303,28 @@ enum LatticesCompanionCockpitCatalog {
             title: focusName,
             detail: detail,
             pages: normalizedLayout.pages.map { page in
-                DeckCockpitPage(
-                    id: page.id,
-                    title: page.title,
-                    subtitle: page.subtitle,
-                    columns: page.columns,
-                    tiles: page.slotIDs.enumerated().map { index, shortcutID in
+                let tiles: [DeckCockpitTile]
+                if let slots = page.slots {
+                    // Span-aware page (authored in the web builder): render each
+                    // non-empty slot at its explicit placement.
+                    tiles = slots.enumerated().compactMap { index, slot in
+                        slot.shortcutID.isEmpty ? nil : renderedTile(
+                            shortcutID: slot.shortcutID,
+                            pageID: page.id,
+                            slotIndex: index,
+                            col: slot.col,
+                            row: slot.row,
+                            colSpan: slot.colSpan,
+                            rowSpan: slot.rowSpan,
+                            voice: voice,
+                            desktop: desktop,
+                            layoutState: layoutState,
+                            talkie: talkie
+                        )
+                    }
+                } else {
+                    // Legacy flat page: row-major flow into `columns` (unchanged).
+                    tiles = page.slotIDs.enumerated().map { index, shortcutID in
                         renderedTile(
                             shortcutID: shortcutID,
                             pageID: page.id,
@@ -288,6 +335,14 @@ enum LatticesCompanionCockpitCatalog {
                             talkie: talkie
                         )
                     }
+                }
+                return DeckCockpitPage(
+                    id: page.id,
+                    title: page.title,
+                    subtitle: page.subtitle,
+                    columns: page.columns,
+                    rows: page.rows,
+                    tiles: tiles
                 )
             }
         )
@@ -305,6 +360,10 @@ enum LatticesCompanionCockpitCatalog {
         shortcutID: String,
         pageID: String,
         slotIndex: Int,
+        col: Int? = nil,
+        row: Int? = nil,
+        colSpan: Int? = nil,
+        rowSpan: Int? = nil,
         voice: DeckVoiceState?,
         desktop: DeckDesktopSummary?,
         layoutState: DeckLayoutState?,
@@ -318,8 +377,12 @@ enum LatticesCompanionCockpitCatalog {
             talkie: talkie
         )
 
+        // Stable id: position-based for span slots (indices can shift when empty
+        // slots are dropped), slot-index-based for legacy flat pages.
+        let id = (col != nil && row != nil) ? "\(pageID)-\(col!)-\(row!)" : "\(pageID)-\(slotIndex)"
+
         return DeckCockpitTile(
-            id: "\(pageID)-\(slotIndex)",
+            id: id,
             shortcutID: shortcutID,
             title: rendered.title,
             subtitle: rendered.subtitle,
@@ -330,7 +393,11 @@ enum LatticesCompanionCockpitCatalog {
             actionID: rendered.actionID,
             payload: rendered.payload,
             isEnabled: rendered.isEnabled,
-            isActive: rendered.isActive
+            isActive: rendered.isActive,
+            col: col,
+            row: row,
+            colSpan: colSpan,
+            rowSpan: rowSpan
         )
     }
 

--- a/swift/Sources/DeckKit/DeckCockpit.swift
+++ b/swift/Sources/DeckKit/DeckCockpit.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+public enum DeckCockpitControlKind: String, Codable, Equatable, Sendable {
+    case button
+    case joystick
+}
+
 public struct DeckCockpitState: Codable, Equatable, Sendable {
     public var title: String?
     public var detail: String?
@@ -56,6 +61,9 @@ public struct DeckCockpitTile: Codable, Equatable, Identifiable, Sendable {
     public var payload: [String: DeckValue]
     public var isEnabled: Bool
     public var isActive: Bool
+    /// Interactive surface rendered by the companion. Absent values decode as
+    /// a regular button for compatibility with older Mac snapshots.
+    public var controlKind: DeckCockpitControlKind?
     /// Grid placement for span-aware layouts (0-based anchor + span). All `nil`
     /// ⇒ legacy row-major flow into `columns`. Codable decodes absent keys as
     /// `nil`, so existing Mac/iPad payloads are unaffected.
@@ -77,6 +85,7 @@ public struct DeckCockpitTile: Codable, Equatable, Identifiable, Sendable {
         payload: [String: DeckValue] = [:],
         isEnabled: Bool = true,
         isActive: Bool = false,
+        controlKind: DeckCockpitControlKind? = nil,
         col: Int? = nil,
         row: Int? = nil,
         colSpan: Int? = nil,
@@ -94,6 +103,7 @@ public struct DeckCockpitTile: Codable, Equatable, Identifiable, Sendable {
         self.payload = payload
         self.isEnabled = isEnabled
         self.isActive = isActive
+        self.controlKind = controlKind
         self.col = col
         self.row = row
         self.colSpan = colSpan

--- a/swift/Sources/DeckKit/DeckCockpit.swift
+++ b/swift/Sources/DeckKit/DeckCockpit.swift
@@ -21,6 +21,9 @@ public struct DeckCockpitPage: Codable, Equatable, Identifiable, Sendable {
     public var title: String
     public var subtitle: String?
     public var columns: Int
+    /// Row count for span-aware layouts. `nil` ⇒ legacy behavior (derive rows
+    /// from the tile count and `columns`).
+    public var rows: Int?
     public var tiles: [DeckCockpitTile]
 
     public init(
@@ -28,12 +31,14 @@ public struct DeckCockpitPage: Codable, Equatable, Identifiable, Sendable {
         title: String,
         subtitle: String? = nil,
         columns: Int = 4,
+        rows: Int? = nil,
         tiles: [DeckCockpitTile]
     ) {
         self.id = id
         self.title = title
         self.subtitle = subtitle
         self.columns = columns
+        self.rows = rows
         self.tiles = tiles
     }
 }
@@ -51,6 +56,13 @@ public struct DeckCockpitTile: Codable, Equatable, Identifiable, Sendable {
     public var payload: [String: DeckValue]
     public var isEnabled: Bool
     public var isActive: Bool
+    /// Grid placement for span-aware layouts (0-based anchor + span). All `nil`
+    /// ⇒ legacy row-major flow into `columns`. Codable decodes absent keys as
+    /// `nil`, so existing Mac/iPad payloads are unaffected.
+    public var col: Int?
+    public var row: Int?
+    public var colSpan: Int?
+    public var rowSpan: Int?
 
     public init(
         id: String,
@@ -64,7 +76,11 @@ public struct DeckCockpitTile: Codable, Equatable, Identifiable, Sendable {
         actionID: String? = nil,
         payload: [String: DeckValue] = [:],
         isEnabled: Bool = true,
-        isActive: Bool = false
+        isActive: Bool = false,
+        col: Int? = nil,
+        row: Int? = nil,
+        colSpan: Int? = nil,
+        rowSpan: Int? = nil
     ) {
         self.id = id
         self.shortcutID = shortcutID
@@ -78,5 +94,9 @@ public struct DeckCockpitTile: Codable, Equatable, Identifiable, Sendable {
         self.payload = payload
         self.isEnabled = isEnabled
         self.isActive = isActive
+        self.col = col
+        self.row = row
+        self.colSpan = colSpan
+        self.rowSpan = rowSpan
     }
 }

--- a/swift/Tests/DeckKitTests/DeckKitTests.swift
+++ b/swift/Tests/DeckKitTests/DeckKitTests.swift
@@ -118,7 +118,12 @@ final class DeckKitTests: XCTestCase {
                                 iconSystemName: "mic.fill",
                                 accentToken: "voice",
                                 actionID: "voice.toggle",
-                                isActive: true
+                                isActive: true,
+                                controlKind: .joystick,
+                                col: 0,
+                                row: 0,
+                                colSpan: 2,
+                                rowSpan: 2
                             )
                         ]
                     )
@@ -271,6 +276,7 @@ final class DeckKitTests: XCTestCase {
         let decoded = try JSONDecoder().decode(DeckRuntimeSnapshot.self, from: data)
 
         XCTAssertEqual(decoded, snapshot)
+        XCTAssertEqual(decoded.cockpit?.pages.first?.tiles.first?.controlKind, .joystick)
         XCTAssertEqual(decoded.cockpit?.pages.first?.tiles.first?.shortcutID, "voice-toggle")
         XCTAssertEqual(decoded.trackpad?.statusTitle, "Trackpad Ready")
         XCTAssertEqual(decoded.voice?.provider, "vox")


### PR DESCRIPTION
Builds the deck builder into the Mac app, stacked on #71 (studio prototype + spec). **The Mac owns the layout; the iPad renders it.** This lands the data path + the editor.

## What's here
- **Spans flow Mac→iPad** — `DeckCockpitTile` gains optional `col/row/colSpan/rowSpan` (+ page `rows`); the Mac layout model gains a span-aware `Slot` alongside the legacy flat `slotIDs`. `renderedState()` carries spans through when a page has `slots`, else the legacy row-major flow is unchanged. Codable back-compat throughout. (`04423aa`)
- **Embedded editor** — Settings → Companion Cockpit hosts the studio deck builder in a `WKWebView` (loads the `/embed/deck-builder` route) with a `deck` script-message bridge; edits persist to `~/.lattices/companion-deck-draft.json`. ATS localhost exception so the sandbox-off app can load the loopback dev server. (`7bc6a2c`)
- **Its own page** — a dedicated "Command Deck" Settings section (Devices group); the Companion card links to it. (`9f49ecb`, `77a91e4`)
- **No load flicker** — the web view paints on a dark background instead of flashing white. (`8da755c`)

## Why
Reuse the finished interactive editor instead of reimplementing drag/resize/span in SwiftUI (see #71 / the spec). The Mac stays the source of truth; the layout ships to the iPad over the existing manifest/snapshot bridge.

## Not in this PR (next)
- Inject the Mac's real layout + catalog into the builder (it currently seeds itself).
- Map `deck-change` → `companionCockpitLayout` slots so edits reach the iPad (currently a draft file).
- The iPad span renderer (`LatsShortcutGrid`), which layers on #70.

Stacked on #71 — review/merge that first.