### PR TITLE
Add Hyper key diagnostics

### DIFF
--- a/apps/mac/Sources/AppShell/SettingsView.swift
+++ b/apps/mac/Sources/AppShell/SettingsView.swift
@@ -125,6 +125,7 @@ struct SettingsContentView: View {
     @ObservedObject var permChecker: PermissionChecker = .shared
     @ObservedObject var mouseGestureController: MouseGestureController = .shared
     @ObservedObject var keyboardRemapController: KeyboardRemapController = .shared
+    @ObservedObject var hyperKeyDiagnostics: HyperKeyDiagnosticRecorder = .shared
     @ObservedObject var assistantSession: WorkspaceAssistantSession = .shared
     var onBack: (() -> Void)? = nil
 
@@ -941,6 +942,58 @@ struct SettingsContentView: View {
                             .buttonStyle(.plain)
 
                             Spacer()
+                        }
+
+                        cardDivider
+
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack(spacing: 8) {
+                                VStack(alignment: .leading, spacing: 3) {
+                                    Text("Hyper troubleshooting trace")
+                                        .font(Typo.monoBold(10.5))
+                                        .foregroundColor(Palette.text)
+                                    Text("Captures Caps/F18 events and remap state only—never typed characters.")
+                                        .font(Typo.caption(9))
+                                        .foregroundColor(Palette.textMuted.opacity(0.78))
+                                }
+                                Spacer()
+                                statusToken(
+                                    hyperKeyDiagnostics.isRecording ? "Recording" : "Stopped",
+                                    color: hyperKeyDiagnostics.isRecording ? Palette.detach : Palette.textDim
+                                )
+                            }
+
+                            HStack(spacing: 8) {
+                                Button {
+                                    if hyperKeyDiagnostics.isRecording {
+                                        hyperKeyDiagnostics.stop()
+                                    } else {
+                                        hyperKeyDiagnostics.start()
+                                        keyboardRemapController.captureHyperDiagnosticSnapshot(reason: "recording started")
+                                    }
+                                } label: {
+                                    settingsActionLabel(
+                                        hyperKeyDiagnostics.isRecording ? "Stop Trace" : "Start Trace",
+                                        icon: hyperKeyDiagnostics.isRecording ? "stop.circle" : "record.circle",
+                                        emphasized: true
+                                    )
+                                }
+                                .buttonStyle(.plain)
+
+                                Button {
+                                    hyperKeyDiagnostics.reveal()
+                                } label: {
+                                    settingsActionLabel("Reveal Trace", icon: "folder")
+                                }
+                                .buttonStyle(.plain)
+
+                                Text("~/.lattices/hyper-key-trace.jsonl")
+                                    .font(Typo.mono(8.5))
+                                    .foregroundColor(Palette.textMuted.opacity(0.64))
+                                    .lineLimit(1)
+
+                                Spacer(minLength: 0)
+                            }
                         }
 
                         if !permChecker.accessibility {

--- a/apps/mac/Sources/Core/Daemon/LatticesApi.swift
+++ b/apps/mac/Sources/Core/Daemon/LatticesApi.swift
@@ -1222,6 +1222,28 @@ final class LatticesApi {
         ))
 
         api.register(Endpoint(
+            method: "diagnostics.hyperTest",
+            description: "Run the direct-Hyper and F18 transport diagnostic sequence",
+            access: .mutate,
+            params: [Param(name: "keyCode", type: "int", required: false, description: "macOS virtual key code (default 19 / key 2)")],
+            returns: .custom("Object with scheduled, Secure Event Input, and HID post access state"),
+            handler: { params in
+                let requested = params?["keyCode"]?.intValue ?? 19
+                let keyCode = UInt16(clamping: requested)
+                var result = (secureInput: false, postAccess: 2)
+                Self.runOnMain {
+                    result = KeyboardRemapController.shared.scheduleEndToEndDiagnostic(keyCode: keyCode)
+                }
+                return .object([
+                    "scheduled": .bool(!result.secureInput),
+                    "secureEventInput": .bool(result.secureInput),
+                    "hidPostAccess": .int(result.postAccess),
+                    "keyCode": .int(Int(keyCode)),
+                ])
+            }
+        ))
+
+        api.register(Endpoint(
             method: "processes.list",
             description: "List interesting developer processes with tmux/window linkage",
             access: .read,

--- a/apps/mac/Sources/Core/Input/HyperKeyDiagnosticRecorder.swift
+++ b/apps/mac/Sources/Core/Input/HyperKeyDiagnosticRecorder.swift
@@ -1,0 +1,210 @@
+import AppKit
+import Combine
+import Foundation
+
+/// Opt-in, bounded diagnostic trace for the Caps Lock → F18 → Hyper pipeline.
+///
+/// This intentionally does not capture general keyboard traffic. Callers only
+/// submit transport events, events handled while the Hyper layer is active,
+/// and lifecycle/state transitions. Records contain key codes and modifier
+/// masks, never characters or text.
+final class HyperKeyDiagnosticRecorder: ObservableObject {
+    static let shared = HyperKeyDiagnosticRecorder()
+
+    @Published private(set) var isRecording: Bool
+
+    let traceURL: URL
+
+    private static let recordingDefaultsKey = "keyboardRemaps.hyperDiagnosticsEnabled"
+    private static let maxTraceBytes: UInt64 = 2_000_000
+    private let stateLock = NSLock()
+    private let activityLock = NSLock()
+    private let writerQueue = DispatchQueue(label: "dev.lattices.hyper-key-trace", qos: .utility)
+    private var recording: Bool
+    private var sequence: UInt64 = 0
+    private var activityCounts: [String: Int] = [:]
+    private var activityWindowStartedAt = ProcessInfo.processInfo.systemUptime
+
+    private init() {
+        let directory = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".lattices", isDirectory: true)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        traceURL = directory.appendingPathComponent("hyper-key-trace.jsonl")
+
+        let persisted = UserDefaults.standard.bool(forKey: Self.recordingDefaultsKey)
+        recording = persisted
+        isRecording = persisted
+        if persisted {
+            record(kind: "trace.resumed", fields: environmentFields())
+        }
+    }
+
+    func start() {
+        stateLock.lock()
+        guard !recording else {
+            stateLock.unlock()
+            return
+        }
+        recording = true
+        sequence = 0
+        stateLock.unlock()
+
+        activityLock.lock()
+        activityCounts.removeAll()
+        activityWindowStartedAt = ProcessInfo.processInfo.systemUptime
+        activityLock.unlock()
+
+        UserDefaults.standard.set(true, forKey: Self.recordingDefaultsKey)
+        isRecording = true
+        writerQueue.async { [weak self] in
+            self?.rotateTraceForNewCapture()
+        }
+        record(kind: "trace.started", fields: environmentFields())
+        DiagnosticLog.shared.info("HyperKeyTrace: recording to ~/.lattices/hyper-key-trace.jsonl")
+    }
+
+    func stop() {
+        flushInputActivity()
+        record(kind: "trace.stopped")
+        stateLock.lock()
+        recording = false
+        stateLock.unlock()
+
+        UserDefaults.standard.set(false, forKey: Self.recordingDefaultsKey)
+        isRecording = false
+        DiagnosticLog.shared.info("HyperKeyTrace: recording stopped")
+    }
+
+    func reveal() {
+        writerQueue.async { [traceURL] in
+            if !FileManager.default.fileExists(atPath: traceURL.path) {
+                FileManager.default.createFile(atPath: traceURL.path, contents: nil)
+            }
+            DispatchQueue.main.async {
+                NSWorkspace.shared.activateFileViewerSelecting([traceURL])
+            }
+        }
+    }
+
+    func record(kind: String, fields: [String: Any] = [:]) {
+        stateLock.lock()
+        guard recording else {
+            stateLock.unlock()
+            return
+        }
+        sequence += 1
+        let recordSequence = sequence
+        stateLock.unlock()
+
+        let capturedAt = Date().timeIntervalSince1970
+        let monotonic = ProcessInfo.processInfo.systemUptime
+        writerQueue.async { [weak self] in
+            guard let self else { return }
+            var payload = fields
+            payload["seq"] = recordSequence
+            payload["time"] = capturedAt
+            payload["uptime"] = monotonic
+            payload["kind"] = kind
+
+            guard JSONSerialization.isValidJSONObject(payload),
+                  let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]) else {
+                return
+            }
+            self.rotateIfNeeded(incomingBytes: UInt64(data.count + 1))
+            self.append(data + Data([0x0A]))
+        }
+    }
+
+    /// Counts all keyboard event-tap traffic without retaining key codes,
+    /// modifier flags, characters, or source applications. This tells a trace
+    /// whether the tap was alive when an expected F18 event went missing.
+    func observeInputEvent(type: String) {
+        stateLock.lock()
+        let active = recording
+        stateLock.unlock()
+        guard active else { return }
+
+        let now = ProcessInfo.processInfo.systemUptime
+        var summary: [String: Int]?
+        var durationMs = 0
+
+        activityLock.lock()
+        activityCounts[type, default: 0] += 1
+        if now - activityWindowStartedAt >= 1 {
+            summary = activityCounts
+            durationMs = Int((now - activityWindowStartedAt) * 1_000)
+            activityCounts.removeAll()
+            activityWindowStartedAt = now
+        }
+        activityLock.unlock()
+
+        if let summary {
+            record(kind: "input.activity", fields: [
+                "durationMs": durationMs,
+                "counts": summary,
+            ])
+        }
+    }
+
+    private func flushInputActivity() {
+        let now = ProcessInfo.processInfo.systemUptime
+        var summary: [String: Int] = [:]
+        var durationMs = 0
+
+        activityLock.lock()
+        if !activityCounts.isEmpty {
+            summary = activityCounts
+            durationMs = Int((now - activityWindowStartedAt) * 1_000)
+            activityCounts.removeAll()
+            activityWindowStartedAt = now
+        }
+        activityLock.unlock()
+
+        guard !summary.isEmpty else { return }
+        record(kind: "input.activity", fields: [
+            "durationMs": durationMs,
+            "counts": summary,
+        ])
+    }
+
+    private func environmentFields() -> [String: Any] {
+        let environment: [String: Any] = [
+            "pid": ProcessInfo.processInfo.processIdentifier,
+            "bundle": Bundle.main.bundleIdentifier ?? "unknown",
+            "version": Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown",
+            "build": Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown",
+        ]
+        return environment.merging(SecureEventInputDiagnostics.snapshot().traceFields) { _, new in new }
+    }
+
+    private func rotateTraceForNewCapture() {
+        let previousURL = traceURL.deletingLastPathComponent()
+            .appendingPathComponent("hyper-key-trace.previous.jsonl")
+        try? FileManager.default.removeItem(at: previousURL)
+        if FileManager.default.fileExists(atPath: traceURL.path) {
+            try? FileManager.default.moveItem(at: traceURL, to: previousURL)
+        }
+        FileManager.default.createFile(atPath: traceURL.path, contents: nil)
+    }
+
+    private func rotateIfNeeded(incomingBytes: UInt64) {
+        let size = ((try? FileManager.default.attributesOfItem(atPath: traceURL.path)[.size]) as? NSNumber)?.uint64Value ?? 0
+        guard size + incomingBytes > Self.maxTraceBytes else { return }
+        rotateTraceForNewCapture()
+    }
+
+    private func append(_ data: Data) {
+        if !FileManager.default.fileExists(atPath: traceURL.path) {
+            FileManager.default.createFile(atPath: traceURL.path, contents: nil)
+        }
+        guard let handle = try? FileHandle(forWritingTo: traceURL) else { return }
+        defer { try? handle.close() }
+        do {
+            try handle.seekToEnd()
+            try handle.write(contentsOf: data)
+        } catch {
+            // The primary logger is deliberately avoided here: a disk error in
+            // a diagnostic sink must not recurse or slow the event-tap thread.
+        }
+    }
+}

--- a/apps/mac/Sources/Core/Input/KeyboardRemapController.swift
+++ b/apps/mac/Sources/Core/Input/KeyboardRemapController.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Carbon
 import Combine
 import CoreGraphics
 import IOKit.hidsystem
@@ -26,6 +27,7 @@ final class KeyboardRemapController: ObservableObject {
     private var lastCapsLayerStaleLogAt: CFAbsoluteTime = 0
     private var pressedKeyCodes: [Int64: CFAbsoluteTime] = [:]
     private let capsLockTransport = CapsLockHIDTransportController()
+    private let hyperTrace = HyperKeyDiagnosticRecorder.shared
     private let breaker = EventTapBreaker(label: "KeyboardRemap")
     private let budgetMeter = TapBudgetMeter(label: "KeyboardRemap")
     private let maxCapsLayerIdleDuration: TimeInterval = 2.0
@@ -63,6 +65,7 @@ final class KeyboardRemapController: ObservableObject {
             refresh()
         }
         DiagnosticLog.shared.warn("KeyboardRemap: manual Caps Lock recovery \(cleared ? "succeeded" : "failed")")
+        traceState("recovery.manual", fields: ["latchCleared": cleared])
         return cleared
     }
 
@@ -71,7 +74,44 @@ final class KeyboardRemapController: ObservableObject {
         refresh()
     }
 
+    func captureHyperDiagnosticSnapshot(reason: String) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        var fields = capsLockTransport.diagnosticSnapshot()
+        fields["reason"] = reason
+        fields.merge(SecureEventInputDiagnostics.snapshot().traceFields) { _, new in new }
+        fields["accessibility"] = PermissionChecker.shared.accessibility
+        fields["remapsEnabled"] = Preferences.shared.keyboardRemapsEnabled
+        traceState("diagnostic.snapshot", fields: fields)
+    }
+
+    /// Schedule a diagnostic keyboard sequence through IOHIDSystem rather than
+    /// CGEvent posting. Synthetic CG events are intentionally ignored by
+    /// Carbon global hotkeys, so they cannot validate the full remap path.
+    /// This posts direct Hyper+key as a control, then F18+key to exercise the
+    /// same transport event the Caps Lock HID mapping produces.
+    func scheduleEndToEndDiagnostic(keyCode: UInt16) -> (secureInput: Bool, postAccess: Int) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        let secureInputSnapshot = SecureEventInputDiagnostics.snapshot()
+        let secureInput = secureInputSnapshot.enabled
+        let access = Int(IOHIDCheckAccess(kIOHIDRequestTypePostEvent).rawValue)
+        let owner = secureInputSnapshot.ownerDescription.map { " owner=\($0)" } ?? ""
+        DiagnosticLog.shared.info(
+            "HyperE2E: scheduled keyCode=\(keyCode) secureInput=\(secureInput) hidPostAccess=\(access)\(owner)"
+        )
+
+        guard !secureInput else {
+            DiagnosticLog.shared.warn("HyperE2E: blocked by Secure Event Input")
+            return (secureInput, access)
+        }
+
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 0.3) {
+            Self.performEndToEndDiagnostic(keyCode: keyCode)
+        }
+        return (secureInput, access)
+    }
+
     func stop() {
+        traceState("controller.stop")
         removeEventTap()
         capsLockTransport.disable()
         capsLockTransportActive = capsLockTransport.isActive
@@ -89,6 +129,7 @@ final class KeyboardRemapController: ObservableObject {
             refresh()
         }
         DiagnosticLog.shared.warn("KeyboardRemap: reset for \(reason)")
+        traceState("controller.reset", fields: ["reason": reason])
     }
 
     private func installObserversIfNeeded() {
@@ -112,6 +153,11 @@ final class KeyboardRemapController: ObservableObject {
     }
 
     private func refresh() {
+        hyperTrace.record(kind: "controller.refresh", fields: [
+            "enabled": Preferences.shared.keyboardRemapsEnabled,
+            "accessibility": PermissionChecker.shared.accessibility,
+            "tapInstalled": eventTap != nil,
+        ])
         guard Preferences.shared.keyboardRemapsEnabled,
               PermissionChecker.shared.accessibility else {
             removeEventTap()
@@ -166,6 +212,7 @@ final class KeyboardRemapController: ObservableObject {
 
         guard let tap else {
             DiagnosticLog.shared.warn("KeyboardRemap: failed to install keyboard event tap")
+            hyperTrace.record(kind: "tap.install.failed")
             return
         }
 
@@ -183,9 +230,11 @@ final class KeyboardRemapController: ObservableObject {
             CGEvent.tapEnable(tap: tap, enable: true)
         }
         DiagnosticLog.shared.info("KeyboardRemap: keyboard event tap installed (\(installedLabel))")
+        hyperTrace.record(kind: "tap.installed", fields: ["location": installedLabel])
     }
 
     private func removeEventTap() {
+        hyperTrace.record(kind: "tap.removed", fields: ["wasInstalled": eventTap != nil])
         if let source = runLoopSource {
             EventTapThread.shared.remove(source: source)
         }
@@ -216,6 +265,7 @@ final class KeyboardRemapController: ObservableObject {
             // re-enabling immediately and getting killed again.
             clearCapsLayer()
             breaker.recordTrip()
+            traceState("tap.disabled.timeout")
             return Unmanaged.passUnretained(event)
         }
         if type == .tapDisabledByUserInput {
@@ -224,6 +274,7 @@ final class KeyboardRemapController: ObservableObject {
             if let eventTap {
                 CGEvent.tapEnable(tap: eventTap, enable: true)
             }
+            traceState("tap.disabled.userInput")
             return Unmanaged.passUnretained(event)
         }
 
@@ -231,8 +282,18 @@ final class KeyboardRemapController: ObservableObject {
             return Unmanaged.passUnretained(event)
         }
 
+        hyperTrace.observeInputEvent(type: eventTypeName(type))
+
+        let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+        let traceThisEvent = capsLayerActive
+            || keyCode == CapsLockHIDTransportController.transportKeyCode
+            || keyCode == KeyboardRemapKey.capsLock.keyCode
+        if traceThisEvent {
+            traceEvent(type: type, event: event, phase: "received")
+        }
+
         expireStalePressedKeys(now: started)
-        updatePressedKeys(type: type, keyCode: event.getIntegerValueField(.keyboardEventKeycode), now: started)
+        updatePressedKeys(type: type, keyCode: keyCode, now: started)
         if shouldTriggerEmergencyReset(type: type, event: event) {
             emergencyClear(now: started)
             InputCaptureResetCenter.reset(reason: "keyboard emergency chord")
@@ -240,6 +301,7 @@ final class KeyboardRemapController: ObservableObject {
         }
 
         if started < bypassUntil {
+            if traceThisEvent { traceEvent(type: type, event: event, phase: "bypassed") }
             return Unmanaged.passUnretained(event)
         }
 
@@ -249,7 +311,6 @@ final class KeyboardRemapController: ObservableObject {
             return Unmanaged.passUnretained(event)
         }
 
-        let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
         if capsLockTransport.isActive,
            keyCode == CapsLockHIDTransportController.transportKeyCode {
             return handleCapsLockTransportEvent(type: type, event: event, rule: rule)
@@ -273,10 +334,12 @@ final class KeyboardRemapController: ObservableObject {
             capsUsedAsModifier = true
             capsLayerLastEventAt = started
             event.flags = normalizedFlags(event.flags).union(.latticesHyper)
+            traceEvent(type: type, event: event, phase: "hyper.applied")
             return Unmanaged.passUnretained(event)
         case .keyUp:
             capsLayerLastEventAt = started
             event.flags = normalizedFlags(event.flags).union(.latticesHyper)
+            traceEvent(type: type, event: event, phase: "hyper.applied")
             return Unmanaged.passUnretained(event)
         default:
             return Unmanaged.passUnretained(event)
@@ -289,6 +352,7 @@ final class KeyboardRemapController: ObservableObject {
             activateCapsLayer(now: CFAbsoluteTimeGetCurrent())
             releaseCapsLockLatchIfNeeded()
             DiagnosticLog.shared.info("KeyboardRemap: Caps Lock layer active")
+            traceState("layer.active", fields: ["source": "caps.flagsChanged"])
         } else {
             let shouldTap = capsLayerActive && !capsUsedAsModifier && rule.toIfAlone == .escape
             clearCapsLayer()
@@ -297,6 +361,7 @@ final class KeyboardRemapController: ObservableObject {
                 postKeyTap(keyCode: 53)
             }
             DiagnosticLog.shared.info("KeyboardRemap: Caps Lock layer inactive")
+            traceState("layer.inactive", fields: ["source": "caps.flagsChanged", "postedEscape": shouldTap])
         }
 
         return nil
@@ -312,7 +377,9 @@ final class KeyboardRemapController: ObservableObject {
             if event.getIntegerValueField(.keyboardEventAutorepeat) == 0 {
                 activateCapsLayer(now: CFAbsoluteTimeGetCurrent())
                 DiagnosticLog.shared.info("KeyboardRemap: Caps Lock transport layer active")
+                traceState("layer.active", fields: ["source": "f18.keyDown"])
             }
+            traceEvent(type: type, event: event, phase: "swallowed")
             return nil
         case .keyUp:
             let shouldTap = capsLayerActive && !capsUsedAsModifier && rule.toIfAlone == .escape
@@ -321,6 +388,8 @@ final class KeyboardRemapController: ObservableObject {
                 postKeyTap(keyCode: 53)
             }
             DiagnosticLog.shared.info("KeyboardRemap: Caps Lock transport layer inactive")
+            traceState("layer.inactive", fields: ["source": "f18.keyUp", "postedEscape": shouldTap])
+            traceEvent(type: type, event: event, phase: "swallowed")
             return nil
         default:
             return Unmanaged.passUnretained(event)
@@ -372,6 +441,7 @@ final class KeyboardRemapController: ObservableObject {
             lastCapsLayerStaleLogAt = now
             DiagnosticLog.shared.warn("KeyboardRemap: Caps Lock layer cleared (\(reason))")
         }
+        traceState("layer.cleared", fields: ["reason": reason])
     }
 
     private func emergencyClear(now: CFAbsoluteTime) {
@@ -379,6 +449,7 @@ final class KeyboardRemapController: ObservableObject {
         pressedKeyCodes.removeAll()
         bypassUntil = now + emergencyBypassDuration
         DiagnosticLog.shared.warn("KeyboardRemap: emergency bypass via Escape")
+        traceState("recovery.emergency", fields: ["bypassSeconds": emergencyBypassDuration])
     }
 
     private func updatePressedKeys(type: CGEventType, keyCode: Int64, now: CFAbsoluteTime) {
@@ -446,6 +517,106 @@ final class KeyboardRemapController: ObservableObject {
         up.setIntegerValueField(.eventSourceUserData, value: Self.syntheticMarker)
         down.post(tap: .cghidEventTap)
         up.post(tap: .cghidEventTap)
+        hyperTrace.record(kind: "synthetic.keyTap", fields: ["keyCode": keyCode])
+    }
+
+    private func traceEvent(type: CGEventType, event: CGEvent, phase: String) {
+        hyperTrace.record(kind: "keyboard.event", fields: [
+            "phase": phase,
+            "type": eventTypeName(type),
+            "keyCode": event.getIntegerValueField(.keyboardEventKeycode),
+            "flags": String(format: "0x%llx", event.flags.rawValue),
+            "autorepeat": event.getIntegerValueField(.keyboardEventAutorepeat),
+            "layerActive": capsLayerActive,
+            "usedAsModifier": capsUsedAsModifier,
+            "transportActive": capsLockTransport.isActive,
+            "pressedKeyCount": pressedKeyCodes.count,
+        ])
+    }
+
+    private func traceState(_ kind: String, fields: [String: Any] = [:]) {
+        var snapshot = fields
+        snapshot["layerActive"] = capsLayerActive
+        snapshot["usedAsModifier"] = capsUsedAsModifier
+        snapshot["transportActive"] = capsLockTransport.isActive
+        snapshot["tapInstalled"] = eventTap != nil
+        snapshot["pressedKeyCount"] = pressedKeyCodes.count
+        snapshot["bypassRemainingMs"] = max(0, Int((bypassUntil - CFAbsoluteTimeGetCurrent()) * 1_000))
+        hyperTrace.record(kind: kind, fields: snapshot)
+    }
+
+    private func eventTypeName(_ type: CGEventType) -> String {
+        switch type {
+        case .keyDown: return "keyDown"
+        case .keyUp: return "keyUp"
+        case .flagsChanged: return "flagsChanged"
+        case .tapDisabledByTimeout: return "tapDisabledByTimeout"
+        case .tapDisabledByUserInput: return "tapDisabledByUserInput"
+        default: return "type.\(type.rawValue)"
+        }
+    }
+
+    private static func performEndToEndDiagnostic(keyCode: UInt16) {
+        let service = IOServiceGetMatchingService(
+            kIOMainPortDefault,
+            IOServiceMatching(kIOHIDSystemClass)
+        )
+        guard service != 0 else {
+            DiagnosticLog.shared.warn("HyperE2E: IOHIDSystem service unavailable")
+            return
+        }
+        defer { IOObjectRelease(service) }
+
+        var connection: io_connect_t = 0
+        let openStatus = IOServiceOpen(
+            service,
+            mach_task_self_,
+            UInt32(kIOHIDParamConnectType),
+            &connection
+        )
+        guard openStatus == kIOReturnSuccess, connection != 0 else {
+            DiagnosticLog.shared.warn("HyperE2E: IOHIDSystem open failed status=\(openStatus)")
+            return
+        }
+        defer { IOServiceClose(connection) }
+
+        let hyperFlags = UInt32(NX_CONTROLMASK | NX_ALTERNATEMASK | NX_SHIFTMASK | NX_COMMANDMASK)
+        let directStatuses = [
+            postHIDKey(connection: connection, keyCode: keyCode, isDown: true, flags: hyperFlags),
+            postHIDKey(connection: connection, keyCode: keyCode, isDown: false, flags: hyperFlags),
+        ]
+        DiagnosticLog.shared.info("HyperE2E: direct Hyper control posted statuses=\(directStatuses)")
+
+        usleep(500_000)
+        let transportKey = UInt16(CapsLockHIDTransportController.transportKeyCode)
+        let transportStatuses = [
+            postHIDKey(connection: connection, keyCode: transportKey, isDown: true, flags: 0),
+            postHIDKey(connection: connection, keyCode: keyCode, isDown: true, flags: 0),
+            postHIDKey(connection: connection, keyCode: keyCode, isDown: false, flags: 0),
+            postHIDKey(connection: connection, keyCode: transportKey, isDown: false, flags: 0),
+        ]
+        DiagnosticLog.shared.info("HyperE2E: F18 transport posted statuses=\(transportStatuses)")
+    }
+
+    private static func postHIDKey(
+        connection: io_connect_t,
+        keyCode: UInt16,
+        isDown: Bool,
+        flags: UInt32
+    ) -> kern_return_t {
+        var data = NXEventData()
+        data.key.keyCode = keyCode
+        let location = IOGPoint(x: 0, y: 0)
+        let options = IOOptionBits(kIOHIDSetGlobalEventFlags | kIOHIDPostHIDManagerEvent)
+        return IOHIDPostEvent(
+            connection,
+            UInt32(isDown ? NX_KEYDOWN : NX_KEYUP),
+            location,
+            &data,
+            UInt32(kNXEventDataVersion),
+            flags,
+            options
+        )
     }
 }
 
@@ -477,8 +648,17 @@ private final class CapsLockHIDTransportController {
         guard let currentMappings = readMappings() else {
             DiagnosticLog.shared.warn("KeyboardRemap: failed to read HID keyboard mappings")
             requested = false
+            HyperKeyDiagnosticRecorder.shared.record(kind: "hid.read.failed")
             return
         }
+
+        let capsMapping: Any = currentMappings
+            .first(where: { $0.src == Self.capsLockUsage })
+            .map { $0.dst } ?? NSNull()
+        HyperKeyDiagnosticRecorder.shared.record(kind: "hid.enable.requested", fields: [
+            "mappingCount": currentMappings.count,
+            "capsMapping": capsMapping,
+        ])
 
         originalMappings = currentMappings
 
@@ -489,12 +669,14 @@ private final class CapsLockHIDTransportController {
                 originalMappings = restoreOriginalMappings() ?? currentMappings.filter { $0.src != Self.capsLockUsage }
             }
             DiagnosticLog.shared.info("KeyboardRemap: Caps Lock HID transport already active")
+            HyperKeyDiagnosticRecorder.shared.record(kind: "hid.active.existing", fields: ["owned": ownsMapping])
             return
         }
 
         if let existing = currentMappings.first(where: { $0.src == Self.capsLockUsage }) {
             DiagnosticLog.shared.warn("KeyboardRemap: Caps Lock already has HID mapping to \(existing.dst); using legacy event-tap fallback")
             requested = false
+            HyperKeyDiagnosticRecorder.shared.record(kind: "hid.conflict", fields: ["destination": existing.dst])
             return
         }
 
@@ -504,6 +686,7 @@ private final class CapsLockHIDTransportController {
         guard writeMappings(nextMappings) else {
             DiagnosticLog.shared.warn("KeyboardRemap: failed to apply Caps Lock HID transport")
             requested = false
+            HyperKeyDiagnosticRecorder.shared.record(kind: "hid.write.failed", fields: ["operation": "enable"])
             return
         }
 
@@ -511,9 +694,15 @@ private final class CapsLockHIDTransportController {
         ownsMapping = true
         persistOriginalMappings(currentMappings)
         DiagnosticLog.shared.info("KeyboardRemap: Caps Lock mapped to F18 transport")
+        HyperKeyDiagnosticRecorder.shared.record(kind: "hid.active.applied", fields: ["originalMappingCount": currentMappings.count])
     }
 
     func disable() {
+        HyperKeyDiagnosticRecorder.shared.record(kind: "hid.disable.requested", fields: [
+            "requested": requested,
+            "active": isActive,
+            "owned": ownsMapping,
+        ])
         guard requested else { return }
         defer {
             requested = false
@@ -526,9 +715,29 @@ private final class CapsLockHIDTransportController {
         if writeMappings(originalMappings) {
             clearPersistedOwnership()
             DiagnosticLog.shared.info("KeyboardRemap: Caps Lock HID transport restored")
+            HyperKeyDiagnosticRecorder.shared.record(kind: "hid.restored")
         } else {
             DiagnosticLog.shared.warn("KeyboardRemap: failed to restore HID keyboard mappings")
+            HyperKeyDiagnosticRecorder.shared.record(kind: "hid.write.failed", fields: ["operation": "restore"])
         }
+    }
+
+    func diagnosticSnapshot() -> [String: Any] {
+        var fields: [String: Any] = [
+            "transportRequested": requested,
+            "transportActive": isActive,
+            "ownsMapping": ownsMapping,
+        ]
+        if let mappings = readMappings() {
+            fields["hidReadSucceeded"] = true
+            fields["hidMappingCount"] = mappings.count
+            fields["capsMapping"] = mappings
+                .first(where: { $0.src == Self.capsLockUsage })
+                .map { $0.dst } ?? NSNull()
+        } else {
+            fields["hidReadSucceeded"] = false
+        }
+        return fields
     }
 
     private func readMappings() -> [HIDKeyboardModifierMapping]? {

--- a/apps/mac/Sources/Core/Input/SecureEventInputMonitor.swift
+++ b/apps/mac/Sources/Core/Input/SecureEventInputMonitor.swift
@@ -1,11 +1,87 @@
+import AppKit
 import Carbon
 import Foundation
+import IOKit
+
+struct SecureEventInputDiagnosticSnapshot {
+    let enabled: Bool
+    let ownerPID: pid_t?
+    let ownerName: String?
+    let ownerBundleIdentifier: String?
+
+    var traceFields: [String: Any] {
+        var fields: [String: Any] = ["secureEventInput": enabled]
+        if let ownerPID {
+            fields["secureEventInputOwnerPID"] = Int(ownerPID)
+        }
+        if let ownerName {
+            fields["secureEventInputOwnerName"] = ownerName
+        }
+        if let ownerBundleIdentifier {
+            fields["secureEventInputOwnerBundle"] = ownerBundleIdentifier
+        }
+        return fields
+    }
+
+    var ownerDescription: String? {
+        guard let ownerPID else { return nil }
+        return "\(ownerName ?? ownerBundleIdentifier ?? "unknown") pid=\(ownerPID)"
+    }
+}
+
+enum SecureEventInputDiagnostics {
+    static func snapshot() -> SecureEventInputDiagnosticSnapshot {
+        let enabled = IsSecureEventInputEnabled()
+        guard enabled, let ownerPID = secureInputOwnerPID() else {
+            return SecureEventInputDiagnosticSnapshot(
+                enabled: enabled,
+                ownerPID: nil,
+                ownerName: nil,
+                ownerBundleIdentifier: nil
+            )
+        }
+
+        let application = NSRunningApplication(processIdentifier: ownerPID)
+        return SecureEventInputDiagnosticSnapshot(
+            enabled: enabled,
+            ownerPID: ownerPID,
+            ownerName: application?.localizedName,
+            ownerBundleIdentifier: application?.bundleIdentifier
+        )
+    }
+
+    private static func secureInputOwnerPID() -> pid_t? {
+        let root = IORegistryGetRootEntry(kIOMainPortDefault)
+        guard root != IO_OBJECT_NULL else { return nil }
+        defer { IOObjectRelease(root) }
+
+        guard let property = IORegistryEntryCreateCFProperty(
+            root,
+            "IOConsoleUsers" as CFString,
+            kCFAllocatorDefault,
+            0
+        )?.takeRetainedValue(),
+            let sessions = property as? [[String: Any]]
+        else {
+            return nil
+        }
+
+        for session in sessions {
+            guard let value = session["kCGSSessionSecureInputPID"] as? NSNumber else {
+                continue
+            }
+            let pid = value.int32Value
+            if pid > 0 { return pid }
+        }
+        return nil
+    }
+}
 
 final class SecureEventInputMonitor {
     static let shared = SecureEventInputMonitor()
 
     private var timer: Timer?
-    private var lastEnabled = IsSecureEventInputEnabled()
+    private var lastSnapshot = SecureEventInputDiagnostics.snapshot()
 
     private init() {}
 
@@ -13,7 +89,7 @@ final class SecureEventInputMonitor {
         dispatchPrecondition(condition: .onQueue(.main))
         guard timer == nil else { return }
 
-        lastEnabled = IsSecureEventInputEnabled()
+        lastSnapshot = SecureEventInputDiagnostics.snapshot()
         let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
             self?.poll()
         }
@@ -28,12 +104,24 @@ final class SecureEventInputMonitor {
     }
 
     private func poll() {
-        let enabled = IsSecureEventInputEnabled()
-        guard enabled != lastEnabled else { return }
+        let snapshot = SecureEventInputDiagnostics.snapshot()
+        let enabledChanged = snapshot.enabled != lastSnapshot.enabled
+        let ownerChanged = snapshot.enabled && snapshot.ownerPID != lastSnapshot.ownerPID
+        guard enabledChanged || ownerChanged else { return }
 
-        lastEnabled = enabled
-        let reason = enabled ? "Secure Event Input enabled" : "Secure Event Input disabled"
-        DiagnosticLog.shared.warn("InputCapture: \(reason)")
-        InputCaptureResetCenter.reset(reason: reason)
+        lastSnapshot = snapshot
+        let state = snapshot.enabled ? "enabled" : "disabled"
+        let owner = snapshot.ownerDescription.map { " owner=\($0)" } ?? ""
+        let reason = ownerChanged && !enabledChanged
+            ? "Secure Event Input owner changed"
+            : "Secure Event Input \(state)"
+        DiagnosticLog.shared.warn("InputCapture: \(reason)\(owner)")
+        HyperKeyDiagnosticRecorder.shared.record(
+            kind: "secure_input.changed",
+            fields: snapshot.traceFields.merging(["reason": reason]) { _, new in new }
+        )
+        if enabledChanged {
+            InputCaptureResetCenter.reset(reason: reason)
+        }
     }
 }

--- a/docs/app.md
+++ b/docs/app.md
@@ -216,6 +216,16 @@ Rules live in `~/.lattices/keyboard-remaps.json`, and the Settings toggle
 can turn the layer off. Keyboard remaps require Accessibility permission
 because they use a local event tap.
 
+If Caps Lock-to-Hyper behaves intermittently, open **Settings > Keyboard** and
+choose **Start Trace**. Reproduce the problem, stop the trace, then choose
+**Reveal Trace**. The bounded JSONL file at
+`~/.lattices/hyper-key-trace.jsonl` records only Caps Lock/F18 events, Hyper
+layer state, event-tap lifecycle, HID mapping transitions, and anonymous
+keyboard-event counts. When macOS Secure Event Input blocks the pipeline, the
+trace also records its owning PID and app identity. It does not record
+characters, key codes for general typing, or source applications. Recording
+stays enabled across one or more app relaunches until explicitly stopped.
+
 ### Companion
 
 Shows the secure local bridge status, Mac bridge fingerprint, supported


### PR DESCRIPTION
## What changed

- add an opt-in, bounded JSONL trace for the Caps Lock → F18 → Hyper pipeline
- expose trace start/stop/reveal controls in Keyboard settings
- attribute macOS Secure Event Input to its owning PID, app name, and bundle when available
- add a local `diagnostics.hyperTest` endpoint that exercises both direct Hyper injection and the F18 transport path
- document the privacy boundary and troubleshooting workflow

## Why

Hyper could stop working while Lattices' event tap and HID mapping still appeared healthy. The new diagnostics distinguish Lattices pipeline failures from macOS Secure Event Input. During validation they identified a stale Secure Input session record that continued to name a dead ChatGPT PID until macOS was rebooted.

The trace is opt-in, rotates at 2 MB, persists across app relaunches until stopped, and never records typed characters or general key codes.

## Validation

- `bun run check` ✅
- `bun test tests/dependency-free.test.ts` ✅
- signed dev build installed and relaunched ✅
- live E2E: direct Hyper path fired registered hotkey ✅
- live E2E: Caps Lock/F18 transport fired registered hotkey ✅
- `bun run test` ⚠️ existing CLI hash fixture mismatch: expected `lattices-c36f74`, current CLI returns `lattices-603d63`; unrelated to these input changes
