### PR TITLE
Fix assistant routing and embedded speech runtime

### DIFF
--- a/apps/mac/Package.swift
+++ b/apps/mac/Package.swift
@@ -11,6 +11,14 @@ let hudsonDependency: Package.Dependency = hudsonSource == "git"
     ? .package(url: "git@github.com:arach/hudson.git", branch: "main")
     : .package(path: "../../../hudson")
 
+// Lattices owns the long-running local voice service. HudsonVoice supplies the
+// client/session API while VoxService supplies the embeddable WebSocket host.
+// Use the same package URL Hudson uses so SwiftPM coalesces the dependency.
+let voxDependency: Package.Dependency = .package(
+    url: "https://github.com/arach/vox.git",
+    branch: "main"
+)
+
 let voiceEnabled = Context.environment["HUDSONKIT_WITH_VOICE"] == "1"
 
 var latticesDependencies: [Target.Dependency] = [
@@ -22,15 +30,26 @@ var latticesDependencies: [Target.Dependency] = [
 ]
 if voiceEnabled {
     latticesDependencies.append(.product(name: "HudsonVoice", package: "hudson"))
+    latticesDependencies.append(.product(name: "VoxService", package: "vox"))
+}
+
+var packageDependencies: [Package.Dependency] = [
+    .package(path: "../../swift"),
+    hudsonDependency,
+]
+if voiceEnabled {
+    packageDependencies.append(voxDependency)
+}
+
+var testDependencies: [Target.Dependency] = ["Lattices"]
+if voiceEnabled {
+    testDependencies.append(.product(name: "HudsonVoice", package: "hudson"))
 }
 
 let package = Package(
     name: "Lattices",
     platforms: [.macOS(.v26)],
-    dependencies: [
-        .package(path: "../../swift"),
-        hudsonDependency,
-    ],
+    dependencies: packageDependencies,
     targets: [
         .executableTarget(
             name: "Lattices",
@@ -45,8 +64,9 @@ let package = Package(
         ),
         .testTarget(
             name: "LatticesTests",
-            dependencies: ["Lattices"],
-            path: "Tests"
+            dependencies: testDependencies,
+            path: "Tests",
+            swiftSettings: voiceEnabled ? [.define("LATTICES_VOICE")] : []
         )
     ],
     // Stay in Swift 5 language mode: adopt macOS 26 / the 6.2 toolchain without

--- a/apps/mac/Sources/AppShell/SettingsView.swift
+++ b/apps/mac/Sources/AppShell/SettingsView.swift
@@ -2424,7 +2424,7 @@ struct SettingsContentView: View {
                                 Text("HudsonVoice runtime")
                                     .font(Typo.mono(12))
                                     .foregroundColor(Palette.text)
-                                Text("Lattices is hosting an authenticated local voice runtime for dictation and voice commands.")
+                                Text("Lattices is hosting an authenticated local speech runtime for dictation, voice commands, and TTS.")
                                     .font(Typo.caption(9.5))
                                     .foregroundColor(Palette.textMuted)
                                     .fixedSize(horizontal: false, vertical: true)

--- a/apps/mac/Sources/AppShell/SettingsView.swift
+++ b/apps/mac/Sources/AppShell/SettingsView.swift
@@ -2424,7 +2424,7 @@ struct SettingsContentView: View {
                                 Text("HudsonVoice runtime")
                                     .font(Typo.mono(12))
                                     .foregroundColor(Palette.text)
-                                Text("Voice mode is compiled in. The Workspace Assistant mic uses HudsonVoice's Vox local WebSocket session.")
+                                Text("Lattices is hosting an authenticated local voice runtime for dictation and voice commands.")
                                     .font(Typo.caption(9.5))
                                     .foregroundColor(Palette.textMuted)
                                     .fixedSize(horizontal: false, vertical: true)

--- a/apps/mac/Sources/Core/Assistant/ScoutAssistantTransport.swift
+++ b/apps/mac/Sources/Core/Assistant/ScoutAssistantTransport.swift
@@ -35,6 +35,17 @@ final class ScoutAssistantTransport {
 
     var isInstalled: Bool { executableURL != nil }
 
+    /// A saved Scout ref is continuity metadata, not a permanent route. Broker
+    /// restarts and retired sessions can invalidate it while project routing is
+    /// still healthy, so callers may safely retry these errors without the ref.
+    static func isUnroutableBindingError(_ error: Error) -> Bool {
+        guard let transportError = error as? ScoutAssistantTransportError,
+              case .commandFailed(let detail) = transportError else { return false }
+        let normalized = detail.lowercased()
+        return normalized.contains("not currently routable")
+            || (normalized.contains("no agent matches") && normalized.contains("ref:"))
+    }
+
     func checkAvailability(projectPath: String?) async -> Bool {
         do {
             _ = try await run(

--- a/apps/mac/Sources/Core/Assistant/WorkspaceAssistantSession.swift
+++ b/apps/mac/Sources/Core/Assistant/WorkspaceAssistantSession.swift
@@ -463,11 +463,30 @@ final class WorkspaceAssistantSession: ObservableObject {
         streamingTask = Task { [weak self] in
             guard let self else { return }
             do {
-                let reply = try await self.scoutTransport.ask(
-                    prompt: prompt,
-                    projectPath: projectPath,
-                    bindingRef: continuingRef
-                )
+                let reply: ScoutAssistantReply
+                do {
+                    reply = try await self.scoutTransport.ask(
+                        prompt: prompt,
+                        projectPath: projectPath,
+                        bindingRef: continuingRef
+                    )
+                } catch {
+                    guard continuingRef != nil,
+                          ScoutAssistantTransport.isUnroutableBindingError(error) else { throw error }
+                    DiagnosticLog.shared.warn(
+                        "Workspace Assistant: saved Scout ref is no longer routable; retrying with the project route"
+                    )
+                    await MainActor.run { [weak self] in
+                        guard let self, self.scoutBindingRef == continuingRef else { return }
+                        self.scoutBindingRef = nil
+                        self.scoutTargetLabel = nil
+                    }
+                    reply = try await self.scoutTransport.ask(
+                        prompt: prompt,
+                        projectPath: projectPath,
+                        bindingRef: nil
+                    )
+                }
                 await MainActor.run { [weak self] in
                     guard let self, self.turnGeneration == generation else { return }
                     self.streamingTask = nil

--- a/apps/mac/Sources/Core/Daemon/LatticesApi.swift
+++ b/apps/mac/Sources/Core/Daemon/LatticesApi.swift
@@ -3435,7 +3435,7 @@ final class LatticesApi {
                     "capabilityPath": runtime?.capabilityPath.map { .string($0) } ?? .null,
                     "requiresAuth": .bool(runtime?.authToken != nil),
                     "runtimeError": .null,
-                    "note": .string("HudsonVoice is compiled in; Lattices uses HudsonVoice's Vox WebSocket contract for live sessions."),
+                    "note": .string("Lattices is hosting an authenticated embedded Vox runtime through HudsonVoice."),
                 ])
                 #else
                 return .object([

--- a/apps/mac/Sources/Core/Daemon/LatticesApi.swift
+++ b/apps/mac/Sources/Core/Daemon/LatticesApi.swift
@@ -3419,23 +3419,28 @@ final class LatticesApi {
             description: "Re-probe the voice runtime. HudsonVoice opens a fresh session per capture, so there is no persistent socket to reconnect.",
             access: .mutate,
             params: [],
-            returns: .custom("Voice runtime reachability: { ok, runtimeAvailable, runtimeHost, service, transport, endpoint, port, pid, capabilityPath }"),
+            returns: .custom("Speech runtime reachability: { ok, runtimeAvailable, runtimeHost, service, transport, capabilities, endpoint, port, pid, capabilityPath }"),
             handler: { _ in
                 #if LATTICES_VOICE && canImport(HudsonVoice)
                 let runtime = HudsonVoiceRuntimeResolver.resolve(clientId: "lattices")
+                let capabilities: [JSON] = runtime == nil ? [] : [
+                    .string("transcription"),
+                    .string("speech-synthesis"),
+                ]
                 return .object([
                     "ok": .bool(true),
                     "runtimeAvailable": .bool(runtime != nil),
                     "runtimeHost": .string(runtime?.source ?? "none"),
                     "service": .string("hudson-voice"),
                     "transport": .string("ws+json-rpc"),
+                    "capabilities": .array(capabilities),
                     "endpoint": runtime.map { .string($0.endpoint.url.absoluteString) } ?? .null,
                     "port": runtime.map { .int(Int($0.endpoint.port)) } ?? .null,
                     "pid": runtime?.pid.map { .int($0) } ?? .null,
                     "capabilityPath": runtime?.capabilityPath.map { .string($0) } ?? .null,
                     "requiresAuth": .bool(runtime?.authToken != nil),
                     "runtimeError": .null,
-                    "note": .string("Lattices is hosting an authenticated embedded Vox runtime through HudsonVoice."),
+                    "note": .string("Lattices is hosting authenticated Vox transcription and TTS through HudsonVoice."),
                 ])
                 #else
                 return .object([
@@ -3444,10 +3449,12 @@ final class LatticesApi {
                     "runtimeHost": .string("none"),
                     "service": .null,
                     "transport": .null,
+                    "capabilities": .array([]),
                     "endpoint": .null,
                     "port": .null,
                     "pid": .null,
                     "capabilityPath": .null,
+                    "requiresAuth": .bool(false),
                     "runtimeError": .string("HudsonVoice is not compiled into this build."),
                     "note": .string("HudsonVoice is not compiled into this build."),
                 ])

--- a/apps/mac/Sources/Core/Voice/AudioProvider.swift
+++ b/apps/mac/Sources/Core/Voice/AudioProvider.swift
@@ -561,7 +561,8 @@ final class HudVoxAudioProvider: AudioProvider {
             do {
                 _ = try await HudVoxProbe.health(
                     endpoint: runtime.endpoint,
-                    clientId: runtime.options.clientId
+                    clientId: runtime.options.clientId,
+                    authToken: runtime.options.authToken
                 )
                 await MainActor.run {
                     self.lastProviderError = nil

--- a/apps/mac/Sources/Core/Voice/LatticesVoiceRuntime.swift
+++ b/apps/mac/Sources/Core/Voice/LatticesVoiceRuntime.swift
@@ -144,13 +144,10 @@ enum LatticesVoiceRuntime {
 
             setenv("VOX_HOME", runtimeHome.path, 1)
             setenv("VOX_RUNTIME_PATH", runtimeURL.path, 1)
-            setenv("VOX_HOST", "127.0.0.1", 1)
-            setenv("VOX_AUTH_TOKEN", authToken, 1)
 
             var lastError: Error?
             for _ in 0..<8 {
                 let port = UInt16.random(in: 49_152...65_535)
-                setenv("VOX_PORT", String(port), 1)
                 let service = VoxRuntimeService(
                     port: port,
                     bindAddress: "127.0.0.1",

--- a/apps/mac/Sources/Core/Voice/LatticesVoiceRuntime.swift
+++ b/apps/mac/Sources/Core/Voice/LatticesVoiceRuntime.swift
@@ -2,12 +2,14 @@ import Foundation
 
 #if LATTICES_VOICE && canImport(HudsonVoice)
 import HudsonVoice
+import Security
+import VoxService
 #endif
 
 enum LatticesVoiceRuntime {
     static func start() {
         #if LATTICES_VOICE && canImport(HudsonVoice)
-        DiagnosticLog.shared.info("HudsonVoice: live session client compiled in")
+        EmbeddedHost.shared.start()
         #else
         DiagnosticLog.shared.info("HudsonVoice: runtime host skipped because HudsonVoice is not compiled into this build")
         #endif
@@ -15,7 +17,195 @@ enum LatticesVoiceRuntime {
 
     static func stop() {
         #if LATTICES_VOICE && canImport(HudsonVoice)
-        DiagnosticLog.shared.info("HudsonVoice: live session client stopped")
+        EmbeddedHost.shared.stop()
         #endif
     }
+
+    #if LATTICES_VOICE && canImport(HudsonVoice)
+    struct Connection {
+        let endpoint: HudVoxEndpoint
+        let options: HudVoxLiveSessionOptions
+        let source: String
+        let pid: Int?
+        let authToken: String
+        let runtimePath: String
+    }
+
+    static func connection(
+        clientId: String,
+        mode: HudVoiceMode?
+    ) -> Connection? {
+        EmbeddedHost.shared.connection(clientId: clientId, mode: mode)
+    }
+
+    private final class EmbeddedHost: @unchecked Sendable {
+        static let shared = EmbeddedHost()
+
+        private struct RunningHost {
+            let service: VoxRuntimeService
+            let endpoint: HudVoxEndpoint
+            let authToken: String
+            let runtimePath: String
+        }
+
+        private let lock = NSLock()
+        private var running: RunningHost?
+        private var isStarting = false
+        private var lastFailure: String?
+
+        private init() {}
+
+        func start() {
+            lock.lock()
+            guard running == nil, !isStarting else {
+                lock.unlock()
+                return
+            }
+            isStarting = true
+            lock.unlock()
+
+            let result = Result { try startService() }
+
+            lock.lock()
+            isStarting = false
+            switch result {
+            case .success(let host):
+                running = host
+                lastFailure = nil
+            case .failure(let error):
+                lastFailure = error.localizedDescription
+            }
+            lock.unlock()
+
+            switch result {
+            case .success(let host):
+                DiagnosticLog.shared.success(
+                    "HudsonVoice: embedded runtime started at \(host.endpoint.url.absoluteString)"
+                )
+            case .failure(let error):
+                DiagnosticLog.shared.error(
+                    "HudsonVoice: embedded runtime failed to start — \(error.localizedDescription)"
+                )
+            }
+        }
+
+        func stop() {
+            lock.lock()
+            let host = running
+            running = nil
+            lastFailure = nil
+            lock.unlock()
+
+            host?.service.stop()
+            if host != nil {
+                DiagnosticLog.shared.info("HudsonVoice: embedded runtime stopped")
+            }
+        }
+
+        func connection(clientId: String, mode: HudVoiceMode?) -> Connection? {
+            start()
+
+            lock.lock()
+            let host = running
+            let failure = lastFailure
+            lock.unlock()
+
+            guard let host else {
+                if let failure {
+                    DiagnosticLog.shared.warn("HudsonVoice: embedded runtime unavailable — \(failure)")
+                }
+                return nil
+            }
+
+            let preferences = (try? HudsonVoicePreferences.load()) ?? HudsonVoicePreferences()
+            let options = HudVoxLiveSessionOptions(
+                clientId: clientId,
+                modelId: preferences.preferredTranscriptionModelId,
+                language: preferences.preferredLanguage,
+                mode: mode ?? preferences.mode,
+                metadata: ["hostApp": "lattices"],
+                authToken: host.authToken,
+                deviceId: preferences.preferredInputDeviceId
+            )
+            return Connection(
+                endpoint: host.endpoint,
+                options: options,
+                source: "lattices-embedded",
+                pid: Int(getpid()),
+                authToken: host.authToken,
+                runtimePath: host.runtimePath
+            )
+        }
+
+        private func startService() throws -> RunningHost {
+            let runtimeHome = try Self.prepareRuntimeHome()
+            let runtimeURL = runtimeHome.appendingPathComponent("vox-runtime.json")
+            let authToken = try Self.generateCapabilityToken()
+
+            setenv("VOX_HOME", runtimeHome.path, 1)
+            setenv("VOX_RUNTIME_PATH", runtimeURL.path, 1)
+            setenv("VOX_HOST", "127.0.0.1", 1)
+            setenv("VOX_AUTH_TOKEN", authToken, 1)
+
+            var lastError: Error?
+            for _ in 0..<8 {
+                let port = UInt16.random(in: 49_152...65_535)
+                setenv("VOX_PORT", String(port), 1)
+                let service = VoxRuntimeService(
+                    port: port,
+                    bindAddress: "127.0.0.1",
+                    authToken: authToken
+                )
+                do {
+                    try service.start()
+                    return RunningHost(
+                        service: service,
+                        endpoint: HudVoxEndpoint(host: "127.0.0.1", port: port),
+                        authToken: authToken,
+                        runtimePath: runtimeURL.path
+                    )
+                } catch {
+                    service.stop()
+                    lastError = error
+                }
+            }
+
+            throw lastError ?? NSError(
+                domain: "LatticesVoiceRuntime",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "No local port was available for the embedded voice service."]
+            )
+        }
+
+        private static func prepareRuntimeHome() throws -> URL {
+            let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+                ?? FileManager.default.temporaryDirectory
+            let url = base
+                .appendingPathComponent("Lattices", isDirectory: true)
+                .appendingPathComponent("Voice", isDirectory: true)
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+            try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: url.path)
+            return url
+        }
+
+        private static func generateCapabilityToken() throws -> String {
+            var bytes = [UInt8](repeating: 0, count: 32)
+            let status = bytes.withUnsafeMutableBytes { buffer in
+                SecRandomCopyBytes(kSecRandomDefault, buffer.count, buffer.baseAddress!)
+            }
+            guard status == errSecSuccess else {
+                throw NSError(
+                    domain: "LatticesVoiceRuntime",
+                    code: Int(status),
+                    userInfo: [NSLocalizedDescriptionKey: "Could not create a voice runtime capability token."]
+                )
+            }
+            return Data(bytes)
+                .base64EncodedString()
+                .replacingOccurrences(of: "+", with: "-")
+                .replacingOccurrences(of: "/", with: "_")
+                .replacingOccurrences(of: "=", with: "")
+        }
+    }
+    #endif
 }

--- a/apps/mac/Sources/Core/Voice/VoxEndpointResolver.swift
+++ b/apps/mac/Sources/Core/Voice/VoxEndpointResolver.swift
@@ -1,154 +1,49 @@
 #if LATTICES_VOICE && canImport(HudsonVoice)
-import Darwin
 import Foundation
 import HudsonVoice
 
-/// Resolves the voice runtime Lattices should use.
+/// Resolves the voice runtime used by every Lattices dictation surface.
 ///
-/// HudsonVoice speaks Vox's local WebSocket JSON-RPC contract directly. Prefer
-/// the runtime file written by Vox so dev builds can move ports without making
-/// Lattices point at a stale default.
+/// Lattices normally owns an authenticated, in-process Vox service. If that
+/// service cannot start, accept a current Hudson capability file as a fallback.
+/// Never manufacture a default endpoint: returning a dead port made the UI say
+/// voice was available even though every capture was guaranteed to fail.
 enum HudsonVoiceRuntimeResolver {
-    private struct RuntimeFile: Decodable {
-        let host: String?
-        let port: UInt16?
-        let pid: Int?
-        let serviceName: String?
-        let service: String?
-        let transport: String?
-        let webSocketUrl: String?
-        let authToken: String?
-    }
-
     static func resolve(
         clientId: String = "lattices",
         mode: HudVoiceMode? = nil
     ) -> (endpoint: HudVoxEndpoint, options: HudVoxLiveSessionOptions, source: String, pid: Int?, authToken: String?, capabilityPath: String?)? {
-        let runtime = resolvedRuntime()
-        let endpoint = HudVoxEndpoint(host: runtime.host, port: runtime.port)
-        let options = HudVoxLiveSessionOptions(
-            clientId: clientId,
-            mode: mode ?? .pushToTalk,
-            metadata: ["hostApp": "lattices"]
-        )
-        return (
-            endpoint: endpoint,
-            options: options,
-            source: runtime.source,
-            pid: runtime.pid,
-            authToken: runtime.authToken,
-            capabilityPath: runtime.path
-        )
-    }
-
-    private static func resolvedRuntime() -> (host: String, port: UInt16, source: String, pid: Int?, authToken: String?, path: String?) {
-        for candidate in runtimeFileCandidates() {
-            guard let runtime = readRuntimeFile(candidate.url),
-                  let port = runtime.port,
-                  port > 0,
-                  runtime.pid.map(processIsAlive) ?? true else { continue }
-            // HudVoxLiveSession does not currently expose an auth-token field,
-            // so authenticated Hudson capability files cannot be used safely yet.
-            guard nonEmpty(runtime.authToken) == nil else { continue }
-
-            let host = runtime.host
-                ?? hostFromWebSocketURL(runtime.webSocketUrl)
-                ?? "127.0.0.1"
-            guard isLoopback(host) else { continue }
-
+        if let embedded = LatticesVoiceRuntime.connection(clientId: clientId, mode: mode) {
             return (
-                host: host,
-                port: port,
-                source: candidate.source,
-                pid: runtime.pid,
-                authToken: nonEmpty(runtime.authToken),
-                path: candidate.url.path
+                endpoint: embedded.endpoint,
+                options: embedded.options,
+                source: embedded.source,
+                pid: embedded.pid,
+                authToken: embedded.authToken,
+                capabilityPath: embedded.runtimePath
             )
         }
 
-        let env = ProcessInfo.processInfo.environment
-        if let rawPort = env["VOX_PORT"] ?? env["HUDSON_VOICE_VOX_PORT"],
-           let port = UInt16(rawPort) {
-            return (
-                host: nonEmpty(env["VOX_HOST"]) ?? "127.0.0.1",
-                port: port,
-                source: "env",
-                pid: nil,
-                authToken: nonEmpty(env["VOX_AUTH_TOKEN"]),
-                path: nil
+        do {
+            let connection = try HudsonVoiceRuntime.resolveConnection(
+                clientId: clientId,
+                mode: mode,
+                metadata: ["hostApp": "lattices"]
             )
+            return (
+                endpoint: connection.endpoint,
+                options: connection.options,
+                source: "hudson-voice",
+                pid: connection.capability.pid.map(Int.init),
+                authToken: connection.capability.authToken,
+                capabilityPath: HudsonVoiceRuntime.runtimeURL().path
+            )
+        } catch {
+            DiagnosticLog.shared.warn(
+                "HudsonVoice: no usable embedded or external runtime — \(error.localizedDescription)"
+            )
+            return nil
         }
-
-        // Vox's current daemon default is 42137. HudsonVoice's older 42138
-        // default is intentionally avoided here because it makes Lattices miss
-        // a running Vox dev daemon and surface a fake transcription failure.
-        return (
-            host: "127.0.0.1",
-            port: 42137,
-            source: "vox-default",
-            pid: nil,
-            authToken: nil,
-            path: nil
-        )
-    }
-
-    private static func runtimeFileCandidates() -> [(url: URL, source: String)] {
-        var candidates: [(URL, String)] = []
-        let env = ProcessInfo.processInfo.environment
-
-        if let path = nonEmpty(env["VOX_RUNTIME_PATH"]) {
-            candidates.append((URL(fileURLWithPath: path), "vox"))
-        }
-        candidates.append((
-            FileManager.default.homeDirectoryForCurrentUser
-                .appendingPathComponent(".vox", isDirectory: true)
-                .appendingPathComponent("runtime.json"),
-            "vox"
-        ))
-
-        let support = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-            ?? FileManager.default.temporaryDirectory
-        if let path = nonEmpty(env["HUDSON_VOICE_RUNTIME_PATH"]) {
-            candidates.append((URL(fileURLWithPath: path), "hudson-voice"))
-        }
-        candidates.append((
-            support
-                .appendingPathComponent("Hudson", isDirectory: true)
-                .appendingPathComponent("Vox", isDirectory: true)
-                .appendingPathComponent("hudson-voice-runtime.json"),
-            "hudson-voice"
-        ))
-
-        var seen = Set<String>()
-        return candidates.filter { candidate in
-            let key = candidate.0.standardizedFileURL.path
-            return seen.insert(key).inserted
-        }
-    }
-
-    private static func readRuntimeFile(_ url: URL) -> RuntimeFile? {
-        guard let data = try? Data(contentsOf: url) else { return nil }
-        return try? JSONDecoder().decode(RuntimeFile.self, from: data)
-    }
-
-    private static func hostFromWebSocketURL(_ raw: String?) -> String? {
-        guard let raw, let url = URL(string: raw), let host = url.host else { return nil }
-        return host
-    }
-
-    private static func isLoopback(_ host: String) -> Bool {
-        let lowered = host.lowercased()
-        return lowered == "localhost" || lowered == "127.0.0.1" || lowered == "::1"
-    }
-
-    private static func processIsAlive(_ pid: Int) -> Bool {
-        guard pid > 0 else { return false }
-        return kill(pid_t(pid), 0) == 0 || errno == EPERM
-    }
-
-    private static func nonEmpty(_ value: String?) -> String? {
-        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? nil : trimmed
     }
 }
 #endif

--- a/apps/mac/Tests/LatticesVoiceRuntimeTests.swift
+++ b/apps/mac/Tests/LatticesVoiceRuntimeTests.swift
@@ -23,5 +23,101 @@ final class LatticesVoiceRuntimeTests: XCTestCase {
         XCTAssertEqual(health.service, "Vox")
         XCTAssertEqual(health.port, Int(runtime.endpoint.port))
     }
+
+    func testEmbeddedRuntimeRejectsMissingAndIncorrectTokens() async throws {
+        LatticesVoiceRuntime.stop()
+        LatticesVoiceRuntime.start()
+        defer { LatticesVoiceRuntime.stop() }
+
+        let runtime = try XCTUnwrap(
+            HudsonVoiceRuntimeResolver.resolve(clientId: "lattices-tests")
+        )
+
+        await assertHealthProbeRejected(endpoint: runtime.endpoint, authToken: nil)
+        await assertHealthProbeRejected(endpoint: runtime.endpoint, authToken: "not-the-capability-token")
+    }
+
+    func testEmbeddedRuntimeExposesAuthenticatedTTSModels() async throws {
+        LatticesVoiceRuntime.stop()
+        LatticesVoiceRuntime.start()
+        defer { LatticesVoiceRuntime.stop() }
+
+        let runtime = try XCTUnwrap(
+            HudsonVoiceRuntimeResolver.resolve(clientId: "lattices-tests")
+        )
+        let result = try await call(
+            endpoint: runtime.endpoint,
+            method: "synthesize.models",
+            authToken: runtime.options.authToken
+        )
+        let models = try XCTUnwrap(result["models"] as? [[String: Any]])
+        XCTAssertTrue(models.contains { $0["id"] as? String == "avspeech:system" })
+    }
+
+    private func assertHealthProbeRejected(
+        endpoint: HudVoxEndpoint,
+        authToken: String?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            _ = try await HudVoxProbe.health(
+                endpoint: endpoint,
+                clientId: "lattices-tests",
+                authToken: authToken
+            )
+            XCTFail("Expected the runtime to reject an invalid capability token.", file: file, line: line)
+        } catch {
+            XCTAssertEqual(error as? HudVoxError, .provider("Unauthorized"), file: file, line: line)
+        }
+    }
+
+    private func call(
+        endpoint: HudVoxEndpoint,
+        method: String,
+        authToken: String?
+    ) async throws -> [String: Any] {
+        let socket = URLSession.shared.webSocketTask(with: endpoint.url)
+        socket.resume()
+        defer { socket.cancel(with: .normalClosure, reason: nil) }
+
+        var params: [String: Any] = ["clientId": "lattices-tests"]
+        if let authToken {
+            params["authToken"] = authToken
+        }
+        let request: [String: Any] = [
+            "id": UUID().uuidString,
+            "method": method,
+            "params": params,
+        ]
+        let requestData = try JSONSerialization.data(withJSONObject: request)
+        try await socket.send(.data(requestData))
+
+        let response = try await socket.receive()
+        let responseData: Data
+        switch response {
+        case .data(let data):
+            responseData = data
+        case .string(let text):
+            responseData = Data(text.utf8)
+        @unknown default:
+            throw TestRPCError.invalidResponse
+        }
+        guard let object = try JSONSerialization.jsonObject(with: responseData) as? [String: Any] else {
+            throw TestRPCError.invalidResponse
+        }
+        if let message = object["error"] as? String {
+            throw TestRPCError.server(message)
+        }
+        guard let result = object["result"] as? [String: Any] else {
+            throw TestRPCError.invalidResponse
+        }
+        return result
+    }
+
+    private enum TestRPCError: Error {
+        case invalidResponse
+        case server(String)
+    }
 }
 #endif

--- a/apps/mac/Tests/LatticesVoiceRuntimeTests.swift
+++ b/apps/mac/Tests/LatticesVoiceRuntimeTests.swift
@@ -1,0 +1,27 @@
+#if LATTICES_VOICE && canImport(HudsonVoice)
+import HudsonVoice
+import XCTest
+@testable import Lattices
+
+final class LatticesVoiceRuntimeTests: XCTestCase {
+    func testEmbeddedRuntimeAcceptsAuthenticatedHealthProbe() async throws {
+        LatticesVoiceRuntime.stop()
+        LatticesVoiceRuntime.start()
+        defer { LatticesVoiceRuntime.stop() }
+
+        let runtime = try XCTUnwrap(
+            HudsonVoiceRuntimeResolver.resolve(clientId: "lattices-tests")
+        )
+        XCTAssertEqual(runtime.source, "lattices-embedded")
+        XCTAssertFalse(runtime.options.authToken?.isEmpty ?? true)
+
+        let health = try await HudVoxProbe.health(
+            endpoint: runtime.endpoint,
+            clientId: runtime.options.clientId,
+            authToken: runtime.options.authToken
+        )
+        XCTAssertEqual(health.service, "Vox")
+        XCTAssertEqual(health.port, Int(runtime.endpoint.port))
+    }
+}
+#endif

--- a/apps/mac/Tests/ScoutAssistantTransportTests.swift
+++ b/apps/mac/Tests/ScoutAssistantTransportTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import Lattices
+
+final class ScoutAssistantTransportTests: XCTestCase {
+    func testRecognizesExpiredScoutBindingRef() {
+        let error = ScoutAssistantTransportError.commandFailed(
+            "error: target ref:w-bon7zf is not currently routable; nothing was sent."
+        )
+
+        XCTAssertTrue(ScoutAssistantTransport.isUnroutableBindingError(error))
+    }
+
+    func testRecognizesNoAgentMatchForScoutBindingRef() {
+        let error = ScoutAssistantTransportError.commandFailed(
+            "No agent matches ref:w-retired"
+        )
+
+        XCTAssertTrue(ScoutAssistantTransport.isUnroutableBindingError(error))
+    }
+
+    func testDoesNotRetryUnrelatedScoutFailure() {
+        let error = ScoutAssistantTransportError.commandFailed(
+            "Scout broker is unavailable"
+        )
+
+        XCTAssertFalse(ScoutAssistantTransport.isUnroutableBindingError(error))
+    }
+
+    func testDoesNotRetryNonBindingNoAgentMatch() {
+        let error = ScoutAssistantTransportError.commandFailed(
+            "No agent matches project lattices"
+        )
+
+        XCTAssertFalse(ScoutAssistantTransport.isUnroutableBindingError(error))
+    }
+}

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "docs:agent": "bun --cwd apps/site agent-docs",
     "check": "bun run check:types && bun run check:app",
     "check:types": "tsc --noEmit",
-    "check:app": "env CLANG_MODULE_CACHE_PATH=/tmp/lattices-clang-cache SWIFTPM_TESTS_MODULECACHE=/tmp/lattices-swiftpm-cache swift build --package-path apps/mac",
+    "check:app": "bash -lc 'eval \"$(bun ./bin/lattices-build-env.ts shell)\"; exec env CLANG_MODULE_CACHE_PATH=/tmp/lattices-clang-cache SWIFTPM_TESTS_MODULECACHE=/tmp/lattices-swiftpm-cache swift build --package-path apps/mac'",
     "test": "node --experimental-strip-types --test tests/cli.test.mjs && bun test tests/dependency-free.test.ts",
     "test:cli": "node --experimental-strip-types --test tests/cli.test.mjs",
     "test:dependencies": "bun test tests/dependency-free.test.ts",


### PR DESCRIPTION
## Summary

- recover Workspace Assistant turns when a persisted Scout binding ref is no longer routable by clearing it and retrying once through project routing
- replace the dead default Vox endpoint/no-op host with an authenticated embedded speech runtime
- pass capability tokens through HudsonVoice health and live-session calls
- expose transcription and speech-synthesis capabilities, including the Apple system TTS model
- make the normal app check compile the manifest-enabled voice configuration

## Root cause

Assistant continuity metadata was treated as a permanent route, so retired Scout refs failed every subsequent turn. Voice startup only logged that the client was compiled in, while endpoint resolution manufactured a default port even when no service was listening. Authenticated runtime files were also unusable because the token was not passed to probes.

## Security and lifecycle

The embedded runtime binds to loopback and uses a fresh 32-byte capability token per launch. The token stays in memory and is passed explicitly to Vox instead of being exported through inherited process environment.

## Validation

- `bun run check:app`
- `HUDSONKIT_WITH_VOICE=1 swift test --package-path apps/mac`
  - 36 tests completed
  - 0 failures
  - 13 Stage Manager-dependent tests skipped because Stage Manager was disabled
- signed dev bundle rebuilt and restarted
- live `voice.reconnect` reports `runtimeAvailable: true`, `requiresAuth: true`, and capabilities `transcription` plus `speech-synthesis`
- regression tests verify valid authenticated health, missing/wrong-token rejection, Scout stale-ref classification, and authenticated TTS model discovery

## Follow-up

A future Vox/Hudson change can move host configuration, automatic port allocation, lifecycle coalescing, and shared-host election into a reusable upstream embedded-runtime actor.