### PR TITLE
Add launch-at-login controls

### DIFF
--- a/bin/lattices-app.ts
+++ b/bin/lattices-app.ts
@@ -2,7 +2,7 @@
 
 import { execFileSync, execSync, spawn } from "node:child_process";
 import { cpSync, existsSync, mkdirSync, chmodSync, createWriteStream, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { get } from "node:https";
 import type { IncomingMessage } from "node:http";
@@ -19,6 +19,9 @@ const resourcesDir = resolve(bundlePath, "Contents/Resources");
 const iconPath = resolve(__dirname, "../assets/AppIcon.icns");
 const tapSoundPath = resolve(__dirname, "../apps/mac/Resources/tap.wav");
 const deckBuilderResourcesPath = resolve(__dirname, "../apps/mac/Resources/DeckBuilder");
+const launchAgentLabel = "dev.lattices.app.login";
+const launchAgentPath = resolve(homedir(), "Library/LaunchAgents", `${launchAgentLabel}.plist`);
+const launchAgentLogPath = resolve(homedir(), ".lattices", "lattices-launchagent.log");
 
 const REPO = "arach/lattices";
 const RELEASE_APP_ASSET_NAMES = ["Lattices.dmg"];
@@ -238,6 +241,114 @@ function launch(extraArgs: string[] = []): void {
   if (appArgs.length) args.push("--args", ...appArgs);
   spawn("open", args, { detached: true, stdio: "ignore" }).unref();
   console.log("lattices app launched.");
+}
+
+function launchctlDomain(): string {
+  if (typeof process.getuid === "function") return `gui/${process.getuid()}`;
+  const uid = execFileSync("/usr/bin/id", ["-u"], { encoding: "utf8" }).trim();
+  return `gui/${uid}`;
+}
+
+function plistString(value: string, indent = "        "): string {
+  return `${indent}<string>${xmlEscape(value)}</string>`;
+}
+
+function writeLaunchAgent(extraArgs: string[] = []): void {
+  mkdirSync(resolve(homedir(), "Library/LaunchAgents"), { recursive: true });
+  mkdirSync(resolve(homedir(), ".lattices"), { recursive: true });
+
+  const args = [
+    "/usr/bin/open",
+    bundlePath,
+    "--args",
+    "--lattices-cli-root",
+    cliRoot,
+    ...extraArgs,
+  ];
+  const plistArgs = args.map((arg) => plistString(arg)).join("\n");
+  const escapedLogPath = xmlEscape(launchAgentLogPath);
+  const plist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${xmlEscape(launchAgentLabel)}</string>
+    <key>ProgramArguments</key>
+    <array>
+${plistArgs}
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>LimitLoadToSessionType</key>
+    <string>Aqua</string>
+    <key>StandardOutPath</key>
+    <string>${escapedLogPath}</string>
+    <key>StandardErrorPath</key>
+    <string>${escapedLogPath}</string>
+</dict>
+</plist>
+`;
+  writeFileSync(launchAgentPath, plist);
+}
+
+function isLaunchAgentLoaded(): boolean {
+  try {
+    execFileSync("/bin/launchctl", ["print", `${launchctlDomain()}/${launchAgentLabel}`], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function unloadLaunchAgent(): void {
+  const domain = launchctlDomain();
+  try {
+    execFileSync("/bin/launchctl", ["bootout", domain, launchAgentPath], { stdio: "ignore" });
+  } catch {}
+  try {
+    execFileSync("/bin/launchctl", ["bootout", `${domain}/${launchAgentLabel}`], { stdio: "ignore" });
+  } catch {}
+}
+
+function loadLaunchAgent(): void {
+  const domain = launchctlDomain();
+  unloadLaunchAgent();
+  execFileSync("/bin/launchctl", ["bootstrap", domain, launchAgentPath], { stdio: "inherit" });
+  try {
+    execFileSync("/bin/launchctl", ["enable", `${domain}/${launchAgentLabel}`], { stdio: "ignore" });
+  } catch {}
+}
+
+function filterStartupArgs(args: string[]): { extraArgs: string[]; shouldLaunch: boolean } {
+  return {
+    extraArgs: args.filter((arg) => arg !== "--no-launch"),
+    shouldLaunch: !args.includes("--no-launch"),
+  };
+}
+
+async function installLaunchAgent(args: string[] = []): Promise<void> {
+  const { extraArgs, shouldLaunch } = filterStartupArgs(args);
+  await ensureBinary();
+  writeLaunchAgent(extraArgs);
+  loadLaunchAgent();
+  console.log(`lattices app will open at login.`);
+  console.log(`LaunchAgent: ${launchAgentPath}`);
+  if (shouldLaunch) launch(extraArgs);
+}
+
+function uninstallLaunchAgent(): void {
+  unloadLaunchAgent();
+  if (existsSync(launchAgentPath)) {
+    rmSync(launchAgentPath, { force: true });
+  }
+  console.log("lattices app startup registration removed.");
+}
+
+function printAppStatus(): void {
+  console.log(`App running: ${isRunning() ? "yes" : "no"}`);
+  console.log(`Startup installed: ${existsSync(launchAgentPath) ? "yes" : "no"}`);
+  console.log(`LaunchAgent loaded: ${isLaunchAgentLoaded() ? "yes" : "no"}`);
+  console.log(`LaunchAgent: ${launchAgentPath}`);
 }
 
 function relaunchIfNeeded(shouldLaunch: boolean, extraArgs: string[] = []): void {
@@ -616,14 +727,18 @@ async function updateApp(extraArgs: string[] = [], shouldLaunch = false): Promis
   relaunchIfNeeded(shouldLaunch || wasRunning || extraArgs.length > 0, extraArgs);
 }
 
-const cmd = process.argv[2];
-const flags = process.argv.slice(3);
+const rawArgs = process.argv.slice(2);
+const firstArg = rawArgs[0];
+const cmd = firstArg && !firstArg.startsWith("-") ? firstArg : "launch";
+const flags = firstArg && !firstArg.startsWith("-") ? rawArgs.slice(1) : rawArgs;
 const launchFlags: string[] = [];
 if (flags.includes("--diagnostics") || flags.includes("-d")) launchFlags.push("--diagnostics");
 if (flags.includes("--screen-map") || flags.includes("-m")) launchFlags.push("--screen-map");
+const startupFlags = [...launchFlags, ...(flags.includes("--no-launch") ? ["--no-launch"] : [])];
 const shouldLaunchAfterUpdate = flags.includes("--launch") || launchFlags.length > 0;
 const shouldDetachUpdate = flags.includes("--detach");
 const isUpdateWorker = flags.includes("--worker");
+const loginAction = flags.find((flag) => !flag.startsWith("-")) ?? "status";
 
 if (cmd === "build") {
   requireBundleNotRunningForBuild();
@@ -653,6 +768,22 @@ if (cmd === "build") {
     process.exit(1);
   }
   launch(launchFlags);
+} else if (cmd === "install") {
+  await installLaunchAgent(startupFlags);
+} else if (cmd === "uninstall") {
+  uninstallLaunchAgent();
+} else if (cmd === "login" || cmd === "startup") {
+  if (["enable", "install", "on"].includes(loginAction)) {
+    await installLaunchAgent(startupFlags);
+  } else if (["disable", "remove", "uninstall", "off"].includes(loginAction)) {
+    uninstallLaunchAgent();
+  } else if (loginAction === "status") {
+    printAppStatus();
+  } else {
+    console.log("Usage: lattices app login [enable|disable|status]");
+  }
+} else if (cmd === "status") {
+  printAppStatus();
 } else if (cmd === "update") {
   if (shouldDetachUpdate && !isUpdateWorker) {
     spawnDetachedUpdateWorker(launchFlags, shouldLaunchAfterUpdate);

--- a/bin/lattices-dev
+++ b/bin/lattices-dev
@@ -16,6 +16,9 @@ BUNDLE_BIN="$BUNDLE/Contents/MacOS/Lattices"
 RESOURCES_DIR="$BUNDLE/Contents/Resources"
 ENTITLEMENTS="$APP_DIR/Lattices.entitlements"
 BUNDLE_ID="${LATTICES_DEV_BUNDLE_ID:-dev.lattices.app.dev}"
+LAUNCH_AGENT_LABEL="$BUNDLE_ID.login"
+LAUNCH_AGENT_PLIST="$HOME/Library/LaunchAgents/$LAUNCH_AGENT_LABEL.plist"
+LAUNCH_AGENT_LOG="$HOME/.lattices/lattices-dev-launchagent.log"
 ICON="$ROOT/assets/AppIcon.icns"
 TAP_SOUND="$APP_DIR/Resources/tap.wav"
 DECK_BUILDER_RESOURCES="$APP_DIR/Resources/DeckBuilder"
@@ -140,6 +143,64 @@ require_build_targets_not_running() {
         dim "Use \`lattices-dev restart\` or \`lattices app restart\` to quit, rebuild, and relaunch."
         exit 1
     fi
+}
+
+xml_escape() {
+    local value="$1"
+    value="${value//&/&amp;}"
+    value="${value//</&lt;}"
+    value="${value//>/&gt;}"
+    printf '%s' "$value"
+}
+
+launchctl_domain() {
+    printf 'gui/%s' "$(id -u)"
+}
+
+is_launch_agent_loaded() {
+    launchctl print "$(launchctl_domain)/$LAUNCH_AGENT_LABEL" >/dev/null 2>&1
+}
+
+unload_launch_agent() {
+    launchctl bootout "$(launchctl_domain)" "$LAUNCH_AGENT_PLIST" >/dev/null 2>&1 || true
+    launchctl bootout "$(launchctl_domain)/$LAUNCH_AGENT_LABEL" >/dev/null 2>&1 || true
+}
+
+write_launch_agent() {
+    ensure_install_bundle
+    mkdir -p "$HOME/Library/LaunchAgents" "$HOME/.lattices"
+
+    {
+        printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>'
+        printf '%s\n' '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">'
+        printf '%s\n' '<plist version="1.0">'
+        printf '%s\n' '<dict>'
+        printf '%s\n' '    <key>Label</key>'
+        printf '    <string>%s</string>\n' "$(xml_escape "$LAUNCH_AGENT_LABEL")"
+        printf '%s\n' '    <key>ProgramArguments</key>'
+        printf '%s\n' '    <array>'
+        local arg
+        for arg in "/usr/bin/open" "$INSTALL_BUNDLE" "--args" "--lattices-cli-root" "$ROOT" "$@"; do
+            printf '        <string>%s</string>\n' "$(xml_escape "$arg")"
+        done
+        printf '%s\n' '    </array>'
+        printf '%s\n' '    <key>RunAtLoad</key>'
+        printf '%s\n' '    <true/>'
+        printf '%s\n' '    <key>LimitLoadToSessionType</key>'
+        printf '%s\n' '    <string>Aqua</string>'
+        printf '%s\n' '    <key>StandardOutPath</key>'
+        printf '    <string>%s</string>\n' "$(xml_escape "$LAUNCH_AGENT_LOG")"
+        printf '%s\n' '    <key>StandardErrorPath</key>'
+        printf '    <string>%s</string>\n' "$(xml_escape "$LAUNCH_AGENT_LOG")"
+        printf '%s\n' '</dict>'
+        printf '%s\n' '</plist>'
+    } > "$LAUNCH_AGENT_PLIST"
+}
+
+load_launch_agent() {
+    unload_launch_agent
+    launchctl bootstrap "$(launchctl_domain)" "$LAUNCH_AGENT_PLIST"
+    launchctl enable "$(launchctl_domain)/$LAUNCH_AGENT_LABEL" >/dev/null 2>&1 || true
 }
 
 write_info_plist() {
@@ -269,6 +330,47 @@ cmd_launch() {
     fi
 }
 
+cmd_install() {
+    local launch_now=1
+    local app_args=()
+    local arg
+
+    for arg in "$@"; do
+        case "$arg" in
+            --no-launch) launch_now=0 ;;
+            *) app_args+=("$arg") ;;
+        esac
+    done
+
+    write_launch_agent "${app_args[@]}"
+    load_launch_agent
+    green "Lattices dev app will open at login."
+    dim "LaunchAgent: $LAUNCH_AGENT_PLIST"
+    if [ "$launch_now" -eq 1 ]; then
+        cmd_launch "${app_args[@]}"
+    fi
+}
+
+cmd_uninstall() {
+    unload_launch_agent
+    rm -f "$LAUNCH_AGENT_PLIST"
+    green "Lattices dev app startup registration removed."
+}
+
+cmd_login() {
+    local action="${1:-status}"
+    if [ "$#" -gt 0 ]; then
+        shift
+    fi
+
+    case "$action" in
+        enable|install|on) cmd_install "$@" ;;
+        disable|remove|uninstall|off) cmd_uninstall ;;
+        status) cmd_status ;;
+        *) red "Usage: lattices-dev login [enable|disable|status]"; exit 1 ;;
+    esac
+}
+
 cmd_logs() {
     if [ -f "$LOG_FILE" ]; then
         tail -f "$LOG_FILE"
@@ -337,6 +439,17 @@ cmd_status() {
         local entries=$(wc -l < "$HOME/.lattices/advisor-learning.jsonl" | tr -d ' ')
         dim "Advisor learning: $entries entries"
     fi
+    if [ -f "$LAUNCH_AGENT_PLIST" ]; then
+        green "Startup installed: yes"
+    else
+        dim "Startup installed: no"
+    fi
+    if is_launch_agent_loaded; then
+        green "LaunchAgent loaded: yes"
+    else
+        dim "LaunchAgent loaded: no"
+    fi
+    dim "LaunchAgent: $LAUNCH_AGENT_PLIST"
 }
 
 cmd_help() {
@@ -348,6 +461,8 @@ cmd_help() {
     echo "  build        Build release binary"
     echo "  quit         Stop the running app"
     echo "  launch       Start the app (if not running)"
+    echo "  install      Register launch-at-login and start now"
+    echo "  login        Manage launch-at-login (enable|disable|status)"
     echo "  logs         Tail the log file (live)"
     echo "  log [N]      Show last N log lines (default 30)"
     echo "  clear-logs   Clear the log file"
@@ -362,6 +477,9 @@ case "${1:-help}" in
     build)      cmd_build ;;
     quit|stop)  cmd_quit ;;
     launch|start) cmd_launch "${@:2}" ;;
+    install)    cmd_install "${@:2}" ;;
+    uninstall)  cmd_uninstall ;;
+    login|startup) cmd_login "${@:2}" ;;
     logs)       cmd_logs ;;
     log)        cmd_log "${2:-30}" ;;
     clear-logs) cmd_clear_logs ;;

--- a/bin/lattices.ts
+++ b/bin/lattices.ts
@@ -3128,7 +3128,10 @@ switch (command) {
     const first = args[1];
     const appSubcommand = first && !first.startsWith("-") ? first : "launch";
     const appFlags = first && !first.startsWith("-") ? args.slice(2) : args.slice(1);
-    const devAppCommands = new Set(["launch", "start", "build", "restart", "quit", "stop"]);
+    const devAppCommands = new Set([
+      "launch", "start", "build", "restart", "quit", "stop",
+      "install", "uninstall", "login", "startup", "status",
+    ]);
 
     if (detectProjectType(dir) === "lattices-app" && devAppCommands.has(appSubcommand)) {
       console.log("Using local dev app bundle so macOS permissions stay attached across rebuilds.");

--- a/docs/app.md
+++ b/docs/app.md
@@ -11,6 +11,7 @@ workspace from there.
 
 ```bash
 lattices app          # Build (or download) and launch
+lattices app install  # Register launch-at-login and launch now
 lattices app update   # Download the latest release and relaunch
 lattices app build    # Rebuild from source
 lattices app restart  # Quit, rebuild, relaunch
@@ -19,6 +20,11 @@ lattices app quit     # Stop the app
 
 The first run builds from source if Swift is available, otherwise
 downloads a pre-built binary from GitHub releases.
+
+Use `lattices app install` when you want the companion to start now and
+open automatically at login. It installs a user LaunchAgent in
+`~/Library/LaunchAgents`; inspect it with `lattices app login status`
+and remove it with `lattices app login disable`.
 
 ## Command palette
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -139,6 +139,9 @@ Run `lattices init` in your project directory to generate a starter
 | `lattices groups`            | List all tab groups with status                   |
 | `lattices tab <group> [tab]` | Switch tab within a group (by label or index)     |
 | `lattices app`               | Launch the menu bar companion app                 |
+| `lattices app install`       | Register launch-at-login and start now            |
+| `lattices app login status`  | Show launch-at-login registration                 |
+| `lattices app login disable` | Disable launch-at-login                           |
 | `lattices app update`        | Download the latest menu bar app and relaunch     |
 | `lattices app build`         | Rebuild the menu bar app from source              |
 | `lattices app restart`       | Rebuild and relaunch the menu bar app             |
@@ -159,6 +162,9 @@ Run `lattices init` in your project directory to generate a starter
 | `lattices scan search <query>` | Search indexed screen text                       |
 | `lattices diag [limit]`       | Show recent diagnostic entries                   |
 | `lattices app`               | Launch the menu bar companion app                 |
+| `lattices app install`       | Register launch-at-login and start now            |
+| `lattices app login status`  | Show launch-at-login registration                 |
+| `lattices app login disable` | Disable launch-at-login                           |
 | `lattices app update`        | Download the latest menu bar app and relaunch     |
 | `lattices app build`         | Rebuild the menu bar app from source              |
 | `lattices app restart`       | Rebuild and relaunch the menu bar app             |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -25,6 +25,12 @@ This builds (or downloads) and launches the native macOS companion.
 Open the command palette with **Cmd+Shift+M** to search and launch
 any project, tile windows, or switch workspace layers.
 
+To also open Lattices automatically when you log in:
+
+```bash
+lattices app install
+```
+
 ## 3. Add a project config
 
 Drop a `.lattices.json` in your project root:


### PR DESCRIPTION
## Summary

- add `lattices app install` plus `login enable`, `login disable`, and `login status` controls
- register the release app with a per-user LaunchAgent and expose matching controls for the stable local dev bundle
- route the new subcommands through the top-level CLI and document setup, inspection, and removal

## Why

The companion app can be launched manually, but there was no CLI-managed way to make it start with the user’s Aqua login session. This adds a reversible registration flow without requiring changes to the native app target.

The branch was rebased onto the v0.9.0 `main`. The earlier Pi runtime onboarding commit was intentionally dropped because v0.9.0 replaced that subprocess architecture with Scout-backed chat and direct HudsonAI voice handling.

## Impact

Users can opt into login startup with `lattices app install`, inspect it with `lattices app login status`, and remove it with `lattices app login disable`. Repository development uses a separate dev-bundle LaunchAgent label so permissions and production startup state stay isolated.

## Validation

- `bun run check:types`
- `bash -n bin/lattices-dev`
- `bun test tests/dependency-free.test.ts`
- `bun run check:app`
- isolated-home smoke tests for release and dev `status` commands
- top-level `bun bin/lattices.ts app status` routing smoke test
- app process relaunched successfully after validation

## Known baseline issue

`bun run test` reaches the existing CLI suite, where the hard-coded session hash fixture depends on a different checkout path (`lattices-c36f74` versus the current checkout’s `lattices-603d63`). The remaining CLI tests pass; this PR does not change session hashing.