### PR TITLE
Fix Settings polling and render churn

### DIFF
--- a/apps/mac/Sources/AppShell/PermissionsAssistantView.swift
+++ b/apps/mac/Sources/AppShell/PermissionsAssistantView.swift
@@ -35,12 +35,6 @@ struct PermissionsAssistantView: View {
         .onAppear {
             PermissionChecker.shared.check()
         }
-        .task {
-            while !Task.isCancelled {
-                PermissionChecker.shared.check()
-                try? await Task.sleep(nanoseconds: 1_000_000_000)
-            }
-        }
     }
 
     // MARK: - Sidebar

--- a/apps/mac/Sources/AppShell/SettingsView.swift
+++ b/apps/mac/Sources/AppShell/SettingsView.swift
@@ -120,9 +120,6 @@ struct SettingsContentView: View {
     @ObservedObject var mouseGestureController: MouseGestureController = .shared
     @ObservedObject var keyboardRemapController: KeyboardRemapController = .shared
     @ObservedObject var assistantSession: WorkspaceAssistantSession = .shared
-    @ObservedObject var audioLayer: AudioLayer = .shared
-    @ObservedObject var handsOffSession: HandsOffSession = .shared
-    @ObservedObject var desktopModel: DesktopModel = .shared
     var onBack: (() -> Void)? = nil
 
     @State private var selectedTab: SettingsSection = .general
@@ -2217,7 +2214,7 @@ struct SettingsContentView: View {
                             spacing: 8
                         ) {
                             ForEach(Array(NSScreen.screens.enumerated()), id: \.offset) { index, screen in
-                                hyperspaceDisplayTile(index: index, screen: screen)
+                                HyperspaceDisplayTile(index: index, screen: screen)
                             }
                         }
                     }
@@ -2317,56 +2314,6 @@ struct SettingsContentView: View {
             }
             .padding(16)
         }
-    }
-
-    private func hyperspaceDisplayTile(index: Int, screen: NSScreen) -> some View {
-        let windows = hyperspaceWindowCount(on: screen)
-        let name = index == 0 ? "Main display" : "Display \(index + 1)"
-        let size = "\(Int(screen.frame.width))×\(Int(screen.frame.height))"
-
-        return VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 7) {
-                Image(systemName: index == 0 ? "display" : "rectangle.on.rectangle")
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundColor(windows > 0 ? Palette.running : Palette.textMuted)
-                    .frame(width: 16)
-
-                Text(name)
-                    .font(Typo.monoBold(10.5))
-                    .foregroundColor(Palette.text)
-                    .lineLimit(1)
-
-                Spacer(minLength: 0)
-            }
-
-            HStack(spacing: 6) {
-                Text(size)
-                    .font(Typo.caption(9.5))
-                    .foregroundColor(Palette.textMuted)
-                Spacer(minLength: 0)
-                Text("\(windows)")
-                    .font(Typo.monoBold(11))
-                    .foregroundColor(windows > 0 ? Palette.running : Palette.textMuted)
-                Text(windows == 1 ? "window" : "windows")
-                    .font(Typo.caption(9.5))
-                    .foregroundColor(Palette.textMuted)
-            }
-        }
-        .padding(10)
-        .background(shortcutsInsetPanel)
-    }
-
-    private func hyperspaceWindowCount(on screen: NSScreen) -> Int {
-        desktopModel.allWindows().filter { entry in
-            entry.pid != ProcessInfo.processInfo.processIdentifier &&
-            entry.isOnScreen &&
-            !entry.title.isEmpty &&
-            hyperspaceEntry(entry, isOn: screen)
-        }.count
-    }
-
-    private func hyperspaceEntry(_ entry: WindowEntry, isOn screen: NSScreen) -> Bool {
-        ObjectIdentifier(WindowTiler.screenForWindowFrame(entry.frame)) == ObjectIdentifier(screen)
     }
 
     // A labeled lighting slider (0…1) with a right-aligned readout.
@@ -4509,6 +4456,68 @@ struct SettingsContentView: View {
                             .strokeBorder(Palette.border, lineWidth: 0.5)
                     )
             )
+    }
+}
+
+/// Keeps the 1.5-second desktop inventory publisher local to the Hyperspace
+/// display tiles instead of invalidating the entire Settings hierarchy.
+private struct HyperspaceDisplayTile: View {
+    let index: Int
+    let screen: NSScreen
+
+    @ObservedObject private var desktopModel = DesktopModel.shared
+
+    private var windowCount: Int {
+        desktopModel.allWindows().filter { entry in
+            entry.pid != ProcessInfo.processInfo.processIdentifier &&
+            entry.isOnScreen &&
+            !entry.title.isEmpty &&
+            ObjectIdentifier(WindowTiler.screenForWindowFrame(entry.frame)) == ObjectIdentifier(screen)
+        }.count
+    }
+
+    var body: some View {
+        let windows = windowCount
+        let name = index == 0 ? "Main display" : "Display \(index + 1)"
+        let size = "\(Int(screen.frame.width))×\(Int(screen.frame.height))"
+
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 7) {
+                Image(systemName: index == 0 ? "display" : "rectangle.on.rectangle")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(windows > 0 ? Palette.running : Palette.textMuted)
+                    .frame(width: 16)
+
+                Text(name)
+                    .font(Typo.monoBold(10.5))
+                    .foregroundColor(Palette.text)
+                    .lineLimit(1)
+
+                Spacer(minLength: 0)
+            }
+
+            HStack(spacing: 6) {
+                Text(size)
+                    .font(Typo.caption(9.5))
+                    .foregroundColor(Palette.textMuted)
+                Spacer(minLength: 0)
+                Text("\(windows)")
+                    .font(Typo.monoBold(11))
+                    .foregroundColor(windows > 0 ? Palette.running : Palette.textMuted)
+                Text(windows == 1 ? "window" : "windows")
+                    .font(Typo.caption(9.5))
+                    .foregroundColor(Palette.textMuted)
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.black.opacity(0.22))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .strokeBorder(Palette.border, lineWidth: 0.5)
+                )
+        )
     }
 }
 

--- a/apps/mac/Sources/Core/System/PermissionChecker.swift
+++ b/apps/mac/Sources/Core/System/PermissionChecker.swift
@@ -14,6 +14,7 @@ final class PermissionChecker: ObservableObject {
     @Published private(set) var lastCheckedAt: Date?
 
     private var pollTimer: Timer?
+    private var pollDeadline: Date?
     private var burstRefreshTask: Task<Void, Never>?
     private var hasLoggedInitial = false
     private var screenProbeInFlight = false
@@ -21,6 +22,7 @@ final class PermissionChecker: ObservableObject {
     private var screenProbeCooldownUntil: Date?
     private static let deniedScreenProbeCooldown: TimeInterval = 20
     private static let successfulScreenProbeTTL: TimeInterval = 8
+    private static let permissionPollingDuration: TimeInterval = 30
     private static let microphoneUsageDescriptionKey = "NSMicrophoneUsageDescription"
 
     var allGranted: Bool { accessibility && screenRecording && microphoneGranted }
@@ -73,9 +75,15 @@ final class PermissionChecker: ObservableObject {
             diag.info("Permissions: Accessibility \(ax ? "✓" : "✗"), Screen Recording \(sr ? "✓" : "✗"), Microphone \(Self.describe(mic))")
         }
 
-        accessibility = ax
-        screenRecording = sr
-        microphone = mic
+        if accessibility != ax {
+            accessibility = ax
+        }
+        if screenRecording != sr {
+            screenRecording = sr
+        }
+        if microphone != mic {
+            microphone = mic
+        }
 
         // Only poll after an intentional permission request. A passive launch-time
         // check should not keep nudging macOS privacy state in the background.
@@ -340,12 +348,19 @@ final class PermissionChecker: ObservableObject {
 
     // MARK: - Polling
 
-    /// Poll every second to detect permission changes made in System Settings.
+    /// Poll briefly after an explicit request so a System Settings toggle is
+    /// reflected quickly without leaving a permanent background timer behind.
     private func startPolling() {
         guard pollTimer == nil else { return }
+        pollDeadline = Date().addingTimeInterval(Self.permissionPollingDuration)
         pollTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
             DispatchQueue.main.async {
-                self?.check()
+                guard let self else { return }
+                guard let deadline = self.pollDeadline, Date() < deadline else {
+                    self.stopPolling()
+                    return
+                }
+                self.check()
             }
         }
     }
@@ -460,6 +475,7 @@ final class PermissionChecker: ObservableObject {
     private func stopPolling() {
         pollTimer?.invalidate()
         pollTimer = nil
+        pollDeadline = nil
         burstRefreshTask?.cancel()
         burstRefreshTask = nil
         refreshInFlight = false


### PR DESCRIPTION
## Summary

- remove the Permissions Assistant's unconditional one-second polling task
- bound intentional permission-recovery polling to 30 seconds and avoid redundant permission-state publications
- scope desktop inventory observation to the Hyperspace display tiles that consume it, while removing unused high-frequency Settings observers

## Root cause

The Permissions Assistant could remain alive across Spaces and poll forever. Each check republished several observed fields, invalidating both the assistant and the large Settings hierarchy. Settings also observed desktop inventory globally, so unrelated window updates could rebuild the entire page.

## Impact

Settings and Permissions remain responsive without keeping Lattices' main thread in a continuous SwiftUI/AppKit layout cycle. In the live reproduction, sustained Lattices CPU fell from roughly 70–96% to 0.3–3% with both surfaces open.

## Validation

- `git diff --check`
- `swift build -c release --scratch-path /Users/arach/dev/lattices/apps/mac/.build`
- live dev-bundle sampling with Settings and Permissions Assistant held open across multiple prior polling intervals
