### PR TITLE
Add cross-app tab groups

### DIFF
--- a/apps/mac/Sources/AppShell/AppDelegate.swift
+++ b/apps/mac/Sources/AppShell/AppDelegate.swift
@@ -24,6 +24,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         HudLoggerSinks.install(HudLogStore.shared)
         HudLoggerSinks.install(LatticesLogDiskSink.shared)
+        traceBuildIdentity()
         HudLogger(category: "lattices").info("Lattices booted", metadata: ["state": "ready"])
 
         AppFocusRingSuppressor.install()
@@ -76,6 +77,24 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 PermissionsAssistantWindowController.shared.show()
             }
         }
+    }
+
+    /// Leave an unmistakable identity line in the persistent log for every
+    /// launch. This is especially useful when a local dev bundle and an older
+    /// installed copy are both present on the machine.
+    private func traceBuildIdentity() {
+        let info = Bundle.main.infoDictionary ?? [:]
+        let version = (info["CFBundleShortVersionString"] as? String) ?? "unknown"
+        let build = (info["CFBundleVersion"] as? String) ?? "unknown"
+        let revision = LatticesRuntime.buildRevision ?? "unknown"
+        let timestamp = LatticesRuntime.buildTimestamp ?? "unknown"
+        let bundleID = Bundle.main.bundleIdentifier ?? "unknown"
+        let bundlePath = Bundle.main.bundleURL.path
+        let executablePath = Bundle.main.executableURL?.path ?? "unknown"
+
+        let trace = "BUILD TRACE | channel=\(LatticesRuntime.buildChannel) version=\(version) build=\(build) revision=\(revision) builtAt=\(timestamp) pid=\(ProcessInfo.processInfo.processIdentifier) bundleID=\(bundleID) bundle=\(bundlePath) executable=\(executablePath)"
+        HudLogger(category: "build").info(trace)
+        NSLog("%@", trace)
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/apps/mac/Sources/Core/Actions/PaletteCommand.swift
+++ b/apps/mac/Sources/Core/Actions/PaletteCommand.swift
@@ -295,17 +295,16 @@ enum CommandBuilder {
                         category: .project,
                         badge: "group",
                         action: {
-                            if let firstTab = group.tabs.first {
-                                let session = WorkspaceManager.sessionName(for: firstTab.path)
-                                let terminal = Preferences.shared.terminal
-                                terminal.focusOrAttach(session: session)
-                            }
+                            workspace.focusTab(
+                                group: group,
+                                tabIndex: workspace.selectedTabIndex(in: group)
+                            )
                         }
                     ))
 
                     // Per-tab focus commands
                     for (idx, tab) in group.tabs.enumerated() {
-                        let tabLabel = tab.label ?? (tab.path as NSString).lastPathComponent
+                        let tabLabel = tab.displayLabel
                         let tabIndex = idx
                         commands.append(PaletteCommand(
                             id: "group-tab-\(group.id)-\(idx)",
@@ -338,7 +337,7 @@ enum CommandBuilder {
                     commands.append(PaletteCommand(
                         id: "group-launch-\(group.id)",
                         title: "Launch \(group.label)",
-                        subtitle: "\(group.tabs.count) tabs \u{2014} \(group.tabs.map { $0.label ?? ($0.path as NSString).lastPathComponent }.joined(separator: ", "))",
+                        subtitle: "\(group.tabs.count) tabs \u{2014} \(group.tabs.map(\.displayLabel).joined(separator: ", "))",
                         icon: "rectangle.stack",
                         category: .project,
                         badge: "group",

--- a/apps/mac/Sources/Core/Daemon/LatticesApi.swift
+++ b/apps/mac/Sources/Core/Daemon/LatticesApi.swift
@@ -231,6 +231,22 @@ final class LatticesApi {
             Field(name: "projectCount", type: "int", required: true, description: "Number of projects in layer"),
         ]))
 
+        api.model(ApiModel(name: "LiveTabGroup", fields: [
+            Field(name: "id", type: "string", required: true, description: "Runtime tab group identifier"),
+            Field(name: "name", type: "string", required: true, description: "Display name"),
+            Field(name: "mode", type: "string", required: true, description: "tabs or grid"),
+            Field(name: "placement", type: "string", required: true, description: "Collapsed stack placement"),
+            Field(name: "selectedIndex", type: "int", required: true, description: "Selected member index"),
+            Field(name: "members", type: "[LiveTabMember]", required: true, description: "Cross-app windows in tab order"),
+        ]))
+
+        api.model(ApiModel(name: "LiveTabMember", fields: [
+            Field(name: "wid", type: "int", required: true, description: "CGWindowID"),
+            Field(name: "pid", type: "int", required: true, description: "Process ID"),
+            Field(name: "app", type: "string", required: true, description: "Application name"),
+            Field(name: "title", type: "string", required: true, description: "Window title"),
+        ]))
+
         api.model(ApiModel(name: "Process", fields: [
             Field(name: "pid", type: "int", required: true, description: "Process ID"),
             Field(name: "ppid", type: "int", required: true, description: "Parent process ID"),
@@ -2679,6 +2695,135 @@ final class LatticesApi {
         ))
 
         api.register(Endpoint(
+            method: "tabStacks.list",
+            description: "List runtime cross-app tab stacks",
+            access: .read,
+            params: [],
+            returns: .array(model: "LiveTabGroup"),
+            handler: { _ in
+                Self.onMain { .array(LiveTabGroupStore.shared.groups.map(Self.liveTabGroup)) }
+            }
+        ))
+
+        api.register(Endpoint(
+            method: "tabStacks.create",
+            description: "Stack selected or explicit windows as live cross-app tabs",
+            access: .mutate,
+            params: [
+                Param(name: "windowIds", type: "[int]", required: false, description: "Window IDs; defaults to the current Hyperspace selection"),
+                Param(name: "name", type: "string", required: false, description: "Tab group name"),
+                Param(name: "placement", type: "string", required: false, description: "Collapsed placement, defaults to top-left"),
+            ],
+            returns: .object(model: "LiveTabGroup"),
+            handler: { params in
+                let explicit = Self.selectedWindowIds(from: params?["windowIds"])
+                let name = params?["name"]?.stringValue
+                let placement = PlacementSpec(json: params?["placement"]) ?? .tile(.topLeft)
+                return try Self.onMain {
+                    let ids = explicit.isEmpty ? LiveTabGroupStore.shared.candidateWindowIDs : explicit
+                    guard let group = LiveTabGroupStore.shared.create(
+                        windowIDs: ids,
+                        name: name,
+                        placement: placement
+                    ) else {
+                        throw RouterError.custom("Invalid windowIds: select or provide at least two live windows")
+                    }
+                    return Self.liveTabGroup(group)
+                }
+            }
+        ))
+
+        api.register(Endpoint(
+            method: "tabStacks.add",
+            description: "Add selected or explicit windows to a live tab stack",
+            access: .mutate,
+            params: [
+                Param(name: "id", type: "string", required: false, description: "Group id; defaults to the active group"),
+                Param(name: "windowIds", type: "[int]", required: false, description: "Window IDs; defaults to the current Hyperspace selection"),
+            ],
+            returns: .ok,
+            handler: { params in
+                let explicit = Self.selectedWindowIds(from: params?["windowIds"])
+                let groupID = params?["id"]?.stringValue
+                return Self.onMain {
+                    let ids = explicit.isEmpty ? LiveTabGroupStore.shared.candidateWindowIDs : explicit
+                    let added = LiveTabGroupStore.shared.add(windowIDs: ids, to: groupID)
+                    return .object(["ok": .bool(added > 0), "added": .int(added)])
+                }
+            }
+        ))
+
+        api.register(Endpoint(
+            method: "tabStacks.select",
+            description: "Select a tab by member index or window id",
+            access: .mutate,
+            params: [
+                Param(name: "id", type: "string", required: false, description: "Group id; defaults to the active group"),
+                Param(name: "index", type: "int", required: false, description: "Zero-based tab index"),
+                Param(name: "windowId", type: "int", required: false, description: "Window ID to select"),
+            ],
+            returns: .ok,
+            handler: { params in
+                try Self.onMain {
+                    guard let id = params?["id"]?.stringValue ?? LiveTabGroupStore.shared.activeGroupID else {
+                        throw RouterError.notFound("active tab stack")
+                    }
+                    if let wid = params?["windowId"]?.uint32Value {
+                        LiveTabGroupStore.shared.select(groupID: id, windowID: wid)
+                    } else if let index = params?["index"]?.intValue {
+                        LiveTabGroupStore.shared.select(groupID: id, index: index)
+                    } else {
+                        throw RouterError.missingParam("index or windowId")
+                    }
+                    return .object(["ok": .bool(true)])
+                }
+            }
+        ))
+
+        api.register(Endpoint(
+            method: "tabStacks.layout",
+            description: "Switch a live tab stack between collapsed tabs and an expanded grid",
+            access: .mutate,
+            params: [
+                Param(name: "id", type: "string", required: false, description: "Group id; defaults to the active group"),
+                Param(name: "mode", type: "string", required: false, description: "tabs, grid, or toggle"),
+            ],
+            returns: .ok,
+            handler: { params in
+                try Self.onMain {
+                    let store = LiveTabGroupStore.shared
+                    guard let id = params?["id"]?.stringValue ?? store.activeGroupID else {
+                        throw RouterError.notFound("active tab stack")
+                    }
+                    switch params?["mode"]?.stringValue?.lowercased() ?? "toggle" {
+                    case "tabs", "stack", "collapsed": store.collapse(id: id)
+                    case "grid", "expanded": store.expand(id: id)
+                    case "toggle": store.toggleLayout(id: id)
+                    default: throw RouterError.custom("Invalid mode: expected tabs, grid, or toggle")
+                    }
+                    return .object(["ok": .bool(true)])
+                }
+            }
+        ))
+
+        api.register(Endpoint(
+            method: "tabStacks.delete",
+            description: "Remove a runtime tab stack without closing its windows",
+            access: .mutate,
+            params: [Param(name: "id", type: "string", required: false, description: "Group id; defaults to the active group")],
+            returns: .ok,
+            handler: { params in
+                try Self.onMain {
+                    guard let id = params?["id"]?.stringValue ?? LiveTabGroupStore.shared.activeGroupID else {
+                        throw RouterError.notFound("active tab stack")
+                    }
+                    LiveTabGroupStore.shared.delete(id: id)
+                    return .object(["ok": .bool(true)])
+                }
+            }
+        ))
+
+        api.register(Endpoint(
             method: "projects.scan",
             description: "Trigger a rescan of project directories",
             access: .mutate,
@@ -4494,6 +4639,29 @@ private extension LatticesApi {
             return app
         }
         return distributableWindows().first?.app
+    }
+
+    static func onMain<T>(_ body: () throws -> T) rethrows -> T {
+        if Thread.isMainThread { return try body() }
+        return try DispatchQueue.main.sync(execute: body)
+    }
+
+    static func liveTabGroup(_ group: LiveTabGroup) -> JSON {
+        .object([
+            "id": .string(group.id),
+            "name": .string(group.name),
+            "mode": .string(group.isExpanded ? "grid" : "tabs"),
+            "placement": .string(group.placement.wireValue),
+            "selectedIndex": .int(group.selectedIndex),
+            "members": .array(group.members.map { member in
+                .object([
+                    "wid": .int(Int(member.id)),
+                    "pid": .int(Int(member.pid)),
+                    "app": .string(member.app),
+                    "title": .string(member.title),
+                ])
+            }),
+        ])
     }
 
     static func normalizeToken(_ raw: String) -> String {

--- a/apps/mac/Sources/Core/Desktop/InventoryManager.swift
+++ b/apps/mac/Sources/Core/Desktop/InventoryManager.swift
@@ -22,7 +22,9 @@ class InventoryManager: ObservableObject {
         if let groups = WorkspaceManager.shared.config?.groups {
             for group in groups {
                 for tab in group.tabs {
-                    managed.insert(WorkspaceManager.sessionName(for: tab.path))
+                    if let path = tab.path {
+                        managed.insert(WorkspaceManager.sessionName(for: path))
+                    }
                 }
             }
         }

--- a/apps/mac/Sources/Core/Overlays/HUD/HUDController.swift
+++ b/apps/mac/Sources/Core/Overlays/HUD/HUDController.swift
@@ -35,7 +35,13 @@ final class HUDController {
     private var previewPanel: NSPanel?
     private var minimapPanels: [NSPanel] = []
     private let hintBezels = HUDWindowHintBezels()
+    private let liveTabChromes = HUDLiveTabChromes()
     private var windowHintObserver: AnyCancellable?
+    private var liveTabObserver: AnyCancellable?
+    private var liveTabGeometryObserver: AnyCancellable?
+    private var pendingLiveTabGeometryRefresh: DispatchWorkItem?
+    private var liveTabFocusObserver: AnyCancellable?
+    private var focusedWindowObserver: AnyCancellable?
     private var keyMonitor: Any?
     private var clickMonitor: Any?
     private var mouseMovedMonitor: Any?
@@ -47,6 +53,7 @@ final class HUDController {
     private var experienceObserver: AnyCancellable?
     private var panelMoveObservers: [Any] = []
     private var lastMouseUpdate: Date = .distantPast
+    private var suppressOutsideDismissUntil: Date = .distantPast
     private let state = HUDState()
     private let previewModel = WindowPreviewStore.shared
 
@@ -170,7 +177,6 @@ final class HUDController {
         DesktopModel.shared.poll()
         precomputeTileGrid(on: screen)
         prewarmLikelyPreviews()
-
         // ── INSTANT SHOW ── alphaValue flip, zero animation
         let isExpanded = state.minimapMode == .expanded
         let showChrome = HUDExperienceStore.shared.showChrome
@@ -197,6 +203,15 @@ final class HUDController {
         installMonitors()
         applyExperienceToAllPanels()
         refreshHintBezels()
+        refreshLiveTabChromes()
+        // Window managers may report the old bounds for a few frames after the
+        // native apps make room for the rail. Re-anchor the composite once the
+        // content rect has settled so its outer frame never jumps on selection.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) { [weak self] in
+            guard self?.isVisible == true else { return }
+            DesktopModel.shared.forcePoll()
+            self?.refreshLiveTabChromes()
+        }
 
         let xp = HUDExperienceStore.shared
         if xp.has(.mouseSpecular) || xp.has(.meshLight) {
@@ -216,6 +231,12 @@ final class HUDController {
         removeMonitors()
         removeMouseMovedMonitor()
         hintBezels.setRevealed(false)
+        // Live tab groups are persistent composite windows. Dismissing Hyper-3
+        // removes only the HUD; their enclosure and reserved rail stay put.
+        refreshLiveTabChromes()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
+            self?.refreshLiveTabChromes()
+        }
 
         // Restore untiled windows only if user actually tiled something
         if !state.tiledWindows.isEmpty {
@@ -310,6 +331,7 @@ final class HUDController {
         positionMinimapPanels()
         positionedScreen = screen
         refreshHintBezels()
+        refreshLiveTabChromes()
     }
 
     private func buildMinimapPanels(dismiss: @escaping () -> Void) {
@@ -460,11 +482,55 @@ final class HUDController {
                 }
             }
 
+        // A grouped app may need a synthetic click to become key. Treat that
+        // click as part of the tab action instead of as a click outside HUD.
+        liveTabFocusObserver = NotificationCenter.default.publisher(for: .liveTabGroupWillFocusWindow)
+            .sink { [weak self] _ in
+                // AX/AppleScript focus can synthesize its click noticeably after
+                // the request on a busy desktop. Keep that owned click from
+                // dismissing the stable composite during a tab swap.
+                self?.suppressOutsideDismissUntil = Date().addingTimeInterval(3.0)
+            }
+
+        // If the user focuses a grouped app directly, reflect the real window
+        // on top so the selected tab never lies about what is being shown.
+        focusedWindowObserver = DesktopModel.shared.$focusedWindowID
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] windowID in
+                LiveTabGroupStore.shared.syncSelection(toFocusedWindow: windowID)
+                self?.refreshLiveTabChromes()
+            }
+
         // Rebuild on-window jump badges whenever the hint assignment changes
         windowHintObserver = state.$windowHints
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.refreshHintBezels() }
+
+        // Live stacks can be edited from Hyperspace, the HUD, the CLI, or an
+        // agent. Keep their spatial chrome in sync regardless of entry point.
+        liveTabObserver = LiveTabGroupStore.shared.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                DispatchQueue.main.async { self?.refreshLiveTabChromes() }
+            }
+
+        // Native layout changes settle asynchronously in some apps. Coalesce
+        // their follow-up inventory/positioning into one refresh; selection-only
+        // tab swaps intentionally stay on the immediate path above.
+        liveTabGeometryObserver = NotificationCenter.default.publisher(for: .liveTabGroupGeometryDidChange)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.pendingLiveTabGeometryRefresh?.cancel()
+                let work = DispatchWorkItem { [weak self] in
+                    DesktopModel.shared.forcePoll()
+                    self?.refreshLiveTabChromes()
+                }
+                self.pendingLiveTabGeometryRefresh = work
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.4, execute: work)
+            }
 
         // Re-apply experience settings when preset changes
         experienceObserver = HUDExperienceStore.shared.$presetIndex
@@ -1304,8 +1370,9 @@ final class HUDController {
             let loc = NSEvent.mouseLocation
             let inAny = self.allPanels
                 .compactMap { $0 }
-                .contains { $0.frame.contains(loc) }
-            if !inAny { self.dismiss() }
+                .contains { $0.frame.contains(loc) } || self.liveTabChromes.contains(loc)
+            let isOwnedLiveTabFocus = Date() < self.suppressOutsideDismissUntil
+            if !inAny && !isOwnedLiveTabFocus { self.dismiss() }
         }
     }
 
@@ -1328,6 +1395,24 @@ final class HUDController {
             obscuredBy: obscured
         )
         hintBezels.setRevealed(true)
+    }
+
+    /// Position browser-like tab bars on the actual grouped windows. This is
+    /// intentionally Hyper-3-only for now; the runtime group itself persists
+    /// after dismissal, ready for a future always-on chrome mode.
+    private func refreshLiveTabChromes() {
+        LiveTabGroupStore.shared.syncSelection(toFocusedWindow: DesktopModel.shared.focusedWindowID)
+        let obscured = (isVisible ? [topPanel, leftPanel, rightPanel] : [])
+            .compactMap { panel -> NSRect? in
+                guard let panel, panel.alphaValue > 0.5 else { return nil }
+                return panel.frame
+            }
+        liveTabChromes.update(
+            groups: LiveTabGroupStore.shared.groups,
+            windows: DesktopModel.shared.windows,
+            obscuredBy: obscured
+        )
+        liveTabChromes.setRevealed(true)
     }
 
     private func mouseScreen() -> NSScreen {

--- a/apps/mac/Sources/Core/Overlays/HUD/HUDLeftBar.swift
+++ b/apps/mac/Sources/Core/Overlays/HUD/HUDLeftBar.swift
@@ -7,6 +7,7 @@ struct HUDLeftBar: View {
     @ObservedObject private var scanner = ProjectScanner.shared
     @ObservedObject private var desktop = DesktopModel.shared
     @ObservedObject private var workspace = WorkspaceManager.shared
+    @ObservedObject private var liveTabs = LiveTabGroupStore.shared
     @ObservedObject private var xp = HUDExperienceStore.shared
     @FocusState private var searchFieldFocused: Bool
     @State private var resizeStartWidth: CGFloat?
@@ -92,6 +93,11 @@ struct HUDLeftBar: View {
             searchBar
 
             HUDHairline(opacity: 0.85)
+
+            if let group = liveTabs.activeGroup {
+                liveTabDeck(group)
+                HUDHairline(opacity: 0.85)
+            }
 
             // Tile mode banner
             if state.tileMode {
@@ -198,6 +204,196 @@ struct HUDLeftBar: View {
                 searchFieldFocused = state.focus == .search
             }
         }
+    }
+
+    // MARK: - Live tab deck
+
+    /// The HUD sidebar is always present, even in freeform/no-chrome presets.
+    /// Give live cross-app tabs a proper home here instead of relying on the
+    /// compact top strip, which is intentionally hidden by some HUD experiences.
+    private func liveTabDeck(_ group: LiveTabGroup) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                ZStack {
+                    Circle()
+                        .fill(HUDChrome.cyan.opacity(0.16))
+                        .frame(width: 24, height: 24)
+                    Image(systemName: "rectangle.stack.fill")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(HUDChrome.cyan)
+                }
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("LIVE TAB STACK")
+                        .font(Typo.monoBold(8))
+                        .tracking(1.1)
+                        .foregroundStyle(HUDChrome.cyan.opacity(0.82))
+                    Text(group.name)
+                        .font(Typo.heading(12))
+                        .foregroundStyle(Palette.text)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 4)
+
+                Text("\(group.members.count) TABS")
+                    .font(Typo.monoBold(8))
+                    .foregroundStyle(Palette.textDim)
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 4)
+                    .background(Capsule().fill(Color.white.opacity(0.06)))
+                    .overlay(Capsule().strokeBorder(HUDChrome.glassStrokeSoft, lineWidth: 0.5))
+            }
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 7) {
+                    ForEach(Array(group.members.enumerated()), id: \.element.id) { index, member in
+                        liveTabCard(member, index: index, group: group)
+                    }
+                }
+                .padding(.horizontal, 1)
+                .padding(.vertical, 2)
+            }
+
+            HStack(spacing: 7) {
+                HStack(spacing: 5) {
+                    Circle()
+                        .fill(group.isExpanded ? Palette.detach : Palette.running)
+                        .frame(width: 5, height: 5)
+                        .shadow(color: (group.isExpanded ? Palette.detach : Palette.running).opacity(0.65), radius: 4)
+                    Text(group.isExpanded ? "GRID VIEW" : "STACKED · TOP LEFT")
+                        .font(Typo.monoBold(8))
+                        .foregroundStyle(Palette.textDim)
+                }
+
+                Spacer()
+
+                liveTabControl(
+                    icon: group.isExpanded ? "rectangle.stack.fill" : "square.grid.2x2",
+                    label: group.isExpanded ? "STACK" : "GRID",
+                    active: group.isExpanded
+                ) {
+                    liveTabs.toggleLayout(id: group.id)
+                }
+
+                liveTabControl(icon: "xmark", label: "UNGROUP", destructive: true) {
+                    liveTabs.delete(id: group.id)
+                }
+            }
+        }
+        .padding(11)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [HUDChrome.cyan.opacity(0.10), Color.white.opacity(0.035)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .strokeBorder(
+                            LinearGradient(
+                                colors: [HUDChrome.cyan.opacity(0.46), HUDChrome.glassStrokeSoft],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            ),
+                            lineWidth: 0.75
+                        )
+                )
+        )
+        .shadow(color: HUDChrome.cyan.opacity(0.08), radius: 14, y: 4)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 10)
+        .transition(.move(edge: .top).combined(with: .opacity))
+        .animation(.easeOut(duration: 0.18), value: group.id)
+    }
+
+    private func liveTabCard(_ member: LiveTabMember, index: Int, group: LiveTabGroup) -> some View {
+        let selected = group.selectedIndex == index
+        return Button {
+            liveTabs.select(groupID: group.id, index: index)
+        } label: {
+            VStack(alignment: .leading, spacing: 7) {
+                HStack(spacing: 6) {
+                    Image(systemName: liveTabIcon(for: member.app))
+                        .font(.system(size: 11, weight: .semibold))
+                    Text(member.app)
+                        .font(Typo.monoBold(9))
+                        .lineLimit(1)
+                    Spacer(minLength: 0)
+                    if selected {
+                        Circle()
+                            .fill(HUDChrome.onSignal)
+                            .frame(width: 5, height: 5)
+                    }
+                }
+
+                Text(member.label)
+                    .font(Typo.caption(9))
+                    .lineLimit(1)
+                    .foregroundStyle(selected ? HUDChrome.onSignal.opacity(0.70) : Palette.textMuted)
+            }
+            .foregroundStyle(selected ? HUDChrome.onSignal : Palette.text)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 9)
+            .frame(width: 132, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .fill(selected ? AnyShapeStyle(HUDChrome.activeGradient) : AnyShapeStyle(Color.white.opacity(0.045)))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 9, style: .continuous)
+                            .strokeBorder(selected ? Color.white.opacity(0.28) : HUDChrome.glassStrokeSoft, lineWidth: 0.6)
+                    )
+            )
+            .shadow(color: selected ? HUDChrome.cyan.opacity(0.20) : .clear, radius: 8, y: 3)
+        }
+        .buttonStyle(.plain)
+        .help("Show \(member.app): \(member.label)")
+    }
+
+    private func liveTabControl(
+        icon: String,
+        label: String,
+        active: Bool = false,
+        destructive: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                Image(systemName: icon)
+                    .font(.system(size: 8, weight: .bold))
+                Text(label)
+                    .font(Typo.monoBold(8))
+            }
+            .foregroundStyle(destructive ? Palette.kill.opacity(0.86) : (active ? HUDChrome.onSignal : Palette.textDim))
+            .padding(.horizontal, 7)
+            .frame(height: 23)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(active ? HUDChrome.cyan : Color.white.opacity(0.045))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(destructive ? Palette.kill.opacity(0.18) : HUDChrome.glassStrokeSoft, lineWidth: 0.5)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func liveTabIcon(for app: String) -> String {
+        let value = app.lowercased()
+        if value.contains("terminal") || value.contains("iterm") || value.contains("warp") {
+            return "terminal.fill"
+        }
+        if value.contains("chrome") || value.contains("safari") || value.contains("firefox") || value.contains("arc") {
+            return "globe"
+        }
+        if value.contains("xcode") || value.contains("code") || value.contains("cursor") || value.contains("zed") {
+            return "chevron.left.forwardslash.chevron.right"
+        }
+        return "macwindow"
     }
 
     /// Push flat items + section offsets to state so HUDController's key handler can use them

--- a/apps/mac/Sources/Core/Overlays/HUD/HUDTopBar.swift
+++ b/apps/mac/Sources/Core/Overlays/HUD/HUDTopBar.swift
@@ -6,6 +6,7 @@ struct HUDTopBar: View {
     @ObservedObject var state: HUDState
     @ObservedObject private var handsOff = HandsOffSession.shared
     @ObservedObject private var workspace = WorkspaceManager.shared
+    @ObservedObject private var liveTabs = LiveTabGroupStore.shared
     @ObservedObject private var xp = HUDExperienceStore.shared
     var onDismiss: () -> Void
 
@@ -24,6 +25,14 @@ struct HUDTopBar: View {
             // Voice status (when active)
             if state.voiceActive {
                 voiceStatus
+                    .padding(.leading, 12)
+            }
+
+            if let group = liveTabs.activeGroup {
+                liveTabStrip(group)
+                    .padding(.leading, 12)
+            } else if let group = workspace.activeLayerGroups.first {
+                mixedTabStrip(group)
                     .padding(.leading, 12)
             }
 
@@ -64,6 +73,139 @@ struct HUDTopBar: View {
         .frame(height: 44)
         .background(HUDPanelBackground())
         .hudEdgeGlow()
+    }
+
+    // MARK: - Cross-app tabs
+
+    private func liveTabStrip(_ group: LiveTabGroup) -> some View {
+        HStack(spacing: 3) {
+            Text(group.name)
+                .font(Typo.monoBold(8))
+                .foregroundColor(Palette.textMuted)
+                .padding(.horizontal, 5)
+
+            ForEach(Array(group.members.enumerated()), id: \.element.id) { index, member in
+                let isSelected = group.selectedIndex == index
+                Button {
+                    liveTabs.select(groupID: group.id, index: index)
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "macwindow")
+                            .font(.system(size: 8, weight: .semibold))
+                        Text(member.app)
+                            .lineLimit(1)
+                    }
+                    .font(Typo.monoBold(8))
+                    .foregroundColor(isSelected ? Palette.bg : Palette.textMuted)
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 4)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(isSelected ? Palette.running : Color.white.opacity(0.04))
+                    )
+                }
+                .buttonStyle(.plain)
+                .help("Show \(member.app): \(member.label)")
+            }
+
+            Button {
+                liveTabs.toggleLayout(id: group.id)
+            } label: {
+                Image(systemName: group.isExpanded ? "rectangle.stack.fill" : "square.grid.2x2")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(group.isExpanded ? Palette.running : Palette.textMuted)
+                    .frame(width: 24, height: 22)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(Color.white.opacity(0.04))
+                    )
+            }
+            .buttonStyle(.plain)
+            .help(group.isExpanded ? "Collapse to tabs" : "Expand to grid")
+
+            Button {
+                liveTabs.delete(id: group.id)
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 8, weight: .semibold))
+                    .foregroundColor(Palette.textMuted)
+                    .frame(width: 20, height: 22)
+            }
+            .buttonStyle(.plain)
+            .help("Ungroup live tabs")
+        }
+        .padding(3)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.black.opacity(0.28))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .strokeBorder(Palette.running.opacity(0.45), lineWidth: 0.5)
+                )
+        )
+    }
+
+    /// A layer group can mix terminal projects and native app windows. All tabs
+    /// occupy the group's configured tile until the grid button fans them out.
+    private func mixedTabStrip(_ group: TabGroup) -> some View {
+        HStack(spacing: 3) {
+            Text(group.label)
+                .font(Typo.monoBold(8))
+                .foregroundColor(Palette.textMuted)
+                .padding(.horizontal, 5)
+
+            ForEach(Array(group.tabs.enumerated()), id: \.offset) { index, tab in
+                let isSelected = workspace.selectedTabIndex(in: group) == index
+                let isRunning = workspace.isTabRunning(tab)
+                Button {
+                    workspace.focusTab(group: group, tabIndex: index)
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: tab.isTerminal ? "terminal" : "macwindow")
+                            .font(.system(size: 8, weight: .semibold))
+                        Text(tab.displayLabel)
+                            .lineLimit(1)
+                    }
+                    .font(Typo.monoBold(8))
+                    .foregroundColor(isSelected ? Palette.bg : Palette.textMuted)
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 4)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(isSelected ? Palette.running : Color.white.opacity(0.04))
+                    )
+                }
+                .buttonStyle(.plain)
+                .opacity(isRunning ? 1 : 0.55)
+                .help(isRunning ? "Show \(tab.displayLabel)" : "Open \(tab.displayLabel)")
+            }
+
+            Button {
+                workspace.toggleGroupLayout(group)
+            } label: {
+                Image(systemName: workspace.isGroupExpanded(group)
+                    ? "rectangle.stack.fill"
+                    : "square.grid.2x2")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(workspace.isGroupExpanded(group) ? Palette.running : Palette.textMuted)
+                    .frame(width: 24, height: 22)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(Color.white.opacity(0.04))
+                    )
+            }
+            .buttonStyle(.plain)
+            .help(workspace.isGroupExpanded(group) ? "Collapse to tabs" : "Expand to grid")
+        }
+        .padding(3)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.black.opacity(0.28))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .strokeBorder(Palette.border, lineWidth: 0.5)
+                )
+        )
     }
 
     // MARK: - Experience badge

--- a/apps/mac/Sources/Core/Overlays/HUD/HUDWindowHints.swift
+++ b/apps/mac/Sources/Core/Overlays/HUD/HUDWindowHints.swift
@@ -67,6 +67,425 @@ struct HUDWindowHintBadge: View {
     }
 }
 
+// MARK: - Live tab chrome
+
+/// Compact app-level tool palette hovering over a live group. It deliberately
+/// avoids the silhouette of native window chrome: the underlying app keeps its
+/// complete title bar and geometry, while Lattices presents grouping actions.
+struct HUDLiveTabChrome: View {
+    let group: LiveTabGroup
+    private let store = LiveTabGroupStore.shared
+    @State private var draggingMemberID: UInt32?
+    @State private var dragTranslation: CGSize = .zero
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 0) {
+            HStack(spacing: 6) {
+                Image(systemName: "rectangle.stack.fill")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(Color.white.opacity(0.50))
+                Text(group.name)
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(Color.white.opacity(0.82))
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 9)
+            .frame(minWidth: 92, maxWidth: 130, minHeight: 29, alignment: .leading)
+
+            Rectangle()
+                .fill(Color.white.opacity(0.09))
+                .frame(width: 1, height: 17)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(alignment: .center, spacing: 4) {
+                    ForEach(Array(group.members.enumerated()), id: \.element.id) { index, member in
+                        tab(member, index: index)
+                    }
+                }
+                .padding(.leading, 7)
+                .padding(.trailing, 5)
+            }
+
+            Rectangle()
+                .fill(Color.white.opacity(0.09))
+                .frame(width: 1, height: 17)
+
+            HStack(spacing: 2) {
+                modeButton
+                Button {
+                    store.delete(id: group.id)
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 8, weight: .semibold))
+                        .foregroundStyle(Color.white.opacity(0.34))
+                        .frame(width: 27, height: 27)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help("Ungroup \(group.name)")
+                .accessibilityLabel("Ungroup \(group.name)")
+            }
+            .padding(.horizontal, 5)
+        }
+        .frame(height: 38)
+        .background(
+            RoundedRectangle(cornerRadius: 11, style: .continuous)
+                .fill(railGradient)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 11, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.18), lineWidth: 0.75)
+        )
+        .shadow(color: Color.black.opacity(0.38), radius: 9, y: 4)
+    }
+
+    private var railGradient: LinearGradient {
+        LinearGradient(
+            colors: [
+                Color(red: 0.13, green: 0.15, blue: 0.17),
+                Color(red: 0.10, green: 0.12, blue: 0.14),
+            ],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+    }
+
+    private func tab(_ member: LiveTabMember, index: Int) -> some View {
+        let selected = index == group.selectedIndex
+        let isDragging = draggingMemberID == member.id
+        let helpText = "Show \(member.app): \(member.label)"
+        let accessibilityText = "\(member.app) tab, \(member.label)" + (selected ? ", selected" : "")
+        let dragX = isDragging ? max(-12, min(12, dragTranslation.width * 0.12)) : 0
+        let dragY = isDragging ? max(-3, min(3, dragTranslation.height * 0.08)) : 0
+        let tabFace = AnyView(HStack(spacing: 7) {
+            Image(systemName: icon(for: member.app))
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(selected ? HUDChrome.cyan : Color.white.opacity(0.30))
+            Text(displayName(for: member.app))
+                .font(.system(size: 10, weight: .medium))
+                .lineLimit(1)
+        }
+        .foregroundStyle(selected ? Color.white.opacity(0.94) : Color.white.opacity(0.48))
+        .padding(.horizontal, 11)
+        .frame(minWidth: 92, maxWidth: 124, minHeight: 28, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .fill(selected ? Color.white.opacity(0.11) : Color.clear)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .strokeBorder(selected ? HUDChrome.cyan.opacity(0.28) : Color.clear, lineWidth: 0.7)
+                )
+        )
+        )
+        return tabFace
+        .contentShape(Rectangle())
+        .offset(x: dragX, y: dragY)
+        .scaleEffect(isDragging ? 1.025 : 1)
+        .shadow(color: isDragging ? Color.black.opacity(0.35) : .clear, radius: 4, y: 2)
+        .zIndex(isDragging ? 10 : 0)
+        .onTapGesture {
+            store.select(groupID: group.id, index: index)
+        }
+        .gesture(
+            DragGesture(minimumDistance: 6, coordinateSpace: .global)
+                .onChanged { value in
+                    draggingMemberID = member.id
+                    dragTranslation = value.translation
+                }
+                .onEnded { value in
+                    let shouldDetach = abs(value.translation.height) >= 22
+                        || abs(value.translation.width) >= 72
+                    draggingMemberID = nil
+                    dragTranslation = .zero
+                    if shouldDetach {
+                        store.detach(
+                            groupID: group.id,
+                            windowID: member.id,
+                            at: NSEvent.mouseLocation
+                        )
+                    }
+                }
+        )
+        .help(helpText)
+        .accessibilityLabel(accessibilityText)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAction { store.select(groupID: group.id, index: index) }
+    }
+
+    private var modeButton: some View {
+        Button {
+            store.toggleLayout(id: group.id)
+        } label: {
+            Image(systemName: group.isExpanded ? "rectangle.stack.fill" : "square.grid.2x2")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(group.isExpanded ? Color.black.opacity(0.78) : Color.white.opacity(0.42))
+                .frame(width: 29, height: 27)
+                .contentShape(Rectangle())
+                .background(
+                    RoundedRectangle(cornerRadius: 5)
+                        .fill(group.isExpanded ? Color.white.opacity(0.86) : Color.white.opacity(0.035))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 5)
+                                .strokeBorder(Color.white.opacity(group.isExpanded ? 0.18 : 0.07), lineWidth: 0.6)
+                        )
+                )
+        }
+        .buttonStyle(.plain)
+        .help(group.isExpanded ? "Stack these windows as tabs" : "Show these tabs in a grid")
+        .accessibilityLabel(group.isExpanded ? "Stack tabs" : "Show tab grid")
+    }
+
+    private func icon(for app: String) -> String {
+        let value = app.lowercased()
+        if value.contains("terminal") || value.contains("iterm") || value.contains("warp") { return "terminal.fill" }
+        if value.contains("chrome") || value.contains("safari") || value.contains("firefox") || value.contains("arc") { return "globe" }
+        if value.contains("xcode") || value.contains("code") || value.contains("cursor") || value.contains("zed") {
+            return "chevron.left.forwardslash.chevron.right"
+        }
+        return "macwindow"
+    }
+
+    private func displayName(for app: String) -> String {
+        let value = app.lowercased()
+        if value.contains("chrome") { return "Chrome" }
+        if value.contains("iterm") { return "iTerm" }
+        if value == "terminal" || value.contains("terminal.app") { return "Terminal" }
+        if value.contains("visual studio code") { return "Code" }
+        return app
+    }
+}
+
+/// A click-through guide showing which native window belongs to the Lattices
+/// rail. It deliberately avoids a filled chassis or complete window outline:
+/// Lattices owns the grouping relationship, while each app remains visibly native.
+private struct HUDLiveTabGroupGuide: View {
+    var body: some View {
+        ZStack {
+            corner
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            corner
+                .rotationEffect(.degrees(90))
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+            corner
+                .rotationEffect(.degrees(-90))
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+            corner
+                .rotationEffect(.degrees(180))
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+        }
+        .padding(4)
+    }
+
+    private var corner: some View {
+        ZStack(alignment: .topLeading) {
+            Color.white.opacity(0.18).frame(width: 18, height: 1)
+            Color.white.opacity(0.18).frame(width: 1, height: 18)
+        }
+        .frame(width: 18, height: 18)
+    }
+}
+
+/// Owns one interactive floating tool palette per live group. The palette sits
+/// over the native window without changing its frame; a separate click-through
+/// corner guide communicates membership without imitating window chrome.
+final class HUDLiveTabChromes {
+    private struct Chrome {
+        let panel: NSPanel
+        let hosting: NSHostingView<HUDLiveTabChrome>
+        let framePanel: NSPanel
+    }
+
+    private var chromes: [String: Chrome] = [:]
+    private var visibleGroupIDs: Set<String> = []
+    private var framedGroupIDs: Set<String> = []
+    private var anchorWindowIDs: [String: UInt32] = [:]
+    private(set) var revealed = false
+
+    func update(groups: [LiveTabGroup], windows: [UInt32: WindowEntry], obscuredBy obscured: [NSRect]) {
+        let primaryHeight = NSScreen.screens.first?.frame.height ?? 900
+        let groupIDs = Set(groups.map(\.id))
+        for id in Array(chromes.keys) where !groupIDs.contains(id) { drop(id) }
+
+        var nextVisible: Set<String> = []
+        var nextFramed: Set<String> = []
+        for group in groups {
+            guard !group.members.isEmpty else { continue }
+            let selected = min(group.selectedIndex, group.members.count - 1)
+            let orderedMembers = [group.members[selected]] + group.members.enumerated()
+                .filter { $0.offset != selected }
+                .map(\.element)
+            guard let anchor = orderedMembers.compactMap({ windows[$0.id] }).first(where: \.isOnScreen) else { continue }
+
+            let anchorFrame = Self.appKitRect(for: anchor.frame, primaryHeight: primaryHeight)
+            let compositeFrame: NSRect
+            let windowFrame: NSRect
+            if group.isExpanded {
+                compositeFrame = anchorFrame
+                windowFrame = anchorFrame
+            } else {
+                // Anchor the guide to the group's intended tile rather than a
+                // transient native-window measurement. The palette does not
+                // reserve layout space inside that tile.
+                let base = WindowTiler.tileFrame(for: group.placement, on: group.screen)
+                compositeFrame = NSRect(
+                    x: base.minX,
+                    y: primaryHeight - base.maxY,
+                    width: base.width,
+                    height: base.height
+                )
+                windowFrame = NSRect(
+                    x: compositeFrame.minX,
+                    y: compositeFrame.minY,
+                    width: compositeFrame.width,
+                    height: compositeFrame.height
+                )
+            }
+            var minX = windowFrame.minX
+            var maxX = windowFrame.maxX
+            var top = windowFrame.maxY - 6
+
+            for frame in obscured where frame.intersects(windowFrame) {
+                if frame.maxX > minX, frame.midX <= windowFrame.midX { minX = max(minX, frame.maxX + 7) }
+                if frame.minX < maxX, frame.midX > windowFrame.midX { maxX = min(maxX, frame.minX - 7) }
+                let crossesWindowCenter = frame.minX <= windowFrame.midX && frame.maxX >= windowFrame.midX
+                if crossesWindowCenter, frame.minY < top, frame.maxY >= top { top = frame.minY - 4 }
+            }
+
+            let availableWidth = maxX - minX - 20
+            guard availableWidth >= 300 else { continue }
+            let preferredWidth = CGFloat(168 + group.members.count * 98)
+            let width = min(availableWidth, min(620, max(340, preferredWidth)))
+            let centeredX = windowFrame.midX - width / 2
+            let x = min(max(centeredX, minX + 10), maxX - width - 10)
+            let chrome = chromes[group.id] ?? makeChrome(group: group)
+            anchorWindowIDs[group.id] = anchor.wid
+            chrome.hosting.rootView = HUDLiveTabChrome(group: group)
+            chrome.panel.setFrame(NSRect(x: x, y: top - 38, width: width, height: 38), display: true)
+            if group.isExpanded {
+                chrome.framePanel.alphaValue = 0
+                chrome.framePanel.orderOut(nil)
+            } else {
+                chrome.framePanel.setFrame(
+                    compositeFrame,
+                    display: true
+                )
+                nextFramed.insert(group.id)
+            }
+            chromes[group.id] = chrome
+            nextVisible.insert(group.id)
+        }
+
+        visibleGroupIDs = nextVisible
+        framedGroupIDs = nextFramed
+        applyVisibility()
+    }
+
+    func setRevealed(_ on: Bool) {
+        revealed = on
+        applyVisibility()
+    }
+
+    func contains(_ point: NSPoint) -> Bool {
+        chromes.values.contains { $0.panel.alphaValue > 0.5 && $0.panel.frame.contains(point) }
+    }
+
+    func clear() {
+        revealed = false
+        for chrome in chromes.values {
+            chrome.panel.orderOut(nil)
+            chrome.framePanel.orderOut(nil)
+        }
+        chromes.removeAll()
+        visibleGroupIDs.removeAll()
+        framedGroupIDs.removeAll()
+        anchorWindowIDs.removeAll()
+    }
+
+    private func applyVisibility() {
+        for (id, chrome) in chromes {
+            let shouldShow = revealed && visibleGroupIDs.contains(id)
+            chrome.panel.alphaValue = shouldShow ? 1 : 0
+            chrome.panel.ignoresMouseEvents = !shouldShow
+            if shouldShow {
+                // Keep the guide directly above its native app, with the
+                // interactive rail directly above the guide. Other normal app
+                // windows can still cover the entire group naturally.
+                let relativeWindow = anchorWindowIDs[id].map(Int.init) ?? 0
+                if framedGroupIDs.contains(id) {
+                    chrome.framePanel.alphaValue = 1
+                    chrome.framePanel.order(.above, relativeTo: relativeWindow)
+                } else {
+                    chrome.framePanel.alphaValue = 0
+                    chrome.framePanel.orderOut(nil)
+                }
+                let railRelative = framedGroupIDs.contains(id)
+                    ? chrome.framePanel.windowNumber
+                    : relativeWindow
+                chrome.panel.order(.above, relativeTo: railRelative)
+            } else {
+                chrome.framePanel.alphaValue = 0
+                chrome.framePanel.orderOut(nil)
+            }
+        }
+    }
+
+    private func drop(_ id: String) {
+        chromes[id]?.panel.orderOut(nil)
+        chromes[id]?.framePanel.orderOut(nil)
+        chromes[id] = nil
+        framedGroupIDs.remove(id)
+        anchorWindowIDs.removeValue(forKey: id)
+    }
+
+    private func makeChrome(group: LiveTabGroup) -> Chrome {
+        let hosting = NSHostingView(rootView: HUDLiveTabChrome(group: group))
+        hosting.sizingOptions = []
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 700, height: 38),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.level = .normal
+        panel.hasShadow = false
+        panel.hidesOnDeactivate = false
+        panel.isReleasedWhenClosed = false
+        panel.ignoresMouseEvents = true
+        panel.alphaValue = 0
+        panel.sharingType = .readOnly
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+        panel.contentView = hosting
+
+        let frameHosting = NSHostingView(rootView: HUDLiveTabGroupGuide())
+        frameHosting.sizingOptions = []
+        let framePanel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 700, height: 500),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        framePanel.isOpaque = false
+        framePanel.backgroundColor = .clear
+        framePanel.level = .normal
+        framePanel.hasShadow = false
+        framePanel.hidesOnDeactivate = false
+        framePanel.isReleasedWhenClosed = false
+        framePanel.ignoresMouseEvents = true
+        framePanel.alphaValue = 0
+        framePanel.sharingType = .readOnly
+        framePanel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+        framePanel.contentView = frameHosting
+
+        return Chrome(panel: panel, hosting: hosting, framePanel: framePanel)
+    }
+
+    private static func appKitRect(for frame: WindowFrame, primaryHeight: CGFloat) -> NSRect {
+        NSRect(x: frame.x, y: primaryHeight - frame.y - frame.h, width: frame.w, height: frame.h)
+    }
+}
+
 // MARK: - Overlay manager
 
 /// Manages one borderless, click-through panel per on-screen, unoccluded hinted

--- a/apps/mac/Sources/Core/Overlays/Motion/InPlaceChordHints.swift
+++ b/apps/mac/Sources/Core/Overlays/Motion/InPlaceChordHints.swift
@@ -280,32 +280,73 @@ final class InPlaceChordHintOverlay {
             if let keyEventTap { CGEvent.tapEnable(tap: keyEventTap, enable: true) }
             return Unmanaged.passUnretained(event)
         }
-        guard isVisible, type == .keyDown || type == .keyUp,
-              let nsEvent = NSEvent(cgEvent: event) else {
+        guard isVisible, type == .keyDown || type == .keyUp else {
             return Unmanaged.passUnretained(event)
         }
 
-        let flags = nsEvent.modifierFlags.intersection(.deviceIndependentFlagsMask)
-        guard flags.isEmpty || flags == .capsLock else {
+        // This callback runs on EventTapThread. AppKit's
+        // `charactersIgnoringModifiers` consults the current input source and
+        // asserts when invoked off its expected queue (which was the source of
+        // the SIGTRAP that took down the menu-bar app). Stay in CGEvent here:
+        // the overlay's labels are intentionally the fixed QWERTY home-row
+        // letters, so physical key codes are the correct match as well.
+        let disallowedModifiers: CGEventFlags = [
+            .maskShift, .maskControl, .maskAlternate, .maskCommand,
+            .maskSecondaryFn,
+        ]
+        guard event.flags.intersection(disallowedModifiers).isEmpty else {
             return Unmanaged.passUnretained(event)
         }
 
-        if nsEvent.keyCode == 53 {
+        let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+        if keyCode == 53 { // Escape
             if type == .keyDown {
                 DispatchQueue.main.async { [weak self] in self?.dismiss() }
             }
             return nil
         }
 
-        guard let key = nsEvent.charactersIgnoringModifiers?.lowercased(),
-              key.count == 1,
-              key.first?.isLetter == true else {
+        guard let key = Self.qwertyLetter(for: keyCode) else {
             return Unmanaged.passUnretained(event)
         }
         if type == .keyDown {
             DispatchQueue.main.async { [weak self] in self?.jump(to: key) }
         }
         return nil
+    }
+
+    /// US-QWERTY virtual-key-code mapping. These codes are layout-independent
+    /// and therefore safe to use from the event-tap run loop.
+    private static func qwertyLetter(for keyCode: Int64) -> String? {
+        switch keyCode {
+        case 0: return "a"
+        case 1: return "s"
+        case 2: return "d"
+        case 3: return "f"
+        case 4: return "h"
+        case 5: return "g"
+        case 6: return "z"
+        case 7: return "x"
+        case 8: return "c"
+        case 9: return "v"
+        case 11: return "b"
+        case 12: return "q"
+        case 13: return "w"
+        case 14: return "e"
+        case 15: return "r"
+        case 16: return "y"
+        case 17: return "t"
+        case 31: return "o"
+        case 32: return "u"
+        case 34: return "i"
+        case 35: return "p"
+        case 37: return "l"
+        case 38: return "j"
+        case 40: return "k"
+        case 45: return "n"
+        case 46: return "m"
+        default: return nil
+        }
     }
 
     private func startPolling() {

--- a/apps/mac/Sources/Core/Overlays/Motion/WindowMotionMode.swift
+++ b/apps/mac/Sources/Core/Overlays/Motion/WindowMotionMode.swift
@@ -117,9 +117,11 @@ final class WindowMotionMode {
         p.loadStart = t0
         p.beginLoadTrace()
         let tInit = CACurrentMediaTime()
-        p.onSelection = { [weak self] entry in
-            self?.finishWindowPick(.selected(entry))
-            self?.deactivate()
+        if selectingWindow {
+            p.onSelection = { [weak self] entry in
+                self?.finishWindowPick(.selected(entry))
+                self?.deactivate()
+            }
         }
         p.onExit = { [weak self] in
             guard let self else { return }
@@ -1007,14 +1009,20 @@ private final class MotionPanel: NSPanel {
     }
 
     /// Command-modified keys arrive here, not in `keyDown`. ⌘L remembers the
-    /// current plucked set as a rule-backed Studio layer — the one ⌘-combo we
-    /// claim while the survey is up (every letter is a pluck hint in Exposé, so
-    /// a bare key won't do).
+    /// current plucked set as a rule-backed Studio layer; ⌘T turns it into a
+    /// live cross-app tab stack.
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
-        if event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
-           event.keyCode == 37 {                                // ⌘L — save the pluck as a layer
+        guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command else {
+            return super.performKeyEquivalent(with: event)
+        }
+        if event.keyCode == 37 {                                // ⌘L — save the pluck as a layer
             guard !selectionOnly else { NSSound.beep(); return true }
             saveGroupAsLayer()
+            return true
+        }
+        if event.keyCode == 17 {                                // ⌘T — stack the pluck as tabs
+            guard !selectionOnly else { NSSound.beep(); return true }
+            createLiveTabsFromSelection()
             return true
         }
         return super.performKeyEquivalent(with: event)
@@ -1115,6 +1123,35 @@ private final class MotionPanel: NSPanel {
         let layer = StudioLayerStore.shared.saveFromPluck(picked)
         DiagnosticLog.shared.info("Motion — saved \(picked.count) selected windows as layer '\(layer.name)' [\(layer.summary)]")
         LayerBezel.shared.show(label: "Saved · \(layer.name)", index: 0, total: 1, allLabels: ["Saved · \(layer.name)"])
+    }
+
+    /// Turn the current per-display pluck into an ephemeral tab stack. The same
+    /// selection is published to `LiveTabGroupStore` continuously, so the
+    /// assistant and daemon agents can perform this exact action too.
+    private func createLiveTabsFromSelection(on targetScreen: NSScreen? = nil) {
+        let picked: [WindowEntry]
+        if let targetScreen {
+            let id = MotionPanel.screenID(targetScreen)
+            let ids = pickOrderByScreen[id] ?? []
+            picked = ids.compactMap { wid in eligible.first(where: { $0.wid == wid }) }
+        } else {
+            picked = orderedGroup()
+        }
+        guard picked.count >= 2 else { NSSound.beep(); return }
+        LiveTabGroupStore.shared.captureCandidateSelection(picked.map(\.wid))
+        guard let tabs = LiveTabGroupStore.shared.create(
+            windowIDs: picked.map(\.wid),
+            placement: .tile(.topLeft),
+            screen: targetScreen ?? activeSurveyScreen ?? screen(for: picked[0])
+        ) else { NSSound.beep(); return }
+        AppFeedback.shared.commitTactile()
+        LayerBezel.shared.show(
+            label: "Tabs · \(tabs.name)",
+            index: 0,
+            total: 1,
+            allLabels: ["Tabs · \(tabs.name)"]
+        )
+        onExit?()
     }
 
     // MARK: - Single-window operations (on the active window)
@@ -2451,6 +2488,10 @@ private final class MotionPanel: NSPanel {
                     guard let self, !self.selectionOnly else { return }
                     self.gatherInPlace(on: screen)
                 },
+                onStackSelection: { [weak self] in
+                    guard let self, !self.selectionOnly else { return }
+                    self.createLiveTabsFromSelection(on: screen)
+                },
                 onSwapFirstTwo: { [weak self] in
                     guard let self, !self.selectionOnly, let a = self.pickOrderByScreen[id]?[safe: 0],
                           let b = self.pickOrderByScreen[id]?[safe: 1] else { NSSound.beep(); return }
@@ -3441,6 +3482,10 @@ private final class MotionPanel: NSPanel {
     }
 
     private func updateStack() {
+        let groupMembers = orderedGroup()
+        if !selectionOnly {
+            LiveTabGroupStore.shared.captureCandidateSelection(groupMembers.map(\.wid))
+        }
         guard let stackHost else { return }
         if inPlaceMode {
             stackHost.isHidden = true
@@ -3448,8 +3493,6 @@ private final class MotionPanel: NSPanel {
         }
         stackHost.isHidden = false
         let activeWid = activeEntry.wid
-        let groupMembers = orderedGroup()                                   // picked set, in pick order
-
         // The minimap mirrors the gather plan: the picked windows in the exact
         // balanced grid they'll snap to. Shown only once you've picked something —
         // while you're just browsing there's nothing to plan, so it stays hidden.
@@ -3619,6 +3662,7 @@ private struct MotionLegend: View {
                     keyHint("⌘scroll", "zoom")
                     keyHint("⏎", "gather")
                     if groupCount > 0 { keyHint("⌘L", "save layer") }
+                    if groupCount > 1 { keyHint("⌘T", "tabs") }
                     keyHint("E", "collapse")
                     keyHint("esc", "cancel")
                     keyHint("Hyper+G", "in-place")
@@ -3630,6 +3674,7 @@ private struct MotionLegend: View {
                 keyHint("G", "grid")
                 keyHint("F", "fill")
                 if groupCount > 0 { keyHint("⌘L", "save layer") }
+                if groupCount > 1 { keyHint("⌘T", "tabs") }
                 keyHint("←↑→↓", "half · gap")
                 keyHint("⇧/⌥", "nudge/size")
                 keyHint("⏎", "confirm")
@@ -4059,6 +4104,7 @@ struct ExposeView: View {
     var onDropLayers: ([UInt32], String) -> Void = { _, _ in }
     var onSwap: (UInt32, UInt32) -> Void = { _, _ in }
     var onGridSelection: () -> Void = {}
+    var onStackSelection: () -> Void = {}
     var onSwapFirstTwo: () -> Void = {}
     var onSwapWith: (UInt32, UInt32) -> Void = { _, _ in }
     var onFocusWindow: (UInt32) -> Void = { _ in }
@@ -6567,6 +6613,9 @@ struct ExposeView: View {
             }
             .disabled(pickCount < 2)
             if pickCount >= 2 {
+                Button { onStackSelection() } label: {
+                    Label("Stack \(pickCount) as Tabs (⌘T)", systemImage: "rectangle.stack")
+                }
                 Button { onSwapFirstTwo() } label: {
                     Label("Swap First Two (S)", systemImage: "arrow.left.arrow.right")
                 }

--- a/apps/mac/Sources/Core/Pi/WorkspaceAssistantSession.swift
+++ b/apps/mac/Sources/Core/Pi/WorkspaceAssistantSession.swift
@@ -1897,6 +1897,44 @@ final class WorkspaceAssistantSession: ObservableObject {
     private func handleImmediateLocalCommand(_ text: String) -> String? {
         let lower = text.lowercased()
 
+        // Window actions are resolved locally so "these" means the windows the
+        // user has just plucked in Hyperspace. No provider round-trip is needed.
+        let liveTabs = LiveTabGroupStore.shared
+        let createTabPhrases = [
+            "stack these as tabs", "make these tabs", "group these as tabs",
+            "turn these into tabs", "add these up",
+        ]
+        if createTabPhrases.contains(where: lower.contains) {
+            guard liveTabs.candidateWindowIDs.count >= 2 else {
+                return "Select at least two windows in Hyperspace first, then say “stack these as tabs.”"
+            }
+            let requestedName = liveTabGroupName(from: text)
+            guard let group = liveTabs.createFromCandidate(name: requestedName) else {
+                return "I couldn’t turn that selection into tabs because fewer than two selected windows are still available."
+            }
+            return "Stacked \(group.members.count) windows as “\(group.name)” in the top-left. Use the grid button to fan them out."
+        }
+
+        if lower.contains("add these to tabs") || lower.contains("add these to the tab group") {
+            guard liveTabs.activeGroup != nil else { return "Create a live tab group first." }
+            let count = liveTabs.addCandidate()
+            return count > 0
+                ? "Added \(count) window\(count == 1 ? "" : "s") to the active tab group."
+                : "Those windows are already in the active tab group, or are no longer available."
+        }
+
+        if lower.contains("grid these tabs") || lower.contains("fan out these tabs") || lower.contains("expand these tabs") {
+            guard liveTabs.activeGroup != nil else { return "There isn’t an active live tab group yet." }
+            liveTabs.expand()
+            return "Expanded the active tabs into a grid."
+        }
+
+        if lower.contains("collapse these tabs") || lower.contains("stack these tabs") || lower.contains("restack these tabs") {
+            guard liveTabs.activeGroup != nil else { return "There isn’t an active live tab group yet." }
+            liveTabs.collapse()
+            return "Collapsed the active group back into tabs."
+        }
+
         if lower.contains("open assistant settings") || lower.contains("show assistant settings") {
             SettingsWindowController.shared.showAssistant()
             return "Opened Assistant settings."
@@ -1907,6 +1945,19 @@ final class WorkspaceAssistantSession: ObservableObject {
             return "Opened Settings."
         }
 
+        return nil
+    }
+
+    private func liveTabGroupName(from text: String) -> String? {
+        let lower = text.lowercased()
+        for marker in [" called ", " named "] {
+            guard let range = lower.range(of: marker) else { continue }
+            let offset = lower.distance(from: lower.startIndex, to: range.upperBound)
+            let start = text.index(text.startIndex, offsetBy: offset)
+            let name = text[start...].trimmingCharacters(in: .whitespacesAndNewlines)
+                .trimmingCharacters(in: CharacterSet(charactersIn: ".!?\"'"))
+            if !name.isEmpty { return name }
+        }
         return nil
     }
 
@@ -2155,6 +2206,7 @@ final class WorkspaceAssistantSession: ObservableObject {
                 ],
                 "mouseShortcuts": mouseShortcutContextPayload(),
                 "studioLayers": StudioLayerStore.shared.assistantContextPayload(),
+                "liveTabGroups": LiveTabGroupStore.shared.assistantContextPayload(),
             ],
             "settingsCatalog": [
                 [

--- a/apps/mac/Sources/Core/Workspace/LiveTabGroupStore.swift
+++ b/apps/mac/Sources/Core/Workspace/LiveTabGroupStore.swift
@@ -1,0 +1,448 @@
+import AppKit
+
+// MARK: - Live cross-app tabs
+
+extension Notification.Name {
+    /// Posted immediately before a live tab activates one of its real windows.
+    /// Hyper-3 uses it to ignore the synthetic focus click that some apps need.
+    static let liveTabGroupWillFocusWindow = Notification.Name("liveTabGroupWillFocusWindow")
+
+    /// Posted after a group operation that can change native window geometry.
+    /// Selection-only changes deliberately do not post this: the HUD can swap
+    /// the active tab immediately without paying for another desktop inventory.
+    static let liveTabGroupGeometryDidChange = Notification.Name("liveTabGroupGeometryDidChange")
+}
+
+struct LiveTabMember: Identifiable {
+    let id: UInt32
+    var pid: Int32
+    var app: String
+    var title: String
+
+    var label: String {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? app : trimmed
+    }
+}
+
+struct LiveTabGroup: Identifiable {
+    let id: String
+    var name: String
+    var members: [LiveTabMember]
+    var selectedIndex: Int
+    var isExpanded: Bool
+    var placement: PlacementSpec
+    var screen: NSScreen
+}
+
+/// Runtime-only tab stacks created from live windows. Hyperspace, the in-app
+/// assistant, and daemon agents all write through this store so every entry
+/// point has identical stack/grid/select behavior.
+final class LiveTabGroupStore: ObservableObject {
+    static let shared = LiveTabGroupStore()
+
+    @Published private(set) var groups: [LiveTabGroup] = []
+    @Published private(set) var activeGroupID: String?
+    @Published private(set) var candidateWindowIDs: [UInt32] = []
+
+    /// Optional reserved space for experiments that alter native layout. The
+    /// persistent group guide is an overlay and leaves this at zero.
+    private var hudChromeInset: CGFloat = 0
+    private var expectedFocusedWindowID: UInt32?
+    private var suppressFocusSyncUntil: Date = .distantPast
+
+    private init() {}
+
+    var activeGroup: LiveTabGroup? {
+        guard let activeGroupID else { return nil }
+        return groups.first(where: { $0.id == activeGroupID })
+    }
+
+    func captureCandidateSelection(_ windowIDs: [UInt32]) {
+        var seen = Set<UInt32>()
+        candidateWindowIDs = windowIDs.filter { seen.insert($0).inserted }
+    }
+
+    @discardableResult
+    func createFromCandidate(
+        name: String? = nil,
+        placement: PlacementSpec = .tile(.topLeft),
+        screen: NSScreen? = nil
+    ) -> LiveTabGroup? {
+        create(windowIDs: candidateWindowIDs, name: name, placement: placement, screen: screen)
+    }
+
+    @discardableResult
+    func create(
+        windowIDs: [UInt32],
+        name: String? = nil,
+        placement: PlacementSpec = .tile(.topLeft),
+        screen: NSScreen? = nil
+    ) -> LiveTabGroup? {
+        DesktopModel.shared.forcePoll()
+        let members = resolvedMembers(windowIDs)
+        guard members.count >= 2 else { return nil }
+
+        if let existing = groups.first(where: { Set($0.members.map(\.id)) == Set(members.map(\.id)) }) {
+            activeGroupID = existing.id
+            collapse(id: existing.id)
+            return groups.first(where: { $0.id == existing.id })
+        }
+
+        let firstEntry = DesktopModel.shared.windows[members[0].id]
+        let targetScreen = screen
+            ?? firstEntry.map { WindowTiler.screenForWindowFrame($0.frame) }
+            ?? NSScreen.main
+            ?? NSScreen.screens.first
+        guard let targetScreen else { return nil }
+
+        let group = LiveTabGroup(
+            id: UUID().uuidString,
+            name: normalizedName(name, members: members),
+            members: members,
+            selectedIndex: 0,
+            isExpanded: false,
+            placement: placement,
+            screen: targetScreen
+        )
+        groups.append(group)
+        activeGroupID = group.id
+        collapse(id: group.id)
+        DiagnosticLog.shared.info("Live tabs: created '\(group.name)' with \(members.count) windows")
+        return groups.first(where: { $0.id == group.id })
+    }
+
+    @discardableResult
+    func addCandidate(to groupID: String? = nil) -> Int {
+        add(windowIDs: candidateWindowIDs, to: groupID)
+    }
+
+    @discardableResult
+    func add(windowIDs: [UInt32], to groupID: String? = nil) -> Int {
+        guard let id = groupID ?? activeGroupID,
+              let index = groups.firstIndex(where: { $0.id == id }) else { return 0 }
+        let existing = Set(groups[index].members.map(\.id))
+        let additions = resolvedMembers(windowIDs).filter { !existing.contains($0.id) }
+        guard !additions.isEmpty else { return 0 }
+        groups[index].members.append(contentsOf: additions)
+        activeGroupID = id
+        collapse(id: id)
+        DiagnosticLog.shared.info("Live tabs: added \(additions.count) window(s) to '\(groups[index].name)'")
+        return additions.count
+    }
+
+    func select(groupID: String, index: Int) {
+        guard let groupIndex = groups.firstIndex(where: { $0.id == groupID }),
+              index >= 0, index < groups[groupIndex].members.count else { return }
+        groups[groupIndex].selectedIndex = index
+        activeGroupID = groupID
+        let group = groups[groupIndex]
+        let selectedMember = group.members[index]
+
+        // A tab switch normally changes only z-order. Re-running collapse here
+        // used to poll the desktop, resize every member, raise the whole stack,
+        // and then focus this member twice. Keep a correctness fallback for a
+        // group that has drifted from its intended tile, but make the common
+        // path one exact-window focus operation.
+        if group.isExpanded || collapsedLayoutIsCurrent(group) {
+            focus(selectedMember)
+        } else {
+            collapse(id: groupID)
+        }
+    }
+
+    func select(groupID: String, windowID: UInt32) {
+        guard let group = groups.first(where: { $0.id == groupID }),
+              let index = group.members.firstIndex(where: { $0.id == windowID }) else { return }
+        select(groupID: groupID, index: index)
+    }
+
+    /// Pull one native window out of a live group and place it beneath the drop
+    /// point. If that leaves fewer than two members, dissolve the group entirely.
+    /// The detached window is focused last so it wins the native z-order race.
+    func detach(groupID: String, windowID: UInt32, at dropPoint: NSPoint) {
+        guard let groupIndex = groups.firstIndex(where: { $0.id == groupID }),
+              let memberIndex = groups[groupIndex].members.firstIndex(where: { $0.id == windowID })
+        else { return }
+
+        DesktopModel.shared.forcePoll()
+        let originalGroup = groups[groupIndex]
+        let detachedMember = originalGroup.members[memberIndex]
+        let currentFrame: CGRect
+        if let frame = DesktopModel.shared.windows[windowID]?.frame {
+            currentFrame = CGRect(x: frame.x, y: frame.y, width: frame.w, height: frame.h)
+        } else {
+            currentFrame = collapsedFrame(for: originalGroup)
+        }
+        let targetFrame = detachedFrame(
+            current: currentFrame,
+            dropPoint: dropPoint,
+            fallbackScreen: originalGroup.screen
+        )
+
+        groups[groupIndex].members.remove(at: memberIndex)
+        if groups[groupIndex].members.count < 2 {
+            let remaining = groups[groupIndex].members
+            let restoredFrame = WindowTiler.tileFrame(
+                for: originalGroup.placement,
+                on: originalGroup.screen
+            )
+            if !remaining.isEmpty {
+                WindowTiler.batchMoveWindows(
+                    remaining.map { (wid: $0.id, pid: $0.pid, frame: restoredFrame) }
+                )
+            }
+            groups.remove(at: groupIndex)
+            activeGroupID = groups.last?.id
+        } else {
+            if memberIndex < originalGroup.selectedIndex {
+                groups[groupIndex].selectedIndex = originalGroup.selectedIndex - 1
+            } else if memberIndex == originalGroup.selectedIndex {
+                groups[groupIndex].selectedIndex = min(
+                    memberIndex,
+                    groups[groupIndex].members.count - 1
+                )
+            }
+            activeGroupID = groupID
+            collapse(id: groupID)
+        }
+
+        WindowTiler.batchMoveAndRaiseWindows([
+            (wid: detachedMember.id, pid: detachedMember.pid, frame: targetFrame),
+        ])
+        focus(detachedMember)
+        DesktopModel.shared.forcePoll()
+        notifyGeometryChanged()
+        DiagnosticLog.shared.info(
+            "Live tabs: detached \(detachedMember.app) from '\(originalGroup.name)'"
+        )
+    }
+
+    /// Keep the visual tab selection honest when a grouped window was focused
+    /// outside the rail before (or while) Hyper-3 is open.
+    func syncSelection(toFocusedWindow windowID: UInt32?) {
+        guard let windowID else { return }
+        // Activation can briefly report the previously-frontmost app while AX
+        // and WindowServer settle. Do not let that transient observation make
+        // the selected tab flicker backward after an explicit tab action.
+        if Date() < suppressFocusSyncUntil,
+           let expectedFocusedWindowID,
+           windowID != expectedFocusedWindowID {
+            return
+        }
+        for groupIndex in groups.indices {
+            guard let memberIndex = groups[groupIndex].members.firstIndex(where: { $0.id == windowID }) else { continue }
+            guard groups[groupIndex].selectedIndex != memberIndex else { return }
+            groups[groupIndex].selectedIndex = memberIndex
+            activeGroupID = groups[groupIndex].id
+            return
+        }
+    }
+
+    func toggleLayout(id: String? = nil) {
+        guard let id = id ?? activeGroupID,
+              let group = groups.first(where: { $0.id == id }) else { return }
+        group.isExpanded ? collapse(id: id) : expand(id: id)
+    }
+
+    func setHUDChromeInset(_ height: CGFloat) {
+        let next = max(0, height)
+        guard abs(next - hudChromeInset) > 0.5 else { return }
+        hudChromeInset = next
+
+        var moves: [(wid: UInt32, pid: Int32, frame: CGRect)] = []
+        for group in groups where !group.isExpanded {
+            let frame = collapsedFrame(for: group)
+            moves.append(contentsOf: group.members.map { (wid: $0.id, pid: $0.pid, frame: frame) })
+        }
+        WindowTiler.batchMoveWindows(moves)
+        DesktopModel.shared.forcePoll()
+        notifyGeometryChanged()
+    }
+
+    func expand(id: String? = nil) {
+        guard let id = id ?? activeGroupID,
+              let index = groups.firstIndex(where: { $0.id == id }) else { return }
+        let windows = liveWindows(for: groups[index])
+        guard !windows.isEmpty else { return }
+        groups[index].isExpanded = true
+        activeGroupID = id
+        WindowTiler.batchRaiseAndDistribute(
+            windows: windows.map { (wid: $0.wid, pid: $0.pid) },
+            reactivateLattices: false
+        )
+        notifyGeometryChanged()
+    }
+
+    func collapse(id: String? = nil) {
+        guard let id = id ?? activeGroupID,
+              let index = groups.firstIndex(where: { $0.id == id }) else { return }
+        refreshMembers(at: index)
+        let group = groups[index]
+        let windows = orderedLiveWindows(for: group)
+        guard !windows.isEmpty else { return }
+        let frame = collapsedFrame(for: group)
+        WindowTiler.batchMoveAndRaiseWindows(
+            windows.map { (wid: $0.wid, pid: $0.pid, frame: frame) }
+        )
+        groups[index].isExpanded = false
+        activeGroupID = id
+        if group.selectedIndex < group.members.count {
+            focus(group.members[group.selectedIndex])
+        }
+        notifyGeometryChanged()
+    }
+
+    func delete(id: String? = nil) {
+        guard let id = id ?? activeGroupID else { return }
+        if let group = groups.first(where: { $0.id == id }), !group.isExpanded {
+            let restoredFrame = WindowTiler.tileFrame(for: group.placement, on: group.screen)
+            WindowTiler.batchMoveWindows(
+                group.members.map { (wid: $0.id, pid: $0.pid, frame: restoredFrame) }
+            )
+        }
+        groups.removeAll { $0.id == id }
+        activeGroupID = groups.last?.id
+        DesktopModel.shared.forcePoll()
+        notifyGeometryChanged()
+    }
+
+    func assistantContextPayload() -> [String: Any] {
+        [
+            "candidateWindowIds": candidateWindowIDs.map(Int.init),
+            "activeGroupId": (activeGroupID as Any?) ?? NSNull(),
+            "groups": groups.map { group in
+                [
+                    "id": group.id,
+                    "name": group.name,
+                    "mode": group.isExpanded ? "grid" : "tabs",
+                    "placement": group.placement.wireValue,
+                    "selectedIndex": group.selectedIndex,
+                    "members": group.members.map { member in
+                        ["wid": Int(member.id), "app": member.app, "title": member.title] as [String: Any]
+                    },
+                ] as [String: Any]
+            },
+        ]
+    }
+
+    private func resolvedMembers(_ windowIDs: [UInt32]) -> [LiveTabMember] {
+        var seen = Set<UInt32>()
+        return windowIDs.compactMap { wid in
+            guard seen.insert(wid).inserted,
+                  let entry = DesktopModel.shared.windows[wid] else { return nil }
+            return LiveTabMember(id: wid, pid: entry.pid, app: entry.app, title: entry.title)
+        }
+    }
+
+    private func refreshMembers(at index: Int) {
+        DesktopModel.shared.forcePoll()
+        for memberIndex in groups[index].members.indices {
+            let wid = groups[index].members[memberIndex].id
+            guard let entry = DesktopModel.shared.windows[wid] else { continue }
+            groups[index].members[memberIndex].pid = entry.pid
+            groups[index].members[memberIndex].app = entry.app
+            groups[index].members[memberIndex].title = entry.title
+        }
+        groups[index].selectedIndex = min(
+            groups[index].selectedIndex,
+            max(0, groups[index].members.count - 1)
+        )
+    }
+
+    private func liveWindows(for group: LiveTabGroup) -> [WindowEntry] {
+        DesktopModel.shared.forcePoll()
+        return group.members.compactMap { DesktopModel.shared.windows[$0.id] }
+    }
+
+    private func orderedLiveWindows(for group: LiveTabGroup) -> [WindowEntry] {
+        var windows: [WindowEntry] = []
+        for (index, member) in group.members.enumerated() where index != group.selectedIndex {
+            if let entry = DesktopModel.shared.windows[member.id] { windows.append(entry) }
+        }
+        if group.selectedIndex < group.members.count,
+           let entry = DesktopModel.shared.windows[group.members[group.selectedIndex].id] {
+            windows.append(entry)
+        }
+        return windows
+    }
+
+    private func collapsedFrame(for group: LiveTabGroup) -> CGRect {
+        let base = WindowTiler.tileFrame(for: group.placement, on: group.screen)
+        guard hudChromeInset > 0 else { return base }
+        return CGRect(
+            x: base.minX,
+            y: base.minY + hudChromeInset,
+            width: base.width,
+            height: max(240, base.height - hudChromeInset)
+        )
+    }
+
+    /// Uses the already-polled desktop snapshot as a cheap drift guard. A
+    /// missing or visibly moved member takes the slower repair path in
+    /// `collapse`; ordinary tab changes avoid a synchronous CG/AX inventory.
+    private func collapsedLayoutIsCurrent(_ group: LiveTabGroup) -> Bool {
+        let target = collapsedFrame(for: group)
+        let tolerance: CGFloat = 3
+        return group.members.allSatisfy { member in
+            guard let frame = DesktopModel.shared.windows[member.id]?.frame else { return false }
+            return abs(CGFloat(frame.x) - target.minX) <= tolerance
+                && abs(CGFloat(frame.y) - target.minY) <= tolerance
+                && abs(CGFloat(frame.w) - target.width) <= tolerance
+                && abs(CGFloat(frame.h) - target.height) <= tolerance
+        }
+    }
+
+    private func notifyGeometryChanged() {
+        NotificationCenter.default.post(name: .liveTabGroupGeometryDidChange, object: self)
+    }
+
+    private func detachedFrame(
+        current: CGRect,
+        dropPoint: NSPoint,
+        fallbackScreen: NSScreen
+    ) -> CGRect {
+        let screen = NSScreen.screens.first(where: { $0.frame.contains(dropPoint) })
+            ?? fallbackScreen
+        let visible = screen.visibleFrame
+        let primaryHeight = NSScreen.screens.first?.frame.height ?? visible.maxY
+        let visibleAX = CGRect(
+            x: visible.minX,
+            y: primaryHeight - visible.maxY,
+            width: visible.width,
+            height: visible.height
+        )
+
+        let width = min(max(480, current.width), visibleAX.width)
+        let height = min(max(320, current.height), visibleAX.height)
+        let desiredX = dropPoint.x - min(150, width * 0.22)
+        let desiredY = primaryHeight - dropPoint.y - 18
+        let x = min(max(desiredX, visibleAX.minX), visibleAX.maxX - width)
+        let y = min(max(desiredY, visibleAX.minY), visibleAX.maxY - height)
+        return CGRect(x: x, y: y, width: width, height: height)
+    }
+
+    private func focus(_ member: LiveTabMember) {
+        guard let entry = DesktopModel.shared.windows[member.id] else { return }
+        expectedFocusedWindowID = member.id
+        suppressFocusSyncUntil = Date().addingTimeInterval(0.8)
+        NotificationCenter.default.post(name: .liveTabGroupWillFocusWindow, object: member.id)
+        _ = WindowTiler.focusWindow(wid: entry.wid, pid: entry.pid)
+        WindowTiler.highlightWindowById(wid: entry.wid)
+    }
+
+    private func normalizedName(_ provided: String?, members: [LiveTabMember]) -> String {
+        if let provided {
+            let trimmed = provided.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { return trimmed }
+        }
+        var apps: [String] = []
+        for member in members where !apps.contains(member.app) { apps.append(member.app) }
+        switch apps.count {
+        case 0: return "Live Tabs"
+        case 1: return apps[0]
+        case 2: return "\(apps[0]) + \(apps[1])"
+        default: return "\(apps[0]) +\(apps.count - 1)"
+        }
+    }
+}

--- a/apps/mac/Sources/Core/Workspace/WorkspaceManager.swift
+++ b/apps/mac/Sources/Core/Workspace/WorkspaceManager.swift
@@ -5,8 +5,20 @@ import Foundation
 // MARK: - Data Model
 
 struct TabGroupTab: Codable {
-    let path: String
+    let path: String?
     let label: String?
+    let app: String?
+    let title: String?
+    let url: String?
+    let launch: String?
+
+    var displayLabel: String {
+        if let label, !label.isEmpty { return label }
+        if let path { return (path as NSString).lastPathComponent }
+        return app ?? title ?? "Tab"
+    }
+
+    var isTerminal: Bool { path != nil }
 }
 
 struct TabGroup: Codable, Identifiable {
@@ -368,6 +380,8 @@ class WorkspaceManager: ObservableObject {
     @Published var gridPresets: [String: GridPreset] = [:]
     @Published var gridLayouts: [String: LayoutConfig] = [:]
     @Published var snapZonesConfig: SnapZonesConfig = .defaults
+    @Published private(set) var selectedGroupTabIndices: [String: Int] = [:]
+    @Published private(set) var expandedGroupIDs: Set<String> = []
 
     private let configPath: String
     private let gridConfigPath: String
@@ -533,35 +547,64 @@ class WorkspaceManager: ObservableObject {
         config?.groups?.first(where: { $0.id == id })
     }
 
-    func isGroupRunning(_ group: TabGroup) -> Bool {
-        group.tabs.contains { tab in
-            let name = Self.sessionName(for: tab.path)
+    var activeLayerGroups: [TabGroup] {
+        guard let layer = activeLayer else { return [] }
+        return layer.projects.compactMap { project in
+            project.group.flatMap(group(byId:))
+        }
+    }
+
+    func selectedTabIndex(in group: TabGroup) -> Int {
+        min(selectedGroupTabIndices[group.id] ?? 0, max(0, group.tabs.count - 1))
+    }
+
+    func isGroupExpanded(_ group: TabGroup) -> Bool {
+        expandedGroupIDs.contains(group.id)
+    }
+
+    func isTabRunning(_ tab: TabGroupTab) -> Bool {
+        if let path = tab.path {
+            let name = Self.sessionName(for: path)
             return shell([tmuxPath, "has-session", "-t", name]) == 0
         }
+        guard let app = tab.app else { return false }
+        return DesktopModel.shared.windowForApp(app: app, title: tab.title) != nil
+            || Self.findAppWindow(app: app, title: tab.title) != nil
+    }
+
+    func isGroupRunning(_ group: TabGroup) -> Bool {
+        group.tabs.contains(where: isTabRunning)
     }
 
     /// Count how many tabs in the group have running sessions
     func runningTabCount(_ group: TabGroup) -> Int {
-        group.tabs.filter { tab in
-            let name = Self.sessionName(for: tab.path)
-            return shell([tmuxPath, "has-session", "-t", name]) == 0
-        }.count
+        group.tabs.filter(isTabRunning).count
     }
 
-    /// Launch a group by opening each tab as a separate iTerm/Terminal tab
+    /// Launch a mixed group. Project tabs open in the terminal; app/URL tabs
+    /// open as native application windows.
     func launchGroup(_ group: TabGroup) {
         let terminal = Preferences.shared.terminal
         let latticesCommand = LatticesRuntime.cliShellCommand
         for (i, tab) in group.tabs.enumerated() {
-            let label = tab.label ?? (tab.path as NSString).lastPathComponent
+            guard !isTabRunning(tab) else { continue }
             DispatchQueue.main.asyncAfter(deadline: .now() + Double(i) * 0.4) {
-                if i == 0 {
-                    terminal.launch(command: "\(latticesCommand) start", in: tab.path)
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                        terminal.nameTab(label)
+                if let path = tab.path {
+                    let earlierTerminalTabs = group.tabs[..<i].contains(where: \.isTerminal)
+                    if !earlierTerminalTabs {
+                        terminal.launch(command: "\(latticesCommand) start", in: path)
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                            terminal.nameTab(tab.displayLabel)
+                        }
+                    } else {
+                        terminal.launchTab(
+                            command: "\(latticesCommand) start",
+                            in: path,
+                            tabName: tab.displayLabel
+                        )
                     }
                 } else {
-                    terminal.launchTab(command: "\(latticesCommand) start", in: tab.path, tabName: label)
+                    self.launch(tab)
                 }
             }
         }
@@ -570,7 +613,8 @@ class WorkspaceManager: ObservableObject {
     /// Kill all individual tab sessions for a group
     func killGroup(_ group: TabGroup) {
         for tab in group.tabs {
-            let name = Self.sessionName(for: tab.path)
+            guard let path = tab.path else { continue }
+            let name = Self.sessionName(for: path)
             let task = Process()
             task.executableURL = URL(fileURLWithPath: tmuxPath)
             task.arguments = ["kill-session", "-t", name]
@@ -581,13 +625,118 @@ class WorkspaceManager: ObservableObject {
         }
     }
 
-    /// Focus a specific tab's session in the terminal
+    /// Focus a specific terminal or application window in a mixed tab group.
+    /// When the group is collapsed, switching tabs keeps every member in the
+    /// group's configured layer slot.
     func focusTab(group: TabGroup, tabIndex: Int) {
         guard tabIndex >= 0, tabIndex < group.tabs.count else { return }
+        selectedGroupTabIndices[group.id] = tabIndex
         let tab = group.tabs[tabIndex]
-        let sessionName = Self.sessionName(for: tab.path)
-        let terminal = Preferences.shared.terminal
-        terminal.focusOrAttach(session: sessionName)
+        if !isGroupExpanded(group) {
+            collapseGroup(group)
+        }
+
+        if let entry = window(for: tab) {
+            _ = WindowTiler.focusWindow(wid: entry.wid, pid: entry.pid)
+            WindowTiler.highlightWindowById(wid: entry.wid)
+        } else if let path = tab.path {
+            Preferences.shared.terminal.focusOrAttach(session: Self.sessionName(for: path))
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+                self.collapseGroup(group)
+            }
+        } else {
+            launch(tab)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+                self.collapseGroup(group)
+            }
+        }
+    }
+
+    /// Toggle between a single-slot cross-app tab stack and a full smart grid.
+    func toggleGroupLayout(_ group: TabGroup) {
+        if isGroupExpanded(group) {
+            collapseGroup(group)
+        } else {
+            expandGroupToGrid(group)
+        }
+    }
+
+    func expandGroupToGrid(_ group: TabGroup) {
+        DesktopModel.shared.poll()
+        let windows = orderedWindows(for: group)
+        guard !windows.isEmpty else { return }
+        expandedGroupIDs.insert(group.id)
+        WindowTiler.batchRaiseAndDistribute(
+            windows: windows.map { (wid: $0.wid, pid: $0.pid) },
+            reactivateLattices: false
+        )
+        DiagnosticLog.shared.info("WorkspaceManager: expanded mixed group '\(group.label)' to grid")
+    }
+
+    func collapseGroup(_ group: TabGroup) {
+        DesktopModel.shared.poll()
+        let windows = orderedWindows(for: group)
+        guard !windows.isEmpty,
+              let (placement, targetScreen) = groupPlacement(group) else { return }
+
+        let frame = WindowTiler.tileFrame(for: placement, on: targetScreen)
+        WindowTiler.batchMoveAndRaiseWindows(
+            windows.map { (wid: $0.wid, pid: $0.pid, frame: frame) }
+        )
+        expandedGroupIDs.remove(group.id)
+
+        let selected = selectedTabIndex(in: group)
+        if selected < group.tabs.count, let entry = window(for: group.tabs[selected]) {
+            _ = WindowTiler.focusWindow(wid: entry.wid, pid: entry.pid)
+        }
+        DiagnosticLog.shared.info("WorkspaceManager: collapsed mixed group '\(group.label)' to \(placement.wireValue)")
+    }
+
+    private func window(for tab: TabGroupTab) -> WindowEntry? {
+        if let path = tab.path {
+            return windowForSession(Self.sessionName(for: path))
+        }
+        guard let app = tab.app else { return nil }
+        return DesktopModel.shared.windowForApp(app: app, title: tab.title)
+    }
+
+    private func orderedWindows(for group: TabGroup) -> [WindowEntry] {
+        let selected = selectedTabIndex(in: group)
+        var result: [WindowEntry] = []
+        for (index, tab) in group.tabs.enumerated() where index != selected {
+            if let entry = window(for: tab), !result.contains(where: { $0.wid == entry.wid }) {
+                result.append(entry)
+            }
+        }
+        if selected < group.tabs.count,
+           let entry = window(for: group.tabs[selected]),
+           !result.contains(where: { $0.wid == entry.wid }) {
+            result.append(entry)
+        }
+        return result
+    }
+
+    private func groupPlacement(_ group: TabGroup) -> (PlacementSpec, NSScreen)? {
+        let project = activeLayer?.projects.first(where: { $0.group == group.id })
+            ?? config?.layers?.lazy.compactMap { layer in
+                layer.projects.first(where: { $0.group == group.id })
+            }.first
+        let placement = project?.tile.flatMap(resolvePlacement) ?? .tile(.topLeft)
+        guard let targetScreen = screen(for: project?.display) else { return nil }
+        return (placement, targetScreen)
+    }
+
+    private func launch(_ tab: TabGroupTab) {
+        if let urlString = tab.url, let url = URL(string: urlString) {
+            NSWorkspace.shared.open(url)
+        } else if let appName = tab.launch ?? tab.app {
+            let task = Process()
+            task.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+            task.arguments = ["-a", appName]
+            task.standardOutput = FileHandle.nullDevice
+            task.standardError = FileHandle.nullDevice
+            try? task.run()
+        }
     }
 
     /// Run a command and return exit code
@@ -675,8 +824,7 @@ class WorkspaceManager: ObservableObject {
             if let groupId = lp.group, let grp = group(byId: groupId) {
                 // Raise all tab windows in the group
                 for tab in grp.tabs {
-                    let sessionName = Self.sessionName(for: tab.path)
-                    if let entry = windowForSession(sessionName) {
+                    if let entry = window(for: tab) {
                         windowsToRaise.append((entry.wid, entry.pid))
                     }
                 }
@@ -764,22 +912,34 @@ class WorkspaceManager: ObservableObject {
             guard let lpScreen = screen(for: lp.display) else { continue }
 
             if let groupId = lp.group, let grp = group(byId: groupId) {
-                let firstTabSession = grp.tabs.first.map { Self.sessionName(for: $0.path) } ?? ""
                 let position = lp.tile.flatMap { resolvePlacement($0) }
+                let groupWindows = orderedWindows(for: grp)
                 let groupRunning = isGroupRunning(grp)
 
-                if groupRunning, let pos = position,
-                   let target = batchTarget(session: firstTabSession, position: pos, screen: lpScreen) {
-                    batchMoves.append(target)
+                if !groupWindows.isEmpty, let pos = position {
+                    let frame = WindowTiler.tileFrame(for: pos, on: lpScreen)
+                    batchMoves.append(contentsOf: groupWindows.map {
+                        (wid: $0.wid, pid: $0.pid, frame: frame)
+                    })
+                    expandedGroupIDs.remove(grp.id)
+                    if launch, runningTabCount(grp) < grp.tabs.count {
+                        launchGroup(grp)
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                            self.collapseGroup(grp)
+                        }
+                    }
                 } else if !groupRunning && launch {
                     diag.info("  launch group: \(grp.label)")
-                    launchQueue.append((firstTabSession, position, lpScreen, { [weak self] in
-                        self?.launchGroup(grp)
+                    launchQueue.append(("group:\(grp.id)", nil, lpScreen, { [weak self] in
+                        guard let self else { return }
+                        self.launchGroup(grp)
+                        if position != nil {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                                self.collapseGroup(grp)
+                            }
+                        }
                     }))
-                } else if groupRunning, let pos = position {
-                    // Running but not in DesktopModel — fallback
-                    fallbacks.append((firstTabSession, pos, lpScreen))
-                } else if !groupRunning {
+                } else if groupWindows.isEmpty {
                     diag.info("  skip (not running): \(grp.label)")
                 }
                 continue

--- a/apps/mac/Sources/UI/TabGroupRow.swift
+++ b/apps/mac/Sources/UI/TabGroupRow.swift
@@ -48,7 +48,7 @@ struct TabGroupRow: View {
                             )
                     }
 
-                    Text(group.tabs.map { $0.label ?? ($0.path as NSString).lastPathComponent }.joined(separator: " \u{00B7} "))
+                    Text(group.tabs.map(\.displayLabel).joined(separator: " \u{00B7} "))
                         .font(Typo.mono(10))
                         .foregroundColor(Palette.textMuted)
                         .lineLimit(1)
@@ -59,6 +59,23 @@ struct TabGroupRow: View {
                 // Actions
                 HStack(spacing: 4) {
                     if isRunning {
+                        Button {
+                            workspace.toggleGroupLayout(group)
+                        } label: {
+                            Image(systemName: workspace.isGroupExpanded(group)
+                                ? "rectangle.stack"
+                                : "square.grid.2x2")
+                                .font(.system(size: 10, weight: .semibold))
+                                .foregroundColor(Palette.textDim)
+                                .frame(width: 24, height: 22)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 4)
+                                        .fill(Palette.surface)
+                                )
+                        }
+                        .buttonStyle(.plain)
+                        .help(workspace.isGroupExpanded(group) ? "Collapse to tabs" : "Expand to grid")
+
                         Button {
                             workspace.killGroup(group)
                             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
@@ -73,12 +90,10 @@ struct TabGroupRow: View {
 
                     Button {
                         if isRunning {
-                            // Focus the first tab's session
-                            if let firstTab = group.tabs.first {
-                                let session = WorkspaceManager.sessionName(for: firstTab.path)
-                                let terminal = Preferences.shared.terminal
-                                terminal.focusOrAttach(session: session)
-                            }
+                            workspace.focusTab(
+                                group: group,
+                                tabIndex: workspace.selectedTabIndex(in: group)
+                            )
                         } else {
                             workspace.launchGroup(group)
                         }
@@ -111,17 +126,19 @@ struct TabGroupRow: View {
         .contextMenu {
             if isRunning {
                 Button("Attach") {
-                    if let firstTab = group.tabs.first {
-                        let session = WorkspaceManager.sessionName(for: firstTab.path)
-                        let terminal = Preferences.shared.terminal
-                        terminal.focusOrAttach(session: session)
-                    }
+                    workspace.focusTab(
+                        group: group,
+                        tabIndex: workspace.selectedTabIndex(in: group)
+                    )
                 }
                 Divider()
                 ForEach(Array(group.tabs.enumerated()), id: \.offset) { idx, tab in
-                    Button("Go to: \(tab.label ?? (tab.path as NSString).lastPathComponent)") {
+                    Button("Go to: \(tab.displayLabel)") {
                         workspace.focusTab(group: group, tabIndex: idx)
                     }
+                }
+                Button(workspace.isGroupExpanded(group) ? "Collapse to Tabs" : "Expand to Grid") {
+                    workspace.toggleGroupLayout(group)
                 }
                 Divider()
                 Button("Kill Group") {
@@ -139,19 +156,20 @@ struct TabGroupRow: View {
     }
 
     private func tabRow(tab: TabGroupTab, index: Int) -> some View {
-        HStack(spacing: 8) {
-            Image(systemName: "rectangle.topthird.inset.filled")
+        let isSelected = workspace.selectedTabIndex(in: group) == index
+        return HStack(spacing: 8) {
+            Image(systemName: tab.isTerminal ? "terminal" : "macwindow")
                 .font(.system(size: 9))
-                .foregroundColor(isRunning ? Palette.running.opacity(0.7) : Palette.textMuted)
+                .foregroundColor(isSelected ? Palette.running : Palette.textMuted)
 
-            Text(tab.label ?? (tab.path as NSString).lastPathComponent)
+            Text(tab.displayLabel)
                 .font(Typo.mono(11))
-                .foregroundColor(Palette.text)
+                .foregroundColor(isSelected ? Palette.text : Palette.textDim)
                 .lineLimit(1)
 
             Spacer()
 
-            if isRunning {
+            if workspace.isTabRunning(tab) {
                 Button {
                     workspace.focusTab(group: group, tabIndex: index)
                 } label: {
@@ -174,5 +192,9 @@ struct TabGroupRow: View {
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
+        .background(
+            RoundedRectangle(cornerRadius: 5)
+                .fill(isSelected ? Palette.running.opacity(0.08) : .clear)
+        )
     }
 }

--- a/bin/lattices.ts
+++ b/bin/lattices.ts
@@ -173,8 +173,12 @@ function createWindowForProject(sessionName: string, windowIndex: number, dir: s
 }
 
 interface TabConfig {
-  path: string;
+  path?: string;
   label?: string;
+  app?: string;
+  title?: string;
+  url?: string;
+  launch?: string;
 }
 
 interface GroupConfig {
@@ -183,10 +187,27 @@ interface GroupConfig {
   tabs?: TabConfig[];
 }
 
+function projectTabs(tabs: TabConfig[]): Array<TabConfig & { path: string }> {
+  return tabs.filter((tab): tab is TabConfig & { path: string } => Boolean(tab.path));
+}
+
+function tabLabel(tab: TabConfig): string {
+  return tab.label || (tab.path ? basename(tab.path) : tab.app || tab.title || "Tab");
+}
+
+function openExternalTab(tab: TabConfig): void {
+  if (tab.url) {
+    run(`open '${esc(tab.url)}'`);
+    return;
+  }
+  const app = tab.launch || tab.app;
+  if (app) run(`open -a '${esc(app)}'`);
+}
+
 /** Create a group session with one tmux window per tab */
 function createGroupSession(group: GroupConfig): string | null {
   const name = toGroupSessionName(group.id);
-  const tabs = group.tabs || [];
+  const tabs = projectTabs(group.tabs || []);
 
   if (!tabs.length) {
     console.log(`Group "${group.id}" has no tabs.`);
@@ -233,12 +254,17 @@ function listGroups(): void {
   console.log("Tab Groups:\n");
   for (const group of ws.groups) {
     const tabs = group.tabs || [];
-    const runningCount = tabs.filter((t: TabConfig) => sessionExists(toSessionName(resolve(t.path)))).length;
+    const terminalTabs = projectTabs(tabs);
+    const runningCount = terminalTabs.filter(
+      (t) => sessionExists(toSessionName(resolve(t.path)))
+    ).length;
     const running = runningCount > 0;
-    const status = running
-      ? `\x1b[32m● ${runningCount}/${tabs.length} running\x1b[0m`
+    const status = terminalTabs.length === 0
+      ? "\x1b[36m◆ app tabs\x1b[0m"
+      : running
+      ? `\x1b[32m● ${runningCount}/${terminalTabs.length} terminal tabs running\x1b[0m`
       : "\x1b[90m○ stopped\x1b[0m";
-    const tabLabels = tabs.map((t: TabConfig) => t.label || basename(t.path)).join(", ");
+    const tabLabels = tabs.map(tabLabel).join(", ");
     console.log(`  ${group.label || group.id}  ${status}`);
     console.log(`    id: ${group.id}`);
     console.log(`    tabs: ${tabLabels}`);
@@ -270,24 +296,31 @@ function groupCommand(id?: string): void {
     return;
   }
 
-  // Each tab gets its own lattices session (individual project sessions)
-  const firstDir = resolve(tabs[0].path);
+  const terminalTabs = projectTabs(tabs);
+  for (const tab of tabs.filter((tab: TabConfig) => !tab.path)) openExternalTab(tab);
+  if (!terminalTabs.length) {
+    console.log(`Opened "${group.label || group.id}" app tabs.`);
+    return;
+  }
+
+  // Each project tab gets its own lattices session.
+  const firstDir = resolve(terminalTabs[0].path);
   const firstName = toSessionName(firstDir);
 
   // If the first tab's session already exists, just attach
   if (sessionExists(firstName)) {
-    console.log(`Reattaching to "${group.label || group.id}" (${tabs[0].label || basename(firstDir)})...`);
+    console.log(`Reattaching to "${group.label || group.id}" (${tabLabel(terminalTabs[0])})...`);
     attach(firstName);
     return;
   }
 
   // Create a detached session for each tab
   console.log(`Launching group "${group.label || group.id}" (${tabs.length} tabs)...`);
-  for (const tab of tabs) {
+  for (const tab of terminalTabs) {
     const dir = resolve(tab.path);
     const name = toSessionName(dir);
     if (!sessionExists(name)) {
-      console.log(`  Creating session: ${tab.label || basename(dir)}`);
+      console.log(`  Creating session: ${tabLabel(tab)}`);
       createSession(dir);
     }
   }
@@ -320,11 +353,16 @@ function tabCommand(groupId?: string, tabName?: string): void {
     // List tabs with their session status
     console.log(`Tabs in "${group.label || group.id}":\n`);
     for (let i = 0; i < tabs.length; i++) {
-      const label = tabs[i].label || basename(tabs[i].path);
-      const tabSession = toSessionName(resolve(tabs[i].path));
-      const running = sessionExists(tabSession);
-      const status = running ? "\x1b[32m●\x1b[0m" : "\x1b[90m○\x1b[0m";
-      console.log(`  ${status} ${i}: ${label}  (session: ${tabSession})`);
+      const tab = tabs[i];
+      const label = tabLabel(tab);
+      if (tab.path) {
+        const tabSession = toSessionName(resolve(tab.path));
+        const running = sessionExists(tabSession);
+        const status = running ? "\x1b[32m●\x1b[0m" : "\x1b[90m○\x1b[0m";
+        console.log(`  ${status} ${i}: ${label}  (session: ${tabSession})`);
+      } else {
+        console.log(`  \x1b[36m◆\x1b[0m ${i}: ${label}  (app tab)`);
+      }
     }
     return;
   }
@@ -335,10 +373,10 @@ function tabCommand(groupId?: string, tabName?: string): void {
     tabIdx = parseInt(tabName, 10);
   } else {
     tabIdx = tabs.findIndex(
-      (t) => (t.label || basename(t.path)).toLowerCase() === tabName.toLowerCase()
+      (t) => tabLabel(t).toLowerCase() === tabName.toLowerCase()
     );
     if (tabIdx === -1) {
-      const available = tabs.map((t) => t.label || basename(t.path)).join(", ");
+      const available = tabs.map(tabLabel).join(", ");
       console.log(`No tab "${tabName}". Available: ${available}`);
       return;
     }
@@ -349,10 +387,17 @@ function tabCommand(groupId?: string, tabName?: string): void {
     return;
   }
 
-  // Each tab is its own lattices session — attach to it
-  const dir = resolve(tabs[tabIdx].path);
+  const selectedTab = tabs[tabIdx];
+  if (!selectedTab.path) {
+    console.log(`Opening app tab: ${tabLabel(selectedTab)}`);
+    openExternalTab(selectedTab);
+    return;
+  }
+
+  // Each project tab is its own lattices session — attach to it.
+  const dir = resolve(selectedTab.path);
   const tabSession = toSessionName(dir);
-  const label = tabs[tabIdx].label || basename(dir);
+  const label = tabLabel(selectedTab);
 
   if (sessionExists(tabSession)) {
     console.log(`Attaching to tab: ${label}`);
@@ -2273,10 +2318,11 @@ async function daemonLsCommand(): Promise<boolean> {
     if (ws?.groups) {
       for (const g of ws.groups) {
         for (const tab of g.tabs || []) {
+          if (!tab.path) continue;
           const tabSession = toSessionName(resolve(tab.path));
           sessionGroupMap.set(tabSession, {
             group: g.label || g.id,
-            tab: tab.label || basename(tab.path),
+            tab: tabLabel(tab),
           });
         }
       }
@@ -2303,8 +2349,9 @@ async function daemonStatusInventory(): Promise<boolean> {
     if (ws?.groups) {
       for (const g of ws.groups) {
         for (const tab of g.tabs || []) {
+          if (!tab.path) continue;
           const name = toSessionName(resolve(tab.path));
-          const label = `${g.label || g.id}: ${tab.label || basename(tab.path)}`;
+          const label = `${g.label || g.id}: ${tabLabel(tab)}`;
           managed.set(name, label);
         }
       }
@@ -2570,10 +2617,11 @@ function listSessions(): void {
   if (ws?.groups) {
     for (const g of ws.groups) {
       for (const tab of g.tabs || []) {
+        if (!tab.path) continue;
         const tabSession = toSessionName(resolve(tab.path));
         sessionGroupMap.set(tabSession, {
           group: g.label || g.id,
-          tab: tab.label || basename(tab.path),
+          tab: tabLabel(tab),
         });
       }
     }
@@ -2837,8 +2885,9 @@ function statusInventory(): void {
   if (ws?.groups) {
     for (const g of ws.groups) {
       for (const tab of g.tabs || []) {
+        if (!tab.path) continue;
         const name = toSessionName(resolve(tab.path));
-        const label = `${g.label || g.id}: ${tab.label || basename(tab.path)}`;
+        const label = `${g.label || g.id}: ${tabLabel(tab)}`;
         managed.set(name, label);
       }
     }

--- a/design/studio/src/studio/StudioPages.tsx
+++ b/design/studio/src/studio/StudioPages.tsx
@@ -4,6 +4,7 @@ import { ArrowRight, Command } from "lucide-react";
 import type { StudioHudsonRenderContext } from "studio/app-shell";
 import { useStudioRouter } from "studio/router";
 import { DeckBuilderStudy } from "@/studio/studies/DeckBuilder";
+import { CrossAppTabsStudy } from "@/studio/studies/CrossAppTabs";
 import {
   HOME_HREF,
   pages,
@@ -19,6 +20,7 @@ export function renderStudioPage({ pathname, page }: RenderContext) {
   if (pathname === HOME_HREF) return <HomePage />;
   if (page?.href === "/studio/studies/nexus") return <NexusStudy page={page} />;
   if (page?.href === "/studio/studies/deck-builder") return <DeckBuilderStudy page={page} />;
+  if (page?.href === "/studio/studies/cross-app-tabs") return <CrossAppTabsStudy page={page} />;
   if (page) return <PlaceholderPage page={page} />;
   return <NotFoundPage />;
 }

--- a/design/studio/src/studio/studies/CrossAppTabs.tsx
+++ b/design/studio/src/studio/studies/CrossAppTabs.tsx
@@ -1,0 +1,408 @@
+"use client";
+
+import { useState } from "react";
+import {
+  ChevronDown,
+  ExternalLink,
+  Globe2,
+  Grid2X2,
+  Layers3,
+  Plus,
+  Search,
+  Terminal,
+  X,
+} from "lucide-react";
+import type { LatticesPage } from "@/studio/studioRegistry";
+
+type TabID = "chrome" | "terminal";
+
+const tabs = [
+  {
+    id: "chrome" as const,
+    app: "Google Chrome",
+    label: "Chrome",
+    title: "lattices — GitHub",
+    icon: Globe2,
+  },
+  {
+    id: "terminal" as const,
+    app: "iTerm2",
+    label: "iTerm",
+    title: "lattices — zsh",
+    icon: Terminal,
+  },
+];
+
+export function CrossAppTabsStudy({ page }: { page: LatticesPage }) {
+  const [activeTab, setActiveTab] = useState<TabID>("chrome");
+  const [isGrid, setIsGrid] = useState(false);
+
+  return (
+    <main className="w-full px-6 py-10 lg:px-7">
+      <header className="max-w-[980px] border-b border-studio-rule pb-7">
+        <div className="font-mono text-[10px] uppercase tracking-eyebrow text-studio-ink-faint">
+          {page.bucket} / {page.surface}
+        </div>
+        <h1 className="mt-4 text-[36px] font-medium leading-tight text-studio-ink-strong">
+          {page.label}
+        </h1>
+        <p className="mt-4 max-w-[70ch] text-[15px] leading-[1.7] text-studio-ink">
+          {page.blurb}
+        </p>
+      </header>
+
+      <section className="py-8">
+        <div className="mb-4 flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-studio-ink-faint">
+              Live specimen / Hyper-3
+            </div>
+            <p className="mt-2 max-w-[66ch] text-[13px] leading-relaxed text-studio-ink-faint">
+              Two real macOS windows occupy one frame. Lattices contributes only the shared
+              chrome: identity, switching, and the stack-to-grid transition.
+            </p>
+          </div>
+          <div className="flex items-center gap-2 rounded-full border border-studio-chip-border bg-studio-chip-bg px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.16em] text-studio-ink-faint">
+            <span className="h-1.5 w-1.5 rounded-full bg-[#68e7d1] shadow-[0_0_8px_rgba(104,231,209,.7)]" />
+            Interactive
+          </div>
+        </div>
+
+        <div className="overflow-hidden rounded-[18px] border border-white/[0.09] bg-[#080a0c] shadow-[0_28px_90px_rgba(0,0,0,.34)]">
+          <DesktopBar />
+
+          <div
+            className="relative min-h-[650px] overflow-hidden p-8 lg:p-12"
+            style={{
+              background:
+                "radial-gradient(circle at 48% 16%, rgba(78,91,96,.14), transparent 42%), linear-gradient(145deg,#101316 0%,#0a0d0f 58%,#07090b 100%)",
+            }}
+          >
+            <div className="absolute inset-0 opacity-[0.035] [background-image:linear-gradient(rgba(255,255,255,.5)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,.5)_1px,transparent_1px)] [background-size:32px_32px]" />
+
+            <div className="relative mx-auto max-w-[1120px]">
+              <div className="mb-5 flex items-center justify-between font-mono text-[9px] uppercase tracking-[0.18em] text-white/35">
+                <span>Topic · Cross-app tab system</span>
+                <span>{isGrid ? "Grid overview" : "Stacked · top left"}</span>
+              </div>
+
+              <div className="rounded-[11px] border border-white/[0.14] bg-[#15191d]/96 p-[3px] shadow-[0_24px_70px_rgba(0,0,0,.52),0_1px_0_rgba(255,255,255,.04)_inset]">
+                <TabRail
+                  activeTab={activeTab}
+                  isGrid={isGrid}
+                  onSelect={(id) => {
+                    setActiveTab(id);
+                    setIsGrid(false);
+                  }}
+                  onToggleGrid={() => setIsGrid((value) => !value)}
+                />
+
+                <div className="overflow-hidden rounded-b-[7px] border border-white/[0.08] border-t-0 bg-[#0d1115]">
+                  {isGrid ? (
+                    <div className="grid min-h-[492px] gap-px bg-white/[0.06] p-px md:grid-cols-2">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setActiveTab("chrome");
+                          setIsGrid(false);
+                        }}
+                        className="group relative min-h-[360px] overflow-hidden bg-[#11161a] text-left"
+                      >
+                        <WindowLabel app="Google Chrome" title="lattices — GitHub" icon={Globe2} />
+                        <ChromeSurface compact />
+                        <OpenHint />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setActiveTab("terminal");
+                          setIsGrid(false);
+                        }}
+                        className="group relative min-h-[360px] overflow-hidden bg-[#090d10] text-left"
+                      >
+                        <WindowLabel app="iTerm2" title="lattices — zsh" icon={Terminal} />
+                        <TerminalSurface compact />
+                        <OpenHint />
+                      </button>
+                    </div>
+                  ) : activeTab === "chrome" ? (
+                    <ChromeSurface />
+                  ) : (
+                    <TerminalSurface />
+                  )}
+                </div>
+              </div>
+
+              <div className="mt-4 flex flex-wrap items-center justify-between gap-3 px-1 font-mono text-[9px] uppercase tracking-[0.16em] text-white/34">
+                <span>⌃⌥⇧⌘3 reveals group chrome</span>
+                <span>Click a tab to raise its real window · Grid never creates a clone</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-8 grid border-y border-studio-rule md:grid-cols-3 md:divide-x md:divide-studio-rule">
+          <Principle number="01" title="One frame">
+            The group owns a single spatial footprint. Selecting a tab raises another native
+            window into that exact frame.
+          </Principle>
+          <Principle number="02" title="Thin ownership">
+            Lattices adds 38 pixels of chrome and a quiet signal border. The apps remain visually
+            and behaviorally themselves.
+          </Principle>
+          <Principle number="03" title="Grid is a mode">
+            Grid temporarily fans the same windows out for comparison; choosing one collapses the
+            group back into a stack.
+          </Principle>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function DesktopBar() {
+  return (
+      <div className="flex h-10 items-center border-b border-white/[0.07] bg-[#111315] px-4">
+      <div className="flex gap-2">
+        <span className="h-2.5 w-2.5 rounded-full bg-white/15" />
+        <span className="h-2.5 w-2.5 rounded-full bg-white/15" />
+        <span className="h-2.5 w-2.5 rounded-full bg-white/15" />
+      </div>
+      <div className="mx-auto flex items-center gap-2 text-[10px] text-white/38">
+        <Layers3 size={12} /> Research workspace
+      </div>
+      <div className="w-[52px] text-right font-mono text-[9px] text-white/25">12:43</div>
+    </div>
+  );
+}
+
+function TabRail({
+  activeTab,
+  isGrid,
+  onSelect,
+  onToggleGrid,
+}: {
+  activeTab: TabID;
+  isGrid: boolean;
+  onSelect: (id: TabID) => void;
+  onToggleGrid: () => void;
+}) {
+  return (
+    <div className="flex h-[38px] items-end gap-1 rounded-t-[7px] border border-white/[0.07] bg-[#202428]/95 px-1.5 pt-1 shadow-[0_1px_0_rgba(255,255,255,.035)_inset] backdrop-blur-xl">
+      <button
+        type="button"
+        className="mb-1 mr-0.5 flex h-7 min-w-[116px] items-center gap-1.5 rounded px-2 text-left text-white/70 hover:bg-white/[0.045] hover:text-white/90"
+        aria-label="Research tab group"
+      >
+        <span className="grid h-4 w-4 place-items-center rounded-[4px] border border-white/[0.08] bg-black/20 text-white/52">
+          <Layers3 size={9} strokeWidth={1.8} />
+        </span>
+        <span className="truncate text-[9.5px] font-medium">Research</span>
+        <ChevronDown size={9} className="ml-auto text-white/25" />
+      </button>
+
+      <span className="mb-2 h-4 w-px bg-white/[0.08]" />
+
+      <div className="flex min-w-0 flex-1 items-end gap-1 overflow-x-auto px-0.5">
+        {tabs.map((tab) => {
+          const Icon = tab.icon;
+          const active = activeTab === tab.id && !isGrid;
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => onSelect(tab.id)}
+              aria-label={`${tab.app} ${tab.title}`}
+              title={`${tab.app} · ${tab.title}`}
+              className={`relative flex h-[30px] min-w-[108px] max-w-[142px] items-center gap-2 rounded-t-[6px] border border-b-0 px-2.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-[#6ed8c8]/65 ${
+                active
+                  ? "border-white/[0.11] bg-[#2d3236] text-white/92 shadow-[0_-1px_0_rgba(255,255,255,.025)_inset]"
+                  : "border-transparent bg-transparent text-white/38 hover:bg-white/[0.04] hover:text-white/70"
+              }`}
+            >
+              {active ? <span className="absolute inset-x-2 bottom-0 h-[2px] rounded-t-full bg-[#6ed8c8]/75" /> : null}
+              <Icon size={11} className={active ? "text-[#6ed8c8]" : "text-white/30"} />
+              <span className="truncate text-[9.5px] font-medium">{tab.label}</span>
+            </button>
+          );
+        })}
+
+        <button
+          type="button"
+          className="mb-1 grid h-7 w-7 shrink-0 place-items-center rounded text-white/20 hover:bg-white/[0.04] hover:text-white/60"
+          aria-label="Add tab"
+        >
+          <Plus size={11} />
+        </button>
+      </div>
+
+      <span className="mb-2 h-4 w-px bg-white/[0.08]" />
+
+      <button
+        type="button"
+        onClick={onToggleGrid}
+        aria-label={isGrid ? "Return to stack" : "Grid"}
+        title={isGrid ? "Return to stack" : "Show group as grid"}
+        className={`mb-1 grid h-7 w-8 place-items-center rounded border transition-colors ${
+          isGrid
+            ? "border-white/[0.16] bg-[#d9dfdf] text-[#161a1d]"
+            : "border-transparent bg-transparent text-white/32 hover:bg-white/[0.04] hover:text-white/72"
+        }`}
+      >
+        <Grid2X2 size={11} />
+      </button>
+    </div>
+  );
+}
+
+function ChromeSurface({ compact = false }: { compact?: boolean }) {
+  const files = [
+    ["apps", "macOS app and website"],
+    ["bin", "CLI and app build tools"],
+    ["design/studio", "product studies"],
+    ["docs", "concepts, API, and layers"],
+    ["README.md", "Lattices workspace manager"],
+  ];
+
+  return (
+    <div className={`${compact ? "h-full min-h-[425px]" : "min-h-[492px]"} bg-[#f6f8fa] text-[#1f2328]`}>
+      <div className="border-b border-black/15 bg-[#dee1e5]">
+        <div className="flex h-9 items-end gap-2 px-3">
+          <div className="mb-3 flex gap-1.5">
+            <span className="h-2.5 w-2.5 rounded-full bg-[#ff5f57]" />
+            <span className="h-2.5 w-2.5 rounded-full bg-[#febc2e]" />
+            <span className="h-2.5 w-2.5 rounded-full bg-[#28c840]" />
+          </div>
+          <div className="flex h-7 min-w-0 max-w-[245px] flex-1 items-center gap-2 rounded-t-lg bg-[#f3f4f5] px-3 text-[9px] text-black/70 shadow-sm">
+            <span className="grid h-3.5 w-3.5 place-items-center rounded-full bg-[#24292f] text-[6px] font-bold text-white">GH</span>
+            <span className="truncate">arach/lattices · GitHub</span>
+            <X size={9} className="ml-auto text-black/35" />
+          </div>
+          <Plus size={11} className="mb-2 text-black/45" />
+        </div>
+        <div className="flex h-9 items-center gap-2 bg-[#f3f4f5] px-3">
+          <span className="text-[13px] text-black/35">‹</span>
+          <span className="text-[13px] text-black/35">›</span>
+          <span className="text-[12px] text-black/38">↻</span>
+          <div className="flex h-6 flex-1 items-center rounded-full border border-black/[0.08] bg-white/80 px-3 text-[8px] text-black/45">
+            <Search size={9} className="mr-2" /> github.com/arach/lattices
+          </div>
+          <span className="grid h-5 w-5 place-items-center rounded-full bg-[#59636d] text-[7px] font-semibold text-white">A</span>
+        </div>
+      </div>
+
+      <div className={`${compact ? "px-5 py-5 pt-14" : "px-8 py-7 lg:px-12"}`}>
+        <div className="mx-auto max-w-[820px]">
+          <div className="flex items-center gap-2 text-[10px] text-[#59636d]">
+            <span className="grid h-6 w-6 place-items-center rounded-md bg-[#24292f] text-[8px] font-bold text-white">L</span>
+            <span className="text-[#0969da]">arach</span>
+            <span>/</span>
+            <strong className="text-[13px] text-[#1f2328]">lattices</strong>
+            <span className="rounded-full border border-black/15 px-1.5 py-0.5 text-[7px]">Public</span>
+          </div>
+
+          <div className="mt-5 flex items-center gap-4 border-b border-black/10 pb-2 text-[9px] text-[#59636d]">
+            <strong className="border-b-2 border-[#fd8c73] pb-2 text-[#1f2328]">Code</strong>
+            <span>Issues&nbsp; 12</span>
+            <span>Pull requests&nbsp; 3</span>
+            <span>Actions</span>
+          </div>
+
+          <div className="mt-4 overflow-hidden rounded-md border border-[#d0d7de] bg-white">
+            <div className="flex h-9 items-center border-b border-[#d0d7de] bg-[#f6f8fa] px-3 text-[8px] text-[#59636d]">
+              <strong className="text-[#1f2328]">main</strong>
+              <span className="ml-auto">02b9c61 · Add cross-app tab groups</span>
+            </div>
+            {files.map(([name, detail]) => (
+              <div key={name} className="grid grid-cols-[1fr_1.7fr_auto] items-center border-b border-[#d8dee4] px-3 py-2.5 text-[9px] last:border-0">
+                <span className="font-medium text-[#0969da]">{name}</span>
+                <span className="truncate text-[#59636d]">{detail}</span>
+                <span className="text-[#8c959f]">today</span>
+              </div>
+            ))}
+          </div>
+
+          {!compact ? (
+            <div className="mt-4 rounded-md border border-[#d0d7de] bg-white p-4">
+              <div className="text-[12px] font-semibold">Lattices</div>
+              <p className="mt-2 text-[10px] leading-relaxed text-[#59636d]">
+                A macOS workspace manager for grouping, arranging, and navigating real application windows.
+              </p>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TerminalSurface({ compact = false }: { compact?: boolean }) {
+  const lines = [
+    ["➜", "lattices git:(codex/cross-app-tabs) bun run check"],
+    ["", "✓ TypeScript typecheck"],
+    ["", "✓ Swift app build"],
+    ["➜", "lattices git:(codex/cross-app-tabs) lattices tabs list"],
+    ["", "Research   tabs   2 windows   top-left"],
+    ["", "Chrome     65433   lattices — GitHub"],
+    ["", "iTerm2     65745   lattices — zsh"],
+  ];
+
+  return (
+    <div className={`${compact ? "h-full min-h-[425px] p-5 pt-14" : "min-h-[492px] p-7 lg:p-9"} bg-[#17191c] font-mono`}>
+      <div className="mx-auto max-w-[860px] overflow-hidden rounded-lg border border-black/50 bg-[#0b0d0f] shadow-[0_18px_45px_rgba(0,0,0,.38)]">
+        <div className="flex h-9 items-center border-b border-black/60 bg-[#25282c] px-3">
+          <div className="flex gap-1.5">
+            <span className="h-2.5 w-2.5 rounded-full bg-[#ff5f57]" />
+            <span className="h-2.5 w-2.5 rounded-full bg-[#febc2e]" />
+            <span className="h-2.5 w-2.5 rounded-full bg-[#28c840]" />
+          </div>
+          <span className="mx-auto text-[9px] text-white/52">lattices — zsh — 132×34</span>
+          <span className="w-[38px]" />
+        </div>
+        <div className="min-h-[365px] space-y-2.5 p-5 text-[10px] leading-relaxed lg:p-7 lg:text-[11px]">
+          {lines.map(([sigil, text], index) => (
+            <div key={`${text}-${index}`} className={text.startsWith("✓") ? "text-[#72c19e]" : "text-[#c6cbd0]"}>
+              <span className={sigil === "➜" ? "text-[#63d4c3]" : "text-white/22"}>{sigil}</span>{" "}
+              {text}
+            </div>
+          ))}
+          <div className="flex items-center gap-1 text-white/70">
+            <span className="text-[#63d4c3]">➜</span>
+            <span className="text-[#b178d3]">lattices</span>
+            <span className="text-[#e1b55c]">git:(codex/cross-app-tabs)</span>
+            <span className="h-4 w-1.5 animate-pulse bg-white/75" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WindowLabel({ app, title, icon: Icon }: { app: string; title: string; icon: typeof Globe2 }) {
+  return (
+    <div className="absolute inset-x-0 top-0 z-10 flex h-11 items-center border-b border-white/[0.07] bg-[#0b1014]/95 px-4 backdrop-blur">
+      <Icon size={12} className="text-[#68e7d1]" />
+      <span className="ml-2 font-mono text-[8px] uppercase tracking-[0.16em] text-white/42">{app}</span>
+      <span className="mx-2 text-white/15">/</span>
+      <span className="truncate text-[10px] text-white/72">{title}</span>
+    </div>
+  );
+}
+
+function OpenHint() {
+  return (
+    <span className="absolute bottom-4 right-4 flex items-center gap-1 rounded-full border border-white/[0.08] bg-black/45 px-2.5 py-1.5 font-mono text-[8px] uppercase tracking-[0.14em] text-white/0 backdrop-blur transition-colors group-hover:text-white/60">
+      Open tab <ExternalLink size={9} />
+    </span>
+  );
+}
+
+function Principle({ number, title, children }: { number: string; title: string; children: React.ReactNode }) {
+  return (
+    <div className="px-5 py-6 first:pl-0 last:pr-0 md:px-7">
+      <div className="font-mono text-[9px] uppercase tracking-[0.2em] text-studio-ink-faint">{number}</div>
+      <h2 className="mt-3 text-[14px] font-medium text-studio-ink-strong">{title}</h2>
+      <p className="mt-2 text-[12px] leading-[1.65] text-studio-ink-faint">{children}</p>
+    </div>
+  );
+}

--- a/design/studio/src/studio/studioRegistry.ts
+++ b/design/studio/src/studio/studioRegistry.ts
@@ -46,6 +46,19 @@ export const pages: readonly LatticesPage[] = [
       "apps/mac/Sources/Core/Companion/LatticesCompanionCockpit.swift",
     ],
   },
+  {
+    href: "/studio/studies/cross-app-tabs",
+    label: "Cross-app tabs — one topic, many tools",
+    bucket: "studies",
+    surface: "cross",
+    status: "in-flight",
+    blurb:
+      "A native-window tab rail for grouping Chrome, terminal, and editor surfaces around one topic. Tabs preserve real app identity; Grid temporarily fans the same windows out for comparison.",
+    source: [
+      "apps/mac/Sources/Core/Workspace/LiveTabGroupStore.swift",
+      "apps/mac/Sources/Core/Overlays/HUD/HUDWindowHints.swift",
+    ],
+  },
 ];
 
 const defined = defineStudio({

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -23,6 +23,8 @@ These are the preferred action identifiers:
 | `window.place` | Place a window or session using a typed placement spec | `actions.execute` |
 | `layer.activate` | Bring up a workspace layer with explicit activation mode | Daemon API |
 | `space.optimize` | Rebalance a set of windows using an explicit scope and strategy | Daemon API |
+| `tabStacks.create` | Turn explicit or Hyperspace-selected windows into ephemeral cross-app tabs | Daemon API |
+| `tabStacks.layout` | Expand a live tab stack to grid or collapse it back to tabs | Daemon API |
 
 Compatibility wrappers still exist:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1860,6 +1860,12 @@ Restart a specific pane's process within a session.
 | `layer.switch` | write | Compatibility wrapper for launch-style layer activation |
 | `group.launch` | write | Launch a tab group |
 | `group.kill` | write | Kill a tab group |
+| `tabStacks.list` | read | List ephemeral cross-app tab stacks |
+| `tabStacks.create` | write | Create a stack from selected or explicit windows |
+| `tabStacks.add` | write | Add windows to a live stack |
+| `tabStacks.select` | write | Focus a member tab |
+| `tabStacks.layout` | write | Toggle or set tabs/grid layout |
+| `tabStacks.delete` | write | Ungroup without closing windows |
 
 #### `projects.list`
 
@@ -1963,6 +1969,25 @@ Kill a tab group session.
 | Field | Type   | Required | Description      |
 |-------|--------|----------|------------------|
 | `id`  | string | yes      | Group ID         |
+
+#### Live tab stacks
+
+Live stacks operate on windows that are already open and last for the current
+Lattices run. If `windowIds` is omitted, create/add uses the latest multi-window
+selection from Hyperspace.
+
+```bash
+lattices call tabStacks.create '{"name":"Research","placement":"top-left"}'
+lattices call tabStacks.layout '{"mode":"grid"}'
+lattices call tabStacks.select '{"index":1}'
+lattices call tabStacks.layout '{"mode":"tabs"}'
+lattices call tabStacks.delete '{}'
+```
+
+`tabStacks.create` needs at least two live windows. You may instead pass
+`{"windowIds":[123,456]}`. The optional `id` on add/select/layout/delete defaults
+to the active group. Layout mode is `tabs`, `grid`, or `toggle`; selecting uses a
+zero-based `index` or `windowId`.
 
 ---
 

--- a/docs/assistant-knowledge.md
+++ b/docs/assistant-knowledge.md
@@ -44,7 +44,10 @@ Group projects into named **layers** you can switch between, and tab-group relat
 windows. `workspace.json` layers launch/focus/tile projects. Studio layers are
 rule-backed live window sets persisted in `~/.lattices/layers.json`; their clauses
 support app/title/session exact, substring, regex, Space, visibility, and exclusion
-matches. → [Layers](/docs/layers).
+matches. For an ephemeral cross-app stack, select windows in Hyperspace and press
+Cmd+T or say “stack these as tabs” / “add these up”; use the HUD grid button to fan
+them out. Agents call `tabStacks.create`, `tabStacks.add`, `tabStacks.select`, and
+`tabStacks.layout`. → [Layers](/docs/layers).
 
 ### Command palette & menu bar app
 The palette (**Cmd+Shift+M**) is the app's primary surface: launch projects, tile,

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -14,10 +14,10 @@ work together.
 
 ## Tab Groups
 
-Tab groups let you bundle related projects as tabs within a single
-terminal session (requires tmux). This is useful when you have a family
-of projects — like an iOS app, macOS app, website, and API — that
-you think of as one logical unit.
+Tab groups let you bundle related work into one Lattices tab stack.
+A tab can be a terminal project or a native application window such as
+Chrome, an editor, Notes, or a design tool. This is useful when several
+windows belong to one topic and should share one screen position.
 
 ### Configuration
 
@@ -31,24 +31,28 @@ Add `groups` to `~/.lattices/workspace.json`:
       "id": "vox",
       "label": "Vox",
       "tabs": [
-        { "path": "/Users/you/dev/vox-ios", "label": "iOS" },
-        { "path": "/Users/you/dev/vox-macos", "label": "macOS" },
-        { "path": "/Users/you/dev/vox-web", "label": "Website" },
-        { "path": "/Users/you/dev/vox-api", "label": "API" }
+        { "path": "/Users/you/dev/vox", "label": "Terminal" },
+        { "app": "Google Chrome", "title": "Vox", "url": "https://github.com/example/vox", "label": "Web" },
+        { "app": "Visual Studio Code", "title": "vox", "launch": "Visual Studio Code", "label": "Editor" }
       ]
     }
   ]
 }
 ```
 
-Each tab's pane layout comes from its own `.lattices.json` — no changes
-to per-project configs.
+Project tabs get their pane layout from their own `.lattices.json`.
+App tabs are matched by app name and optional window-title substring.
+`url` or `launch` tells Lattices how to open a missing app tab.
 
 ### How it works
 
-- Session name follows the pattern `lattices-group-<id>` (e.g. `lattices-group-vox`)
-- 1 group = 1 tmux session. Each tab is a tmux window, and each window
-  gets its own panes from that project's `.lattices.json`
+- Each project tab keeps its normal `<basename>-<hash>` tmux session
+- Native app tabs are tracked by `app` and optional `title`
+- When a layer references the group with a `tile`, all matched windows
+  collapse into that slot as a cross-app tab stack
+- The HUD shows a Lattices tab strip for the active layer's first group
+- The grid button fans the group out across the display; press it again
+  to collapse the windows back into their shared slot
 - You can still launch projects independently: `cd vox-ios && lattices start`
   creates its own standalone session as before
 
@@ -59,8 +63,14 @@ to per-project configs.
 | `id`           | string   | Unique identifier for the group      |
 | `label`        | string   | Display name shown in the UI         |
 | `tabs`         | array    | List of tab definitions              |
-| `tabs[].path`  | string   | Absolute path to project directory   |
-| `tabs[].label` | string?  | Tab name (defaults to directory name) |
+| `tabs[].path`  | string?  | Absolute path for a terminal project tab |
+| `tabs[].app`   | string?  | Application name for a native app tab |
+| `tabs[].title` | string?  | Window-title substring used to select the right app window |
+| `tabs[].url`   | string?  | URL to open when an app tab is missing |
+| `tabs[].launch`| string?  | Application name passed to `open -a` when missing |
+| `tabs[].label` | string?  | Tab name (defaults to directory or app name) |
+
+Each tab needs either `path` or `app`.
 
 ### CLI commands
 
@@ -73,8 +83,8 @@ lattices tab <group> [tab]  # Switch tab by label or index
 Examples:
 
 ```bash
-lattices group vox       # Launch all Vox tabs
-lattices tab vox iOS     # Switch to the iOS tab
+lattices group vox       # Launch all Vox terminal and app tabs
+lattices tab vox Editor  # Open the editor tab
 lattices tab vox 0       # Switch to first tab (by index)
 ```
 
@@ -88,6 +98,7 @@ Each group row shows:
 - Expand/collapse to see individual tabs
 - Launch/Attach and Kill buttons
 - Per-tab "Go" buttons to switch and focus a specific tab
+- A grid/collapse button for changing between stack and overview
 
 The command palette also includes group commands:
 
@@ -97,6 +108,24 @@ The command palette also includes group commands:
 | Attach *group*             | Focus the running group session        |
 | *Group*: *Tab*             | Switch to a specific tab in a group    |
 | Kill *group* Group         | Terminate the group session            |
+
+### Live tab stacks
+
+You do not need to edit `workspace.json` for an ad-hoc group. Open
+Hyperspace, select two or more windows, and press **⌘T** (or choose
+**Stack N as Tabs** from a selected window's menu). Lattices immediately
+stacks those existing terminal, browser, editor, or other app windows in
+the top-left and shows their switcher in the HUD.
+
+Use a tab button to bring that member forward. Use the grid button to fan
+the group out, then press it again to collapse back to the shared slot.
+The × button ungroups the windows without closing them. Live stacks are
+runtime-only; use the configured groups above when the group should return
+after Lattices restarts.
+
+The Workspace Assistant understands the same selection. With windows still
+selected, say **“stack these as tabs”** or **“add these up.”** Agents can use
+the `tabStacks.*` daemon methods described in the Agent API.
 
 ## Layers
 
@@ -203,9 +232,11 @@ This lets you tile a whole group into a screen position:
 }
 ```
 
-When switching to this layer, lattices launches (or focuses) the
-"vox" group session and tiles it to the top-left quarter, alongside
-the design-system project on the right.
+When switching to this layer, Lattices launches or focuses the "vox"
+group and stacks all of its terminal and app windows in the top-left
+quarter, alongside the design-system project on the right. Use the HUD
+tab strip to change the visible member, or its grid button to fan out
+the whole topic.
 
 ### Layer fields
 


### PR DESCRIPTION
## What changed

- adds runtime cross-app tab groups backed by real macOS windows
- adds floating Lattices tab tools and group guides that persist beyond Hyper-3
- supports selecting, grid expansion, collapse, drag-to-detach, and ungrouping
- adds Hyper-3, configured workspace-group, assistant, CLI, and `tabStacks.*` daemon entry points
- adds the realistic Cross App Tabs Design Studio study
- traces the running dev build identity and documents the new workflows

## Why

Related terminal, browser, and editor windows should behave like one coherent workspace without imitating or displacing each app's native tab chrome.

The original selection path also re-polled and re-laid out every grouped window before focusing the selected app. The optimized path changes only focus/z-order in the common case, preserves a geometry-drift repair fallback, and coalesces native-layout refreshes.

## Impact

In the Chrome/iTerm benchmark, median tab-switch RPC latency fell from 116 ms to 31–40 ms and average latency from 125 ms to about 53 ms. Explicit selection remains stable while macOS focus settles, and the verified z-order is palette → guide → selected app → background member.

## Validation

- `swift build --package-path apps/mac`
- `bun run check:types`
- `bun run test:dependencies`
- signed dev build exercised with Chrome + iTerm: selection, grid → tabs, shared geometry, drag detach, and z-order
- Studio production bundle compiles, then hits the existing HudsonKit `ShellAppConfig` mismatch in `StudioApp.tsx` (`rightPanel` / `agentContext`)
- CLI tests: 7 passed, 1 skipped; the single failure is the existing hard-coded canonical checkout hash when run from a temporary worktree path

## Stack

This is a focused stacked PR targeting `deck-builder-mac` so the unrelated dirty worktree and command-bar commits are not included.