### PR TITLE
Add reversible Focus Mode controls

### DIFF
--- a/apps/mac/Sources/AppShell/AppDelegate.swift
+++ b/apps/mac/Sources/AppShell/AppDelegate.swift
@@ -79,6 +79,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        FocusModeController.shared.resetForTermination()
         removeSystemInputBoundaryObservers()
         SecureEventInputMonitor.shared.stop()
         KeyboardRemapController.shared.stop()

--- a/apps/mac/Sources/AppShell/HotkeyBootstrap.swift
+++ b/apps/mac/Sources/AppShell/HotkeyBootstrap.swift
@@ -35,6 +35,7 @@ enum HotkeyBootstrap {
         store.register(action: .omniSearch) { UnifiedCommandBarWindow.shared.toggle(mode: .search) }
         store.register(action: .gridPlacement) { GridPlacementWindow.shared.toggle() }
         store.register(action: .commandBar) { UnifiedCommandBarWindow.shared.toggle(mode: .command) }
+        store.register(action: .focusMode) { FocusModeController.shared.toggle() }
         store.register(action: .activityLog) {
             DiagnosticLog.shared.info("Hotkey: activityLog triggered")
             ScreenMapWindowController.shared.showPage(.activity)

--- a/apps/mac/Sources/Core/Actions/HotkeyStore.swift
+++ b/apps/mac/Sources/Core/Actions/HotkeyStore.swift
@@ -30,6 +30,7 @@ enum HotkeyAction: String, CaseIterable, Codable {
     case activityLog
     case gridPlacement
     case commandBar
+    case focusMode
     // Layers
     case layer1, layer2, layer3, layer4, layer5, layer6, layer7, layer8, layer9
     case layerNext, layerPrev, layerTag
@@ -61,6 +62,7 @@ enum HotkeyAction: String, CaseIterable, Codable {
         case .activityLog:     return "Activity Log"
         case .gridPlacement:   return "Grid Placement"
         case .commandBar:      return "Command Bar"
+        case .focusMode:       return "Focus Mode"
         case .layer1:          return "Layer 1"
         case .layer2:          return "Layer 2"
         case .layer3:          return "Layer 3"
@@ -98,7 +100,7 @@ enum HotkeyAction: String, CaseIterable, Codable {
 
     var group: HotkeyGroup {
         switch self {
-        case .palette, .screenMap, .bezel, .cheatSheet, .desktopInventory, .omniSearch, .voiceCommand, .handsOff, .unifiedWindow, .hud, .mouseFinder, .overlayActors, .workspaceAssistant, .activityLog, .gridPlacement, .commandBar, .inPlaceMode, .chordHints: return .app
+        case .palette, .screenMap, .bezel, .cheatSheet, .desktopInventory, .omniSearch, .voiceCommand, .handsOff, .unifiedWindow, .hud, .mouseFinder, .overlayActors, .workspaceAssistant, .activityLog, .gridPlacement, .commandBar, .focusMode, .inPlaceMode, .chordHints: return .app
         case .layer1, .layer2, .layer3, .layer4, .layer5,
              .layer6, .layer7, .layer8, .layer9,
              .layerNext, .layerPrev, .layerTag: return .layers
@@ -124,6 +126,7 @@ enum HotkeyAction: String, CaseIterable, Codable {
         case .activityLog:     return 212
         case .gridPlacement:   return 213
         case .commandBar:      return 214
+        case .focusMode:       return 215
         case .layer1:          return 101
         case .layer2:          return 102
         case .layer3:          return 103
@@ -293,6 +296,7 @@ class HotkeyStore: ObservableObject {
         bind(.mouseFinder, 26, hyper)      // Hyper+7
         bind(.gridPlacement, 5, ctrlOpt)   // Ctrl+Opt+G (4x4 placement target)
         bind(.commandBar, 49, ctrlOpt)     // Ctrl+Opt+Space (precise placement command bar)
+        bind(.focusMode, 6, hyper)         // Hyper+Z — reversible window spotlight
 
         // Layers: Cmd+Option+1-9
         let layerKeyCodes: [UInt32] = [18, 19, 20, 21, 23, 22, 26, 28, 25]

--- a/apps/mac/Sources/Core/Actions/PaletteCommand.swift
+++ b/apps/mac/Sources/Core/Actions/PaletteCommand.swift
@@ -443,6 +443,17 @@ enum CommandBuilder {
         ))
 
         commands.append(PaletteCommand(
+            id: "app-focus-mode",
+            title: "Toggle Focus Mode",
+            subtitle: "Spotlight the frontmost window (Hyper+Z)",
+            icon: "viewfinder",
+            category: .app,
+            badge: nil,
+            keywords: ["zen", "spotlight", "blackout", "distraction free", "window focus"],
+            action: { FocusModeController.shared.toggle() }
+        ))
+
+        commands.append(PaletteCommand(
             id: "app-settings",
             title: "Settings",
             subtitle: "Terminal, scan root, keyboard, shortcuts, voice, and OCR",

--- a/apps/mac/Sources/Core/Daemon/LatticesApi.swift
+++ b/apps/mac/Sources/Core/Daemon/LatticesApi.swift
@@ -1108,6 +1108,63 @@ final class LatticesApi {
         ))
 
         api.register(Endpoint(
+            method: "focus.status",
+            description: "Check whether Focus Mode is active",
+            access: .read,
+            params: [],
+            returns: .custom("Object with active state"),
+            handler: { _ in
+                var active = false
+                Self.runOnMain { active = FocusModeController.shared.isActive }
+                return .object(["active": .bool(active)])
+            }
+        ))
+
+        api.register(Endpoint(
+            method: "focus.enter",
+            description: "Enter Focus Mode for the frontmost window",
+            access: .mutate,
+            params: [],
+            returns: .custom("Object with ok and active state"),
+            handler: { _ in
+                var active = false
+                Self.runOnMain {
+                    FocusModeController.shared.enter()
+                    active = FocusModeController.shared.isActive
+                }
+                return .object(["ok": .bool(active), "active": .bool(active)])
+            }
+        ))
+
+        api.register(Endpoint(
+            method: "focus.exit",
+            description: "Exit Focus Mode and restore the original window frame",
+            access: .mutate,
+            params: [],
+            returns: .custom("Object with ok and active state"),
+            handler: { _ in
+                Self.runOnMain { FocusModeController.shared.exit() }
+                return .object(["ok": .bool(true), "active": .bool(false)])
+            }
+        ))
+
+        api.register(Endpoint(
+            method: "focus.toggle",
+            description: "Toggle Focus Mode for the frontmost window",
+            access: .mutate,
+            params: [],
+            returns: .custom("Object with ok and active state"),
+            handler: { _ in
+                var active = false
+                Self.runOnMain {
+                    FocusModeController.shared.toggle()
+                    active = FocusModeController.shared.isActive
+                }
+                return .object(["ok": .bool(true), "active": .bool(active)])
+            }
+        ))
+
+        api.register(Endpoint(
             method: "daemon.status",
             description: "Get daemon status including uptime and counts",
             access: .read,

--- a/apps/mac/Sources/Core/Input/MouseGestureController.swift
+++ b/apps/mac/Sources/Core/Input/MouseGestureController.swift
@@ -143,6 +143,10 @@ final class MouseGestureController: ObservableObject {
     private var subscriptions: Set<AnyCancellable> = []
     private var installedObservers = false
     private var frontmostApplicationObserver: NSObjectProtocol?
+    private var healthTimer: Timer?
+    private var lastObservedTapHealth: TapHealth?
+    private let eventActivityLock = NSLock()
+    private var lastEventReceivedAt: CFAbsoluteTime?
     private let shapeRecognizer = ShapeRecognizer()
     private let breaker = EventTapBreaker(label: "MouseGesture")
     private let budgetMeter = TapBudgetMeter(label: "MouseGesture")
@@ -158,6 +162,16 @@ final class MouseGestureController: ObservableObject {
         "company.thebrowser.Browser",
         "org.mozilla.firefox",
     ]
+
+    private struct TapHealth: Equatable {
+        let installed: Bool
+        let valid: Bool
+        let enabled: Bool
+
+        var summary: String {
+            "installed=\(installed) valid=\(valid) enabled=\(enabled)"
+        }
+    }
 
     private struct TapTrackingState {
         let buttonNumber: Int64
@@ -246,15 +260,19 @@ final class MouseGestureController: ObservableObject {
     func start() {
         installObserversIfNeeded()
         refresh()
+        startHealthMonitoring()
     }
 
     func stop() {
+        healthTimer?.invalidate()
+        healthTimer = nil
         clearSession()
         removeEventTap()
     }
 
     func resetForSystemInputBoundary(reason: String) {
         dispatchPrecondition(condition: .onQueue(.main))
+        let healthBeforeReset = currentTapHealth()
         clearSession()
         breaker.reset()
         if let eventTap {
@@ -262,7 +280,10 @@ final class MouseGestureController: ObservableObject {
         } else {
             refresh()
         }
-        DiagnosticLog.shared.warn("MouseGesture: reset for \(reason)")
+        let healthAfterReset = currentTapHealth()
+        DiagnosticLog.shared.warn(
+            "MouseGesture: reset for \(reason) (before: \(healthBeforeReset.summary); after: \(healthAfterReset.summary))"
+        )
     }
 
     static func resolveDirection(
@@ -334,6 +355,44 @@ final class MouseGestureController: ObservableObject {
                 CGEvent.tapEnable(tap: eventTap, enable: true)
             }
         }
+    }
+
+    private func startHealthMonitoring() {
+        guard healthTimer == nil else { return }
+        lastObservedTapHealth = currentTapHealth()
+        healthTimer = Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { [weak self] _ in
+            self?.recordTapHealthIfChanged()
+        }
+    }
+
+    private func currentTapHealth() -> TapHealth {
+        guard let eventTap else {
+            return TapHealth(installed: false, valid: false, enabled: false)
+        }
+        return TapHealth(
+            installed: true,
+            valid: CFMachPortIsValid(eventTap),
+            enabled: CGEvent.tapIsEnabled(tap: eventTap)
+        )
+    }
+
+    private func recordTapHealthIfChanged() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        let health = currentTapHealth()
+        guard health != lastObservedTapHealth else { return }
+        let idleDescription: String
+        eventActivityLock.lock()
+        let lastEventReceivedAt = lastEventReceivedAt
+        eventActivityLock.unlock()
+        if let lastEventReceivedAt {
+            idleDescription = String(format: "%.1fs", CFAbsoluteTimeGetCurrent() - lastEventReceivedAt)
+        } else {
+            idleDescription = "no events observed"
+        }
+        DiagnosticLog.shared.warn(
+            "MouseGesture: tap health changed -> \(health.summary); last event \(idleDescription) ago; breaker=\(breakerState)"
+        )
+        lastObservedTapHealth = health
     }
 
     /// Re-enable the tap after a breaker trip, clearing trip history.
@@ -413,6 +472,9 @@ final class MouseGestureController: ObservableObject {
 
     private func handleEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         let started = CFAbsoluteTimeGetCurrent()
+        eventActivityLock.lock()
+        lastEventReceivedAt = started
+        eventActivityLock.unlock()
         defer {
             let elapsedMs = (CFAbsoluteTimeGetCurrent() - started) * 1000
             budgetMeter.record(durationMs: elapsedMs)

--- a/apps/mac/Sources/Core/Overlays/FocusModeController.swift
+++ b/apps/mac/Sources/Core/Overlays/FocusModeController.swift
@@ -1,0 +1,454 @@
+import AppKit
+import CoreGraphics
+import QuartzCore
+
+/// A reversible, system-wide spotlight for the frontmost window.
+///
+/// Focus Mode keeps the target window fully interactive while a cursor-level
+/// panel blacks out everything around it. Window geometry is read back after
+/// every AX mutation so grid-snapping apps and terminals cannot leave a bright
+/// seam between the real window and the cutout.
+final class FocusModeController {
+    static let shared = FocusModeController()
+
+    private struct Session {
+        let application: NSRunningApplication
+        let applicationElement: AXUIElement
+        let window: AXUIElement
+        let originalAXFrame: CGRect
+        let screen: NSScreen
+    }
+
+    private let topMargin: CGFloat = 40
+    private let bottomMargin: CGFloat = 40
+    private let horizontalMargin: CGFloat = 40
+    private let moveDuration: TimeInterval = 0.28
+    private let resizeDuration: TimeInterval = 0.28
+
+    private var session: Session?
+    private var overlay: FocusModeOverlayWindow?
+    private var animationTimer: Timer?
+    private var trackingTimer: Timer?
+    private var escapeEventTap: CFMachPort?
+    private var escapeRunLoopSource: CFRunLoopSource?
+    private var isTransitioning = false
+
+    private init() {}
+
+    var isActive: Bool { session != nil }
+
+    func toggle() {
+        isActive ? exit() : enter()
+    }
+
+    func enter() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard session == nil, !isTransitioning else { return }
+        guard let captured = captureFrontmostWindow() else {
+            DiagnosticLog.shared.warn("Focus Mode: no resizable frontmost window")
+            return
+        }
+
+        session = captured
+        isTransitioning = true
+        setEnhancedUI(false, for: captured.applicationElement)
+
+        let overlay = FocusModeOverlayWindow(screen: captured.screen)
+        self.overlay = overlay
+        updateOverlayCutout(for: captured.window)
+        overlay.orderFrontRegardless()
+        overlay.alphaValue = 0
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = moveDuration
+            context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            overlay.animator().alphaValue = 1
+        }
+
+        installEscapeCapture()
+
+        let original = captured.originalAXFrame
+        let target = focusFrame(for: original, on: captured.screen)
+        let centered = CGRect(
+            x: target.midX - original.width / 2,
+            y: target.midY - original.height / 2,
+            width: original.width,
+            height: original.height
+        )
+
+        animate(window: captured.window, from: original, to: centered, duration: moveDuration) { [weak self] in
+            guard let self, self.session != nil else { return }
+            self.animate(window: captured.window, from: self.readAXFrame(captured.window) ?? centered, to: target, duration: self.resizeDuration) { [weak self] in
+                guard let self else { return }
+                self.isTransitioning = false
+                self.setEnhancedUI(true, for: captured.applicationElement)
+                self.startTracking()
+                DiagnosticLog.shared.success("Focus Mode: entered for \(captured.application.localizedName ?? "window")")
+            }
+        }
+    }
+
+    func exit(restoreWindow: Bool = true) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard let captured = session else { return }
+
+        session = nil
+        isTransitioning = true
+        stopTracking()
+        removeEscapeCapture()
+        animationTimer?.invalidate()
+        animationTimer = nil
+
+        guard restoreWindow, let current = readAXFrame(captured.window) else {
+            finishExit(captured: captured)
+            return
+        }
+
+        setEnhancedUI(false, for: captured.applicationElement)
+        let original = captured.originalAXFrame
+        let originalSizeCentered = CGRect(
+            x: current.midX - original.width / 2,
+            y: current.midY - original.height / 2,
+            width: original.width,
+            height: original.height
+        )
+
+        animate(window: captured.window, from: current, to: originalSizeCentered, duration: resizeDuration) { [weak self] in
+            guard let self else { return }
+            let actual = self.readAXFrame(captured.window) ?? originalSizeCentered
+            self.fadeOverlayOut(duration: self.moveDuration)
+            self.animate(window: captured.window, from: actual, to: original, duration: self.moveDuration) { [weak self] in
+                self?.finishExit(captured: captured)
+            }
+        }
+    }
+
+    func resetForTermination() {
+        guard let captured = session else { return }
+        animationTimer?.invalidate()
+        animationTimer = nil
+        stopTracking()
+        removeEscapeCapture()
+        setAXFrame(captured.originalAXFrame, for: captured.window)
+        setEnhancedUI(true, for: captured.applicationElement)
+        overlay?.orderOut(nil)
+        overlay = nil
+        session = nil
+        isTransitioning = false
+    }
+
+    // MARK: - Window capture and geometry
+
+    private func captureFrontmostWindow() -> Session? {
+        guard let application = NSWorkspace.shared.frontmostApplication,
+              !LatticesRuntime.isLatticesBundleIdentifier(application.bundleIdentifier) else {
+            return nil
+        }
+
+        let applicationElement = AXUIElementCreateApplication(application.processIdentifier)
+        var focusedValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            applicationElement,
+            kAXFocusedWindowAttribute as CFString,
+            &focusedValue
+        ) == .success,
+        let focusedValue else {
+            return nil
+        }
+
+        let window = focusedValue as! AXUIElement
+        guard let frame = readAXFrame(window), frame.width > 1, frame.height > 1 else { return nil }
+        let screen = screen(containingAXFrame: frame)
+        return Session(
+            application: application,
+            applicationElement: applicationElement,
+            window: window,
+            originalAXFrame: frame,
+            screen: screen
+        )
+    }
+
+    private func focusFrame(for original: CGRect, on screen: NSScreen) -> CGRect {
+        let full = screen.frame
+        let width = min(original.width, max(1, full.width - horizontalMargin * 2))
+        let height = max(1, full.height - topMargin - bottomMargin)
+        let appKitFrame = CGRect(
+            x: full.midX - width / 2,
+            y: full.minY + bottomMargin,
+            width: width,
+            height: height
+        )
+        return axFrame(fromAppKitFrame: appKitFrame)
+    }
+
+    private func screen(containingAXFrame frame: CGRect) -> NSScreen {
+        let appKitFrame = appKitFrame(fromAXFrame: frame)
+        let center = CGPoint(x: appKitFrame.midX, y: appKitFrame.midY)
+        return NSScreen.screens.first(where: { $0.frame.contains(center) })
+            ?? NSScreen.screens.min(by: {
+                hypot(center.x - $0.frame.midX, center.y - $0.frame.midY)
+                    < hypot(center.x - $1.frame.midX, center.y - $1.frame.midY)
+            })
+            ?? NSScreen.main!
+    }
+
+    private func appKitFrame(fromAXFrame frame: CGRect) -> CGRect {
+        let primaryHeight = NSScreen.screens.first?.frame.height ?? 0
+        return CGRect(
+            x: frame.minX,
+            y: primaryHeight - frame.maxY,
+            width: frame.width,
+            height: frame.height
+        )
+    }
+
+    private func axFrame(fromAppKitFrame frame: CGRect) -> CGRect {
+        let primaryHeight = NSScreen.screens.first?.frame.height ?? 0
+        return CGRect(
+            x: frame.minX,
+            y: primaryHeight - frame.maxY,
+            width: frame.width,
+            height: frame.height
+        )
+    }
+
+    private func readAXFrame(_ window: AXUIElement) -> CGRect? {
+        var positionValue: CFTypeRef?
+        var sizeValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(window, kAXPositionAttribute as CFString, &positionValue) == .success,
+              AXUIElementCopyAttributeValue(window, kAXSizeAttribute as CFString, &sizeValue) == .success,
+              let positionValue, let sizeValue else {
+            return nil
+        }
+
+        var position = CGPoint.zero
+        var size = CGSize.zero
+        guard AXValueGetValue(positionValue as! AXValue, .cgPoint, &position),
+              AXValueGetValue(sizeValue as! AXValue, .cgSize, &size) else {
+            return nil
+        }
+        return CGRect(origin: position, size: size)
+    }
+
+    private func setAXFrame(_ frame: CGRect, for window: AXUIElement) {
+        var position = frame.origin
+        var size = frame.size
+        if let sizeValue = AXValueCreate(.cgSize, &size) {
+            AXUIElementSetAttributeValue(window, kAXSizeAttribute as CFString, sizeValue)
+        }
+        if let positionValue = AXValueCreate(.cgPoint, &position) {
+            AXUIElementSetAttributeValue(window, kAXPositionAttribute as CFString, positionValue)
+        }
+        if let sizeValue = AXValueCreate(.cgSize, &size) {
+            AXUIElementSetAttributeValue(window, kAXSizeAttribute as CFString, sizeValue)
+        }
+    }
+
+    private func setEnhancedUI(_ enabled: Bool, for application: AXUIElement) {
+        AXUIElementSetAttributeValue(
+            application,
+            "AXEnhancedUserInterface" as CFString,
+            enabled as CFTypeRef
+        )
+    }
+
+    // MARK: - Animation and tracking
+
+    private func animate(
+        window: AXUIElement,
+        from start: CGRect,
+        to end: CGRect,
+        duration: TimeInterval,
+        completion: @escaping () -> Void
+    ) {
+        animationTimer?.invalidate()
+        guard duration > 0 else {
+            setAXFrame(end, for: window)
+            updateOverlayCutout(for: window)
+            completion()
+            return
+        }
+
+        let startedAt = ProcessInfo.processInfo.systemUptime
+        animationTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) { [weak self] timer in
+            guard let self else {
+                timer.invalidate()
+                return
+            }
+            let elapsed = ProcessInfo.processInfo.systemUptime - startedAt
+            let rawProgress = min(max(elapsed / duration, 0), 1)
+            let progress = rawProgress * rawProgress * (3 - 2 * rawProgress)
+            let frame = CGRect(
+                x: start.minX + (end.minX - start.minX) * progress,
+                y: start.minY + (end.minY - start.minY) * progress,
+                width: start.width + (end.width - start.width) * progress,
+                height: start.height + (end.height - start.height) * progress
+            )
+            self.setAXFrame(frame, for: window)
+            self.updateOverlayCutout(for: window)
+
+            if rawProgress >= 1 {
+                timer.invalidate()
+                self.animationTimer = nil
+                completion()
+            }
+        }
+    }
+
+    private func startTracking() {
+        stopTracking()
+        trackingTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 30.0, repeats: true) { [weak self] _ in
+            guard let self, let captured = self.session else { return }
+            guard self.readAXFrame(captured.window) != nil else {
+                self.exit(restoreWindow: false)
+                return
+            }
+            self.updateOverlayCutout(for: captured.window)
+        }
+    }
+
+    private func stopTracking() {
+        trackingTimer?.invalidate()
+        trackingTimer = nil
+    }
+
+    private func updateOverlayCutout(for window: AXUIElement) {
+        guard let overlay, let frame = readAXFrame(window) else { return }
+        let appKitFrame = appKitFrame(fromAXFrame: frame)
+        overlay.cutoutFrame = appKitFrame.offsetBy(
+            dx: -overlay.screenFrame.minX,
+            dy: -overlay.screenFrame.minY
+        )
+    }
+
+    private func fadeOverlayOut(duration: TimeInterval) {
+        guard let overlay else { return }
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = duration
+            context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            overlay.animator().alphaValue = 0
+        }
+    }
+
+    private func finishExit(captured: Session) {
+        animationTimer?.invalidate()
+        animationTimer = nil
+        setEnhancedUI(true, for: captured.applicationElement)
+        overlay?.orderOut(nil)
+        overlay = nil
+        isTransitioning = false
+        DiagnosticLog.shared.info("Focus Mode: exited")
+    }
+
+    // MARK: - Escape capture
+
+    private func installEscapeCapture() {
+        removeEscapeCapture()
+        let mask = (CGEventMask(1) << CGEventType.keyDown.rawValue)
+            | (CGEventMask(1) << CGEventType.keyUp.rawValue)
+        guard let tap = CGEvent.tapCreate(
+            tap: .cghidEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: mask,
+            callback: Self.escapeEventTapCallback,
+            userInfo: UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
+        ) else {
+            DiagnosticLog.shared.warn("Focus Mode: could not install Escape capture")
+            return
+        }
+
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        escapeEventTap = tap
+        escapeRunLoopSource = source
+        if let source { EventTapThread.shared.add(source: source) }
+        CGEvent.tapEnable(tap: tap, enable: true)
+    }
+
+    private func removeEscapeCapture() {
+        if let source = escapeRunLoopSource {
+            EventTapThread.shared.remove(source: source)
+        }
+        escapeRunLoopSource = nil
+        if let tap = escapeEventTap { CFMachPortInvalidate(tap) }
+        escapeEventTap = nil
+    }
+
+    private static let escapeEventTapCallback: CGEventTapCallBack = { _, type, event, userInfo in
+        guard let userInfo else { return Unmanaged.passUnretained(event) }
+        let controller = Unmanaged<FocusModeController>.fromOpaque(userInfo).takeUnretainedValue()
+
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            if let tap = controller.escapeEventTap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            }
+            return Unmanaged.passUnretained(event)
+        }
+
+        guard event.getIntegerValueField(.keyboardEventKeycode) == 53 else {
+            return Unmanaged.passUnretained(event)
+        }
+        if type == .keyDown {
+            DispatchQueue.main.async { controller.exit() }
+        }
+        return nil
+    }
+}
+
+private final class FocusModeOverlayWindow: NSPanel {
+    let screenFrame: CGRect
+    private let backdropView = FocusModeBackdropView(frame: .zero)
+
+    var cutoutFrame: CGRect {
+        get { backdropView.cutoutFrame }
+        set { backdropView.cutoutFrame = newValue }
+    }
+
+    init(screen: NSScreen) {
+        screenFrame = screen.frame
+        super.init(
+            contentRect: screen.frame,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        setFrame(screen.frame, display: false)
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = false
+        ignoresMouseEvents = true
+        level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.maximumWindow)))
+        collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
+        isMovable = false
+        hidesOnDeactivate = false
+        animationBehavior = .none
+        backdropView.frame = NSRect(origin: .zero, size: screen.frame.size)
+        backdropView.autoresizingMask = [.width, .height]
+        contentView = backdropView
+    }
+
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+}
+
+private final class FocusModeBackdropView: NSView {
+    var cutoutFrame: CGRect = .zero {
+        didSet { needsDisplay = true }
+    }
+
+    override var isOpaque: Bool { false }
+
+    override func draw(_ dirtyRect: NSRect) {
+        NSColor.clear.setFill()
+        bounds.fill()
+
+        let path = NSBezierPath(rect: bounds)
+        let sealedCutout = cutoutFrame.insetBy(dx: 2, dy: 2)
+        if sealedCutout.width > 0, sealedCutout.height > 0 {
+            path.appendRoundedRect(sealedCutout, xRadius: 24, yRadius: 24)
+        }
+        path.windingRule = .evenOdd
+        NSColor.black.withAlphaComponent(0.92).setFill()
+        path.fill()
+    }
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -1256,6 +1256,10 @@ sources at an app-owned folder such as `~/Library/Application Support/...`.
 | `deck.manifest` | read | Shared companion deck manifest |
 | `deck.snapshot` | read | Current companion deck runtime snapshot |
 | `deck.perform` | write | Perform a companion deck action |
+| `focus.status` | read | Check whether Focus Mode is active |
+| `focus.enter` | write | Spotlight the frontmost window |
+| `focus.exit` | write | Exit Focus Mode and restore the window |
+| `focus.toggle` | write | Toggle Focus Mode for the frontmost window |
 | `daemon.status` | read | Health check and stats |
 | `api.schema` | read | Full API schema for self-discovery |
 | `diagnostics.list` | read | Recent diagnostic entries |
@@ -1311,6 +1315,22 @@ Example:
   }
 }
 ```
+
+#### `focus.status`, `focus.enter`, `focus.exit`, `focus.toggle`
+
+Control the same reversible Focus Mode exposed through the **Hyper+Z** chord
+and command palette. `focus.enter` targets the currently frontmost window;
+`focus.exit` restores the exact frame captured on entry.
+
+```bash
+lattices call focus.enter
+lattices call focus.status
+lattices call focus.exit
+```
+
+Each method returns the resulting `active` state. Mutating methods also return
+`ok`; `focus.enter` returns `ok: false` when there is no eligible frontmost
+window.
 
 #### `daemon.status`
 


### PR DESCRIPTION
## Summary

- add reversible Focus Mode for the frontmost window, including a blackout overlay and Escape restoration
- expose it through Hyper+Z, the command palette, and four local daemon RPCs
- restore the original window frame when Focus Mode exits or Lattices terminates
- add mouse-gesture tap-health diagnostics for future input-capture investigations

## Validation

- `git diff --check origin/main...HEAD`
- `swift build -c release` with the project build environment

