### PR TITLE
Add multi-host iPad companion foundation

### DIFF
--- a/.codex/reports/lats-deck-transition-audit-2026-07-30.md
+++ b/.codex/reports/lats-deck-transition-audit-2026-07-30.md
@@ -1,0 +1,182 @@
+# Solo deck transition performance audit
+
+Date: 2026-07-30
+Branch inspected: `codex/fix-assistant-voice-runtime`
+Scope: Home host tap -> `fullScreenCover` -> `HostDeckHost` -> `LatsDeckScreen`
+
+## Bottom line
+
+The operator's premise is correct: the slow solo-deck presentation is primarily local main-thread view construction/diff/layout, not network wait, the recording waveform, or the Fleet Deck shadows.
+
+The largest measured event is constructing the full `LatsDeckScreen` tree during presentation. A local representative snapshot added roughly 90 ms to time-to-appearance and about 130 ms to the worst display-link interval over a lightweight cover. Removing either of the two large visible subtrees—the cockpit or shortcut grid—saved 26–35 ms of time-to-appearance and about 52 ms of the worst interval. Publishing a new snapshot later re-evaluated the whole deck and produced roughly 37 ms hitches in an optimized simulator build.
+
+The single biggest win is therefore to stop constructing/diffing the entire cockpit and shortcut tree on the presentation animation frame, then keep those stable subtrees out of unrelated 1 Hz snapshot updates.
+
+## What was measured
+
+I temporarily added a CADisplayLink harness, then removed it completely. The harness presented a local `DeckRuntimeSnapshot` with the production-size cockpit catalog (6 pages x 16 tiles) and a 24-window layout preview. No network was involved.
+
+- Build: Release-optimized iOS app.
+- Target: iPad Pro 13-inch (M5) iOS 26.5 Simulator.
+- Simulator display cadence: 60 Hz, despite requesting 120 Hz. These numbers do not predict the exact 120 Hz device result, but the multi-frame main-run-loop stalls are far above either budget.
+- Values below are medians of three runs for the controlled A/B set unless stated otherwise.
+
+| Variant | Presentation request -> content `onAppear` | Worst display-link interval | Delta from matched baseline |
+|---|---:|---:|---:|
+| Lightweight cover | 32.6 ms | 43.9 ms | reference only |
+| Full local deck | 122.4 ms | 175.1 ms | baseline |
+| No shortcut grid | 96.8 ms | 123.2 ms | -25.6 ms appear, -51.9 ms stall |
+| No cockpit subtree | 87.4 ms | 123.1 ms | -35.0 ms appear, -52.0 ms stall |
+| No cockpit and no grid | 75.8 ms | 97.3 ms | -46.6 ms appear, -77.8 ms stall |
+| Solo-deck shadows disabled | 130.3 ms | 176.8 ms | no improvement within run variance |
+
+There was substantial cold/warm variance: one cold full-deck run was 234.1 ms to appearance with a 321.2 ms interval. A separate five-run full-deck set had a 156.7 ms / 213.5 ms median. The direction and ranking of the A/B results were stable; absolute simulator timings were not.
+
+For steady state, I changed only `updatedAt`/telemetry in the representative snapshot three times at approximately 1 Hz:
+
+- `LatsDeckScreen.body` evaluated once initially plus once per publication (4 total).
+- The otherwise-idle 16.67 ms cadence acquired a 37.05 ms maximum interval and two over-33 ms frames across the three updates.
+
+This is direct evidence that broad snapshot publication, not only presentation, causes visible deck hitches.
+
+I attempted Instruments/xctrace SwiftUI/Animation Hitches and Time Profiler capture. The SwiftUI template was not usable against the Simulator, and Time Profiler did not yield an actionable call tree. Therefore this ranking is based on frame intervals plus controlled subtree A/Bs, not a physical-device CPU/GPU trace. A device Core Animation trace is still required before making the shadows a priority.
+
+## Ranked costs and causes
+
+### 1. Full synchronous deck-tree construction on cover presentation — dominant transition cost
+
+Relevant code:
+
+- `apps/ios/Sources/ContentView.swift:128` creates the `fullScreenCover` destination.
+- `apps/ios/Sources/ContentView.swift:309-328` conditionally creates the deck.
+- `apps/ios/Sources/ContentView.swift:350-360` instantiates `LatsDeckScreen` from the already-held snapshot.
+- `apps/ios/Sources/LatsDeckScreen.swift:2158-2245` builds the root tree, cockpit, and shortcut grid.
+- `apps/ios/Sources/LatsDeckScreen.swift:1475-1526` lays out the shortcut controls; the production catalog is six 16-slot pages at `apps/mac/Sources/Core/Companion/LatticesCompanionCockpit.swift:141-212` (only the active 16 are mounted, but all pages are decoded and mapped as needed).
+
+The cover closure is evaluated and reconciled on the main actor as presentation begins. The lightweight-vs-full and subtree A/B results show the local tree is what turns a normal cover into a long frame. It is not necessary to wait for I/O to reproduce the symptom.
+
+The current working tree already has a 300 ms fixed deferral in `ContentView.swift:289-337`. I measured the same strategy: initial cover appearance improved to 22.4 ms, but mounting the deck then caused a 240.9 ms interval beginning about 336 ms after the presentation request. In other words, 300 ms relocates the stall into the later portion of the transition; it does not remove it. It can also produce a skeleton-then-pop experience.
+
+Clean tactical deferral should be keyed to the actual presentation transition completion, not a guessed 300 ms timer. A small `UIViewControllerRepresentable` bridge can observe the presentation controller's transition coordinator completion. During the transition, show a cheap snapshot-derived deck shell (host/deck title, fixed cockpit frame, key placeholders) so arrival is not blank. Then crossfade the live tree. This protects the transition, but tree cost still needs reduction or staged mounting to avoid an after-arrival hitch.
+
+The structural fix is to make the cockpit and key grid separately diffable/reusable and cheap enough to mount. If an interim staged mount is needed, build shell -> cockpit -> key grid on separate main-loop turns after transition completion rather than inserting both large subtrees at once.
+
+### 2. Whole-tree invalidation on every snapshot — dominant steady-state cost
+
+Relevant code:
+
+- `apps/ios/Sources/DeckStore.swift:14-31` makes one `@MainActor ObservableObject` with 14 `@Published` properties.
+- `apps/ios/Sources/ContentView.swift:285-300` observes the entire store, although the solo view mainly needs snapshot and connection state.
+- `apps/ios/Sources/DeckStore.swift:446-455` publishes the full snapshot, then also assigns selected page and error state.
+- `apps/ios/Sources/DeckStore.swift:646-653` republishes every secondary store's `objectWillChange` through `DeckFleetStore`; a secondary solo deck can therefore invalidate both `HostDeckHost` directly and the root `ContentView` indirectly.
+- `apps/ios/Sources/LatsDeckScreen.swift:2093-2135` sorts/maps transcript, preview windows, and shortcuts during root evaluation; `liveShortcuts()` maps the active page at `LatsDeckScreen.swift:2284-2316`.
+
+`DeckRuntimeSnapshot` and its component types already conform to `Equatable`, so missing model conformance is not the problem. The full snapshot includes `updatedAt` (`swift/Sources/DeckKit/DeckRuntimeSnapshot.swift:3-4`), and telemetry timestamps also change, so the whole value is intentionally different every poll even when the cockpit page/tiles did not change.
+
+Fix by publishing/observing derived, narrowly scoped presentation state:
+
+1. Split stable cockpit page/tiles, trackpad/mode, telemetry/status, and activity/transcript into separate `Equatable` inputs.
+2. Make the cockpit and shortcut grid explicit equatable boundaries so telemetry or `updatedAt` cannot rebuild them. Closures prevent relying on synthesized view equality; use a wrapper whose equality compares only the relevant model.
+3. Do not forward every inner store change through `DeckFleetStore` to the root. Publish a fleet-specific derived revision/state only while the Fleet view needs it, or let per-host row subviews observe their own store.
+4. Avoid assigning `selectedCockpitPageID`/`errorMessage` when the value did not change. This is smaller than the snapshot fix but removes unnecessary `@Published` emissions.
+
+### 3. Poll fanout and duplicate refresh work — an avoidable transition amplifier
+
+Relevant code:
+
+- `apps/ios/Sources/ContentView.swift:238-252` now contains the correct policy: only the selected host is `.fast` for a solo deck; all hosts are `.fast` only for Fleet.
+- `apps/ios/Sources/DeckStore.swift:488-521` implements 1 s fast and 5 s ambient polling.
+- `apps/ios/Sources/ContentView.swift:94-102` explicitly refreshes on the tap.
+- `apps/ios/Sources/ContentView.swift:332-337` refreshes the same store again inside `HostDeckHost.task`.
+
+The previous "solo deck makes every host fast" behavior was wrong. The current targeted `applyPollPriority` is the right policy and should be kept. Note that `setUIPriority` only changes the interval chosen at the next poll iteration; it does not wake an existing sleep or immediately fetch.
+
+The two explicit `refreshSnapshot()` calls are redundant, and neither is needed to present an already-fetched local snapshot. They can cause a snapshot publication/invalidation during the transition. Remove both for the cached-snapshot path; refresh only when there is no usable snapshot or when staleness policy explicitly requires it, and deduplicate in-flight refreshes in the store.
+
+### 4. Recording waveform — real CPU/energy cost, but not an idle or presentation cause
+
+Relevant code:
+
+- `apps/ios/Sources/LatsDeckScreen.swift:1007-1014` mounts `recView` only for `.rec` mode.
+- `apps/ios/Sources/LatsDeckScreen.swift:1030-1044` ticks at 30 Hz and creates 70 capsules with two sine calculations per element.
+
+Measured:
+
+- Idle mode: zero recording timeline ticks.
+- Recording mode: 132 ticks in roughly 4.4 seconds (~30 Hz).
+- The timeline invalidated its own subtree; it did not re-evaluate the `LatsDeckScreen` root.
+- The optimized 60 Hz simulator stayed at a 16.67 ms steady maximum during this isolated run.
+
+So the suspicion is numerically correct—about 2,100 capsule instances and 4,200 `sin` calls per second while recording—but it is absent when idle and was not the slow host-tap transition. Replace the 70-view `HStack` with one `Canvas` draw pass, use actual audio levels, and pause it whenever recording is not visible/active. This is an energy/recording-mode fix after the two items above.
+
+### 5. Shadows — not the measured main-thread transition cause; device GPU validation remains
+
+Relevant solo-deck sites include:
+
+- shell: `apps/ios/Sources/LatsDeckScreen.swift:378`
+- four inset panels: `LatsDeckScreen.swift:454-484`, modifier at `:670`
+- every key surface: `LatsDeckScreen.swift:1715-1720`
+- every key icon: `LatsDeckScreen.swift:1748`
+- recent-key adornments: `LatsDeckScreen.swift:1710` and `:1790`
+
+The large radius-30/radius-22 and every-keycap Fleet shadows at `apps/ios/Sources/FleetDeck/FleetDeckView.swift:164` and `FleetDeck/FleetDeckTheme.swift:187,258` are not mounted for `DeckDestination.host`; they cannot explain the solo transition.
+
+Disabling the mounted solo-deck shadows did not improve simulator presentation timing. That rules them out as the primary main-thread cause in this path, not as a physical-device GPU/render-server cost. On the real iPad, use Core Animation's Color Offscreen-Rendered / Color Blended Layers and GPU counters before removing visual depth. If the device trace implicates them, start with per-tile/icon shadows because cost scales with the 16 visible controls, then the four large inset panels.
+
+### 6. Fleet timelines — low priority for this path
+
+- `apps/ios/Sources/FleetDeck/FleetDeckVoiceBar.swift:138` is already paused when inactive.
+- `FleetDeckVoiceBar.swift:163` has an ungated 0.55 s caret timer, but the voice-bar caret is only mounted while listening at `:49-51`.
+- `apps/ios/Sources/FleetDeck/FleetDeckFocusPane.swift:102` mounts a caret continuously while the Fleet focus pane is visible.
+
+These views are not in the solo host deck. The continuously mounted Fleet focus caret is worth gating on scene activity/visibility, but at ~1.8 updates/s for one rectangle it is far below the measured solo-deck costs.
+
+### 7. File size/type-check complexity — maintenance issue, not runtime evidence
+
+I built with:
+
+```text
+-Xfrontend -warn-long-expression-type-checking=100
+-Xfrontend -warn-long-function-bodies=100
+```
+
+There were warnings in `LatsDeckScreen.swift` (for example a 318 ms action-key body and a 750 ms Fleet header getter) and a 171 ms warning in `FleetDeckVoiceBar`. There was no >100 ms compiler warning for the actual solo `LatsDeckScreen.body` around line 2158. These are compiler times, not runtime frame times. Splitting the 4,134-line file is good maintenance and can improve build times, but doing so without new observation/equality boundaries will not fix the transition.
+
+## Structural suspect check
+
+- **Broad `@ObservedObject` invalidation:** confirmed and measured; high-priority steady-state issue.
+- **Missing `Equatable` on wire models:** no; snapshot components are already equatable. The missing piece is using smaller equatable presentation projections/boundaries.
+- **`AnyView` erasure:** present in the general `LatsTopBar` API (`apps/ios/Sources/LatsDesignSystem.swift:26`), but `LatsDeckScreen` uses its own `LatsTopChrome` and does not hit that erasure on the solo root. Not causal here.
+- **`.id()` churn:** `apps/ios/Sources/LatsDeckScreen.swift:2238` uses `.id(effectiveDeckID)`. The ID is stable across polls and changes only when switching decks, where resetting the grid is intentional. Not causal here.
+- **Eager construction:** confirmed by local presentation and subtree A/B measurements.
+
+## Decode executor finding
+
+Relevant path:
+
+- `apps/ios/Sources/DeckStore.swift:446-450` starts on the main actor and awaits `client.snapshot`.
+- `apps/ios/Sources/DeckBridgeClient.swift:244-268` resumes the protected request and calls `openProtectedResponse`.
+- `apps/ios/Sources/DeckBridgeSecurityStore.swift:251-270` decodes the envelope, decrypts, and decodes the snapshot.
+- The app is Swift 5 mode (`apps/ios/LatticesCompanion.xcodeproj/project.pbxproj:523,583`) with no default-main-actor setting.
+
+I called a temporary probe through `DeckBridgeClient` from `Task { @MainActor in ... }`, suspended, then used the client's real encoder/decoder. It reported `Thread.isMainThread == false`. That empirically confirms the plain async client method resumes on the generic executor in this configuration. Because the decrypt/decode calls are synchronous inside that nonisolated async client chain, they should remain off main; only the returned snapshot assignment is main-actor work.
+
+Limitation: the Simulator was not paired to a live Mac, so I did not capture an actual encrypted full-snapshot response. The protected-path conclusion is executor inference backed by the client probe, not a live ChaChaPoly stack trace. If this must be made invariant rather than configuration-dependent, put decrypt/decode behind an explicit nonisolated worker/actor and add an assertion/signpost test.
+
+## Recommended fix order
+
+1. **Protect presentation:** replace the fixed 300 ms delay with actual transition-completion signaling and a cheap local snapshot-derived shell; remove the two automatic refreshes from the cached-snapshot path. This is the quickest user-visible win.
+2. **Stop whole-tree snapshot churn:** introduce stable presentation projections and equatable boundaries for cockpit and keys; stop root-level forwarding of every secondary-store change. This addresses the measured 37 ms 1 Hz hitches and also reduces mount/diff work.
+3. **Reduce/stage the two heavy subtrees:** cockpit and shortcut grid independently account for the largest A/B savings. Cache their derived arrays, avoid sorting/mapping in root body evaluation, and if needed mount them on separate turns after transition completion.
+4. **Keep solo polling targeted:** retain the current selected-host-only `.fast` logic. Reserve fleet-wide `.fast` for Fleet Deck.
+5. **Optimize recording waveform:** one `Canvas`, activity/visibility gating, lower/adaptive cadence.
+6. **Run the physical-device GPU pass before shadow edits:** prioritize repeated tile/icon shadows only if Core Animation shows offscreen-render/render-server pressure.
+7. **Refactor the monolithic source for build maintainability**, but do not count that alone as a runtime fix.
+
+## Verification after fixes
+
+On the operator's iPad Pro, record SwiftUI + Animation Hitches + Core Animation while tapping the same host 10 times (first run and warm runs separately). Add `os_signpost` intervals for tap, cover content creation, cockpit mount, grid mount, snapshot assignment, and protected decode. Success criteria should be no >16.7 ms main-thread hitch during the 60 Hz transition (ideally <8.3 ms on the 120 Hz panel), and no visible 1 Hz hitch when only telemetry/timestamps change.
+
+## Build verification
+
+After removing all temporary instrumentation, a clean Debug simulator build of the current working tree succeeded with `xcodebuild` for the iPad Pro 13-inch (M5) simulator. Existing Home preview trailing-closure warnings remain; there were no errors.

--- a/apps/ios/LatticesCompanion.xcodeproj/project.pbxproj
+++ b/apps/ios/LatticesCompanion.xcodeproj/project.pbxproj
@@ -7,44 +7,62 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0058D393E44DEF775DA31C65 /* FleetDeckView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A141DE2D3AA7C43AE670B36A /* FleetDeckView.swift */; };
 		015334E9F01E2EC8CE7C6C77 /* DeckStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11238FFB50336470B6A97CE0 /* DeckStore.swift */; };
+		025FA3204BAD8CD313BA29A7 /* HomeActivityFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6098E179D9E917692848D127 /* HomeActivityFeed.swift */; };
 		02DFEEC584B5BE76F4E0EF59 /* Icon-App-29x29@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = AB70174A80BDBEF97964B1D1 /* Icon-App-29x29@3x.png */; };
 		0B62E8780B2EF68BB75DCB77 /* DeckKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1D4FCB5C53FAA6DC26531C63 /* DeckKit */; };
 		0F0698A95BD07D14D89D5BA1 /* HomeRoutinesList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23261457659049EF7D390F0E /* HomeRoutinesList.swift */; };
-		111111111111111111111111 /* HomeActivityFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 444444444444444444444444 /* HomeActivityFeed.swift */; };
-		222222222222222222222222 /* HomeMachineGauges.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555555555555555555555555 /* HomeMachineGauges.swift */; };
 		2495F9FA74E60FE3935AF9AB /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6008CE13AA2719DE4CFEFBA5 /* ContentView.swift */; };
 		29EB1F420B2143258D6BE3E6 /* HomeVoiceOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F80BAECD547AFCAF6FB4487 /* HomeVoiceOverlay.swift */; };
 		303C0ED6FF5A801009E72EBD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E0A62477A93C15EBE3917B2E /* LaunchScreen.storyboard */; };
+		31B02262C2B0BF05CE8CFAA8 /* HomeVoicePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5C0AF5BDF4BE3A05157A33 /* HomeVoicePanel.swift */; };
+		33F614CE777865FEFB936F6E /* FleetDeckTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4E739253EC58DB13D63E59 /* FleetDeckTheme.swift */; };
 		3638B83B044C466CDFC95D74 /* HomeRecentTape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C92E6807AE18FFB1268EDA /* HomeRecentTape.swift */; };
-		333333333333333333333333 /* HomeVoicePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666666666666666666666666 /* HomeVoicePanel.swift */; };
 		39910639463B85C88940415F /* DeckBridgeClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B31BBB86BC2F6969B6F8C6AC /* DeckBridgeClient.swift */; };
+		3A1671AC9709B03CC97F9D13 /* FleetDeckCommandBay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E8338D3E7435105844A04A0 /* FleetDeckCommandBay.swift */; };
 		3CD5F4319B4419DA9ACCA70A /* Icon-App-60x60@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = D6A573A92276901B84AA3EE4 /* Icon-App-60x60@2x.png */; };
 		41CC7A2C0996C6F6DB3772B0 /* HomeOverflowGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4AFBCA3400844A37C27E7E3 /* HomeOverflowGrid.swift */; };
+		432575F519F865BDCFE18B25 /* FleetDeckCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2DF53527C0D8B29AB3ECF51 /* FleetDeckCommands.swift */; };
 		463B785BA54ED05DE516BAC5 /* HomeTargetsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36A4114F8C72CC8E8B22BED3 /* HomeTargetsRow.swift */; };
+		466A7968EA0D32CAB12A314F /* FleetDeckFocusPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDEBF60950520605C2AFCAB6 /* FleetDeckFocusPane.swift */; };
 		477B603FA482CD0AF55BC9C7 /* DeckBridgeSecurityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D303982A361559374D4ECAF /* DeckBridgeSecurityStore.swift */; };
 		48AB2F1093E08D5F972BEF57 /* Icon-App-76x76@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 2008FE641E08A7EA3F1142D8 /* Icon-App-76x76@2x.png */; };
 		49328530140603E31D3C44C4 /* Icon-App-29x29@1x.png in Resources */ = {isa = PBXBuildFile; fileRef = 763E58A4536019D1C0D225B5 /* Icon-App-29x29@1x.png */; };
 		4932E64B0E7CF7E4C48DB05E /* LatsDeckScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE37E6C4302786080981EE9 /* LatsDeckScreen.swift */; };
+		52A7A84BD7038A00D44473CB /* FleetDeckConsole.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8CF4F00C46E366B32EC05B6 /* FleetDeckConsole.swift */; };
+		57C2B51D869407F1BC8823C1 /* FleetDeckModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 402515ACE950AAA6EB8DC125 /* FleetDeckModel.swift */; };
 		58104483ED43F7B6EADEDD47 /* Icon-App-29x29@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 5E31C91E44E310ECB2F450E6 /* Icon-App-29x29@2x.png */; };
 		5D875934B56A9DC50211E1C3 /* HomeDataAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EFEF38997FEAEB9C381D62 /* HomeDataAdapter.swift */; };
+		638DE62C1A554C5E39F0D430 /* FleetDeckVoiceBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFEA84FACFEF2BC028E68125 /* FleetDeckVoiceBar.swift */; };
 		6D5C7D4A62CD79AB8E33AEA1 /* HomeZeroState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0124DA4C4A5337F1FCDE85F0 /* HomeZeroState.swift */; };
+		702E0CE9E43B03A228EB124B /* DeckSkeleton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3829B428DD890399011344 /* DeckSkeleton.swift */; };
 		75E303C90FD9763D830E6DAE /* HomeMockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C0C0DD3A5DE3971145E8B4 /* HomeMockData.swift */; };
 		7EDE2F31F72E36E314649728 /* HomeCloudStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9BAE762CC872FFCA8CB25DD /* HomeCloudStrip.swift */; };
+		830D5F288DDE1326F8AD0354 /* FleetDeckFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCE94827305E1EAA62E3E39 /* FleetDeckFeed.swift */; };
 		84F9131A8649EB980EC5A378 /* BridgeDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4603482511D3BE1F2132C82 /* BridgeDiscovery.swift */; };
 		8509FE10337BF9B4286C77DF /* LatticesCompanionApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BAB98213FEF0182FB2EA32 /* LatticesCompanionApp.swift */; };
 		890DFAA5138BB9EFA7C21D8C /* Icon-App-20x20@1x.png in Resources */ = {isa = PBXBuildFile; fileRef = D91400AA758EB6C7BDEFA067 /* Icon-App-20x20@1x.png */; };
 		89AB5D05E905F1A23A38C4F3 /* Icon-App-40x40@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 742860D211F50B7F0B23A4DB /* Icon-App-40x40@3x.png */; };
 		8C0507D98FBDCCF4D9E2D2D1 /* HomeSyncSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB1F87999BB14714FBFACB9F /* HomeSyncSection.swift */; };
+		93CDDD1693747AEA8F93A53D /* FleetDeckHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F62141EE310B1E14C10F6D /* FleetDeckHost.swift */; };
+		956F8FD18A151C41F808CF3D /* FleetDeckFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCD1E352126CF05657A6F7B /* FleetDeckFixture.swift */; };
+		A554A5F6BEE7A1D19133D7E3 /* DeckTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D07069EDC1FC31F2D17855 /* DeckTheme.swift */; };
+		A922FDD1ECB6EC0325799626 /* AddHostController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98064778419B457BD396A587 /* AddHostController.swift */; };
 		AE392FBE93D051B87EF6EB52 /* Icon-App-40x40@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 65151992218EDBCB6BFC8518 /* Icon-App-40x40@2x.png */; };
 		B5BD61D18065255F3BA23397 /* Icon-App-40x40@1x.png in Resources */ = {isa = PBXBuildFile; fileRef = B9B6EE50773DB75253F67837 /* Icon-App-40x40@1x.png */; };
 		B87350C3DF5953681D197E24 /* Icon-App-60x60@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = D0A784E5230CF4A1207A5B63 /* Icon-App-60x60@3x.png */; };
 		C521143339E9016DF721F243 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E418F5CA4F95128A4654679B /* HomeView.swift */; };
+		C690A1C61C0A8A0FBE4639FA /* LocalNetworkScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48879BE5FDAA5E9B1F69EB2 /* LocalNetworkScanner.swift */; };
+		C7C2501F8E91C0BB8B1E8CE3 /* AddHostSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8DF3079141147D2D920A0D6 /* AddHostSheet.swift */; };
 		CAF7F48B371B153DED55637D /* Icon-App-20x20@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 358CE7599268D7E37739DA40 /* Icon-App-20x20@2x.png */; };
 		D087EC7E9542F2EB5989500F /* Icon-App-1024x1024@1x.png in Resources */ = {isa = PBXBuildFile; fileRef = 2484AA38E059AA293C768446 /* Icon-App-1024x1024@1x.png */; };
 		D22111B43C6A48912D6E5A96 /* Icon-App-20x20@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 2569702CC7CAC0677B8C6524 /* Icon-App-20x20@3x.png */; };
 		D34392C35E4145D4262AC87F /* Icon-App-83.5x83.5@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = BCF0269F9663D59AA5D8BEF6 /* Icon-App-83.5x83.5@2x.png */; };
 		D6EEC01EF1A11293570069EF /* HomeTopBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BAA7488EF7726F4258EABF6 /* HomeTopBar.swift */; };
+		DFB63FF98BF7CE3D5A28A37D /* HomeMachineGauges.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC75F1AC3E0B76173D0E3EA /* HomeMachineGauges.swift */; };
+		E28369386027FFF51101E239 /* FleetDeckChannelStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D6C98FFC4F744672C96DB8C /* FleetDeckChannelStrip.swift */; };
+		E49DB476A1AF62CF00A48A94 /* FleetDeckAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B864A7A18AF861B84FA6AF38 /* FleetDeckAdapter.swift */; };
 		E7EC416CD4478DCF4FEBB4FC /* CompanionTrackpadSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2C2E756959812A344E33FA /* CompanionTrackpadSurface.swift */; };
 		EC49AAE0FD658F4D651D6CB1 /* LatsDesignSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5BE58AB3627168981D1D91F /* LatsDesignSystem.swift */; };
 		F72E10BB85375949AAE483F2 /* HomeScenesGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EE0F84AD8C6B6C5109C4628 /* HomeScenesGrid.swift */; };
@@ -65,32 +83,44 @@
 		2484AA38E059AA293C768446 /* Icon-App-1024x1024@1x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-1024x1024@1x.png"; sourceTree = "<group>"; };
 		2569702CC7CAC0677B8C6524 /* Icon-App-20x20@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-20x20@3x.png"; sourceTree = "<group>"; };
 		31BAB98213FEF0182FB2EA32 /* LatticesCompanionApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatticesCompanionApp.swift; sourceTree = "<group>"; };
+		33D07069EDC1FC31F2D17855 /* DeckTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeckTheme.swift; sourceTree = "<group>"; };
 		358CE7599268D7E37739DA40 /* Icon-App-20x20@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-20x20@2x.png"; sourceTree = "<group>"; };
 		36A4114F8C72CC8E8B22BED3 /* HomeTargetsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTargetsRow.swift; sourceTree = "<group>"; };
 		39EFEF38997FEAEB9C381D62 /* HomeDataAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeDataAdapter.swift; sourceTree = "<group>"; };
-		444444444444444444444444 /* HomeActivityFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeActivityFeed.swift; sourceTree = "<group>"; };
-		555555555555555555555555 /* HomeMachineGauges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeMachineGauges.swift; sourceTree = "<group>"; };
-		666666666666666666666666 /* HomeVoicePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeVoicePanel.swift; sourceTree = "<group>"; };
+		3E8338D3E7435105844A04A0 /* FleetDeckCommandBay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDeckCommandBay.swift; sourceTree = "<group>"; };
+		402515ACE950AAA6EB8DC125 /* FleetDeckModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDeckModel.swift; sourceTree = "<group>"; };
 		5E31C91E44E310ECB2F450E6 /* Icon-App-29x29@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-29x29@2x.png"; sourceTree = "<group>"; };
 		6008CE13AA2719DE4CFEFBA5 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		6098E179D9E917692848D127 /* HomeActivityFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeActivityFeed.swift; sourceTree = "<group>"; };
 		65151992218EDBCB6BFC8518 /* Icon-App-40x40@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-40x40@2x.png"; sourceTree = "<group>"; };
 		6BAA7488EF7726F4258EABF6 /* HomeTopBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTopBar.swift; sourceTree = "<group>"; };
+		6BCD1E352126CF05657A6F7B /* FleetDeckFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDeckFixture.swift; sourceTree = "<group>"; };
 		6F80BAECD547AFCAF6FB4487 /* HomeVoiceOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeVoiceOverlay.swift; sourceTree = "<group>"; };
 		742860D211F50B7F0B23A4DB /* Icon-App-40x40@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-40x40@3x.png"; sourceTree = "<group>"; };
 		763E58A4536019D1C0D225B5 /* Icon-App-29x29@1x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-29x29@1x.png"; sourceTree = "<group>"; };
 		7D303982A361559374D4ECAF /* DeckBridgeSecurityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeckBridgeSecurityStore.swift; sourceTree = "<group>"; };
+		8D6C98FFC4F744672C96DB8C /* FleetDeckChannelStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDeckChannelStrip.swift; sourceTree = "<group>"; };
 		924A59FEB2399ED0CF09A4B5 /* Icon-App-76x76@1x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-76x76@1x.png"; sourceTree = "<group>"; };
 		977D8E982F70B14D99DF82FE /* LatticesCompanion.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = LatticesCompanion.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		98064778419B457BD396A587 /* AddHostController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddHostController.swift; sourceTree = "<group>"; };
+		9D4E739253EC58DB13D63E59 /* FleetDeckTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDeckTheme.swift; sourceTree = "<group>"; };
 		9EE0F84AD8C6B6C5109C4628 /* HomeScenesGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScenesGrid.swift; sourceTree = "<group>"; };
+		A141DE2D3AA7C43AE670B36A /* FleetDeckView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDeckView.swift; sourceTree = "<group>"; };
 		A9BAE762CC872FFCA8CB25DD /* HomeCloudStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCloudStrip.swift; sourceTree = "<group>"; };
 		AB70174A80BDBEF97964B1D1 /* Icon-App-29x29@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-29x29@3x.png"; sourceTree = "<group>"; };
+		ADCE94827305E1EAA62E3E39 /* FleetDeckFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDeckFeed.swift; sourceTree = "<group>"; };
 		B31BBB86BC2F6969B6F8C6AC /* DeckBridgeClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeckBridgeClient.swift; sourceTree = "<group>"; };
 		B4603482511D3BE1F2132C82 /* BridgeDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeDiscovery.swift; sourceTree = "<group>"; };
+		B864A7A18AF861B84FA6AF38 /* FleetDeckAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDeckAdapter.swift; sourceTree = "<group>"; };
+		B8DF3079141147D2D920A0D6 /* AddHostSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddHostSheet.swift; sourceTree = "<group>"; };
 		B9B6EE50773DB75253F67837 /* Icon-App-40x40@1x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-40x40@1x.png"; sourceTree = "<group>"; };
 		BA2C2E756959812A344E33FA /* CompanionTrackpadSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionTrackpadSurface.swift; sourceTree = "<group>"; };
 		BB1F87999BB14714FBFACB9F /* HomeSyncSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSyncSection.swift; sourceTree = "<group>"; };
+		BCC75F1AC3E0B76173D0E3EA /* HomeMachineGauges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeMachineGauges.swift; sourceTree = "<group>"; };
 		BCF0269F9663D59AA5D8BEF6 /* Icon-App-83.5x83.5@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-83.5x83.5@2x.png"; sourceTree = "<group>"; };
+		CE3829B428DD890399011344 /* DeckSkeleton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeckSkeleton.swift; sourceTree = "<group>"; };
 		D0A784E5230CF4A1207A5B63 /* Icon-App-60x60@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-60x60@3x.png"; sourceTree = "<group>"; };
+		D2DF53527C0D8B29AB3ECF51 /* FleetDeckCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDeckCommands.swift; sourceTree = "<group>"; };
 		D6A573A92276901B84AA3EE4 /* Icon-App-60x60@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-60x60@2x.png"; sourceTree = "<group>"; };
 		D91400AA758EB6C7BDEFA067 /* Icon-App-20x20@1x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-App-20x20@1x.png"; sourceTree = "<group>"; };
 		E0A62477A93C15EBE3917B2E /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -98,6 +128,12 @@
 		E418F5CA4F95128A4654679B /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		E4AFBCA3400844A37C27E7E3 /* HomeOverflowGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeOverflowGrid.swift; sourceTree = "<group>"; };
 		E5BE58AB3627168981D1D91F /* LatsDesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatsDesignSystem.swift; sourceTree = "<group>"; };
+		E8CF4F00C46E366B32EC05B6 /* FleetDeckConsole.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDeckConsole.swift; sourceTree = "<group>"; };
+		EDEBF60950520605C2AFCAB6 /* FleetDeckFocusPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDeckFocusPane.swift; sourceTree = "<group>"; };
+		EE5C0AF5BDF4BE3A05157A33 /* HomeVoicePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeVoicePanel.swift; sourceTree = "<group>"; };
+		EFEA84FACFEF2BC028E68125 /* FleetDeckVoiceBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDeckVoiceBar.swift; sourceTree = "<group>"; };
+		F48879BE5FDAA5E9B1F69EB2 /* LocalNetworkScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNetworkScanner.swift; sourceTree = "<group>"; };
+		F6F62141EE310B1E14C10F6D /* FleetDeckHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDeckHost.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -137,11 +173,13 @@
 		513162B6C40BBCE8437AF800 /* Home */ = {
 			isa = PBXGroup;
 			children = (
-				444444444444444444444444 /* HomeActivityFeed.swift */,
+				98064778419B457BD396A587 /* AddHostController.swift */,
+				B8DF3079141147D2D920A0D6 /* AddHostSheet.swift */,
+				6098E179D9E917692848D127 /* HomeActivityFeed.swift */,
 				239FA0F75F234965764D0C62 /* HomeBottomBar.swift */,
 				A9BAE762CC872FFCA8CB25DD /* HomeCloudStrip.swift */,
 				39EFEF38997FEAEB9C381D62 /* HomeDataAdapter.swift */,
-				555555555555555555555555 /* HomeMachineGauges.swift */,
+				BCC75F1AC3E0B76173D0E3EA /* HomeMachineGauges.swift */,
 				E2C0C0DD3A5DE3971145E8B4 /* HomeMockData.swift */,
 				E4AFBCA3400844A37C27E7E3 /* HomeOverflowGrid.swift */,
 				14C92E6807AE18FFB1268EDA /* HomeRecentTape.swift */,
@@ -152,7 +190,7 @@
 				6BAA7488EF7726F4258EABF6 /* HomeTopBar.swift */,
 				E418F5CA4F95128A4654679B /* HomeView.swift */,
 				6F80BAECD547AFCAF6FB4487 /* HomeVoiceOverlay.swift */,
-				666666666666666666666666 /* HomeVoicePanel.swift */,
+				EE5C0AF5BDF4BE3A05157A33 /* HomeVoicePanel.swift */,
 				0124DA4C4A5337F1FCDE85F0 /* HomeZeroState.swift */,
 			);
 			path = Home;
@@ -184,6 +222,26 @@
 			name = Packages;
 			sourceTree = "<group>";
 		};
+		DA52BA5893F13E053DBA42E5 /* FleetDeck */ = {
+			isa = PBXGroup;
+			children = (
+				B864A7A18AF861B84FA6AF38 /* FleetDeckAdapter.swift */,
+				8D6C98FFC4F744672C96DB8C /* FleetDeckChannelStrip.swift */,
+				3E8338D3E7435105844A04A0 /* FleetDeckCommandBay.swift */,
+				D2DF53527C0D8B29AB3ECF51 /* FleetDeckCommands.swift */,
+				E8CF4F00C46E366B32EC05B6 /* FleetDeckConsole.swift */,
+				ADCE94827305E1EAA62E3E39 /* FleetDeckFeed.swift */,
+				6BCD1E352126CF05657A6F7B /* FleetDeckFixture.swift */,
+				EDEBF60950520605C2AFCAB6 /* FleetDeckFocusPane.swift */,
+				F6F62141EE310B1E14C10F6D /* FleetDeckHost.swift */,
+				402515ACE950AAA6EB8DC125 /* FleetDeckModel.swift */,
+				9D4E739253EC58DB13D63E59 /* FleetDeckTheme.swift */,
+				A141DE2D3AA7C43AE670B36A /* FleetDeckView.swift */,
+				EFEA84FACFEF2BC028E68125 /* FleetDeckVoiceBar.swift */,
+			);
+			path = FleetDeck;
+			sourceTree = "<group>";
+		};
 		F3908548B1A4941A6C97B64B /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -200,12 +258,16 @@
 				6008CE13AA2719DE4CFEFBA5 /* ContentView.swift */,
 				B31BBB86BC2F6969B6F8C6AC /* DeckBridgeClient.swift */,
 				7D303982A361559374D4ECAF /* DeckBridgeSecurityStore.swift */,
+				CE3829B428DD890399011344 /* DeckSkeleton.swift */,
 				11238FFB50336470B6A97CE0 /* DeckStore.swift */,
+				33D07069EDC1FC31F2D17855 /* DeckTheme.swift */,
 				0A0454EF94BCB42389D5B90B /* Info.plist */,
 				0AE37E6C4302786080981EE9 /* LatsDeckScreen.swift */,
 				E5BE58AB3627168981D1D91F /* LatsDesignSystem.swift */,
 				31BAB98213FEF0182FB2EA32 /* LatticesCompanionApp.swift */,
 				E0A62477A93C15EBE3917B2E /* LaunchScreen.storyboard */,
+				F48879BE5FDAA5E9B1F69EB2 /* LocalNetworkScanner.swift */,
+				DA52BA5893F13E053DBA42E5 /* FleetDeck */,
 				513162B6C40BBCE8437AF800 /* Home */,
 			);
 			path = Sources;
@@ -250,7 +312,6 @@
 				};
 			};
 			buildConfigurationList = 5A74D3F6041E0DD23E4479FA /* Build configuration list for PBXProject "LatticesCompanion" */;
-			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -263,6 +324,7 @@
 				A9A9C52D0A538CA736CDB7B5 /* XCLocalSwiftPackageReference "../../swift" */,
 			);
 			preferredProjectObjectVersion = 77;
+			productRefGroup = F3908548B1A4941A6C97B64B /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -302,17 +364,34 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A922FDD1ECB6EC0325799626 /* AddHostController.swift in Sources */,
+				C7C2501F8E91C0BB8B1E8CE3 /* AddHostSheet.swift in Sources */,
 				84F9131A8649EB980EC5A378 /* BridgeDiscovery.swift in Sources */,
 				E7EC416CD4478DCF4FEBB4FC /* CompanionTrackpadSurface.swift in Sources */,
 				2495F9FA74E60FE3935AF9AB /* ContentView.swift in Sources */,
 				39910639463B85C88940415F /* DeckBridgeClient.swift in Sources */,
 				477B603FA482CD0AF55BC9C7 /* DeckBridgeSecurityStore.swift in Sources */,
+				702E0CE9E43B03A228EB124B /* DeckSkeleton.swift in Sources */,
 				015334E9F01E2EC8CE7C6C77 /* DeckStore.swift in Sources */,
-				111111111111111111111111 /* HomeActivityFeed.swift in Sources */,
+				A554A5F6BEE7A1D19133D7E3 /* DeckTheme.swift in Sources */,
+				E49DB476A1AF62CF00A48A94 /* FleetDeckAdapter.swift in Sources */,
+				E28369386027FFF51101E239 /* FleetDeckChannelStrip.swift in Sources */,
+				3A1671AC9709B03CC97F9D13 /* FleetDeckCommandBay.swift in Sources */,
+				432575F519F865BDCFE18B25 /* FleetDeckCommands.swift in Sources */,
+				52A7A84BD7038A00D44473CB /* FleetDeckConsole.swift in Sources */,
+				830D5F288DDE1326F8AD0354 /* FleetDeckFeed.swift in Sources */,
+				956F8FD18A151C41F808CF3D /* FleetDeckFixture.swift in Sources */,
+				466A7968EA0D32CAB12A314F /* FleetDeckFocusPane.swift in Sources */,
+				93CDDD1693747AEA8F93A53D /* FleetDeckHost.swift in Sources */,
+				57C2B51D869407F1BC8823C1 /* FleetDeckModel.swift in Sources */,
+				33F614CE777865FEFB936F6E /* FleetDeckTheme.swift in Sources */,
+				0058D393E44DEF775DA31C65 /* FleetDeckView.swift in Sources */,
+				638DE62C1A554C5E39F0D430 /* FleetDeckVoiceBar.swift in Sources */,
+				025FA3204BAD8CD313BA29A7 /* HomeActivityFeed.swift in Sources */,
 				FF2C00D84ADBC9A2241BA55A /* HomeBottomBar.swift in Sources */,
 				7EDE2F31F72E36E314649728 /* HomeCloudStrip.swift in Sources */,
 				5D875934B56A9DC50211E1C3 /* HomeDataAdapter.swift in Sources */,
-				222222222222222222222222 /* HomeMachineGauges.swift in Sources */,
+				DFB63FF98BF7CE3D5A28A37D /* HomeMachineGauges.swift in Sources */,
 				75E303C90FD9763D830E6DAE /* HomeMockData.swift in Sources */,
 				41CC7A2C0996C6F6DB3772B0 /* HomeOverflowGrid.swift in Sources */,
 				3638B83B044C466CDFC95D74 /* HomeRecentTape.swift in Sources */,
@@ -323,11 +402,12 @@
 				D6EEC01EF1A11293570069EF /* HomeTopBar.swift in Sources */,
 				C521143339E9016DF721F243 /* HomeView.swift in Sources */,
 				29EB1F420B2143258D6BE3E6 /* HomeVoiceOverlay.swift in Sources */,
-				333333333333333333333333 /* HomeVoicePanel.swift in Sources */,
+				31B02262C2B0BF05CE8CFAA8 /* HomeVoicePanel.swift in Sources */,
 				6D5C7D4A62CD79AB8E33AEA1 /* HomeZeroState.swift in Sources */,
 				4932E64B0E7CF7E4C48DB05E /* LatsDeckScreen.swift in Sources */,
 				EC49AAE0FD658F4D651D6CB1 /* LatsDesignSystem.swift in Sources */,
 				8509FE10337BF9B4286C77DF /* LatticesCompanionApp.swift in Sources */,
+				C690A1C61C0A8A0FBE4639FA /* LocalNetworkScanner.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ios/Sources/BridgeDiscovery.swift
+++ b/apps/ios/Sources/BridgeDiscovery.swift
@@ -9,6 +9,16 @@ final class BridgeDiscovery: NSObject {
     private var resolvingServices: [String: NetService] = [:]
     private var discoveredEndpoints: [String: BridgeEndpoint] = [:]
 
+    /// Bumped per rescan, so a late prune from an older rescan can't fire.
+    private var scanGeneration = 0
+    /// Services the current rescan has *seen*, which is a different and much
+    /// earlier signal than having resolved them — see `refresh()`.
+    private var seenThisScan: Set<String> = []
+    /// Comfortably longer than `resolveTimeout`, so a slow resolve is never
+    /// mistaken for a host that went away.
+    private let rescanGracePeriod: TimeInterval = 12
+    private let resolveTimeout: TimeInterval = 5
+
     override init() {
         super.init()
         browser.delegate = self
@@ -18,12 +28,38 @@ final class BridgeDiscovery: NSObject {
         browser.searchForServices(ofType: Self.serviceType, inDomain: "local.")
     }
 
+    /// Re-browse the network without ever publishing an empty roster.
+    ///
+    /// Clearing the list first looked harmless and was not: subscribers treat a
+    /// Mac's absence as a reason to tear down its live session, so a rescan
+    /// disconnected every secondary Mac and rebuilt it as a *new* session with
+    /// a new identity — which the Fleet Deck keys its channels on. Rescanning is
+    /// exactly what someone does while adding a Mac, so it has to be harmless.
+    ///
+    /// Instead the current roster stands, and only what the new browse never
+    /// even *sees* is pruned.
+    ///
+    /// That distinction matters: pruning on "hasn't resolved yet" raced the
+    /// resolve timeout, so tapping refresh could delete a host that was simply
+    /// slow to answer — the host then stayed gone until something else provoked
+    /// the browser. Being *found* means the service is there; resolving is just
+    /// how long it takes to learn its address.
     func refresh() {
         browser.stop()
         resolvingServices.removeAll()
-        discoveredEndpoints.removeAll()
-        onUpdate?([])
+
+        scanGeneration += 1
+        let generation = scanGeneration
+        seenThisScan.removeAll()
         start()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + rescanGracePeriod) { [weak self] in
+            guard let self, self.scanGeneration == generation else { return }
+            let vanished = self.discoveredEndpoints.keys.filter { !self.seenThisScan.contains($0) }
+            guard !vanished.isEmpty else { return }
+            vanished.forEach { self.discoveredEndpoints.removeValue(forKey: $0) }
+            self.publish()
+        }
     }
 
     func stop() {
@@ -42,8 +78,11 @@ extension BridgeDiscovery: NetServiceBrowserDelegate, NetServiceDelegate {
     ) {
         let key = service.name + service.type + service.domain
         resolvingServices[key] = service
+        // Seen is enough to keep it: the service is on the network whether or
+        // not we have its address yet.
+        seenThisScan.insert(key)
         service.delegate = self
-        service.resolve(withTimeout: 5)
+        service.resolve(withTimeout: resolveTimeout)
     }
 
     func netServiceBrowser(
@@ -66,6 +105,7 @@ extension BridgeDiscovery: NetServiceBrowserDelegate, NetServiceDelegate {
         guard !normalizedHost.isEmpty, sender.port > 0 else { return }
         let txt = txtDictionary(from: sender.txtRecordData())
 
+        seenThisScan.insert(key)
         discoveredEndpoints[key] = BridgeEndpoint(
             name: sender.name,
             host: normalizedHost,

--- a/apps/ios/Sources/ContentView.swift
+++ b/apps/ios/Sources/ContentView.swift
@@ -3,16 +3,48 @@ import SwiftUI
 
 // MARK: - Router
 
+/// Where a tap on Home leads.
+///
+/// Home is the roster, so the choice of surface is made there and carried here
+/// intact — nothing downstream re-decides it. With one Mac there is no choice to
+/// make; with several, tapping a machine opens that host and the fleet entry
+/// opens the deck.
+enum DeckDestination: Identifiable, Hashable {
+    /// One Mac's focus environment, keyed by `BridgeEndpoint.id`.
+    case host(String)
+    /// The multi-host deck, optionally opening on a particular Mac's channel.
+    case fleet(initialMachineID: String?)
+
+    var id: String {
+        switch self {
+        case .host(let machineID):    return "host:\(machineID)"
+        case .fleet(let machineID):   return "fleet:\(machineID ?? "-")"
+        }
+    }
+}
+
 struct ContentView: View {
     @StateObject private var store = DeckStore()
     @StateObject private var fleetStore = DeckFleetStore()
-    @State private var showLatsDeck = false
-    @State private var requestedMachineID: String?
+    @State private var deckDestination: DeckDestination?
+    /// The machine whose tap re-pointed the primary store for first-time pairing.
+    @State private var repointedMachineID: String?
     @State private var showSettings = false
+    @State private var showAddHost = false
     @State private var trustedBridges: [StoredBridgeTrust] = []
 
     private var liveMachines: [HomeMachine] {
-        HomeDataAdapter.machines(store: store, trustedBridges: trustedBridges)
+        HomeDataAdapter.machines(
+            store: store,
+            secondaryStores: fleetStore.secondaryStores,
+            trustedBridges: trustedBridges
+        )
+    }
+
+    /// Unpaired Macs on the network right now. Home shows the count and does
+    /// nothing else with it — deciding to pair is the user's.
+    private var nearbyCandidateCount: Int {
+        AddHostController.candidates(from: store).count
     }
 
     private var liveRecent: [HomeRecentEntry] {
@@ -61,24 +93,21 @@ struct ContentView: View {
 
                     onEnterDeck: { machine in
                         guard machine.status != .offline else { return }
-                        if machine.status != .active,
-                           let endpoint = store.discoveredBridges.first(where: { $0.id == machine.id }) {
-                            let isTrusted = endpoint.bridgeFingerprint.map { fingerprint in
-                                DeckBridgeSecurityStore.shared.trustedBridgeList().contains {
-                                    $0.bridgeFingerprint.caseInsensitiveCompare(fingerprint) == .orderedSame
-                                }
-                            } ?? false
-                            if !isTrusted {
-                                // Keep first-time pairing explicit and scoped to
-                                // the Mac the user actually tapped.
-                                store.connect(to: endpoint)
-                            }
-                        }
-                        fleetStore.synchronize(with: store)
-                        requestedMachineID = machine.id
-                        showLatsDeck = true
+                        prepareConnection(for: machine)
+                        // Start fetching on the tap rather than on arrival, so
+                        // the request is already in flight while the cover
+                        // animates instead of starting after it.
+                        hostStore(for: machine.id)?.setUIPriority(.fast)
+                        hostStore(for: machine.id)?.refreshSnapshot()
+                        deckDestination = .host(machine.id)
                     },
-                    onPair:      { showSettings = true },
+                    onEnterFleet: {
+                        fleetStore.synchronize(with: store)
+                        deckDestination = .fleet(initialMachineID: nil)
+                    },
+                    onAddHost:   { showAddHost = true },
+                    nearbyCandidateCount: nearbyCandidateCount,
+                    onPair:      { showAddHost = true },
                     onSettings:  { showSettings = true },
 
                     // Voice relay — wired to the active Mac via /deck/perform.
@@ -96,22 +125,73 @@ struct ContentView: View {
             }
             .navigationBarHidden(true)
             .toolbar(.hidden, for: .navigationBar)
-            .fullScreenCover(isPresented: $showLatsDeck) {
-                FleetDeckScreen(
-                    primaryStore: store,
-                    fleetStore: fleetStore,
-                    initialMachineID: requestedMachineID
-                )
+            .fullScreenCover(item: $deckDestination) { destination in
+                switch destination {
+                case .host(let machineID):
+                    if let hostStore = hostStore(for: machineID) {
+                        HostDeckHost(store: hostStore, onClose: { deckDestination = nil })
+                    } else {
+                        // Better to say we lost it than to silently open a
+                        // different Mac's cockpit.
+                        LatsBackground {
+                            LatsEmptyState(
+                                title: "That Mac is no longer reachable",
+                                subtitle: "Its connection changed while you were opening it. Go back and pick it again.",
+                                icon: "laptopcomputer.slash"
+                            )
+                            .padding(24)
+                        }
+                        .onTapGesture { deckDestination = nil }
+                    }
+                case .fleet(let machineID):
+                    FleetDeckScreen(
+                        primaryStore: store,
+                        fleetStore: fleetStore,
+                        initialMachineID: machineID
+                    )
+                }
             }
             .sheet(isPresented: $showSettings) {
-                LatsSettingsView(store: store)
-                    .preferredColorScheme(.dark)
+                LatsSettingsView(
+                    store: store,
+                    onForget: {
+                        fleetStore.releaseUntrusted()
+                        trustedBridges = DeckBridgeSecurityStore.shared.trustedBridgeList()
+                    }
+                )
+                .preferredColorScheme(.dark)
+            }
+            .sheet(isPresented: $showAddHost) {
+                AddHostSheet(
+                    store: store,
+                    onPaired: { endpoint in
+                        // Adding is additive. The Mac on screen does not move
+                        // just because another one joined — the user asked to
+                        // add, not to switch. The only exception is having
+                        // nothing to look at yet.
+                        if store.activeEndpoint == nil {
+                            repointedMachineID = endpoint.id
+                            store.connect(to: endpoint)
+                        } else {
+                            fleetStore.adopt(endpoint)
+                        }
+                        trustedBridges = DeckBridgeSecurityStore.shared.trustedBridgeList()
+                    },
+                    onOpen: { endpoint in
+                        deckDestination = .host(endpoint.id)
+                    }
+                )
+                .preferredColorScheme(.dark)
             }
             // Adaptive polling: speed up while the user is in the cockpit
             // (Deck or settings) — Home alone runs in ambient mode.
-            .onChange(of: showLatsDeck) { _, isOpen in
-                store.setUIPriority(isOpen ? .fast : .ambient)
-                fleetStore.setUIPriority(isOpen ? .fast : .ambient, primaryStore: store)
+            .onChange(of: deckDestination) { _, destination in
+                applyPollPriority(for: destination)
+                // The escape hatch below is only good for the presentation that
+                // opened it. Left standing, it would keep vouching for the
+                // primary store long after the primary had been pointed at some
+                // other Mac — which is the exact confusion it exists to prevent.
+                if destination == nil { repointedMachineID = nil }
             }
             .onChange(of: showSettings) { _, isOpen in
                 store.setUIPriority(isOpen ? .fast : .ambient)
@@ -120,10 +200,164 @@ struct ContentView: View {
         .preferredColorScheme(.dark)
         .onChange(of: store.discoveredBridges) { _, _ in
             fleetStore.synchronize(with: store)
+            promoteNewSessionsIfPresenting()
         }
         .onChange(of: store.activeEndpoint) { _, _ in
             fleetStore.synchronize(with: store)
+            promoteNewSessionsIfPresenting()
         }
+    }
+
+    /// Pair with (and connect to) the tapped Mac if this device has not trusted
+    /// it yet. Keeps first-time pairing explicit and scoped to the one Mac the
+    /// user actually tapped, rather than every Bonjour peer on the network.
+    private func prepareConnection(for machine: HomeMachine) {
+        // Any previous tap's vouching is void the moment a new one happens.
+        repointedMachineID = nil
+
+        if machine.status != .active,
+           let endpoint = store.discoveredBridges.first(where: { $0.id == machine.id }),
+           !DeckBridgeSecurityStore.shared.isTrusted(endpoint: endpoint) {
+            // Home only lists Macs this device has paired with, so reaching here
+            // means the fingerprint went missing rather than that the user is
+            // pairing from the roster — pairing has its own flow now.
+            store.connect(to: endpoint)
+            // Remember that *this* tap is what re-pointed the primary, so the
+            // lookup in `hostStore(for:)` may legitimately return it.
+            repointedMachineID = machine.id
+        }
+        fleetStore.synchronize(with: store)
+    }
+
+    /// Poll fast for what is actually on screen, and only that.
+    ///
+    /// One Mac's cockpit does not make the other Macs urgent. Lifting the whole
+    /// fleet to 1Hz meant opening a solo deck kicked every host into a snapshot
+    /// fetch, decrypt and decode — on the exact frame the presentation was
+    /// trying to animate.
+    private func applyPollPriority(for destination: DeckDestination?) {
+        let sessions = fleetStore.stores(including: store)
+
+        switch destination {
+        case .none:
+            sessions.forEach { $0.setUIPriority(.ambient) }
+
+        case .host(let machineID):
+            let target = hostStore(for: machineID)
+            sessions.forEach { $0.setUIPriority($0 === target ? .fast : .ambient) }
+
+        case .fleet:
+            // The fleet view really is watching everything at once.
+            sessions.forEach { $0.setUIPriority(.fast) }
+        }
+    }
+
+    /// Sessions created while a deck is on screen start at the default ambient
+    /// cadence; give them whatever the current presentation calls for.
+    private func promoteNewSessionsIfPresenting() {
+        guard deckDestination != nil else { return }
+        applyPollPriority(for: deckDestination)
+    }
+
+    /// The session backing one Mac, or nil when we cannot prove we have it.
+    ///
+    /// `BridgeEndpoint.id` is derived from host:port and is not stable — a Mac
+    /// that changes address, or falls back to another endpoint, keeps its
+    /// fingerprint but not its id. Falling back to the primary store on a miss
+    /// would then open whichever Mac the primary happens to hold, which is a
+    /// host-ownership violation: the user taps one machine and drives another.
+    /// The primary is only acceptable when this very tap re-pointed it.
+    private func hostStore(for machineID: String) -> DeckStore? {
+        if let match = fleetStore.stores(including: store)
+            .first(where: { $0.activeEndpoint?.id == machineID }) {
+            return match
+        }
+        return repointedMachineID == machineID ? store : nil
+    }
+}
+
+/// Presents one Mac's focus environment.
+///
+/// This exists to *observe* the store: `LatsDeckScreen` takes plain values, so
+/// without an `@ObservedObject` here a secondary Mac's cockpit would render its
+/// first snapshot and then freeze — `ContentView` only observes the primary
+/// store and the fleet roster, not each secondary session.
+private struct HostDeckHost: View {
+    @ObservedObject var store: DeckStore
+    var onClose: () -> Void = {}
+
+    /// The cover's own animation has to finish before the deck's view tree is
+    /// built, or the two compete and the transition is what loses.
+    @State private var transitionSettled = false
+    /// Only true once waiting has gone on long enough to deserve an explanation.
+    @State private var waitIsWorthExplaining = false
+
+    /// Roughly the length of a `fullScreenCover` presentation.
+    private let settleDelay = Duration.milliseconds(300)
+    /// Below this, saying anything would be noise nobody finishes reading.
+    private let narrationDelay = Duration.milliseconds(550)
+
+    private var isReady: Bool { transitionSettled && store.snapshot != nil }
+
+    /// A failure only counts once there is nothing to show instead. A stale
+    /// snapshot plus a transient error is still a usable deck.
+    private var failure: String? {
+        guard store.snapshot == nil, let message = store.errorMessage else { return nil }
+        return message
+    }
+
+    var body: some View {
+        ZStack {
+            if isReady {
+                deck.transition(.opacity)
+            } else if let failure {
+                DeckUnavailable(
+                    title: "Can't open \(store.connectionLabel)",
+                    detail: failure,
+                    onRetry: { store.refreshSnapshot() },
+                    onClose: onClose
+                )
+                .transition(.opacity)
+            } else {
+                DeckSkeleton(
+                    narration: narration,
+                    showsNarration: waitIsWorthExplaining
+                )
+                .transition(.opacity)
+            }
+        }
+        .animation(.easeInOut(duration: 0.22), value: isReady)
+        .preferredColorScheme(.dark)
+        .statusBarHidden(true)
+        .task {
+            // Data goes in flight immediately; the tree is built after the
+            // animation lands. The two costs stop overlapping.
+            store.refreshSnapshot()
+            try? await Task.sleep(for: settleDelay)
+            transitionSettled = true
+            try? await Task.sleep(for: narrationDelay)
+            if store.snapshot == nil { waitIsWorthExplaining = true }
+        }
+    }
+
+    /// Real state, not a generic "loading" — if someone is made to wait, the
+    /// least we owe them is the truth about what for.
+    private var narration: String {
+        if store.health == nil { return "Connecting to \(store.connectionLabel)…" }
+        return "Reading \(store.connectionLabel)…"
+    }
+
+    private var deck: some View {
+        LatsDeckScreen(
+            liveSnapshot: store.snapshot,
+            connectionLabel: store.connectionLabel,
+            onAction: { actionID, payload, label in
+                store.perform(actionID: actionID, pageID: "cockpit", payload: payload, label: label)
+            },
+            onTrackpadEvent: { event, dx, dy in
+                store.sendTrackpad(event: event, dx: dx, dy: dy)
+            }
+        )
     }
 }
 
@@ -638,6 +872,10 @@ struct LatsConnectedHome: View {
 
 struct LatsSettingsView: View {
     @ObservedObject var store: DeckStore
+    /// Forgetting has to reach the fleet too — the primary store cannot see the
+    /// secondary sessions, and a forgotten Mac with a live session goes on
+    /// polling a host the user just dropped.
+    var onForget: (() -> Void)? = nil
     @Environment(\.dismiss) private var dismiss
 
     @State private var trustedBridges: [StoredBridgeTrust] = []
@@ -838,6 +1076,30 @@ struct LatsSettingsView: View {
                 Spacer()
 
                 LatsBadge(text: stateLabel, tint: stateTint.color, dot: entry.isActive)
+
+                // A visible control rather than a swipe. `.swipeActions` only
+                // does anything inside a `List`, and these rows are in a
+                // `VStack` — so forgetting a Mac was unreachable, which is a
+                // bad thing to discover when a stale pairing is the very thing
+                // you are trying to clear.
+                if let publicKey = entry.publicKey {
+                    Button {
+                        store.forget(publicKey: publicKey)
+                        onForget?()
+                        reloadTrustedBridges()
+                    } label: {
+                        Text("Forget")
+                            .font(LatsFont.ui(11, weight: .medium))
+                            .foregroundStyle(LatsPalette.red)
+                            .padding(.horizontal, 9)
+                            .padding(.vertical, 5)
+                            .background(
+                                RoundedRectangle(cornerRadius: 5)
+                                    .fill(LatsPalette.red.opacity(0.12))
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 9)
@@ -851,14 +1113,6 @@ struct LatsSettingsView: View {
             )
         }
         .buttonStyle(.plain)
-        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-            if let pk = entry.publicKey, !entry.isActive {
-                Button(role: .destructive) {
-                    DeckBridgeSecurityStore.shared.forgetBridge(publicKey: pk)
-                    reloadTrustedBridges()
-                } label: { Label("Forget", systemImage: "trash") }
-            }
-        }
     }
 
     private func reloadTrustedBridges() {

--- a/apps/ios/Sources/ContentView.swift
+++ b/apps/ios/Sources/ContentView.swift
@@ -106,6 +106,14 @@ struct ContentView: View {
                         deckDestination = .fleet(initialMachineID: nil)
                     },
                     onAddHost:   { showAddHost = true },
+
+                    // Per-host dictation. Routed to *that machine's* store, not
+                    // the primary — which is the point: the primary is whichever
+                    // trusted host Bonjour listed first, so "who hears me" was
+                    // decided by discovery order rather than by the user.
+                    onMachineVoice: { machine in
+                        hostStore(for: machine.id)?.toggleVoice()
+                    },
                     nearbyCandidateCount: nearbyCandidateCount,
                     onPair:      { showAddHost = true },
                     onSettings:  { showSettings = true },

--- a/apps/ios/Sources/DeckBridgeClient.swift
+++ b/apps/ios/Sources/DeckBridgeClient.swift
@@ -31,6 +31,26 @@ struct BridgeEndpoint: Identifiable, Hashable {
     var id: String {
         "\(host):\(port)"
     }
+
+    /// Carry the Mac's own identity onto this endpoint once `/health` has
+    /// reported it.
+    ///
+    /// A manually-typed endpoint has no Bonjour `fp` record, so without this it
+    /// would never match a trust record and would never dedupe against the same
+    /// Mac discovered over Bonjour — it would live in the fleet twice, or not
+    /// at all.
+    func adoptingIdentity(from health: BridgeHealthResponse) -> BridgeEndpoint {
+        let reportedName = health.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return BridgeEndpoint(
+            name: reportedName.isEmpty ? name : reportedName,
+            host: host,
+            port: port,
+            source: source,
+            bridgeFingerprint: health.bridgeFingerprint,
+            securityMode: securityMode ?? health.mode,
+            capabilities: capabilities.isEmpty ? (health.capabilities ?? []) : capabilities
+        )
+    }
 }
 
 struct BridgeHealthResponse: Codable, Equatable {
@@ -71,6 +91,22 @@ struct DeckBridgeClient {
         configuration.timeoutIntervalForResource = 10
         return URLSession(configuration: configuration)
     }()
+
+    /// Pairing waits on a person, not on a network.
+    ///
+    /// It cannot share `session`: `timeoutIntervalForResource` caps the whole
+    /// transfer regardless of the request's own timeout, so a 10s resource
+    /// limit silently overrode the 90s we thought we were asking for and the
+    /// iPad abandoned pairing ten seconds into a human decision — while the Mac
+    /// went on to approve and store trust the iPad never received. Both limits
+    /// have to be raised, not just one.
+    private let pairingSession: URLSession = {
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = 180
+        configuration.timeoutIntervalForResource = 180
+        return URLSession(configuration: configuration)
+    }()
+
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
 
@@ -82,13 +118,32 @@ struct DeckBridgeClient {
         try await get(path: "/deck/manifest", endpoint: endpoint)
     }
 
+    /// Ask the Mac to pair. Returns the Mac's answer — including a refusal.
+    ///
+    /// A denial is an answer, not a transport failure, so it must not be thrown:
+    /// the Mac replies `403` *with* a `DeckPairingResponse` body, and the
+    /// generic `send` path threw on the status before ever decoding it, which
+    /// made `.denied` unreachable for callers and surfaced refusals as raw JSON.
     func pair(endpoint: BridgeEndpoint) async throws -> DeckPairingResponse {
         var request = URLRequest(url: try makeURL(path: "/pairing/request", endpoint: endpoint))
         request.httpMethod = "POST"
-        request.timeoutInterval = 90
+        request.timeoutInterval = 180
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try encoder.encode(security.pairingRequest())
-        return try await send(request)
+
+        let (data, response) = try await pairingSession.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw DeckBridgeClientError.invalidResponse
+        }
+
+        if (200..<300).contains(http.statusCode) || http.statusCode == 403 {
+            if let pairing = try? decoder.decode(DeckPairingResponse.self, from: data) {
+                return pairing
+            }
+        }
+
+        let detail = decodeErrorDetail(from: data) ?? String(data: data, encoding: .utf8) ?? ""
+        throw DeckBridgeClientError.badStatus(http.statusCode, detail)
     }
 
     func snapshot(
@@ -226,12 +281,11 @@ private extension DeckBridgeClient {
     }
 
     func decodeErrorDetail(from data: Data) -> String? {
-        guard
-            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let error = object["error"] as? String
-        else {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             return nil
         }
-        return error
+        // `sendError` writes `error`; the pairing response carries `detail`.
+        // Reading only the first turned every refusal into a wall of JSON.
+        return (object["error"] as? String) ?? (object["detail"] as? String)
     }
 }

--- a/apps/ios/Sources/DeckBridgeSecurityStore.swift
+++ b/apps/ios/Sources/DeckBridgeSecurityStore.swift
@@ -33,6 +33,15 @@ struct StoredBridgeTrust: Codable, Equatable, Sendable {
     var grantedCapabilities: [String]?
     var pairedAt: Date
 
+    /// Where this Mac was last reachable. Optional so records written before
+    /// these fields existed still decode — synthesized `Decodable` uses
+    /// `decodeIfPresent` for optionals, so old JSON reads back with both nil.
+    ///
+    /// This is what lets a paired-but-not-currently-discovered Mac stay in the
+    /// roster as something you can reconnect to, rather than a dead card.
+    var lastKnownHost: String?
+    var lastKnownPort: Int?
+
     var effectiveCapabilities: [String] {
         grantedCapabilities ?? DeckBridgeCapability.defaultCompanionCapabilities
     }
@@ -82,8 +91,51 @@ final class DeckBridgeSecurityStore {
         Data(privateKey.publicKey.rawRepresentation).base64EncodedString()
     }
 
+    /// This device's own fingerprint, derived exactly as the Mac derives it for
+    /// its approval alert (`LatticesCompanionSecurityCoordinator.fingerprint`).
+    /// Both screens show the same string — that is the whole point of showing
+    /// it, and it is why this derivation must not drift from the Mac's.
+    ///
+    /// Hex has no confusable pairs to worry about: `O`, `I` and `L` are not in
+    /// the alphabet, so `0` and `1` are unambiguous.
+    var deviceFingerprint: String {
+        let digest = SHA256.hash(data: Data(devicePublicKeyBase64.utf8))
+        let hex = digest.map { String(format: "%02x", $0) }.joined()
+        let compact = String(hex.prefix(12)).uppercased()
+        return stride(from: 0, to: compact.count, by: 4).map { offset in
+            let start = compact.index(compact.startIndex, offsetBy: offset)
+            let end = compact.index(start, offsetBy: min(4, compact.count - offset))
+            return String(compact[start..<end])
+        }.joined(separator: "-")
+    }
+
     func isTrusted(health: BridgeHealthResponse) -> Bool {
         trustedBridges[health.bridgePublicKey] != nil
+    }
+
+    /// Whether this device has paired with the Mac behind an endpoint.
+    ///
+    /// One definition, because this comparison was previously written out by
+    /// hand in `ContentView.prepareConnection` and `DeckFleetStore.synchronize`
+    /// and the two are easy to let drift apart.
+    ///
+    /// Note the limit of what this proves: the fingerprint arrives in an
+    /// unauthenticated Bonjour TXT record, so a match is a *hint* that this is
+    /// a Mac we know, good enough to decide what to show in a roster. It is not
+    /// authentication — that happens against `health.bridgePublicKey` when the
+    /// connection is actually made.
+    func isTrusted(endpoint: BridgeEndpoint) -> Bool {
+        guard let fingerprint = endpoint.bridgeFingerprint, !fingerprint.isEmpty else { return false }
+        return trustedBridges.values.contains {
+            $0.bridgeFingerprint.caseInsensitiveCompare(fingerprint) == .orderedSame
+        }
+    }
+
+    /// The trust record for a Mac, by the public key its `/health` reports.
+    /// This is the authenticated identity — prefer it over fingerprint matching
+    /// anywhere the answer decides what a control does.
+    func trust(forPublicKey publicKey: String) -> StoredBridgeTrust? {
+        trustedBridges[publicKey]
     }
 
     /// All Macs this device has paired with (most recently paired first).
@@ -108,7 +160,15 @@ final class DeckBridgeSecurityStore {
         )
     }
 
-    func storePairing(_ response: DeckPairingResponse) {
+    func storePairing(
+        _ response: DeckPairingResponse,
+        lastKnownHost: String? = nil,
+        lastKnownPort: Int? = nil
+    ) {
+        // `alreadyTrusted` comes back for a Mac we have paired with before, so
+        // keep the original pairing date rather than restamping it every time
+        // a retry resolves.
+        let existing = trustedBridges[response.bridgePublicKey]
         trustedBridges[response.bridgePublicKey] = StoredBridgeTrust(
             bridgeName: response.bridgeName,
             bridgePublicKey: response.bridgePublicKey,
@@ -116,8 +176,22 @@ final class DeckBridgeSecurityStore {
             requestSigningRequired: response.requestSigningRequired,
             payloadEncryptionRequired: response.payloadEncryptionRequired,
             grantedCapabilities: response.grantedCapabilities,
-            pairedAt: Date()
+            pairedAt: existing?.pairedAt ?? Date(),
+            lastKnownHost: lastKnownHost ?? existing?.lastKnownHost,
+            lastKnownPort: lastKnownPort ?? existing?.lastKnownPort
         )
+        persistTrustedBridges()
+    }
+
+    /// Remember where a Mac answered, so it stays reconnectable once it stops
+    /// advertising on Bonjour. Only ever called after `/health` has proved the
+    /// public key, so an address can never be attached to the wrong Mac.
+    func rememberAddress(forPublicKey publicKey: String, host: String, port: Int) {
+        guard var trust = trustedBridges[publicKey] else { return }
+        guard trust.lastKnownHost != host || trust.lastKnownPort != port else { return }
+        trust.lastKnownHost = host
+        trust.lastKnownPort = port
+        trustedBridges[publicKey] = trust
         persistTrustedBridges()
     }
 

--- a/apps/ios/Sources/DeckSkeleton.swift
+++ b/apps/ios/Sources/DeckSkeleton.swift
@@ -1,0 +1,159 @@
+import SwiftUI
+
+/// What the deck looks like in the moment before it is the deck.
+///
+/// Two jobs, and the second one is the reason this exists rather than a spinner.
+///
+/// **Presenting and loading are separate costs, and the user should never pay
+/// both at once.** The real deck is a large view tree; building it on the same
+/// frame the cover is animating is what makes the transition drag. So the
+/// transition renders this instead — a handful of rounded rectangles in the
+/// deck's own geometry — and the expensive tree is built once the animation has
+/// somewhere quiet to land.
+///
+/// **A wait should only announce itself once it is a wait.** Nothing here says
+/// "loading" for the first fraction of a second. If the deck arrives quickly the
+/// skeleton is never really perceived and the whole thing simply feels instant;
+/// if it takes longer, a single line fades in saying what is actually happening.
+/// Fast feels fast, slow becomes informative — rather than slow feeling slow.
+struct DeckSkeleton: View {
+
+    /// What to say if this ends up being a real wait. Nil says nothing.
+    var narration: String?
+    /// Set once the wait has gone on long enough to be worth explaining.
+    var showsNarration: Bool = false
+
+    @State private var breathe = false
+
+    private var blockFill: Color {
+        // Barely there. A skeleton that reads as strongly as content invites
+        // people to try to read it.
+        DeckTheme.card.opacity(breathe ? 0.85 : 0.55)
+    }
+
+    var body: some View {
+        ZStack {
+            DeckTheme.canvas.ignoresSafeArea()
+
+            VStack(spacing: DeckTheme.Space.x12) {
+                topBar
+                console
+                tiles
+                bottomBar
+            }
+            .padding(DeckTheme.Space.margin)
+
+            if showsNarration, let narration {
+                VStack {
+                    Spacer()
+                    Text(narration)
+                        .font(DeckTheme.secondary())
+                        .foregroundStyle(DeckTheme.textSecondary)
+                        .padding(.bottom, DeckTheme.Space.x32)
+                }
+                .transition(.opacity)
+            }
+        }
+        .animation(.easeInOut(duration: 0.25), value: showsNarration)
+        .onAppear {
+            // A skeleton is allowed to promise imminent change, because that
+            // promise is true. Slow and shallow, so it reads as breathing
+            // rather than as something demanding attention.
+            withAnimation(.easeInOut(duration: 1.1).repeatForever(autoreverses: true)) {
+                breathe = true
+            }
+        }
+    }
+
+    private var topBar: some View {
+        HStack(spacing: DeckTheme.Space.x8) {
+            block(width: 120, height: 18)
+            Spacer(minLength: 0)
+            block(width: 64, height: 18)
+        }
+        .frame(height: 26)
+    }
+
+    private var console: some View {
+        RoundedRectangle(cornerRadius: DeckTheme.radiusWell, style: .continuous)
+            .fill(blockFill)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var tiles: some View {
+        HStack(spacing: DeckTheme.Space.cardGap) {
+            ForEach(0..<6, id: \.self) { _ in
+                RoundedRectangle(cornerRadius: DeckTheme.radiusCard, style: .continuous)
+                    .fill(blockFill)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+        .frame(height: 96)
+    }
+
+    private var bottomBar: some View {
+        HStack(spacing: DeckTheme.Space.x8) {
+            block(width: 90, height: 14)
+            Spacer(minLength: 0)
+            block(width: 140, height: 14)
+        }
+        .frame(height: 22)
+    }
+
+    private func block(width: CGFloat, height: CGFloat) -> some View {
+        RoundedRectangle(cornerRadius: DeckTheme.radiusSmall, style: .continuous)
+            .fill(blockFill)
+            .frame(width: width, height: height)
+    }
+}
+
+/// Something went wrong on the way in, and saying so beats a skeleton that
+/// never resolves. Escapable by construction — see the lifecycle review; a
+/// state you cannot leave from the iPad is the bug class that started all this.
+struct DeckUnavailable: View {
+    let title: String
+    let detail: String
+    var onRetry: () -> Void
+    var onClose: () -> Void
+
+    var body: some View {
+        ZStack {
+            DeckTheme.canvas.ignoresSafeArea()
+
+            VStack(alignment: .leading, spacing: DeckTheme.Space.x16) {
+                Text(title)
+                    .font(DeckTheme.title())
+                    .foregroundStyle(DeckTheme.text)
+                Text(detail)
+                    .font(DeckTheme.secondary())
+                    .foregroundStyle(DeckTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                HStack(spacing: DeckTheme.Space.x12) {
+                    Button(action: onRetry) {
+                        Text("Try again")
+                            .font(DeckTheme.body(.semibold))
+                            .foregroundStyle(DeckTheme.canvas)
+                            .padding(.horizontal, DeckTheme.Space.x24)
+                            .padding(.vertical, DeckTheme.Space.x12)
+                            .background(
+                                RoundedRectangle(cornerRadius: DeckTheme.radiusCard, style: .continuous)
+                                    .fill(DeckTheme.accent)
+                            )
+                    }
+                    .buttonStyle(.plain)
+
+                    Button(action: onClose) {
+                        Text("Back")
+                            .font(DeckTheme.body())
+                            .foregroundStyle(DeckTheme.textSecondary)
+                            .padding(.vertical, DeckTheme.Space.x12)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .frame(maxWidth: 420)
+            .padding(DeckTheme.Space.x32)
+        }
+    }
+}

--- a/apps/ios/Sources/DeckStore.swift
+++ b/apps/ios/Sources/DeckStore.swift
@@ -1,3 +1,4 @@
+import Combine
 import DeckKit
 import Foundation
 
@@ -63,6 +64,20 @@ final class DeckStore: ObservableObject {
     /// activity or pending questions, so callers don't have to be exhaustive.
     private var uiPriority: DeckPollPriority = .ambient
 
+    /// Set by a deliberate disconnect or by discovering that a Mac revoked us.
+    /// Cleared the moment the user connects to something on purpose.
+    private var autoConnectSuppressed = false
+
+    /// Bumped by every `connect`. `loadConnection` walks six mutations with
+    /// awaits between them, so without this two overlapping connects interleave
+    /// and the *later-finishing* one wins rather than the later-requested one —
+    /// which can leave one Mac's health signing another Mac's requests.
+    private var connectionGeneration = 0
+
+    /// Consecutive failed polls, for backoff. A host that is not answering
+    /// should be asked less often, not more.
+    private var consecutivePollFailures = 0
+
     var connectionLabel: String {
         // Prefer human-readable names (Bonjour service name / health-reported name)
         // over raw hosts/UUIDs which look like "F8B453FB-…" in the UI.
@@ -118,6 +133,12 @@ final class DeckStore: ObservableObject {
     func connect(to endpoint: BridgeEndpoint) {
         pollingTask?.cancel()
         pollingTask = nil
+        // An explicit connection is the user changing their mind about a
+        // previous explicit disconnect.
+        autoConnectSuppressed = false
+        connectionGeneration += 1
+        consecutivePollFailures = 0
+        let generation = connectionGeneration
         activeEndpoint = endpoint
         health = nil
         manifest = nil
@@ -130,7 +151,7 @@ final class DeckStore: ObservableObject {
         isPerformingAction = false
 
         Task {
-            await loadConnection(endpoint: endpoint, forceManifest: true)
+            await loadConnection(endpoint: endpoint, forceManifest: true, generation: generation)
         }
     }
 
@@ -149,7 +170,13 @@ final class DeckStore: ObservableObject {
         connect(to: BridgeEndpoint(name: host, host: host, port: port, source: "Manual"))
     }
 
-    func disconnect() {
+    /// Close the session.
+    ///
+    /// `suppressAutoReconnect` matters more than it looks: discovery reconnects
+    /// to any trusted host the moment there is no active one, so without it a
+    /// deliberate disconnect was undone by the next Bonjour update — the button
+    /// appeared to do nothing at all.
+    func disconnect(suppressAutoReconnect: Bool = true) {
         pollingTask?.cancel()
         pollingTask = nil
         activeEndpoint = nil
@@ -159,6 +186,21 @@ final class DeckStore: ObservableObject {
         lastActionResult = nil
         lastActionLabel = nil
         isPerformingAction = false
+        autoConnectSuppressed = suppressAutoReconnect
+    }
+
+    /// Stop trusting a Mac and let go of it.
+    ///
+    /// Trust is two separate records — one on each device — and the Mac can
+    /// revoke its own at any time without telling anybody. This is the iPad's
+    /// half, so that a host whose trust is gone leaves the roster and returns to
+    /// being something you add, rather than sitting there failing forever.
+    func forget(publicKey: String) {
+        DeckBridgeSecurityStore.shared.forgetBridge(publicKey: publicKey)
+        if health?.bridgePublicKey == publicKey {
+            disconnect(suppressAutoReconnect: true)
+        }
+        objectWillChange.send()
     }
 
     func refreshSnapshot() {
@@ -192,6 +234,7 @@ final class DeckStore: ObservableObject {
                 isPerformingAction = true
                 let request = DeckActionRequest(pageID: pageID, actionID: actionID, payload: payload)
                 let result = try await performWithFallback(request: request, preferred: endpoint, health: health)
+                consecutivePollFailures = 0
                 lastActionResult = result
                 if let runtimeSnapshot = result.runtimeSnapshot {
                     snapshot = runtimeSnapshot
@@ -202,9 +245,24 @@ final class DeckStore: ObservableObject {
             } catch {
                 lastActionResult = nil
                 errorMessage = error.localizedDescription
+                // Deliberately not treated as revocation here. The Mac answers
+                // 403 for *both* "I don't trust you" and "you weren't granted
+                // that capability", so forgetting on this path would destroy a
+                // perfectly good pairing because one action wasn't permitted.
+                // A snapshot read is granted to every pairing, so let that be
+                // the arbiter.
+                await probeTrustIfRefused(error, endpoint: endpoint)
             }
             isPerformingAction = false
         }
+    }
+
+    /// Ask the one question every pairing is allowed to ask, so a 403 can be
+    /// attributed. If the snapshot read is refused too, trust really is gone and
+    /// `refreshSnapshot` will drop it.
+    private func probeTrustIfRefused(_ error: Error, endpoint: BridgeEndpoint) async {
+        guard case DeckBridgeClientError.badStatus(403, _) = error else { return }
+        await refreshSnapshot(endpoint: endpoint)
     }
 
     // MARK: - Voice (relay)
@@ -283,6 +341,7 @@ private extension DeckStore {
                 }
             } catch {
                 errorMessage = error.localizedDescription
+                await probeTrustIfRefused(error, endpoint: endpoint)
             }
             finishTrackpadEvent()
         }
@@ -307,8 +366,17 @@ private extension DeckStore {
     func handleDiscoveryUpdate(_ bridges: [BridgeEndpoint]) {
         discoveredBridges = bridges
 
-        if activeEndpoint == nil, let first = bridges.first {
-            connect(to: first)
+        // Finding a Mac on the network is an observation; pairing with one is a
+        // decision that raises a modal alert on somebody's desk. Reconnecting to
+        // a Mac this device already paired with is silent and welcome, so that
+        // still happens on its own — but a stranger now waits in the roster as a
+        // candidate until the user actually asks for it.
+        //
+        // `first(where:)` rather than `first`: with several Macs on the network
+        // the paired one wins regardless of where it sorts.
+        if activeEndpoint == nil, !autoConnectSuppressed,
+           let known = bridges.first(where: { DeckBridgeSecurityStore.shared.isTrusted(endpoint: $0) }) {
+            connect(to: known)
             return
         }
 
@@ -321,31 +389,56 @@ private extension DeckStore {
         }
     }
 
-    func loadConnection(endpoint: BridgeEndpoint, forceManifest: Bool) async {
+    /// Bring a session up.
+    ///
+    /// `generation` is checked after every suspension: if a newer connect has
+    /// started meanwhile, this one abandons rather than writing its half of a
+    /// session over someone else's. Without that the sequence below can splice
+    /// one Mac's `health` onto another's `manifest`, and every protected request
+    /// signs against `health` — so the mismatch authenticates to the wrong Mac
+    /// instead of failing loudly.
+    func loadConnection(endpoint: BridgeEndpoint, forceManifest: Bool, generation: Int) async {
         isLoading = true
-        defer { isLoading = false }
+        defer { if generation == connectionGeneration { isLoading = false } }
 
         do {
             let healthResponse = try await client.health(endpoint: endpoint)
+            guard generation == connectionGeneration else { return }
             health = healthResponse
             let resolvedEndpoint = canonicalEndpoint(from: endpoint, health: healthResponse)
             activeEndpoint = resolvedEndpoint
             manualHost = resolvedEndpoint.host
             manualPort = String(resolvedEndpoint.port)
             if forceManifest || manifest == nil {
-                manifest = try await client.manifest(endpoint: resolvedEndpoint)
+                let loaded = try await client.manifest(endpoint: resolvedEndpoint)
+                guard generation == connectionGeneration else { return }
+                manifest = loaded
                 if let firstPage = manifest?.pages.first(where: { $0.id == selectedPageID }) ?? manifest?.pages.first {
                     selectedPageID = firstPage.id
                 }
             }
             try await ensurePairing(endpoint: resolvedEndpoint, health: healthResponse)
-            snapshot = try await client.snapshot(endpoint: resolvedEndpoint, health: healthResponse)
+            guard generation == connectionGeneration else { return }
+            // Macs move. Recording where this one answered — keyed by the public
+            // key `/health` just proved, never by name or address — is what
+            // keeps it reconnectable once it stops advertising on Bonjour.
+            DeckBridgeSecurityStore.shared.rememberAddress(
+                forPublicKey: healthResponse.bridgePublicKey,
+                host: resolvedEndpoint.host,
+                port: resolvedEndpoint.port
+            )
+            let loadedSnapshot = try await client.snapshot(endpoint: resolvedEndpoint, health: healthResponse)
+            guard generation == connectionGeneration else { return }
+            snapshot = loadedSnapshot
             if let firstCockpitPage = snapshot?.cockpit?.pages.first(where: { $0.id == selectedCockpitPageID }) ?? snapshot?.cockpit?.pages.first {
                 selectedCockpitPageID = firstCockpitPage.id
             }
             errorMessage = nil
+            consecutivePollFailures = 0
             startPolling(endpoint: resolvedEndpoint)
         } catch {
+            guard generation == connectionGeneration else { return }
+            guard !handleRevokedTrust(error) else { return }
             errorMessage = error.localizedDescription
         }
     }
@@ -359,9 +452,37 @@ private extension DeckStore {
                 selectedCockpitPageID = firstCockpitPage.id
             }
             errorMessage = nil
+            consecutivePollFailures = 0
         } catch {
+            consecutivePollFailures += 1
+            guard !handleRevokedTrust(error) else { return }
             errorMessage = error.localizedDescription
         }
+    }
+
+    /// Notice that a Mac has stopped trusting this device, and let go.
+    ///
+    /// Trust lives in two records — one per device — and the Mac can drop its
+    /// own at any time. When it does, every protected request comes back 403
+    /// while this side still holds a record saying all is well. That record is
+    /// exactly what makes `ensurePairing` skip re-pairing, so the session can
+    /// never recover on its own: it reconnects, gets refused, reconnects, and
+    /// reports a different flavour of the same failure forever.
+    ///
+    /// Dropping our half breaks the loop. The host leaves the roster and turns
+    /// back into something you can add, which is the one action that fixes it.
+    private func handleRevokedTrust(_ error: Error) -> Bool {
+        guard case DeckBridgeClientError.badStatus(403, _) = error,
+              let publicKey = health?.bridgePublicKey,
+              DeckBridgeSecurityStore.shared.trust(forPublicKey: publicKey) != nil else {
+            return false
+        }
+
+        let name = connectionLabel
+        DeckBridgeSecurityStore.shared.forgetBridge(publicKey: publicKey)
+        disconnect(suppressAutoReconnect: true)
+        errorMessage = "\(name) no longer trusts this iPad. Add it again to reconnect."
+        return true
     }
 
     func startPolling(endpoint: BridgeEndpoint) {
@@ -381,6 +502,16 @@ private extension DeckStore {
     /// pull us into 1s mode; otherwise we sip at 5s. Intervals are
     /// re-evaluated each tick so the loop adapts as state changes.
     private var currentPollInterval: TimeInterval {
+        // A host that is not answering gets asked less often, not more. Without
+        // this the failure state was the most expensive state in the app: a
+        // snapshot that went stale while holding a question pinned the loop at
+        // 1Hz against a Mac that had stopped replying, each attempt paying a
+        // full connect timeout.
+        if consecutivePollFailures > 0 {
+            let step = min(consecutivePollFailures, 5)
+            return min(60.0, 2.0 * pow(2.0, Double(step - 1)))
+        }
+
         if uiPriority == .fast { return 1.0 }
         if let voice = snapshot?.voice {
             if voice.phase != .idle { return 1.0 }
@@ -499,6 +630,33 @@ final class DeckFleetStore: ObservableObject {
 
     private var storesByEndpointKey: [String: DeckStore] = [:]
 
+    /// Macs the user added deliberately. Discovery may never report them — a
+    /// hand-entered address on a network where Bonjour is blocked never will —
+    /// so reconciliation must not treat their absence as a reason to reap them.
+    private var adoptedKeys: Set<String> = []
+
+    /// Republish when any secondary session changes.
+    ///
+    /// `secondaryStores` being `@Published` only announces the *array* — adding
+    /// or removing a Mac. It says nothing when a Mac inside it gets a new
+    /// snapshot, so anything observing this store alone saw every host but the
+    /// primary frozen at whatever it happened to hold when it arrived.
+    private var storeSubscriptions: [ObjectIdentifier: AnyCancellable] = [:]
+
+    private func observe(_ store: DeckStore) {
+        let key = ObjectIdentifier(store)
+        guard storeSubscriptions[key] == nil else { return }
+        storeSubscriptions[key] = store.objectWillChange
+            // `objectWillChange` fires *before* the value lands, so republishing
+            // synchronously would broadcast the old state.
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+    }
+
+    private func stopObserving(_ store: DeckStore) {
+        storeSubscriptions.removeValue(forKey: ObjectIdentifier(store))
+    }
+
     func synchronize(with primaryStore: DeckStore) {
         let primaryKey = primaryStore.activeEndpoint.map(Self.endpointKey)
         var desiredKeys = Set<String>()
@@ -508,12 +666,7 @@ final class DeckFleetStore: ObservableObject {
             // Secondary sessions are created only for Macs this device has
             // already paired with. This prevents Fleet Deck from spraying
             // approval prompts across every Bonjour peer on the network.
-            let isTrusted = endpoint.bridgeFingerprint.map { fingerprint in
-                DeckBridgeSecurityStore.shared.trustedBridgeList().contains {
-                    $0.bridgeFingerprint.caseInsensitiveCompare(fingerprint) == .orderedSame
-                }
-            } ?? false
-            guard isTrusted else { continue }
+            guard DeckBridgeSecurityStore.shared.isTrusted(endpoint: endpoint) else { continue }
 
             let key = Self.endpointKey(endpoint)
             guard key != primaryKey else { continue }
@@ -528,16 +681,91 @@ final class DeckFleetStore: ObservableObject {
             } else {
                 store = DeckStore(endpoint: endpoint, discoversBridges: false)
                 storesByEndpointKey[key] = store
+                observe(store)
             }
             orderedStores.append(store)
         }
 
-        let staleKeys = storesByEndpointKey.keys.filter { !desiredKeys.contains($0) }
+        let staleKeys = storesByEndpointKey.keys.filter {
+            !desiredKeys.contains($0) && !adoptedKeys.contains($0)
+        }
         for key in staleKeys {
-            storesByEndpointKey.removeValue(forKey: key)?.disconnect()
+            if let reaped = storesByEndpointKey.removeValue(forKey: key) {
+                stopObserving(reaped)
+                reaped.disconnect()
+            }
+        }
+
+        // A Mac the user added by hand keeps its place in the fleet even when
+        // this pass didn't see it on the network.
+        for key in adoptedKeys where !desiredKeys.contains(key) {
+            guard let store = storesByEndpointKey[key] else { continue }
+            orderedStores.append(store)
         }
 
         secondaryStores = orderedStores
+    }
+
+    /// Bring a just-paired Mac into the fleet now, instead of waiting for the
+    /// next discovery tick to notice it.
+    ///
+    /// Safe against the trust guard in `synchronize` because callers pair
+    /// *before* they adopt: by the time this runs the Mac is trusted like any
+    /// other, so nothing has to be held open or specially exempted while a
+    /// human is deciding.
+    func adopt(_ endpoint: BridgeEndpoint) {
+        let key = Self.endpointKey(endpoint)
+        adoptedKeys.insert(key)
+
+        if let existing = storesByEndpointKey[key] {
+            if !secondaryStores.contains(where: { $0 === existing }) {
+                secondaryStores.append(existing)
+            }
+            return
+        }
+
+        let store = DeckStore(endpoint: endpoint, discoversBridges: false)
+        storesByEndpointKey[key] = store
+        observe(store)
+        secondaryStores.append(store)
+    }
+
+    /// Drop a Mac from the fleet. Adoption is user intent, so only the user
+    /// undoes it — discovery never does.
+    func release(_ endpoint: BridgeEndpoint) {
+        let key = Self.endpointKey(endpoint)
+        adoptedKeys.remove(key)
+        guard let store = storesByEndpointKey.removeValue(forKey: key) else { return }
+        stopObserving(store)
+        store.disconnect()
+        secondaryStores.removeAll { $0 === store }
+    }
+
+    /// Let go of every secondary whose pairing is gone.
+    ///
+    /// Forgetting a Mac removes its trust record, but reconciliation only runs
+    /// when discovery changes — and forgetting doesn't change discovery. So
+    /// without this a forgotten Mac kept its session alive and went on signing
+    /// requests against a host the user had just told us to drop.
+    func releaseUntrusted() {
+        let security = DeckBridgeSecurityStore.shared
+        for (key, store) in storesByEndpointKey {
+            let isTrusted: Bool
+            if let publicKey = store.health?.bridgePublicKey {
+                isTrusted = security.trust(forPublicKey: publicKey) != nil
+            } else if let endpoint = store.activeEndpoint {
+                isTrusted = security.isTrusted(endpoint: endpoint)
+            } else {
+                continue  // Still connecting — nothing proven either way yet.
+            }
+            guard !isTrusted else { continue }
+
+            adoptedKeys.remove(key)
+            storesByEndpointKey.removeValue(forKey: key)
+            stopObserving(store)
+            store.disconnect()
+            secondaryStores.removeAll { $0 === store }
+        }
     }
 
     func stores(including primaryStore: DeckStore) -> [DeckStore] {
@@ -705,9 +933,63 @@ extension DeckStore {
                     tint: ["green", "violet", "blue", "green"][index],
                     text: ["fixture data refreshed", "checking shared controls", "spacing pass complete", "all services nominal"][index]
                 )
-            ]
+            ],
+            // Two of the four Macs are blocked on a human decision, so the deck
+            // has something to triage — the Fleet Deck's whole reason to exist.
+            questions: previewQuestions(index: index)
         )
         return store
+    }
+
+    private static func previewQuestions(index: Int) -> [DeckQuestionCard] {
+        switch index {
+        case 2:
+            return [
+                DeckQuestionCard(
+                    id: "preview-question-lane",
+                    prompt: "Which naming scheme should I apply across all screens?",
+                    detail: "Lane model review is blocked — two naming options need your call.",
+                    options: [
+                        DeckQuestionOption(
+                            id: "lane-a",
+                            title: "route / lane / bus",
+                            detail: "matches the audio-desk metaphor",
+                            actionID: "agent.answer"
+                        ),
+                        DeckQuestionOption(
+                            id: "lane-b",
+                            title: "channel / track / send",
+                            detail: "matches the deck labels",
+                            actionID: "agent.answer"
+                        )
+                    ]
+                )
+            ]
+        case 3:
+            return [
+                DeckQuestionCard(
+                    id: "preview-question-ship",
+                    prompt: "Push build 412 to TestFlight now?",
+                    detail: "Build 412 is signed and staged — needs your go before it ships.",
+                    options: [
+                        DeckQuestionOption(
+                            id: "ship-now",
+                            title: "Ship it",
+                            detail: "notify the fleet when live",
+                            actionID: "agent.answer"
+                        ),
+                        DeckQuestionOption(
+                            id: "ship-hold",
+                            title: "Hold for nightly",
+                            detail: "roll it into the 02:00 batch",
+                            actionID: "agent.answer"
+                        )
+                    ]
+                )
+            ]
+        default:
+            return []
+        }
     }
 }
 #endif

--- a/apps/ios/Sources/DeckTheme.swift
+++ b/apps/ios/Sources/DeckTheme.swift
@@ -1,0 +1,206 @@
+import SwiftUI
+
+// MARK: - DeckTheme
+//
+// The single token layer for the iPad companion. Replaces `LatsPalette`/`LatsFont`
+// and `FleetV6`, which had drifted into two design systems with near-miss values
+// (amber #F5BD5C vs #E4B65C, green #6EDB8C vs #81DD85) that read as a mistake
+// rather than a choice.
+//
+// Spec: design/fleet-deck/token-spec-v7.md
+// Brief: "full font sizes, smaller is better, fewest possible colors,
+//         no mono / technical vibe across the board"
+//
+// The governing idea: this app operates *agents*, dictation, and the Mac's
+// window surface — it is a remote control, not a terminal. Remote controls
+// should look like the OS they live on, not like the thing they point at.
+
+enum DeckTheme {
+
+    // MARK: - Surfaces
+    //
+    // Five levels, all opaque, ~4-5% luminance apart. `well` and `card` sit
+    // either side of `canvas`: that pair *is* the depth model — down for a
+    // group, up for an item, nothing in between. If two adjacent surfaces don't
+    // need a visible seam, they are the same level. Do not invent a sixth.
+
+    /// Root background. Everything sits on this.
+    static let canvas = rgb(0x0D0F12)
+
+    /// Recessed group — channel strip, activity screen, voice bar. Depth −1.
+    static let well = rgb(0x0A0B0D)
+
+    /// Flush item — cards, tiles, list rows. Depth +1.
+    static let card = rgb(0x131518)
+
+    /// Focused/hero console, popovers, sheets. Reserved; never an ordinary card.
+    static let raised = rgb(0x181B1F)
+
+    /// Anything tappable inside a card — buttons, inputs, chips.
+    static let control = rgb(0x1E2126)
+
+    // MARK: - Text
+    //
+    // Four opaque greys, carried over from v6 unchanged. Opaque rather than
+    // white-at-opacity so a label reads the same on `well` as on `raised`, and
+    // warm-neutral so the amber doesn't vibrate against it.
+
+    static let text          = rgb(0xE2E2DF)
+    static let textSecondary = rgb(0xA0A09B)
+    static let textTertiary  = rgb(0x71716C)
+    static let textDisabled  = rgb(0x4A4A4D)
+
+    // MARK: - Hairlines
+    //
+    // Two, and mostly forbidden. Not between a well and the canvas (spacing
+    // carries the recess), not between sections inside one card, not under card
+    // heads. No dotted rules, no black seams.
+
+    /// Stroke on a flush card; row separator only when the gap is under 8pt.
+    static let hairline = Color.white.opacity(0.08)
+
+    /// Focused / selected / recently-changed. The only "look at me" that is not amber.
+    static let hairlineStrong = Color.white.opacity(0.14)
+
+    // MARK: - Accent
+    //
+    // Two hues for the whole app. Attention and selection share one, because
+    // they share a meaning: look here.
+
+    static let accent        = rgb(0xE4B65C)
+    static let accentPressed = rgb(0xC29B4E)
+    static let accentFill    = rgb(0xE4B65C).opacity(0.14)
+    static let accentDisabled = rgb(0xE4B65C).opacity(0.35)
+
+    static let error        = rgb(0xEA6A64)
+    static let errorPressed = rgb(0xC85A55)
+    static let errorFill    = rgb(0xEA6A64).opacity(0.14)
+
+    // MARK: - Radii
+
+    static let radiusSmall: CGFloat = 4   // chips, badges
+    static let radiusCard:  CGFloat = 8   // cards, tiles, controls
+    static let radiusWell:  CGFloat = 12  // wells, panels, sheets
+
+    // MARK: - Spacing (8pt grid)
+
+    enum Space {
+        static let x2:  CGFloat = 2
+        static let x4:  CGFloat = 4
+        static let x8:  CGFloat = 8
+        static let x12: CGFloat = 12
+        static let x16: CGFloat = 16
+        static let x24: CGFloat = 24
+        static let x32: CGFloat = 32
+
+        /// Screen margin.
+        static let margin: CGFloat = 16
+        /// Card interior — the 14 is v6's own vertical rhythm, kept.
+        static let cardPadH: CGFloat = 16
+        static let cardPadV: CGFloat = 14
+        /// Inside a recessed well.
+        static let wellPad: CGFloat = 12
+        /// Between sibling cards.
+        static let cardGap: CGFloat = 8
+        /// Between sections within one card.
+        static let sectionGap: CGFloat = 12
+        /// Icon to its label.
+        static let iconGap: CGFloat = 8
+    }
+
+    // MARK: - Type
+    //
+    // Two faces, split by *who is speaking* rather than by data shape.
+    //
+    // SF Pro is the system voice: every label, name, value, and control. No
+    // tracking, no uppercase — size and weight carry the emphasis that 9pt
+    // tracked caps used to fake.
+    //
+    // The serif is the communication voice, and only that: an agent's question,
+    // a voice transcript, an agent's message. It marks *someone is talking to
+    // you*, which on a surface whose signature state is an agent blocked on a
+    // human is worth a face of its own.
+
+    /// Console names, sheet titles, the thing you would tap.
+    static func title(_ weight: Font.Weight = .semibold) -> Font {
+        .system(size: 17, weight: weight)
+    }
+
+    /// Primary rows, channel names, input text.
+    static func body(_ weight: Font.Weight = .regular) -> Font {
+        .system(size: 15, weight: weight)
+    }
+
+    /// Metadata, descriptions, the activity narrative.
+    static func secondary(_ weight: Font.Weight = .regular) -> Font {
+        .system(size: 13, weight: weight)
+    }
+
+    /// Timestamps, status words, and everything the tracked micro-caps used to do.
+    static func caption(_ weight: Font.Weight = .regular) -> Font {
+        .system(size: 11, weight: weight)
+    }
+
+    /// An agent asking you something.
+    static let said = Font.system(size: 17, design: .serif)
+
+    /// Voice transcript and agent message bodies.
+    static let saidSecondary = Font.system(size: 15, design: .serif)
+
+    // MARK: - Helpers
+
+    static func rgb(_ hex: UInt32) -> Color {
+        Color(
+            red:   Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue:  Double(hex & 0xFF) / 255
+        )
+    }
+}
+
+// MARK: - State presentation
+//
+// Running is the default healthy condition, so running looks like *nothing*.
+// Health is the absence of signal — which is what stops the deck reading as a
+// status board where everything is lit and therefore nothing is.
+
+extension DeckTheme {
+    /// How a channel's state renders. `nil` dot means draw no dot at all.
+    struct StatePresentation {
+        var dotFill: Color?
+        var dotStroke: Color?
+        var glows: Bool
+        var label: Color
+        var rowFill: Color?
+    }
+
+    static func presentation(running: Bool) -> StatePresentation {
+        StatePresentation(
+            dotFill: nil, dotStroke: nil, glows: false,
+            label: running ? text : textTertiary, rowFill: nil
+        )
+    }
+
+    static var idlePresentation: StatePresentation {
+        // Hollow dot, demoted row. Present but not asking for anything.
+        StatePresentation(
+            dotFill: nil, dotStroke: textTertiary, glows: false,
+            label: textTertiary, rowFill: nil
+        )
+    }
+
+    static var attentionPresentation: StatePresentation {
+        // The one place colour is spent. Never amber the whole row.
+        StatePresentation(
+            dotFill: accent, dotStroke: nil, glows: true,
+            label: text, rowFill: nil
+        )
+    }
+
+    static var errorPresentation: StatePresentation {
+        StatePresentation(
+            dotFill: error, dotStroke: nil, glows: false,
+            label: text, rowFill: errorFill
+        )
+    }
+}

--- a/apps/ios/Sources/FleetDeck/FleetDeckAdapter.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckAdapter.swift
@@ -1,0 +1,208 @@
+import DeckKit
+import Foundation
+
+/// Projects live `DeckStore` snapshots onto the design's channel model.
+///
+/// The mapping follows the design's premise — a channel describes an *agent*
+/// working on a Mac, not the Mac itself — so the agent plan drives the task and
+/// step list, `snapshot.questions` drives the blocked ("needs you") state, and
+/// the activity log drives both the per-channel tape and the fleet feed.
+@MainActor
+enum FleetDeckAdapter {
+
+    static func channels(from stores: [DeckStore]) -> [FleetChannel] {
+        stores.enumerated().map { index, store in channel(from: store, index: index) }
+    }
+
+    static func channel(from store: DeckStore, index: Int) -> FleetChannel {
+        let snapshot = store.snapshot
+        let name = store.connectionLabel
+        let question = snapshot?.questions.first
+        let agentRows = snapshot?.cockpitMode?.agentRows ?? []
+        let log = snapshot?.activityLog ?? []
+
+        // `.attn` means exactly one thing: an agent is blocked on a human
+        // decision. It must not be reachable any other way — it is what sorts a
+        // channel to the front of the strip and what `focusAttention()` hunts
+        // for, so anything else wearing it sends the user somewhere with
+        // nothing to answer. `DeckStore.errorMessage` in particular covers
+        // everything from a lost connection to a single rejected trackpad
+        // gesture; it reports as `fault`, never as state.
+        let state: FleetChannelState = {
+            if question != nil { return .attn }
+            if snapshot == nil { return .down }
+            if snapshot?.cockpitMode?.mode == .agent { return .run }
+            if agentRows.contains(where: { $0.state == .live }) { return .run }
+            return .idle
+        }()
+
+        let liveRow = agentRows.first { $0.state == .live }
+        let task: String = {
+            if let question { return question.detail ?? question.prompt }
+            if let liveRow { return liveRow.text }
+            if let error = store.errorMessage { return error }
+            if let layer = snapshot?.desktop?.activeLayerName { return "Standing by on \(layer)." }
+            return "No agent running on this Mac."
+        }()
+
+        return FleetChannel(
+            id: store.sessionID.uuidString,
+            channelLabel: "CH \(String(format: "%02d", index + 1))",
+            deviceName: name,
+            deviceIcon: FleetDeviceIcon.infer(from: name),
+            appName: snapshot?.layout?.frontmostWindow?.appName
+                ?? snapshot?.desktop?.activeAppName
+                ?? "—",
+            fileName: snapshot?.layout?.frontmostWindow?.title
+                ?? snapshot?.desktop?.currentSpaceName
+                ?? "",
+            agentName: log.first?.tag.uppercased() ?? "AGENT",
+            hue: index,
+            state: state,
+            task: task,
+            steps: steps(from: agentRows, isBlocked: question != nil),
+            output: output(store: store, log: log),
+            decision: question.map { decision(from: $0) },
+            lastEventText: log.first?.text ?? "no activity yet",
+            lastEventTime: log.first.map { relativeTime(since: $0.createdAt) } ?? "—",
+            fault: store.errorMessage,
+            cpu: snapshot?.telemetry?.cpuLoadPercent.map { Int($0.rounded()) },
+            mem: snapshot?.telemetry?.memoryUsedPercent.map { Int($0.rounded()) },
+            latency: nil,
+            logLines: logLines(from: log, channel: index),
+            logSource: "~/lats/ch\(String(format: "%02d", index + 1))/agent.log",
+            logLineCount: log.count
+        )
+    }
+
+    /// The fleet feed is every Mac's activity log merged newest-first, which is
+    /// what the design's right-hand column shows.
+    static func feed(from stores: [DeckStore], channels: [FleetChannel]) -> [FleetFeedEvent] {
+        var events: [(FleetFeedEvent, Date)] = []
+
+        for (index, store) in stores.enumerated() {
+            guard channels.indices.contains(index) else { continue }
+            let isBlocked = channels[index].state == .attn
+
+            if let question = store.snapshot?.questions.first {
+                events.append((
+                    FleetFeedEvent(
+                        id: "q-\(store.sessionID)-\(question.id)",
+                        time: "now",
+                        channelIndex: index,
+                        agent: channels[index].agentName,
+                        text: "needs your call · \(question.prompt)",
+                        kind: .attn
+                    ),
+                    .now
+                ))
+            }
+
+            let entries = store.snapshot?.activityLog ?? []
+            for (entryIndex, entry) in entries.enumerated() {
+                events.append((
+                    FleetFeedEvent(
+                        id: "\(store.sessionID)-\(entry.id)",
+                        time: relativeTime(since: entry.createdAt),
+                        channelIndex: index,
+                        agent: entry.tag.uppercased(),
+                        text: entry.text,
+                        // The newest line on a blocked channel is the one the
+                        // design brightens.
+                        kind: isBlocked && entryIndex == 0 ? .hot : .normal
+                    ),
+                    entry.createdAt
+                ))
+            }
+        }
+
+        return events
+            .sorted { $0.1 > $1.1 }
+            .map(\.0)
+    }
+
+    /// A Mac's advertised cockpit pages become the command bay's sets. Falls
+    /// back to the design's canonical four when the bridge advertises none.
+    static func sets(from store: DeckStore?) -> [FleetCommandSet] {
+        let pages = store?.snapshot?.cockpit?.pages ?? []
+        guard !pages.isEmpty else { return FleetCommandSet.canonical }
+        return pages.map(FleetCommandSet.init(page:))
+    }
+
+    // MARK: Pieces
+
+    private static func steps(from rows: [DeckAgentPlanRow], isBlocked: Bool) -> [FleetStep] {
+        rows.enumerated().map { index, row in
+            let state: FleetStepState
+            switch row.state {
+            case .done: state = .done
+            case .live: state = isBlocked ? .blocked : .now
+            case .next: state = .queued
+            }
+            return FleetStep(id: index, state: state, text: row.text)
+        }
+    }
+
+    private static func output(store: DeckStore, log: [DeckActivityLogEntry]) -> String {
+        if let error = store.errorMessage { return error }
+        if let summary = store.snapshot?.voice?.responseSummary, !summary.isEmpty { return summary }
+        if let replay = store.snapshot?.cockpitMode?.replayMessage, !replay.isEmpty { return replay }
+        if log.count > 1 { return log[1].text }
+        return log.first?.text ?? "Nothing reported yet."
+    }
+
+    private static func decision(from card: DeckQuestionCard) -> FleetDecision {
+        let keys = ["A", "B", "C", "D"]
+        return FleetDecision(
+            question: card.prompt,
+            options: card.options.enumerated().map { index, option in
+                FleetDecisionOption(
+                    id: option.id,
+                    key: index < keys.count ? keys[index] : "\(index + 1)",
+                    title: option.title,
+                    detail: option.detail ?? "",
+                    verb: "SEND",
+                    actionID: option.actionID,
+                    resolvedTask: "Applying: \(option.title).",
+                    resolvedOutput: "Sent to the Mac — waiting for the agent to pick it up.",
+                    feedText: "answered · \(option.title)"
+                )
+            }
+        )
+    }
+
+    private static func logLines(from log: [DeckActivityLogEntry], channel: Int) -> [FleetLogLine] {
+        // The design's log screen reads bottom-up (newest last), the opposite of
+        // the activity log's newest-first order.
+        log.reversed().enumerated().map { index, entry in
+            FleetLogLine(
+                id: "\(channel)-\(entry.id)",
+                time: clockTime(entry.createdAt),
+                tag: entry.tag.lowercased(),
+                message: entry.text,
+                style: index == log.count - 1 ? .highlight : .normal
+            )
+        }
+    }
+
+    // MARK: Formatting
+
+    private static let clockFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter
+    }()
+
+    private static func clockTime(_ date: Date) -> String {
+        clockFormatter.string(from: date)
+    }
+
+    /// The design's compact age stamps: 4s, 12s, 2m, 9m, 1h.
+    static func relativeTime(since date: Date) -> String {
+        let seconds = max(0, Int(Date.now.timeIntervalSince(date)))
+        if seconds < 60 { return "\(seconds)s" }
+        if seconds < 3600 { return "\(seconds / 60)m" }
+        if seconds < 86_400 { return "\(seconds / 3600)h" }
+        return "\(seconds / 86_400)d"
+    }
+}

--- a/apps/ios/Sources/FleetDeck/FleetDeckChannelStrip.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckChannelStrip.swift
@@ -1,0 +1,227 @@
+import SwiftUI
+
+// MARK: - Channel strip
+//
+// `.fd-channels` — four columns in one recessed well. Tap a column to put that
+// Mac on deck. Blocked channels sort to the front; the status dot is the only
+// marker they carry.
+
+struct FleetChannelStrip: View {
+    let channels: [FleetChannel]
+    let order: [Int]
+    let currentIndex: Int
+    /// `focus` collapses the strip to a 52pt switcher rail.
+    let layout: FleetDeckLayout
+    let onSelect: (Int) -> Void
+
+    var body: some View {
+        FleetWell {
+            HStack(spacing: 0) {
+                ForEach(order, id: \.self) { index in
+                    if channels.indices.contains(index) {
+                        FleetChannelColumn(
+                            channel: channels[index],
+                            isActive: index == currentIndex,
+                            isRail: layout == .focus,
+                            onSelect: { onSelect(index) }
+                        )
+                        .frame(maxWidth: .infinity)
+                        .overlay(alignment: .leading) {
+                            if index != order.first {
+                                Rectangle().fill(FleetV6.brk2).frame(width: 1)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .frame(height: layout == .focus ? FleetV6.M.channelsRailHeight : FleetV6.M.channelsHeight)
+    }
+}
+
+private struct FleetChannelColumn: View {
+    let channel: FleetChannel
+    let isActive: Bool
+    let isRail: Bool
+    let onSelect: () -> Void
+
+    var body: some View {
+        Button(action: onSelect) {
+            VStack(alignment: .leading, spacing: 0) {
+                head
+                if !isRail {
+                    body_
+                    Spacer(minLength: 0)
+                    foot
+                }
+            }
+            .padding(.top, isRail ? 0 : 11)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: isRail ? .leading : .topLeading)
+            .background {
+                if isActive {
+                    LinearGradient(
+                        stops: [
+                            .init(color: Color.white.opacity(0.05), location: 0),
+                            .init(color: Color.white.opacity(0.012), location: 0.55),
+                            .init(color: .clear, location: 1)
+                        ],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                    .overlay(alignment: .top) {
+                        Rectangle().fill(Color.white.opacity(0.06)).frame(height: 1)
+                    }
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        // The design makes the active column non-interactive with `cursor:default`,
+        // not by dimming it — `.disabled` would fade the whole label.
+        .allowsHitTesting(!isActive)
+        .accessibilityLabel("\(channel.channelLabel), \(channel.deviceName)")
+        .accessibilityValue("\(channel.agentName), \(channel.state.label)")
+        .accessibilityAddTraits(isActive ? [.isSelected, .isButton] : .isButton)
+    }
+
+    // `.chan-head`
+    private var head: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 8) {
+                Text(channel.channelLabel)
+                    .font(FleetV6.mono(10, .medium))
+                    .tracking(1.4)
+                    .foregroundStyle(FleetV6.fg4)
+                    .fixedSize()
+
+                Image(systemName: channel.deviceIcon.symbol)
+                    .font(.system(size: 13, weight: .light))
+                    .foregroundStyle(FleetV6.fg3)
+                    .frame(width: 20, alignment: .leading)
+
+                Text(channel.deviceName)
+                    .font(FleetV6.mono(12.5, .medium))
+                    .foregroundStyle(FleetV6.fg)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                Spacer(minLength: 6)
+
+                FleetChannelStatus(state: channel.state, isActive: isActive)
+            }
+            .padding(.horizontal, 15)
+            .padding(.bottom, isRail ? 0 : 9)
+
+            if !isRail {
+                FleetDottedRule(color: Color.white.opacity(0.09))
+                    .padding(.horizontal, 15)
+            }
+        }
+        .frame(maxHeight: isRail ? .infinity : nil)
+    }
+
+    // `.chan-body`
+    private var body_: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Circle()
+                    .fill(FleetV6.agentHue(channel.hue))
+                    .frame(width: 5, height: 5)
+                    .alignmentGuide(.firstTextBaseline) { $0[.bottom] - 1 }
+                Text(channel.agentName)
+                    .font(FleetV6.mono(16, .medium))
+                    .foregroundStyle(FleetV6.fg)
+                Text(channel.appName)
+                    .font(FleetV6.mono(10))
+                    .tracking(1)
+                    .foregroundStyle(FleetV6.fg4)
+                    .lineLimit(1)
+            }
+            .padding(.top, 10)
+
+            Text(channel.task)
+                .font(FleetV6.mono(11))
+                .foregroundStyle(FleetV6.fg3)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .padding(.top, 4)
+
+            HStack(spacing: 7) {
+                FleetDot(color: FleetV6.fg3, size: 5)
+                Text(channel.lastEventText)
+                    .font(FleetV6.mono(10.5))
+                    .foregroundStyle(FleetV6.fg3)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Spacer(minLength: 4)
+                Text(channel.lastEventTime)
+                    .font(FleetV6.mono(9.5))
+                    .monospacedDigit()
+                    .foregroundStyle(FleetV6.fg4)
+            }
+            .padding(.top, 9)
+        }
+        .padding(.horizontal, 15)
+    }
+
+    // `.chan-foot`
+    private var foot: some View {
+        HStack(spacing: 0) {
+            HStack(spacing: 7) {
+                FleetDot(color: isActive ? FleetV6.fg2 : FleetV6.fg4, size: 6)
+                Text(isActive ? "ON DECK" : "TAP TO SWITCH")
+                    .font(FleetV6.mono(9.5, .medium))
+                    .tracking(1.1)
+                    .foregroundStyle(isActive ? FleetV6.fg2 : FleetV6.fg4)
+            }
+            Spacer(minLength: 4)
+            Text(channel.footerMetrics)
+                .font(FleetV6.mono(9.5, .medium))
+                .tracking(1.1)
+                .monospacedDigit()
+                .foregroundStyle(FleetV6.fg4)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 15)
+        .padding(.vertical, 8)
+        .overlay(alignment: .top) {
+            Rectangle().fill(FleetV6.brk2).frame(height: 1)
+        }
+    }
+}
+
+/// `.chan-st` — the state readout. The active channel's RUNNING dot is the only
+/// place the phosphor green appears in the strip.
+struct FleetChannelStatus: View {
+    let state: FleetChannelState
+    var isActive: Bool = false
+
+    private var color: Color {
+        switch state {
+        case .run:  return FleetV6.fg3
+        case .attn: return FleetV6.amber
+        case .idle: return FleetV6.fg4
+        case .down: return FleetV6.red
+        }
+    }
+
+    private var dotColor: Color {
+        switch state {
+        case .run:  return isActive ? FleetV6.green : FleetV6.fg3
+        case .attn: return FleetV6.amber
+        case .idle: return FleetV6.fg4
+        case .down: return FleetV6.red
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            FleetDot(color: dotColor, size: 5, glow: state == .attn)
+            Text(state.label)
+                .font(FleetV6.mono(9, .medium))
+                .tracking(1.26)
+                .foregroundStyle(color)
+                .fixedSize()
+        }
+    }
+}

--- a/apps/ios/Sources/FleetDeck/FleetDeckCommandBay.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckCommandBay.swift
@@ -1,0 +1,344 @@
+import SwiftUI
+
+// MARK: - Command bay
+//
+// `.deck-tiles-wrap` — sets as tabs, tiles as the hero. Eight big targets in a
+// 4×2 grid, sized to be hit at arm's length.
+
+struct FleetCommandBay: View {
+    let sets: [FleetCommandSet]
+    let setIndex: Int
+    let onSelectSet: (Int) -> Void
+    let onTile: (FleetCommandTile) -> Void
+
+    private var tiles: [FleetCommandTile] {
+        sets.indices.contains(setIndex) ? sets[setIndex].tiles : []
+    }
+
+    private var columns: [GridItem] {
+        Array(repeating: GridItem(.flexible(), spacing: FleetV6.M.tileGap), count: 4)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            tabs
+            grid
+        }
+        .background(FleetV6.tilesWrapBG)
+        .overlay(alignment: .top) {
+            ZStack(alignment: .top) {
+                Rectangle().fill(FleetV6.seam).frame(height: 1)
+                Rectangle().fill(Color.white.opacity(0.03)).frame(height: 1).offset(y: 1)
+            }
+        }
+    }
+
+    // `.set-tabs`
+    private var tabs: some View {
+        HStack(spacing: 8) {
+            FleetLabel(text: "COMMANDS")
+                .padding(.trailing, 4)
+
+            ForEach(Array(sets.enumerated()), id: \.element.id) { index, set in
+                Button { onSelectSet(index) } label: {
+                    HStack(spacing: 6) {
+                        Text("\(index + 1)")
+                            .foregroundStyle(FleetV6.fg4)
+                        Text(set.key)
+                            .foregroundStyle(index == setIndex ? FleetV6.fg : FleetV6.fg4)
+                    }
+                    .font(FleetV6.mono(10, .medium))
+                    .tracking(1.4)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 6)
+                    .background {
+                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            .fill(
+                                index == setIndex
+                                    ? AnyShapeStyle(Color.white.opacity(0.07))
+                                    : AnyShapeStyle(
+                                        LinearGradient(
+                                            colors: [FleetV6.rgb(0x101113), FleetV6.rgb(0x0B0C0D)],
+                                            startPoint: .top,
+                                            endPoint: .bottom
+                                        )
+                                    )
+                            )
+                            .overlay {
+                                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                    .strokeBorder(
+                                        index == setIndex ? Color.white.opacity(0.16) : FleetV6.brk2,
+                                        lineWidth: 1
+                                    )
+                            }
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityAddTraits(index == setIndex ? [.isSelected, .isButton] : .isButton)
+            }
+
+            Spacer(minLength: 8)
+
+            Text("SET \(setIndex + 1) / \(max(sets.count, 1))")
+                .font(FleetV6.mono(9.5, .medium))
+                .tracking(1.33)
+                .monospacedDigit()
+                .foregroundStyle(FleetV6.fg4)
+        }
+        .padding(.horizontal, 15)
+        .padding(.top, 10)
+    }
+
+    // `.deck-tiles`
+    private var grid: some View {
+        LazyVGrid(columns: columns, spacing: FleetV6.M.tileGap) {
+            ForEach(tiles) { tile in
+                FleetCommandTileView(tile: tile) { onTile(tile) }
+            }
+        }
+        .padding(.horizontal, 15)
+        .padding(.top, 10)
+        .padding(.bottom, 12)
+        .frame(height: FleetV6.M.tilesHeight + 22)
+    }
+}
+
+/// `.tile` — domed icon cap on the left, title and caption stacked to its right.
+struct FleetCommandTileView: View {
+    let tile: FleetCommandTile
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: tile.symbol)
+                    .font(.system(size: 15, weight: .regular))
+                    .foregroundStyle(FleetV6.tileIcon)
+                    .frame(width: 31, height: 31)
+                    .background {
+                        RoundedRectangle(cornerRadius: 9, style: .continuous)
+                            .fill(FleetV6.dome)
+                            .overlay {
+                                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                                    .strokeBorder(Color.white.opacity(0.09), lineWidth: 1)
+                            }
+                            .shadow(color: .black.opacity(0.6), radius: 1, y: 1)
+                    }
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(tile.title)
+                        .font(FleetV6.mono(13.5, .medium))
+                        .foregroundStyle(FleetV6.fg)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.85)
+                    Text(tile.meta.uppercased())
+                        .font(FleetV6.mono(8.5, .medium))
+                        .tracking(1.02)
+                        .foregroundStyle(FleetV6.fg4)
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(.horizontal, 13)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background {
+                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .fill(FleetV6.tileFace)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 9, style: .continuous)
+                            .strokeBorder(FleetV6.brk2, lineWidth: 1)
+                    }
+                    .overlay(alignment: .top) {
+                        LinearGradient(
+                            colors: [Color.white.opacity(0.03), .clear],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                        .frame(maxHeight: .infinity)
+                        .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
+                        .allowsHitTesting(false)
+                    }
+                    .shadow(color: .black.opacity(0.6), radius: 3, y: 2)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(FleetPressStyle())
+        .accessibilityLabel(tile.title)
+        .accessibilityHint(tile.meta)
+    }
+}
+
+// MARK: - Key row
+//
+// `.deck-keys` — the machined strip along the bottom of the enclosure. Sends
+// real keystrokes to whichever Mac is on deck.
+
+struct FleetKeyRow: View {
+    let onKey: (String, [String]) -> Void
+
+    var body: some View {
+        HStack(spacing: 14) {
+            HStack(spacing: 7) {
+                key("esc") { onKey("escape", []) }
+                key("⌘C") { onKey("c", ["command"]) }
+                key("⌘V") { onKey("v", ["command"]) }
+                key("⌘Z") { onKey("z", ["command"]) }
+                key("space", wide: true) { onKey("space", []) }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            HStack(spacing: 7) {
+                symbolKey("arrow.left") { onKey("left", []) }
+                symbolKey("arrow.up") { onKey("up", []) }
+                symbolKey("arrow.down") { onKey("down", []) }
+                symbolKey("arrow.right") { onKey("right", []) }
+            }
+
+            HStack(spacing: 7) {
+                key("⌃") { onKey("control", []) }
+                key("⌥") { onKey("option", []) }
+                key("⇧") { onKey("shift", []) }
+                key("⌘") { onKey("command", []) }
+                key("↵ enter", wide: true) { onKey("return", []) }
+            }
+            .frame(maxWidth: .infinity, alignment: .trailing)
+        }
+        .padding(.horizontal, 13)
+        .padding(.vertical, 8)
+        .background(FleetV6.bezel)
+        .overlay(alignment: .top) {
+            ZStack(alignment: .top) {
+                Rectangle().fill(FleetV6.seam).frame(height: 1)
+                Rectangle().fill(Color.white.opacity(0.10)).frame(height: 1).offset(y: 1)
+            }
+        }
+    }
+
+    private func key(_ label: String, wide: Bool = false, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label)
+                .font(FleetV6.mono(12))
+                .foregroundStyle(FleetV6.fg2)
+                .padding(.horizontal, 12)
+                .frame(minWidth: wide ? 84 : 42, minHeight: 30)
+                .background { FleetKeycapBackground() }
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(FleetPressStyle())
+        .accessibilityLabel(label)
+    }
+
+    private func symbolKey(_ symbol: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: symbol)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(FleetV6.fg2)
+                .frame(minWidth: 42, minHeight: 30)
+                .background { FleetKeycapBackground() }
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(FleetPressStyle())
+        .accessibilityLabel(symbol.replacingOccurrences(of: "arrow.", with: "") + " arrow")
+    }
+}
+
+// MARK: - Status bar
+//
+// `.fd-status` — the bottom rail. Left is where you are, right is what the
+// fleet is doing; ATTN is a button, not a readout.
+
+struct FleetStatusBar: View {
+    let deviceName: String
+    let routeLabel: String
+    let attentionCount: Int
+    let machineCount: Int
+    let agentCount: Int
+    let layout: FleetDeckLayout
+    let isOnline: Bool
+    let onAttention: () -> Void
+    let onToggleLayout: () -> Void
+
+    var body: some View {
+        HStack(spacing: 0) {
+            group(showsDivider: false) {
+                FleetDot(color: isOnline ? FleetV6.green : FleetV6.fg4, size: 6, glow: isOnline)
+                Text(isOnline ? "ONLINE" : "OFFLINE")
+                    .foregroundStyle(isOnline ? FleetV6.green : FleetV6.fg4)
+            }
+
+            group {
+                Text(deviceName.uppercased()).foregroundStyle(FleetV6.fg2).lineLimit(1)
+            }
+
+            group {
+                Text("ROUTE")
+                Text(routeLabel).foregroundStyle(FleetV6.fg2)
+            }
+
+            Spacer(minLength: 0)
+
+            Button(action: onAttention) {
+                HStack(spacing: 7) {
+                    Text(attentionCount > 0 ? "ATTN \(attentionCount)" : "ALL CLEAR")
+                        .foregroundStyle(attentionCount > 0 ? FleetV6.amber : FleetV6.green)
+                }
+                .padding(.horizontal, 13)
+                .frame(maxHeight: .infinity)
+                .overlay(alignment: .leading) { Rectangle().fill(FleetV6.brk2).frame(width: 1) }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(attentionCount == 0)
+
+            group {
+                Text("MACS")
+                Text("\(machineCount)").foregroundStyle(FleetV6.fg2)
+            }
+
+            group {
+                Text("AGENTS")
+                Text("\(agentCount)").foregroundStyle(FleetV6.fg2)
+            }
+
+            Button(action: onToggleLayout) {
+                HStack(spacing: 7) {
+                    Text("VIEW ·")
+                    Text(layout.rawValue.uppercased()).foregroundStyle(FleetV6.fg2)
+                }
+                .padding(.horizontal, 13)
+                .frame(maxHeight: .infinity)
+                .overlay(alignment: .leading) { Rectangle().fill(FleetV6.brk2).frame(width: 1) }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Toggle deck view")
+            .accessibilityValue(layout.rawValue)
+        }
+        .font(FleetV6.mono(9.5, .medium))
+        .tracking(1.14)
+        .monospacedDigit()
+        .foregroundStyle(FleetV6.fg3)
+        .frame(height: FleetV6.M.statusHeight)
+        .background(FleetV6.statusBG)
+        .overlay(alignment: .top) {
+            ZStack(alignment: .top) {
+                Rectangle().fill(FleetV6.brk2).frame(height: 1)
+                Rectangle().fill(Color.white.opacity(0.03)).frame(height: 1).offset(y: 1)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func group<Content: View>(
+        showsDivider: Bool = true,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        HStack(spacing: 7) { content() }
+            .padding(.horizontal, 13)
+            .frame(maxHeight: .infinity)
+            .overlay(alignment: .leading) {
+                if showsDivider { Rectangle().fill(FleetV6.brk2).frame(width: 1) }
+            }
+    }
+}

--- a/apps/ios/Sources/FleetDeck/FleetDeckCommands.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckCommands.swift
@@ -1,0 +1,104 @@
+import DeckKit
+import Foundation
+
+extension FleetCommandSet {
+
+    /// The design's four command sets, in its order — AGENT first, because this
+    /// deck steers agents, not cursors.
+    ///
+    /// These are the *shape* of the bay, used when a Mac advertises no cockpit
+    /// pages of its own (and by the design fixture). Tiles here carry no
+    /// `actionID`: a live deck builds its sets from `snapshot.cockpit.pages`,
+    /// which come with the bridge's real action IDs attached.
+    static let canonical: [FleetCommandSet] = [
+        FleetCommandSet(
+            id: "agent",
+            key: "AGENT",
+            tiles: tiles([
+                ("Run Agent", "spawn", "sparkles"),
+                ("Steer", "redirect", "slider.horizontal.3"),
+                ("Approve", "unblock", "checkmark.circle"),
+                ("Reject", "redo", "xmark.circle"),
+                ("Handoff", "pass work", "arrow.right.to.line"),
+                ("Delegate", "fan out", "point.3.connected.trianglepath.dotted"),
+                ("Summarize", "digest", "text.alignleft"),
+                ("Stop", "halt", "stop.circle")
+            ], prefix: "agent")
+        ),
+        FleetCommandSet(
+            id: "review",
+            key: "REVIEW",
+            tiles: tiles([
+                ("Open Diff", "inspect", "plusminus"),
+                ("Run Tests", "suite", "testtube.2"),
+                ("Browser Check", "see result", "globe"),
+                ("Screenshot", "capture", "camera"),
+                ("Logs", "stream", "list.bullet"),
+                ("Commit", "git", "smallcircle.filled.circle"),
+                ("Push", "ship", "arrow.up.to.line"),
+                ("Revert", "undo", "arrow.uturn.backward")
+            ], prefix: "review")
+        ),
+        FleetCommandSet(
+            id: "window",
+            key: "WINDOW",
+            tiles: tiles([
+                ("Focus App", "front", "scope"),
+                ("Tile Left", "snap", "rectangle.lefthalf.inset.filled"),
+                ("Tile Right", "snap", "rectangle.righthalf.inset.filled"),
+                ("Fullscreen", "zoom", "arrow.up.left.and.arrow.down.right"),
+                ("Center", "place", "rectangle.center.inset.filled"),
+                ("Next Window", "cycle", "arrow.right.square"),
+                ("Paste", "clip", "doc.on.clipboard"),
+                ("Terminal", "shell", "terminal")
+            ], prefix: "window")
+        ),
+        FleetCommandSet(
+            id: "system",
+            key: "SYSTEM",
+            tiles: tiles([
+                ("Lock", "secure", "lock"),
+                ("Sleep", "idle", "moon"),
+                ("Restart", "reboot", "arrow.clockwise"),
+                ("Snapshot", "capture", "camera"),
+                ("Sync", "push", "arrow.triangle.2.circlepath"),
+                ("Mute", "silence", "speaker.slash"),
+                ("Journal", "history", "list.bullet"),
+                ("Clear", "reset", "xmark.circle")
+            ], prefix: "system")
+        )
+    ]
+
+    private static func tiles(_ raw: [(String, String, String)], prefix: String) -> [FleetCommandTile] {
+        raw.enumerated().map { index, entry in
+            FleetCommandTile(
+                id: "\(prefix)-\(index)",
+                title: entry.0,
+                meta: "\(String(format: "%02d", index + 1)) · \(entry.1)",
+                symbol: entry.2,
+                actionID: nil
+            )
+        }
+    }
+
+    /// Build a set from a Mac's advertised cockpit page. The design's tile
+    /// caption is `NN · hint`, so the tile's own subtitle is used when it has
+    /// one and the index alone otherwise.
+    init(page: DeckCockpitPage) {
+        self.init(
+            id: page.id,
+            key: page.title.uppercased(),
+            tiles: page.tiles.enumerated().map { index, tile in
+                let hint = tile.subtitle?.lowercased() ?? tile.shortcutID.lowercased()
+                return FleetCommandTile(
+                    id: tile.id,
+                    title: tile.title,
+                    meta: "\(String(format: "%02d", index + 1)) · \(hint)",
+                    symbol: tile.iconSystemName,
+                    actionID: tile.actionID,
+                    payload: tile.payload
+                )
+            }
+        )
+    }
+}

--- a/apps/ios/Sources/FleetDeck/FleetDeckConsole.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckConsole.swift
@@ -1,0 +1,484 @@
+import SwiftUI
+
+// MARK: - Agent console
+//
+// `.acon .mcard.console` — the raised card that carries one agent's whole story:
+// who it is, what it is doing, how far it got, and — when it is blocked — the
+// decision itself, answerable right here rather than somewhere else.
+
+struct FleetAgentConsole: View {
+    let channel: FleetChannel
+    /// Attention queue position, e.g. "1 OF 2" above the question.
+    let queuePosition: Int?
+    let queueCount: Int
+    let nextBlockerLabel: String?
+    /// True right after this channel's decision was answered — the design swaps
+    /// the muted output line for a green confirmation.
+    let justResolved: Bool
+    /// Marks the card that changed with corner ticks.
+    let isRecent: Bool
+    /// Console buttons the Mac on deck can service.
+    let enabledActions: Set<FleetConsoleAction>
+    let onChoose: (Int) -> Void
+    let onDefer: () -> Void
+    let onApprove: () -> Void
+    let onSteer: () -> Void
+    let onRecap: () -> Void
+
+    var body: some View {
+        FleetCard(hero: true, recent: isRecent) {
+            VStack(alignment: .leading, spacing: 0) {
+                FleetCardHead(
+                    title: "agent console",
+                    trailing: channel.state.label,
+                    trailingColor: headTrailingColor
+                )
+
+                HStack(alignment: .firstTextBaseline, spacing: 10) {
+                    Text(channel.agentName)
+                        .font(FleetV6.mono(21, .medium))
+                        .foregroundStyle(FleetV6.fg)
+                    stateChip
+                }
+
+                if channel.decision == nil {
+                    Text(channel.task)
+                        .font(FleetV6.mono(12.5))
+                        .foregroundStyle(FleetV6.fg2)
+                        .lineSpacing(2.5)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.top, 6)
+                }
+
+                steps.padding(.top, 12)
+
+                if let decision = channel.decision {
+                    FleetDecisionCard(
+                        decision: decision,
+                        queuePosition: queuePosition,
+                        queueCount: queueCount,
+                        nextBlockerLabel: nextBlockerLabel,
+                        onChoose: onChoose,
+                        onDefer: onDefer
+                    )
+                    .padding(.top, 11)
+                } else if justResolved {
+                    resolvedNote.padding(.top, 11)
+                } else {
+                    outputNote.padding(.top, 10)
+                }
+
+                if channel.decision == nil {
+                    actionButtons.padding(.top, 11)
+                    Spacer(minLength: 8)
+                    stats
+                } else {
+                    Spacer(minLength: 0)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        }
+    }
+
+    private var headTrailingColor: Color {
+        switch channel.state {
+        case .run:  return FleetV6.green
+        case .attn: return FleetV6.fg3
+        case .idle: return FleetV6.fg4
+        case .down: return FleetV6.red
+        }
+    }
+
+    // `.ac-chip`
+    private var stateChip: some View {
+        Text("\(channel.channelLabel) · \(channel.deviceName.uppercased())")
+            .font(FleetV6.mono(9, .medium))
+            .tracking(1.26)
+            .foregroundStyle(channel.state == .idle ? FleetV6.fg4 : FleetV6.fg3)
+            .lineLimit(1)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background {
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(channel.state == .idle ? Color.clear : Color.white.opacity(0.03))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 5, style: .continuous)
+                            .strokeBorder(FleetV6.brk, lineWidth: 1)
+                    }
+            }
+    }
+
+    // `.ac-steps` — condensed to a single rollup line while a decision is open,
+    // so the question is what the eye lands on.
+    @ViewBuilder
+    private var steps: some View {
+        if channel.decision != nil {
+            let blocked = channel.steps.first { $0.state == .blocked }?.text ?? "Waiting on you"
+            let doneCount = channel.steps.filter { $0.state == .done }.count
+            HStack(alignment: .center, spacing: 9) {
+                FleetStepTick(state: .now)
+                (
+                    Text(blocked).foregroundColor(FleetV6.fg)
+                        + Text(" · \(doneCount) steps done").foregroundColor(FleetV6.fg4)
+                )
+                .font(FleetV6.mono(11.5))
+            }
+        } else {
+            VStack(alignment: .leading, spacing: 7) {
+                ForEach(channel.steps) { step in
+                    HStack(alignment: .center, spacing: 9) {
+                        FleetStepTick(state: step.state)
+                        Text(step.text)
+                            .font(FleetV6.mono(11.5))
+                            .foregroundStyle(stepColor(step.state))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+        }
+    }
+
+    private func stepColor(_ state: FleetStepState) -> Color {
+        switch state {
+        case .done:    return FleetV6.fg4
+        case .now:     return FleetV6.fg
+        case .blocked: return FleetV6.fg
+        case .queued:  return FleetV6.fg3
+        }
+    }
+
+    // `.ac-out`
+    private var outputNote: some View {
+        HStack(alignment: .top, spacing: 6) {
+            Text("›").foregroundStyle(FleetV6.fg4)
+            Text(channel.output)
+                .foregroundStyle(FleetV6.fg3)
+                .lineSpacing(2.5)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .font(FleetV6.mono(11))
+        .padding(.horizontal, 11)
+        .padding(.vertical, 7)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .modifier(FleetWellFill(radius: 4))
+    }
+
+    // `.ac-done`
+    private var resolvedNote: some View {
+        HStack(alignment: .top, spacing: 7) {
+            Text("✓")
+            Text(channel.output)
+                .lineSpacing(2)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .font(FleetV6.mono(11))
+        .foregroundStyle(FleetV6.green)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background {
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(FleetV6.green.opacity(0.07))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .strokeBorder(FleetV6.green.opacity(0.3), lineWidth: 1)
+                }
+        }
+    }
+
+    // `.ac-btns`
+    private var actionButtons: some View {
+        HStack(spacing: 8) {
+            FleetConsoleButton(
+                symbol: "checkmark.circle",
+                title: "Approve",
+                tint: FleetV6.green,
+                isEnabled: enabledActions.contains(.approve),
+                action: onApprove
+            )
+            FleetConsoleButton(
+                symbol: "slider.horizontal.3",
+                title: "Steer",
+                isEnabled: enabledActions.contains(.steer),
+                action: onSteer
+            )
+            FleetConsoleButton(
+                symbol: "text.alignleft",
+                title: "Recap",
+                isEnabled: enabledActions.contains(.recap),
+                action: onRecap
+            )
+        }
+    }
+
+    // `.ac-stats`
+    private var stats: some View {
+        HStack(spacing: 0) {
+            statPair("CPU", channel.cpu.map { "\($0)%" })
+            Spacer(minLength: 6)
+            statPair("MEM", channel.mem.map { "\($0)%" })
+            Spacer(minLength: 6)
+            statPair("NET", channel.latency)
+            Spacer(minLength: 6)
+            Text(channel.deviceName.uppercased())
+                .font(FleetV6.mono(9.5, .medium))
+                .tracking(0.95)
+                .foregroundStyle(FleetV6.fg4)
+                .lineLimit(1)
+        }
+        .padding(.top, 8)
+        .overlay(alignment: .top) { FleetDottedRule() }
+    }
+
+    private func statPair(_ key: String, _ value: String?) -> some View {
+        HStack(spacing: 5) {
+            Text(key)
+                .font(FleetV6.mono(9.5, .medium))
+                .tracking(0.95)
+                .foregroundStyle(FleetV6.fg4)
+            Text(value ?? "—")
+                .font(FleetV6.mono(9.5))
+                .monospacedDigit()
+                .foregroundStyle(FleetV6.fg2)
+        }
+    }
+}
+
+// MARK: - Decision
+
+/// `.ac-ask` — the inline decision. Answer it here; don't go look for it.
+struct FleetDecisionCard: View {
+    let decision: FleetDecision
+    let queuePosition: Int?
+    let queueCount: Int
+    let nextBlockerLabel: String?
+    let onChoose: (Int) -> Void
+    let onDefer: () -> Void
+
+    private var queueLabel: String {
+        guard let queuePosition, queueCount > 0 else { return "NEEDS YOU" }
+        return "NEEDS YOU · \(queuePosition) OF \(queueCount)"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 7) {
+                FleetDot(color: FleetV6.amber, size: 5, glow: true)
+                Text(queueLabel)
+                    .font(FleetV6.mono(8.5, .medium))
+                    .tracking(1.7)
+                    .foregroundStyle(FleetV6.fg4)
+            }
+            .padding(.bottom, 6)
+
+            // The one serif in the design — the question reads as a sentence,
+            // not as instrumentation.
+            Text(decision.question)
+                .font(FleetV6.serif(14.5))
+                .foregroundStyle(FleetV6.fg)
+                .lineSpacing(1.5)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(spacing: 7) {
+                ForEach(Array(decision.options.enumerated()), id: \.element.id) { index, option in
+                    FleetDecisionRow(option: option) { onChoose(index) }
+                }
+            }
+            .padding(.top, 10)
+
+            HStack {
+                Button(action: onDefer) {
+                    Text("ASK ME LATER")
+                        .font(FleetV6.mono(9, .medium))
+                        .tracking(1.08)
+                        .foregroundStyle(FleetV6.fg4)
+                }
+                .buttonStyle(.plain)
+                Spacer()
+                if let nextBlockerLabel {
+                    Text("NEXT → \(nextBlockerLabel)")
+                        .font(FleetV6.mono(9, .medium))
+                        .tracking(1.08)
+                        .foregroundStyle(FleetV6.fg4)
+                }
+            }
+            .padding(.top, 8)
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, 11)
+        .padding(.bottom, 12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .modifier(FleetWellFill(radius: 6))
+    }
+}
+
+/// `.ask-opt` — a keycap-faced row: letter, label, verb.
+private struct FleetDecisionRow: View {
+    let option: FleetDecisionOption
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 11) {
+                Text(option.key)
+                    .font(FleetV6.mono(9.5))
+                    .foregroundStyle(FleetV6.fg3)
+                    .frame(width: 17, height: 17)
+                    .background {
+                        RoundedRectangle(cornerRadius: 4, style: .continuous)
+                            .fill(Color.white.opacity(0.03))
+                            .overlay {
+                                RoundedRectangle(cornerRadius: 4, style: .continuous)
+                                    .strokeBorder(FleetV6.brk, lineWidth: 1)
+                            }
+                    }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(option.title)
+                        .font(FleetV6.mono(12, .medium))
+                        .tracking(0.24)
+                        .foregroundStyle(FleetV6.fg)
+                    if !option.detail.isEmpty {
+                        Text(option.detail)
+                            .font(FleetV6.mono(10))
+                            .foregroundStyle(FleetV6.fg4)
+                            .lineLimit(1)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                Text(option.verb)
+                    .font(FleetV6.mono(9, .medium))
+                    .tracking(1.08)
+                    .foregroundStyle(FleetV6.fg4)
+            }
+            .padding(.horizontal, 11)
+            .padding(.vertical, 7)
+            .background { FleetKeycapBackground(radius: 6) }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(FleetPressStyle())
+        .accessibilityLabel("\(option.title). \(option.detail)")
+        .accessibilityHint(option.verb)
+    }
+}
+
+// MARK: - Pieces
+
+/// `.mh` — every card's head: title left, state right, dotted rule under.
+struct FleetCardHead<Trailing: View>: View {
+    let title: String
+    @ViewBuilder var trailingContent: () -> Trailing
+
+    var body: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 10) {
+                Text(title)
+                    .font(FleetV6.mono(12.5, .medium))
+                    .foregroundStyle(FleetV6.fg)
+                Spacer(minLength: 6)
+                trailingContent()
+            }
+            FleetDottedRule()
+        }
+        .padding(.bottom, 10)
+    }
+}
+
+extension FleetCardHead where Trailing == Text {
+    init(title: String, trailing: String, trailingColor: Color = FleetV6.fg4) {
+        self.title = title
+        self.trailingContent = {
+            Text(trailing)
+                .font(FleetV6.mono(10, .medium))
+                .tracking(1)
+                .foregroundStyle(trailingColor)
+        }
+    }
+}
+
+/// `.ac-step .tick` — done is a filled check, now is an open ring with a dot,
+/// queued is an empty ring.
+struct FleetStepTick: View {
+    let state: FleetStepState
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(state == .done ? Color.white.opacity(0.06) : .clear)
+                .overlay { Circle().strokeBorder(ringColor, lineWidth: 1) }
+            switch state {
+            case .done:
+                Image(systemName: "checkmark")
+                    .font(.system(size: 6, weight: .bold))
+                    .foregroundStyle(FleetV6.fg4)
+            case .now, .blocked:
+                Circle().fill(FleetV6.fg2).frame(width: 6, height: 6)
+            case .queued:
+                EmptyView()
+            }
+        }
+        .frame(width: 12, height: 12)
+    }
+
+    private var ringColor: Color {
+        switch state {
+        case .done:            return Color.white.opacity(0.22)
+        case .now, .blocked:   return Color.white.opacity(0.5)
+        case .queued:          return Color.white.opacity(0.18)
+        }
+    }
+}
+
+/// `.abtn`
+struct FleetConsoleButton: View {
+    let symbol: String
+    let title: String
+    var tint: Color = FleetV6.fg2
+    var isEnabled: Bool = true
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 7) {
+                Image(systemName: symbol).font(.system(size: 12, weight: .regular))
+                Text(title).font(FleetV6.mono(11.5)).tracking(0.46)
+            }
+            .foregroundStyle(isEnabled ? tint : FleetV6.fg4)
+            .frame(maxWidth: .infinity)
+            .frame(height: 32)
+            .background { FleetKeycapBackground(radius: 7) }
+            .opacity(isEnabled ? 1 : 0.55)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(FleetPressStyle())
+        .disabled(!isEnabled)
+    }
+}
+
+/// `--well-bg` used as a fill inside a card (the output note, the ask block).
+struct FleetWellFill: ViewModifier {
+    var radius: CGFloat
+
+    func body(content: Content) -> some View {
+        content.background {
+            RoundedRectangle(cornerRadius: radius, style: .continuous)
+                .fill(FleetV6.wellBG)
+                .overlay(alignment: .bottom) {
+                    Rectangle().fill(Color.white.opacity(0.035)).frame(height: 1)
+                }
+                .clipShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
+        }
+    }
+}
+
+/// `:active { transform: translateY(1px) }` — every pressable face in the design
+/// sinks by a point.
+struct FleetPressStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .offset(y: configuration.isPressed ? 1 : 0)
+            .brightness(configuration.isPressed ? 0.04 : 0)
+            .animation(.easeOut(duration: 0.08), value: configuration.isPressed)
+    }
+}

--- a/apps/ios/Sources/FleetDeck/FleetDeckFeed.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckFeed.swift
@@ -1,0 +1,192 @@
+import SwiftUI
+
+// MARK: - Fleet feed
+//
+// `.ffeed` — what the agents did, newest first, across every Mac. Filterable
+// down to just the things blocked on you; when that list empties the panel says
+// so rather than showing an empty box.
+
+struct FleetFeedPanel: View {
+    let events: [FleetFeedEvent]
+    let channels: [FleetChannel]
+    let currentIndex: Int
+    let filter: FleetFeedFilter
+    let attentionCount: Int
+    let onFilter: (FleetFeedFilter) -> Void
+    let onSelect: (Int) -> Void
+
+    var body: some View {
+        FleetCard(padding: EdgeInsets(top: 12, leading: 14, bottom: 12, trailing: 14)) {
+            VStack(spacing: 0) {
+                FleetCardHead(title: "fleet feed") {
+                    Text("\(events.count) EVENTS")
+                        .font(FleetV6.mono(10, .medium))
+                        .tracking(1)
+                        .monospacedDigit()
+                        .foregroundStyle(FleetV6.fg4)
+                    filterChips
+                }
+
+                if events.isEmpty {
+                    emptyState
+                } else {
+                    list
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        }
+    }
+
+    // `.ff-filter`
+    private var filterChips: some View {
+        HStack(spacing: 0) {
+            chip(title: "ALL", isOn: filter == .all, showsDivider: false) { onFilter(.all) }
+            chip(title: "NEEDS YOU · \(attentionCount)", isOn: filter == .attention, showsDivider: true) {
+                onFilter(.attention)
+            }
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: 6, style: .continuous).strokeBorder(FleetV6.brk, lineWidth: 1)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+    }
+
+    private func chip(title: String, isOn: Bool, showsDivider: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(FleetV6.mono(9, .medium))
+                .tracking(1.08)
+                .foregroundStyle(isOn ? FleetV6.fg : FleetV6.fg4)
+                .padding(.horizontal, 9)
+                .padding(.vertical, 4)
+                .background(isOn ? Color.white.opacity(0.07) : .clear)
+                .overlay(alignment: .leading) {
+                    if showsDivider { Rectangle().fill(FleetV6.brk2).frame(width: 1) }
+                }
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(isOn ? [.isSelected, .isButton] : .isButton)
+    }
+
+    private var list: some View {
+        ScrollView(.vertical) {
+            LazyVStack(spacing: 0) {
+                ForEach(Array(events.enumerated()), id: \.element.id) { index, event in
+                    FleetFeedRow(
+                        event: event,
+                        channelLabel: channels.indices.contains(event.channelIndex)
+                            ? channels[event.channelIndex].channelLabel
+                            : "—",
+                        agentHue: channels.indices.contains(event.channelIndex)
+                            ? channels[event.channelIndex].hue
+                            : 0,
+                        isOnCurrent: event.channelIndex == currentIndex,
+                        showsRule: index < events.count - 1,
+                        onTap: { onSelect(event.channelIndex) }
+                    )
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 2)
+        }
+        .scrollIndicators(.hidden)
+        .padding(.horizontal, -4)
+        .modifier(FleetWellFill(radius: 4))
+        // The design fades the last 14px of the list so it reads as continuing
+        // past the card edge.
+        .mask {
+            LinearGradient(
+                stops: [
+                    .init(color: .black, location: 0),
+                    .init(color: .black, location: 0.93),
+                    .init(color: .clear, location: 1)
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        }
+    }
+
+    // `.ff-empty`
+    private var emptyState: some View {
+        VStack(spacing: 9) {
+            Text("QUEUE EMPTY")
+                .font(FleetV6.mono(12.5, .medium))
+                .tracking(2)
+                .foregroundStyle(FleetV6.green)
+            Text("nothing is waiting on you")
+                .font(FleetV6.mono(11))
+                .tracking(0.66)
+                .foregroundStyle(FleetV6.fg4)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+/// `.ff-row` — time, channel, agent, what happened.
+private struct FleetFeedRow: View {
+    let event: FleetFeedEvent
+    let channelLabel: String
+    let agentHue: Int
+    let isOnCurrent: Bool
+    let showsRule: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Text(event.time)
+                    .font(FleetV6.mono(9.5))
+                    .monospacedDigit()
+                    .foregroundStyle(FleetV6.fg4)
+                    .frame(width: 34, alignment: .leading)
+
+                Text(channelLabel)
+                    .font(FleetV6.mono(9.5, .medium))
+                    .tracking(0.95)
+                    .foregroundStyle(channelColor)
+                    .frame(width: 46, alignment: .leading)
+
+                HStack(spacing: 7) {
+                    Circle()
+                        .fill(FleetV6.agentHue(agentHue))
+                        .frame(width: 5, height: 5)
+                    Text(event.agent)
+                        .font(FleetV6.mono(11, .medium))
+                        .tracking(0.66)
+                        .foregroundStyle(FleetV6.fg2)
+                }
+                .frame(width: 70, alignment: .leading)
+
+                Text(event.text)
+                    .font(FleetV6.mono(11))
+                    .foregroundStyle(textColor)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(.horizontal, 2)
+            .padding(.vertical, 6)
+            .contentShape(Rectangle())
+            .overlay(alignment: .bottom) {
+                if showsRule { FleetDottedRule(color: Color.white.opacity(0.06)) }
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(channelLabel), \(event.agent), \(event.text), \(event.time) ago")
+    }
+
+    private var channelColor: Color {
+        if event.kind == .attn { return FleetV6.fg3 }
+        if isOnCurrent { return FleetV6.fg2 }
+        return FleetV6.fg4
+    }
+
+    private var textColor: Color {
+        switch event.kind {
+        case .hot, .attn: return FleetV6.fg2
+        case .normal:     return FleetV6.fg3
+        }
+    }
+}

--- a/apps/ios/Sources/FleetDeck/FleetDeckFixture.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckFixture.swift
@@ -1,0 +1,272 @@
+import Foundation
+
+/// The design's own `CHANS` / `FEED` / `LOGS` data, carried over verbatim so the
+/// deck can be rendered and reviewed against the source artifact without a Mac
+/// on the network. Used by `FleetDeckPreviewHost` (`--fleet-preview`) and by
+/// SwiftUI previews; never by a live deck.
+enum FleetDeckFixture {
+
+    static let channels: [FleetChannel] = [
+        FleetChannel(
+            id: "ch01",
+            channelLabel: "CH 01",
+            deviceName: "Arach MacBook Pro",
+            deviceIcon: .laptop,
+            appName: "Xcode",
+            fileName: "FleetDeckScreen.swift",
+            agentName: "CODEX",
+            hue: 0,
+            state: .run,
+            task: "Polishing the common deck layout — spacing pass on control tiles.",
+            steps: [
+                FleetStep(id: 0, state: .done, text: "Read design notes + current layout"),
+                FleetStep(id: 1, state: .done, text: "Retuned tile grid to 4-up"),
+                FleetStep(id: 2, state: .now, text: "Adjusting key-row shadows"),
+                FleetStep(id: 3, state: .queued, text: "Post diff for review")
+            ],
+            output: "Rebuilt tile bay at 150px; contrast on tile-meta bumped to pass at arm’s length.",
+            decision: nil,
+            lastEventText: "polishing common deck",
+            lastEventTime: "12s",
+            cpu: 24,
+            mem: 52,
+            latency: "14ms",
+            logLines: logLines(0),
+            logSource: "~/lats/ch01/agent.log",
+            logLineCount: 2100
+        ),
+        FleetChannel(
+            id: "ch02",
+            channelLabel: "CH 02",
+            deviceName: "Studio",
+            deviceIcon: .studio,
+            appName: "iTerm2",
+            fileName: "simulator · 12/18",
+            agentName: "TESTER",
+            hue: 1,
+            state: .run,
+            task: "Running the simulator suite across three device profiles.",
+            steps: [
+                FleetStep(id: 0, state: .done, text: "Booted 3 simulators"),
+                FleetStep(id: 1, state: .done, text: "Unit suite green · 212/212"),
+                FleetStep(id: 2, state: .now, text: "UI suite running · 12/18"),
+                FleetStep(id: 3, state: .queued, text: "Publish results to feed")
+            ],
+            output: "FleetDeckScreenTests: 12 of 18 passing so far, no flakes.",
+            decision: nil,
+            lastEventText: "UI suite 12/18",
+            lastEventTime: "4s",
+            cpu: 35,
+            mem: 59,
+            latency: "11ms",
+            logLines: logLines(1),
+            logSource: "~/lats/ch02/agent.log",
+            logLineCount: 2237
+        ),
+        FleetChannel(
+            id: "ch03",
+            channelLabel: "CH 03",
+            deviceName: "Mac mini",
+            deviceIcon: .mini,
+            appName: "Figma",
+            fileName: "lane model v3",
+            agentName: "SCOUT",
+            hue: 2,
+            state: .attn,
+            task: "Lane model review is blocked — two naming options need your call.",
+            steps: [
+                FleetStep(id: 0, state: .done, text: "Mapped interaction lanes"),
+                FleetStep(id: 1, state: .done, text: "Drafted two naming schemes"),
+                FleetStep(id: 2, state: .blocked, text: "Waiting on your pick"),
+                FleetStep(id: 3, state: .queued, text: "Apply across screens")
+            ],
+            output: "Option A: route/lane/bus. Option B: channel/track/send. Say the word.",
+            decision: FleetDecision(
+                question: "Which naming scheme should I apply across all screens?",
+                options: [
+                    FleetDecisionOption(
+                        id: "ch03-a",
+                        key: "A",
+                        title: "route / lane / bus",
+                        detail: "matches the audio-desk metaphor",
+                        verb: "APPLY",
+                        actionID: nil,
+                        resolvedTask: "Applying route/lane/bus naming across 14 screens.",
+                        resolvedOutput: "Renaming in progress — 6 of 14 screens updated, no conflicts.",
+                        feedText: "applying naming A · route/lane/bus"
+                    ),
+                    FleetDecisionOption(
+                        id: "ch03-b",
+                        key: "B",
+                        title: "channel / track / send",
+                        detail: "matches the deck labels",
+                        verb: "APPLY",
+                        actionID: nil,
+                        resolvedTask: "Applying channel/track/send naming across 14 screens.",
+                        resolvedOutput: "Renaming in progress — 6 of 14 screens updated, matches deck labels.",
+                        feedText: "applying naming B · channel/track/send"
+                    )
+                ]
+            ),
+            lastEventText: "awaiting your review",
+            lastEventTime: "2m",
+            cpu: 46,
+            mem: 66,
+            latency: "18ms",
+            logLines: logLines(2),
+            logSource: "~/lats/ch03/agent.log",
+            logLineCount: 2374
+        ),
+        FleetChannel(
+            id: "ch04",
+            channelLabel: "CH 04",
+            deviceName: "Build Mac",
+            deviceIcon: .laptop,
+            appName: "Safari",
+            fileName: "ci dashboard",
+            agentName: "BUILD",
+            hue: 3,
+            state: .attn,
+            task: "Build 412 is signed and staged — needs your go before it ships.",
+            steps: [
+                FleetStep(id: 0, state: .done, text: "Build 412 succeeded"),
+                FleetStep(id: 1, state: .done, text: "Artifacts signed + uploaded"),
+                FleetStep(id: 2, state: .blocked, text: "Waiting on ship approval"),
+                FleetStep(id: 3, state: .queued, text: "Push to TestFlight")
+            ],
+            output: "412 is clean: 0 warnings, 212/212 tests. Ship it or hold?",
+            decision: FleetDecision(
+                question: "Push build 412 to TestFlight now?",
+                options: [
+                    FleetDecisionOption(
+                        id: "ch04-a",
+                        key: "A",
+                        title: "Ship it",
+                        detail: "notify the fleet when live",
+                        verb: "PUSH",
+                        actionID: nil,
+                        resolvedTask: "Pushing build 412 to TestFlight and notifying the fleet.",
+                        resolvedOutput: "Upload started — processing usually takes about 8 minutes.",
+                        feedText: "shipping build 412 → TestFlight"
+                    ),
+                    FleetDecisionOption(
+                        id: "ch04-b",
+                        key: "B",
+                        title: "Hold for nightly",
+                        detail: "roll it into the 02:00 batch",
+                        verb: "HOLD",
+                        actionID: nil,
+                        resolvedTask: "Holding 412 — queued behind tonight’s nightly batch.",
+                        resolvedOutput: "412 parked. Nightly kicks off at 02:00 and will pick it up.",
+                        feedText: "held build 412 for nightly"
+                    )
+                ]
+            ),
+            lastEventText: "awaiting ship approval",
+            lastEventTime: "9m",
+            cpu: 8,
+            mem: 31,
+            latency: "12ms",
+            logLines: logLines(3),
+            logSource: "~/lats/ch04/agent.log",
+            logLineCount: 2511
+        )
+    ]
+
+    static let feed: [FleetFeedEvent] = [
+        event(0, "4s", 1, "TESTER", "UI suite 12/18 · no flakes", .normal),
+        event(1, "12s", 0, "CODEX", "tile bay rebuilt · diff staged", .hot),
+        event(2, "31s", 1, "TESTER", "unit suite green · 212/212", .normal),
+        event(3, "48s", 0, "CODEX", "key-row shadow pass started", .normal),
+        event(4, "1m", 2, "SCOUT", "needs your call · lane naming", .attn),
+        event(5, "2m", 3, "BUILD", "needs your go · ship build 412", .attn),
+        event(6, "2m", 0, "CODEX", "read design notes · started task", .normal),
+        event(7, "3m", 2, "SCOUT", "drafted naming schemes A/B", .normal),
+        event(8, "5m", 1, "TESTER", "booted 3 simulators", .normal),
+        event(9, "9m", 3, "BUILD", "build 412 signed · 0 warnings", .normal)
+    ]
+
+    private static func event(
+        _ index: Int,
+        _ time: String,
+        _ channel: Int,
+        _ agent: String,
+        _ text: String,
+        _ kind: FleetFeedKind
+    ) -> FleetFeedEvent {
+        FleetFeedEvent(id: "fx-\(index)", time: time, channelIndex: channel, agent: agent, text: text, kind: kind)
+    }
+
+    // MARK: Logs
+
+    private static let rawLogs: [[(String, String, String, FleetLogStyle)]] = [
+        [
+            ("09:40:38", "agent", "picked up task · deck layout polish", .dim),
+            ("09:40:41", "fs", "watching 24 files in FleetDeck/", .dim),
+            ("09:40:44", "agent", "read design notes · 6 constraints", .normal),
+            ("09:40:51", "layout", "measuring tile bay at arm’s length", .dim),
+            ("09:40:57", "layout", "row pitch 128 → 150px", .normal),
+            ("09:41:02", "xcodebuild", "Compiling FleetDeckScreen.swift", .dim),
+            ("09:41:04", "layout", "tile grid → 4 columns, pitch 150px", .normal),
+            ("09:41:07", "layout", "contrast(tile-meta) 3.1 → 4.6 · pass", .normal),
+            ("09:41:09", "xcodebuild", "Build succeeded · 0 warnings", .dim),
+            ("09:41:12", "agent", "shadow pass · key row, 3 of 5 layers", .highlight),
+            ("09:41:14", "diff", "+142 −38 · 2 files staged", .normal),
+            ("09:41:15", "agent", "waiting for review before commit", .dim)
+        ],
+        [
+            ("09:40:12", "agent", "picked up task · simulator suite", .dim),
+            ("09:40:18", "simctl", "erasing stale devices · 3 removed", .dim),
+            ("09:40:24", "simctl", "Booted iPhone SE · iOS 18.2", .dim),
+            ("09:40:27", "xctest", "discovering test bundles", .dim),
+            ("09:40:29", "xctest", "230 cases across 4 targets", .normal),
+            ("09:40:31", "simctl", "Booted iPhone 15 Pro · iOS 18.2", .dim),
+            ("09:40:33", "simctl", "Booted iPad Pro 11″ · iOS 18.2", .dim),
+            ("09:40:35", "xctest", "FleetDeckUnitTests · 212/212 passed", .normal),
+            ("09:40:52", "xctest", "FleetDeckScreenTests · starting 18 cases", .dim),
+            ("09:41:03", "xctest", "case 09 testChannelSwitch · 0.41s", .normal),
+            ("09:41:08", "xctest", "case 12 testDecisionRoute · 0.36s", .normal),
+            ("09:41:11", "agent", "12 of 18 green · no flakes detected", .highlight)
+        ],
+        [
+            ("09:38:31", "agent", "picked up task · lane model review", .dim),
+            ("09:38:40", "figma", "fetching lane model v3", .dim),
+            ("09:38:47", "figma", "14 frames · 62 layers", .normal),
+            ("09:38:55", "agent", "diffing against v2 naming", .dim),
+            ("09:38:58", "agent", "9 labels differ", .normal),
+            ("09:39:02", "figma", "opened lane model v3 · 14 frames", .dim),
+            ("09:39:20", "agent", "mapped 6 interaction lanes", .normal),
+            ("09:39:44", "agent", "naming scheme A · route / lane / bus", .normal),
+            ("09:39:46", "agent", "naming scheme B · channel / track / send", .normal),
+            ("09:39:47", "agent", "conflict: deck labels already say channel", .warn),
+            ("09:39:48", "agent", "blocked · needs a human decision", .warn),
+            ("09:41:15", "agent", "idle 2m · holding 14 frames unrenamed", .dim)
+        ],
+        [
+            ("09:31:40", "agent", "nightly queue drained · 0 pending", .dim),
+            ("09:31:52", "git", "fetched origin/main · 4 commits", .dim),
+            ("09:32:01", "ci", "resolving package graph", .dim),
+            ("09:32:05", "ci", "cache hit · restored 1.2 GB", .normal),
+            ("09:32:08", "ci", "build 412 queued", .normal),
+            ("09:32:10", "ci", "build 412 · archive started", .dim),
+            ("09:33:58", "ci", "archive succeeded in 1m48s", .normal),
+            ("09:34:02", "codesign", "signed with Developer ID · valid", .dim),
+            ("09:34:19", "ci", "artifacts uploaded · 84.2 MB", .normal),
+            ("09:34:20", "ci", "tests 212/212 · warnings 0", .highlight),
+            ("09:34:21", "agent", "ship gate · needs approval to push", .warn),
+            ("09:41:15", "agent", "holding · nightly window opens 02:00", .dim)
+        ]
+    ]
+
+    private static func logLines(_ channel: Int) -> [FleetLogLine] {
+        rawLogs[channel].enumerated().map { index, line in
+            FleetLogLine(
+                id: "log-\(channel)-\(index)",
+                time: line.0,
+                tag: line.1,
+                message: line.2,
+                style: line.3
+            )
+        }
+    }
+}

--- a/apps/ios/Sources/FleetDeck/FleetDeckFocusPane.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckFocusPane.swift
@@ -1,0 +1,181 @@
+import SwiftUI
+
+// MARK: - Focus pane
+//
+// `.pv` — the focus layout's left column: one Mac's agent log at full size,
+// tailing. The channel strip collapses to a rail above it, so the deck goes from
+// "watch four" to "watch one" without changing where anything lives.
+
+struct FleetFocusPane: View {
+    let channel: FleetChannel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            caption
+            screen
+        }
+    }
+
+    // `.pv-cap`
+    private var caption: some View {
+        HStack(spacing: 8) {
+            HStack(spacing: 6) {
+                FleetDot(color: FleetV6.green, size: 4)
+                Text("LIVE")
+            }
+            Text(channel.deviceName).foregroundStyle(FleetV6.fg3)
+            Text("·").foregroundStyle(Color.white.opacity(0.14))
+            Text(channel.appName)
+            Text("·").foregroundStyle(Color.white.opacity(0.14))
+            Text(channel.state.label).foregroundStyle(stateColor)
+            Spacer(minLength: 8)
+            Text("\(channel.logLineCount.formatted()) lines")
+                .monospacedDigit()
+        }
+        .font(FleetV6.mono(9, .medium))
+        .tracking(1.44)
+        .foregroundStyle(FleetV6.fg4)
+        .lineLimit(1)
+        .padding(.horizontal, 3)
+        .padding(.bottom, 8)
+    }
+
+    private var stateColor: Color {
+        switch channel.state {
+        case .run:  return FleetV6.fg3
+        case .attn: return FleetV6.amber
+        case .idle: return FleetV6.fg4
+        case .down: return FleetV6.red
+        }
+    }
+
+    // `.pv-screen`
+    private var screen: some View {
+        VStack(spacing: 0) {
+            logHead
+            logBody
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background {
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(FleetV6.wellBG)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .strokeBorder(FleetV6.brk2, lineWidth: 1)
+                }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+    }
+
+    // `.lg-head`
+    private var logHead: some View {
+        HStack(spacing: 12) {
+            Text(channel.appName).foregroundStyle(FleetV6.fg3)
+            Text(channel.logSource)
+                .font(FleetV6.mono(9.5, .medium))
+                .tracking(0.38)
+                .lineLimit(1)
+                .truncationMode(.head)
+            Spacer(minLength: 8)
+            Text("FOLLOW · TAIL")
+        }
+        .font(FleetV6.mono(9, .medium))
+        .tracking(1.26)
+        .foregroundStyle(FleetV6.fg4)
+        .padding(.horizontal, 12)
+        .frame(height: 22)
+        .overlay(alignment: .bottom) { Rectangle().fill(FleetV6.brk2).frame(height: 1) }
+    }
+
+    // `.lg-body` — pinned to the bottom, newest line last, with the top of the
+    // scrollback fading out.
+    private var logBody: some View {
+        ScrollViewReader { proxy in
+            ScrollView(.vertical) {
+                VStack(alignment: .leading, spacing: 1) {
+                    ForEach(channel.logLines) { line in
+                        FleetLogRow(line: line)
+                    }
+                    HStack(spacing: 12) {
+                        Color.clear.frame(width: 56, height: 1)
+                        Color.clear.frame(width: 66, height: 1)
+                        FleetCaret()
+                        Spacer(minLength: 0)
+                    }
+                    .id(Self.tailID)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 13)
+                .padding(.top, 14)
+                .padding(.bottom, 12)
+                .frame(maxHeight: .infinity, alignment: .bottom)
+            }
+            .scrollIndicators(.hidden)
+            .defaultScrollAnchor(.bottom)
+            .onChange(of: channel.logLines.count) { _, _ in
+                withAnimation(.easeOut(duration: 0.2)) { proxy.scrollTo(Self.tailID, anchor: .bottom) }
+            }
+        }
+        .mask {
+            LinearGradient(
+                stops: [
+                    .init(color: .clear, location: 0),
+                    .init(color: .black, location: 0.08),
+                    .init(color: .black, location: 1)
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        }
+    }
+
+    private static let tailID = "fleet-log-tail"
+}
+
+/// `.lg-row` — timestamp, source tag, message.
+private struct FleetLogRow: View {
+    let line: FleetLogLine
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            Text(line.time)
+                .font(FleetV6.mono(10, weight))
+                .monospacedDigit()
+                .foregroundStyle(line.style == .warn ? FleetV6.amber : FleetV6.fg4)
+                .frame(width: 56, alignment: .leading)
+
+            Text(line.tag)
+                .font(FleetV6.mono(9.5, weight))
+                .tracking(0.95)
+                .foregroundStyle(line.style == .warn ? FleetV6.amber : FleetV6.fg4)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(width: 66, alignment: .leading)
+
+            Text(line.message)
+                .font(FleetV6.mono(11, weight))
+                .foregroundStyle(messageColor)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.vertical, 1.5)
+    }
+
+    private var weight: Font.Weight {
+        switch line.style {
+        case .dim:       return .light
+        case .highlight: return .medium
+        default:         return .regular
+        }
+    }
+
+    private var messageColor: Color {
+        switch line.style {
+        case .normal:    return FleetV6.fg3
+        case .dim:       return FleetV6.fg4
+        case .highlight: return FleetV6.fg
+        case .warn:      return FleetV6.amber
+        }
+    }
+}

--- a/apps/ios/Sources/FleetDeck/FleetDeckHost.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckHost.swift
@@ -1,0 +1,233 @@
+import Combine
+import DeckKit
+import SwiftUI
+
+/// Keeps a `FleetDeckModel` fed from live `DeckStore`s.
+///
+/// The stores are independent `ObservableObject`s, one per Mac, so the host
+/// subscribes to each and re-projects the deck whenever any of them lands a new
+/// snapshot. Re-projection happens on the next run loop turn — `objectWillChange`
+/// fires *before* the store mutates — so the model always reads settled values.
+@MainActor
+final class FleetDeckController: ObservableObject {
+    let model = FleetDeckModel()
+
+    private var stores: [DeckStore] = []
+    private var cancellables: [AnyCancellable] = []
+    private var modelCancellables: [AnyCancellable] = []
+
+    init() {
+        // Selection lives on the model, but the host reads per-host values off
+        // `currentStore` (voice phase, busy, which console actions the Mac can
+        // service). Without forwarding, picking a channel invalidates the deck
+        // body but not the host that computes those, so they keep describing
+        // the Mac you just left.
+        modelCancellables.append(
+            model.objectWillChange.sink { [weak self] _ in self?.objectWillChange.send() }
+        )
+        // Command sets belong to the Mac on deck; re-derive them whenever the
+        // deck changes hands.
+        modelCancellables.append(
+            model.$currentIndex
+                .removeDuplicates()
+                .receive(on: RunLoop.main)
+                .sink { [weak self] _ in self?.syncSets() }
+        )
+    }
+
+    func bind(stores: [DeckStore], initialMachineID: String? = nil) {
+        let sameStores = stores.count == self.stores.count
+            && zip(stores, self.stores).allSatisfy { $0.sessionID == $1.sessionID }
+        guard !sameStores else {
+            requestHost(machineID: initialMachineID, in: stores)
+            refresh()
+            return
+        }
+
+        self.stores = stores
+        cancellables = stores.map { store in
+            store.objectWillChange
+                .receive(on: RunLoop.main)
+                .sink { [weak self] _ in self?.refresh() }
+        }
+        requestHost(machineID: initialMachineID, in: stores)
+        refresh()
+    }
+
+    /// Translate the presenter's `BridgeEndpoint.id` into the channel identity
+    /// the model speaks — a store's `sessionID`.
+    ///
+    /// One-shot. `bind` runs again on every roster change, and an opening
+    /// preference must not survive as standing policy: otherwise any Mac
+    /// appearing or dropping would drag the user back to wherever they entered.
+    private var didApplyInitialHost = false
+
+    private func requestHost(machineID: String?, in stores: [DeckStore]) {
+        guard !didApplyInitialHost, let machineID else { return }
+        guard let match = stores.first(where: { $0.activeEndpoint?.id == machineID }) else {
+            // Its store may still be connecting; try again on the next roster change.
+            return
+        }
+        didApplyInitialHost = true
+        model.requestHost(match.sessionID.uuidString)
+    }
+
+    func refresh() {
+        let channels = FleetDeckAdapter.channels(from: stores)
+        let feed = FleetDeckAdapter.feed(from: stores, channels: channels)
+        model.ingest(channels: channels, feed: feed)
+        // After ingest, never before: ingest can move the selection.
+        syncSets()
+    }
+
+    private func syncSets() {
+        // Always reassign. Two Macs can advertise pages with identical ids, so
+        // there is no cheap equality check that is also correct — and getting
+        // this wrong means dispatching one Mac's tile to another.
+        model.sets = FleetDeckAdapter.sets(from: currentStore)
+    }
+
+    /// The store backing whatever channel is on deck.
+    ///
+    /// Resolved by identity rather than position. Indexing `stores` with
+    /// `model.currentIndex` happens to work — the adapter builds one channel per
+    /// store, in order — but nothing enforces that, and every control on the
+    /// deck routes through here. If the two collections ever diverge, the
+    /// failure is keystrokes and trackpad input landing on the wrong Mac, which
+    /// is both silent and the worst outcome this screen has.
+    var currentStore: DeckStore? {
+        guard let hostID = model.currentHostID else { return stores.first }
+        return stores.first { $0.sessionID.uuidString == hostID } ?? stores.first
+    }
+
+    /// Which of the three console buttons the Mac on deck can actually service.
+    /// The bridge has no dedicated agent-control actions yet, so this looks for
+    /// a matching tile in the Mac's advertised cockpit pages.
+    func availableConsoleActions() -> Set<FleetConsoleAction> {
+        guard let store = currentStore else { return [] }
+        let tiles = (store.snapshot?.cockpit?.pages ?? []).flatMap(\.tiles)
+        var available: Set<FleetConsoleAction> = []
+        for action in [FleetConsoleAction.approve, .steer, .recap] where resolve(action, in: tiles) != nil {
+            available.insert(action)
+        }
+        return available
+    }
+
+    func perform(_ action: FleetConsoleAction) {
+        guard let store = currentStore else { return }
+        let tiles = (store.snapshot?.cockpit?.pages ?? []).flatMap(\.tiles)
+        guard let tile = resolve(action, in: tiles), let actionID = tile.actionID else { return }
+        store.perform(actionID: actionID, pageID: "cockpit", payload: tile.payload, label: tile.title)
+    }
+
+    private func resolve(_ action: FleetConsoleAction, in tiles: [DeckCockpitTile]) -> DeckCockpitTile? {
+        tiles.first { tile in
+            guard tile.isEnabled, tile.actionID != nil else { return false }
+            let haystack = [tile.shortcutID, tile.actionID ?? ""].map { $0.lowercased() }
+            return action.shortcutKeys.contains { key in
+                haystack.contains { $0 == key || $0.hasSuffix(".\(key)") }
+            }
+        }
+    }
+}
+
+extension FleetConsoleAction {
+    /// Shortcut / action identifiers a Mac may advertise for this control.
+    var shortcutKeys: [String] {
+        switch self {
+        case .approve: return ["approve", "unblock"]
+        case .steer:   return ["steer", "redirect"]
+        case .recap:   return ["summarize", "recap", "digest"]
+        }
+    }
+}
+
+// MARK: - Host
+
+/// Binds the deck to a set of live Macs and wires every control to the Mac that
+/// is on deck.
+struct FleetDeckHost: View {
+    let stores: [DeckStore]
+    /// `BridgeEndpoint.id` of the Mac the deck should open on, when the caller
+    /// knows which one the user meant.
+    var initialMachineID: String?
+    var onClose: (() -> Void)?
+
+    @StateObject private var controller = FleetDeckController()
+
+    var body: some View {
+        FleetDeckView(
+            model: controller.model,
+            voicePhase: controller.currentStore?.snapshot?.voice?.phase,
+            voiceTranscript: controller.currentStore?.snapshot?.voice?.transcript ?? "",
+            isBusy: controller.currentStore?.isPerformingAction ?? false,
+            isOnline: !stores.isEmpty && stores.contains { $0.snapshot != nil },
+            enabledConsoleActions: controller.availableConsoleActions(),
+            onClose: onClose,
+            onPushToTalk: { controller.currentStore?.toggleVoice() },
+            onTile: { tile in
+                guard let actionID = tile.actionID else { return }
+                controller.currentStore?.perform(
+                    actionID: actionID,
+                    pageID: controller.model.activeSet?.id ?? "cockpit",
+                    payload: tile.payload,
+                    label: tile.title
+                )
+            },
+            onKey: { key, modifiers in
+                controller.currentStore?.perform(
+                    actionID: "keys.send",
+                    pageID: "cockpit",
+                    payload: [
+                        "key": .string(key),
+                        "modifiers": .array(modifiers.map { .string($0) })
+                    ],
+                    label: (modifiers + [key.uppercased()]).joined()
+                )
+            },
+            onChoose: { option in
+                guard let actionID = option.actionID else { return }
+                controller.currentStore?.perform(
+                    actionID: actionID,
+                    pageID: "cockpit",
+                    label: option.title
+                )
+            },
+            onConsoleAction: { controller.perform($0) },
+            onTrackpad: { event, dx, dy in
+                controller.currentStore?.sendTrackpad(event: event, dx: dx, dy: dy)
+            }
+        )
+        .onAppear { controller.bind(stores: stores, initialMachineID: initialMachineID) }
+        .onChange(of: stores.map(\.sessionID)) { _, _ in
+            // Keep passing the requested host: it may only now have connected.
+            controller.bind(stores: stores, initialMachineID: initialMachineID)
+        }
+    }
+}
+
+#if DEBUG
+/// Renders the deck against the design's own fixture data — no Macs required.
+struct FleetDeckFixtureHost: View {
+    @StateObject private var model = FleetDeckModel()
+    var initialLayout: FleetDeckLayout = .ops
+    var onClose: (() -> Void)?
+
+    var body: some View {
+        FleetDeckView(
+            model: model,
+            voicePhase: .listening,
+            voiceTranscript: "run the simulator suite again, then post the diff for review",
+            isOnline: true,
+            enabledConsoleActions: [.approve, .steer, .recap],
+            onClose: onClose
+        )
+        .onAppear {
+            if model.channels.isEmpty {
+                model.loadFixture()
+                model.layout = initialLayout
+            }
+        }
+    }
+}
+#endif

--- a/apps/ios/Sources/FleetDeck/FleetDeckModel.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckModel.swift
@@ -1,0 +1,403 @@
+import DeckKit
+import SwiftUI
+
+// MARK: - Channel
+
+/// Mirrors the design's three channel states. The design leads with what the
+/// agent is doing, not what the Mac is: a channel is `attn` when its agent is
+/// blocked on a human decision, which is the only state that reorders the strip.
+enum FleetChannelState: String {
+    case run, attn, idle, down
+
+    var label: String {
+        switch self {
+        case .run:  return "RUNNING"
+        case .attn: return "NEEDS YOU"
+        case .idle: return "IDLE"
+        case .down: return "UNREACHABLE"
+        }
+    }
+}
+
+/// `.chan-ic` — the three machine silhouettes the design draws.
+enum FleetDeviceIcon: String {
+    case laptop, studio, mini
+
+    var symbol: String {
+        switch self {
+        case .laptop: return "laptopcomputer"
+        case .studio: return "desktopcomputer"
+        case .mini:   return "macmini"
+        }
+    }
+
+    /// Best-effort match on the Mac's advertised name.
+    static func infer(from name: String) -> FleetDeviceIcon {
+        let lowered = name.lowercased()
+        if lowered.contains("studio") || lowered.contains("imac") { return .studio }
+        if lowered.contains("mini") { return .mini }
+        return .laptop
+    }
+}
+
+/// Design step states: `1` done, `2` running, `3` blocked on you, `0` queued.
+enum FleetStepState {
+    case done, now, blocked, queued
+}
+
+struct FleetStep: Identifiable {
+    let id: Int
+    var state: FleetStepState
+    var text: String
+}
+
+struct FleetDecisionOption: Identifiable {
+    let id: String
+    /// The keyboard letter shown in the `kbd` chip — A, B, …
+    var key: String
+    var title: String
+    var detail: String
+    /// The verb on the right edge of the row: APPLY / PUSH / HOLD.
+    var verb: String
+    /// Bridge action fired when the option is picked. `nil` in the design fixture.
+    var actionID: String?
+    /// What the console reads once this option is taken.
+    var resolvedTask: String
+    var resolvedOutput: String
+    var feedText: String
+}
+
+struct FleetDecision {
+    var question: String
+    var options: [FleetDecisionOption]
+}
+
+struct FleetChannel: Identifiable {
+    let id: String
+    var channelLabel: String
+    var deviceName: String
+    var deviceIcon: FleetDeviceIcon
+    var appName: String
+    var fileName: String
+    var agentName: String
+    /// 0-based index into `FleetV6.agentHues`.
+    var hue: Int
+    var state: FleetChannelState
+    var task: String
+    var steps: [FleetStep]
+    var output: String
+    var decision: FleetDecision?
+    var lastEventText: String
+    var lastEventTime: String
+    /// Last transport or action failure, if any. Deliberately *not* folded into
+    /// `state`: a rejected trackpad gesture is not an agent asking you a
+    /// question, and conflating them hijacks the deck's triage.
+    var fault: String? = nil
+    var cpu: Int?
+    var mem: Int?
+    var latency: String?
+    var logLines: [FleetLogLine]
+    var logSource: String
+    var logLineCount: Int
+
+    /// `.chan-foot` right edge — "CPU 24% · 14ms".
+    var footerMetrics: String {
+        var parts: [String] = []
+        if let cpu { parts.append("CPU \(cpu)%") }
+        if let latency { parts.append(latency) }
+        else if let mem { parts.append("MEM \(mem)%") }
+        return parts.joined(separator: " · ")
+    }
+}
+
+// MARK: - Feed
+
+enum FleetFeedKind {
+    case normal, hot, attn
+}
+
+struct FleetFeedEvent: Identifiable {
+    let id: String
+    var time: String
+    /// Index into `FleetDeckModel.channels`.
+    var channelIndex: Int
+    var agent: String
+    var text: String
+    var kind: FleetFeedKind
+}
+
+enum FleetFeedFilter {
+    case all, attention
+}
+
+// MARK: - Log
+
+enum FleetLogStyle {
+    case normal, dim, highlight, warn
+}
+
+struct FleetLogLine: Identifiable {
+    let id: String
+    var time: String
+    var tag: String
+    var message: String
+    var style: FleetLogStyle
+}
+
+// MARK: - Command bay
+
+struct FleetCommandTile: Identifiable {
+    let id: String
+    var title: String
+    /// The uppercase caption under the title — "01 · spawn".
+    var meta: String
+    var symbol: String
+    var actionID: String?
+    var payload: [String: DeckValue] = [:]
+}
+
+struct FleetCommandSet: Identifiable {
+    let id: String
+    var key: String
+    var tiles: [FleetCommandTile]
+}
+
+// MARK: - Layout
+
+/// The design's two body layouts. `ops` is the default four-up triage view;
+/// `focus` collapses the channel strip to a switcher rail and gives one Mac's
+/// log the full panel.
+enum FleetDeckLayout: String {
+    case ops, focus
+
+    var label: String {
+        switch self {
+        case .ops:   return "AGENT OPS"
+        case .focus: return "FOCUS"
+        }
+    }
+}
+
+// MARK: - Model
+
+/// Holds everything the deck renders plus the selection/triage logic the design
+/// spells out in JS: attention-first channel ordering, "answer here, then jump
+/// to the next blocker", and the optimistic console flip after a decision.
+@MainActor
+final class FleetDeckModel: ObservableObject {
+    @Published private(set) var channels: [FleetChannel] = []
+    @Published private(set) var feed: [FleetFeedEvent] = []
+    @Published var sets: [FleetCommandSet] = FleetCommandSet.canonical
+
+    @Published var currentIndex = 0
+    /// Voice routing target. `channels.count` means ALL.
+    @Published var routeIndex = 0
+    @Published var setIndex = 0
+    @Published var feedFilter: FleetFeedFilter = .all
+    @Published var layout: FleetDeckLayout = .ops
+    @Published private(set) var lastResolvedIndex: Int?
+
+    /// Set for the design fixture so decisions resolve locally instead of being
+    /// dispatched to a Mac.
+    private(set) var isFixture = false
+
+    /// Cleared once the deck has picked its opening channel.
+    private var needsInitialSelection = true
+
+    /// A host the presenter asked us to open on, held until a matching channel
+    /// exists. Honored once, then cleared — after that the user's taps win.
+    private var pendingHostID: String?
+
+    init() {}
+
+    // MARK: Derived
+
+    var current: FleetChannel? {
+        channels.indices.contains(currentIndex) ? channels[currentIndex] : nil
+    }
+
+    /// The identity of whatever is on deck. This — not `currentIndex` — is what
+    /// callers should resolve a host against; indices shift as channels come and
+    /// go, and nothing guarantees channel order matches any other collection's.
+    var currentHostID: String? { current?.id }
+
+    var attentionIndices: [Int] {
+        channels.indices.filter { channels[$0].state == .attn }
+    }
+
+    /// Blocked channels promote to the front of the strip — the design's only
+    /// triage affordance beyond the status dot.
+    var channelOrder: [Int] {
+        let blocked = channels.indices.filter { channels[$0].state == .attn }
+        let rest = channels.indices.filter { channels[$0].state != .attn }
+        return blocked + rest
+    }
+
+    var visibleFeed: [FleetFeedEvent] {
+        switch feedFilter {
+        case .all: return feed
+        case .attention: return feed.filter { $0.kind == .attn }
+        }
+    }
+
+    var routeLabel: String {
+        guard channels.indices.contains(routeIndex) else { return "ALL" }
+        return channels[routeIndex].channelLabel
+    }
+
+    var activeSet: FleetCommandSet? {
+        sets.indices.contains(setIndex) ? sets[setIndex] : nil
+    }
+
+    // MARK: Selection
+
+    func select(_ index: Int) {
+        guard channels.indices.contains(index), index != currentIndex else { return }
+        // A deliberate tap retires any host request still waiting to land, so a
+        // late arrival cannot yank the user off the channel they just chose.
+        pendingHostID = nil
+        currentIndex = index
+        routeIndex = index
+    }
+
+    /// Put a specific host on deck. Used when the deck is opened from somewhere
+    /// that already knows which Mac the user meant — tapping one on Home, say.
+    /// An explicit request outranks the "open on what needs you" default: the
+    /// user named a Mac, so triage does not get to override them.
+    func requestHost(_ hostID: String?) {
+        guard let hostID else { return }
+        needsInitialSelection = false
+        if let index = channels.firstIndex(where: { $0.id == hostID }) {
+            currentIndex = index
+            routeIndex = index
+            pendingHostID = nil
+        } else {
+            // The channel may not exist yet — its store is still connecting.
+            pendingHostID = hostID
+        }
+    }
+
+    /// Jump to the next channel that is blocked on a decision, skipping `from`.
+    func nextBlocker(from index: Int) -> Int? {
+        attentionIndices.first { $0 != index }
+    }
+
+    /// The status-bar ATTN chip: hop to the first blocker, or the next one if
+    /// you are already standing on a blocker.
+    func focusAttention() {
+        let blocked = attentionIndices
+        guard !blocked.isEmpty else { return }
+        if blocked.contains(currentIndex) {
+            if let next = nextBlocker(from: currentIndex) { select(next) }
+        } else if let first = blocked.first {
+            select(first)
+        }
+    }
+
+    // MARK: Decisions
+
+    /// Answer a channel's open question. The console flips to the chosen branch
+    /// immediately and the deck moves on to the next blocker, so the user never
+    /// has to go looking for what is waiting.
+    func resolve(channelIndex: Int, optionIndex: Int, dispatch: ((FleetDecisionOption) -> Void)? = nil) {
+        guard channels.indices.contains(channelIndex),
+              let decision = channels[channelIndex].decision,
+              decision.options.indices.contains(optionIndex)
+        else { return }
+
+        let option = decision.options[optionIndex]
+        dispatch?(option)
+
+        var channel = channels[channelIndex]
+        channel.decision = nil
+        channel.state = .run
+        channel.task = option.resolvedTask
+        channel.output = option.resolvedOutput
+        channel.steps = channel.steps.map { step in
+            guard step.state == .blocked else { return step }
+            var resolved = step
+            resolved.state = .done
+            resolved.text = "You chose: \(option.title)"
+            return resolved
+        }
+        if let queued = channel.steps.firstIndex(where: { $0.state == .queued }) {
+            channel.steps[queued].state = .now
+        }
+        channel.lastEventText = option.feedText
+        channel.lastEventTime = "now"
+        channels[channelIndex] = channel
+
+        feed.removeAll { $0.channelIndex == channelIndex && $0.kind == .attn }
+        feed.insert(
+            FleetFeedEvent(
+                id: "resolved-\(channelIndex)-\(option.id)",
+                time: "now",
+                channelIndex: channelIndex,
+                agent: channel.agentName,
+                text: option.feedText,
+                kind: .hot
+            ),
+            at: 0
+        )
+
+        lastResolvedIndex = channelIndex
+
+        if let next = nextBlocker(from: channelIndex) {
+            currentIndex = next
+            routeIndex = next
+        } else if feedFilter == .attention {
+            feedFilter = .all
+        }
+    }
+
+    func deferDecision() {
+        if let next = nextBlocker(from: currentIndex) { select(next) }
+    }
+
+    // MARK: Ingest
+
+    /// Replace the deck's contents from live snapshots, holding the user's
+    /// place: selection follows the channel it was on, not its position.
+    /// Command sets are deliberately *not* ingested here. They belong to whichever
+    /// Mac is on deck, and selection can change inside this call — deriving them
+    /// from the pre-ingest host is how a tile advertised by one Mac ends up
+    /// dispatched to another. The controller sets them once selection settles.
+    func ingest(channels newChannels: [FleetChannel], feed newFeed: [FleetFeedEvent]) {
+        let previousID = channels.indices.contains(currentIndex) ? channels[currentIndex].id : nil
+        channels = newChannels
+        feed = newFeed
+
+        if let pendingHostID, let index = newChannels.firstIndex(where: { $0.id == pendingHostID }) {
+            // The host the presenter asked for has finally shown up.
+            currentIndex = index
+            routeIndex = index
+            self.pendingHostID = nil
+            needsInitialSelection = false
+        } else if needsInitialSelection, !newChannels.isEmpty {
+            // "The deck opens on what needs you."
+            currentIndex = newChannels.firstIndex { $0.state == .attn } ?? 0
+            routeIndex = currentIndex
+            needsInitialSelection = false
+        } else if let previousID, let index = newChannels.firstIndex(where: { $0.id == previousID }) {
+            currentIndex = index
+        } else {
+            currentIndex = min(currentIndex, max(0, newChannels.count - 1))
+        }
+        routeIndex = min(routeIndex, newChannels.count)
+        setIndex = min(setIndex, max(0, sets.count - 1))
+        if lastResolvedIndex.map({ !newChannels.indices.contains($0) }) ?? false {
+            lastResolvedIndex = nil
+        }
+    }
+
+    func loadFixture() {
+        isFixture = true
+        channels = FleetDeckFixture.channels
+        feed = FleetDeckFixture.feed
+        sets = FleetCommandSet.canonical
+        // "The deck opens on what needs you" — the design boots on CH 03.
+        currentIndex = 2
+        routeIndex = 2
+        needsInitialSelection = false
+    }
+}

--- a/apps/ios/Sources/FleetDeck/FleetDeckTheme.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckTheme.swift
@@ -1,0 +1,323 @@
+import SwiftUI
+
+// MARK: - Tokens
+//
+// Ported from the design source `Lats Fleet Deck v6.html` and its linked
+// `system.css` (claude.ai/design project e010d8da-5dd8-4f3f-bb3e-a24dd4c75532).
+//
+// The artifact is authored on a fixed 1376×1032 iPad-landscape canvas, so its
+// CSS pixel values map 1:1 to SwiftUI points — every number below is the
+// design's own. `oklch()` accents were converted to sRGB.
+
+enum FleetV6 {
+
+    // MARK: Text — now DeckTheme's ramp (the values were already identical)
+
+    static let fg      = DeckTheme.text
+    static let fg2     = DeckTheme.textSecondary
+    static let fg3     = DeckTheme.textTertiary
+    static let fg4     = DeckTheme.textDisabled
+
+    // MARK: Accents
+    //
+    // Sixteen hues collapse to two. Green in particular is deliberate: running
+    // is the default healthy state, and colouring it made the deck read as a
+    // board where everything is lit and therefore nothing is. Anything that
+    // used to be green/violet/blue now resolves to a text grey, so the only
+    // saturation left on screen is something asking for you.
+
+    static let green   = DeckTheme.textSecondary
+    static let violet  = DeckTheme.textSecondary
+    static let blue    = DeckTheme.textSecondary
+    static let amber   = DeckTheme.accent
+    static let red     = DeckTheme.error
+    static let tileIcon = DeckTheme.textSecondary
+
+    /// Identity no longer uses colour — a dot meant "which agent" in one place
+    /// and "what state" thirty lines later, which is the actual incoherence.
+    /// Identity is now icon + name + stable column position.
+    static func agentHue(_ index: Int) -> Color { DeckTheme.textSecondary }
+
+    // MARK: Hairlines
+
+    static let brk     = DeckTheme.hairline
+    static let brk2    = DeckTheme.hairline
+    static let dotted  = DeckTheme.hairline
+    static let seam    = Color.clear          // hard black seams: deleted
+
+    // MARK: Surfaces
+    //
+    // Every gradient is now a flat fill. The machined enclosure — bezels,
+    // keycaps, domes, black seams, top-gloss — was the technical vibe made
+    // literal, and none of it survives at the sizes it was drawn: nobody's eye
+    // resolves a three-stop keycap gradient on a 46pt key.
+
+    static let wellBG  = DeckTheme.well
+    static let cardBG  = DeckTheme.card
+    static let cardBR  = DeckTheme.hairline
+    static let heroBG  = DeckTheme.raised
+    static let heroBR  = DeckTheme.hairlineStrong
+
+    static let padBG       = DeckTheme.canvas
+    static let deckPanelBG = DeckTheme.canvas
+    static let bezel       = DeckTheme.raised
+    static let keycap      = DeckTheme.control
+    static let keycapHover = DeckTheme.raised
+    static let tileFace    = DeckTheme.card
+    static let dome        = DeckTheme.control
+    static let tilesWrapBG = DeckTheme.well
+    static let statusBG    = DeckTheme.canvas
+
+    // MARK: Type
+    //
+    // The deck was authored entirely in tracked monospace. It now speaks in the
+    // system face, because this app operates agents and dictation — not
+    // terminals — and a remote control should look like the OS it lives on
+    // rather than the thing it points at.
+    //
+    // `mono(_:_:)` keeps its name so 13 files of call sites stay put, but it is
+    // SF Pro now. The serif survives, and only for utterances: an agent's
+    // question, a transcript. It marks *someone is talking to you*.
+
+    static func mono(_ size: CGFloat, _ weight: Font.Weight = .regular) -> Font {
+        .system(size: size, weight: weight)
+    }
+
+    static func serif(_ size: CGFloat, _ weight: Font.Weight = .regular) -> Font {
+        .system(size: size, weight: weight, design: .serif)
+    }
+
+    // MARK: Metrics — the design's own px values, as points
+
+    enum M {
+        static let padH: CGFloat = 16
+        static let padTop: CGFloat = 12
+        static let padBottom: CGFloat = 9
+        static let stackGap: CGFloat = 9
+
+        static let topBarHeight: CGFloat = 26
+        static let channelsHeight: CGFloat = 158
+        static let channelsRailHeight: CGFloat = 52     // .layout-focus
+        static let voiceBarHeight: CGFloat = 58
+        static let statusHeight: CGFloat = 26
+
+        static let wellRadius: CGFloat = 10
+        static let panelRadius: CGFloat = 12
+        static let cardRadius: CGFloat = 5
+
+        static let panelBodyPadH: CGFloat = 15
+        static let panelBodyPadV: CGFloat = 12
+        static let bodyGap: CGFloat = 14
+        static let consoleWidth: CGFloat = 390          // #bodyOps  390px 1fr
+        static let focusConsoleWidth: CGFloat = 340     // #bodyFocus 1fr 340px
+
+        static let tilesHeight: CGFloat = 128
+        static let tileGap: CGFloat = 8
+        static let trackpadHeight: CGFloat = 84
+        static let keyRowHeight: CGFloat = 46
+    }
+
+    // MARK: Helper
+
+    static func rgb(_ hex: UInt32) -> Color {
+        Color(
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255
+        )
+    }
+}
+
+// MARK: - Surfaces
+
+/// `--well-bg` + `--well-sh` + `--well-lip`: a recessed well. The browser draws
+/// this with an inset box-shadow; natively it is a dark fill, a hairline inner
+/// stroke, and a lit bottom lip that reads as the far wall of the recess.
+struct FleetWell<Content: View>: View {
+    var radius: CGFloat = FleetV6.M.wellRadius
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        content()
+            .background {
+                RoundedRectangle(cornerRadius: radius, style: .continuous)
+                    .fill(FleetV6.wellBG)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: radius, style: .continuous)
+                            .strokeBorder(Color.white.opacity(0.03), lineWidth: 1)
+                    }
+                    .overlay(alignment: .top) {
+                        LinearGradient(
+                            colors: [Color.black.opacity(0.55), .clear],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                        .frame(height: 14)
+                        .allowsHitTesting(false)
+                    }
+                    .overlay(alignment: .bottom) {
+                        Rectangle()
+                            .fill(Color.white.opacity(0.035))
+                            .frame(height: 1)
+                    }
+                    .clipShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
+            }
+    }
+}
+
+/// `.mcard` — the flat card. `hero` promotes it to `.mcard.console` (raised,
+/// gradient face, top gloss); `recent` draws the eight corner ticks the design
+/// uses to mark the card that just changed.
+struct FleetCard<Content: View>: View {
+    var hero: Bool = false
+    var recent: Bool = false
+    var padding: EdgeInsets = EdgeInsets(top: 12, leading: 14, bottom: 12, trailing: 14)
+    @ViewBuilder var content: () -> Content
+
+    private let radius = FleetV6.M.cardRadius
+
+    var body: some View {
+        content()
+            .padding(padding)
+            .background {
+                ZStack {
+                    if hero {
+                        RoundedRectangle(cornerRadius: radius, style: .continuous)
+                            .fill(FleetV6.heroBG)
+                            .shadow(color: .black.opacity(0.9), radius: 22, y: 20)
+                        // ::before — a 46%-tall gloss down from the top edge
+                        LinearGradient(
+                            colors: [Color.white.opacity(0.035), .clear],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                        .clipShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
+                        .frame(maxHeight: .infinity, alignment: .top)
+                    } else {
+                        RoundedRectangle(cornerRadius: radius, style: .continuous)
+                            .fill(FleetV6.cardBG)
+                    }
+                }
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: radius, style: .continuous)
+                    .strokeBorder(
+                        recent ? Color.white.opacity(0.18) : (hero ? FleetV6.heroBR : FleetV6.cardBR),
+                        lineWidth: 1
+                    )
+            }
+            .overlay(alignment: .top) {
+                Rectangle().fill(Color.white.opacity(0.035)).frame(height: 1)
+                    .clipShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
+            }
+            .overlay { if recent { FleetCornerTicks() } }
+    }
+}
+
+/// `.mcard.recent::after` — 12×1.5pt ticks at each corner.
+private struct FleetCornerTicks: View {
+    private let length: CGFloat = 12
+    private let weight: CGFloat = 1.5
+
+    private let corners: [Alignment] = [.topLeading, .topTrailing, .bottomLeading, .bottomTrailing]
+
+    var body: some View {
+        ZStack {
+            ForEach(Array(corners.enumerated()), id: \.offset) { _, corner in
+                Color.clear.overlay(alignment: corner) {
+                    ZStack(alignment: corner) {
+                        Rectangle().fill(.white).frame(width: length, height: weight)
+                        Rectangle().fill(.white).frame(width: weight, height: length)
+                    }
+                }
+            }
+        }
+        .opacity(0.7)
+        .padding(-2)
+        .allowsHitTesting(false)
+    }
+}
+
+/// `.key` / `.abtn` / `.ask-opt` — one keycap face, reused everywhere the
+/// design presses a physical-feeling control into the enclosure.
+struct FleetKeycapBackground: View {
+    var radius: CGFloat = 7
+    var pressed: Bool = false
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: radius, style: .continuous)
+            .fill(pressed ? FleetV6.keycapHover : FleetV6.keycap)
+            .overlay {
+                RoundedRectangle(cornerRadius: radius, style: .continuous)
+                    .strokeBorder(Color.black.opacity(0.7), lineWidth: 1)
+            }
+            .overlay(alignment: .top) {
+                Rectangle().fill(Color.white.opacity(0.09)).frame(height: 1)
+                    .clipShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
+            }
+            .shadow(color: .black.opacity(0.6), radius: 2, y: 2)
+    }
+}
+
+/// The 30pt engineering grid printed on `.deck-panel`.
+/// Retired alongside `LatsGridBackground` — see the note there. Kept as an empty
+/// view so its call sites can stay put.
+struct FleetPanelGrid: View {
+    var spacing: CGFloat = 30
+    var line: Color = .clear
+
+    var body: some View {
+        EmptyView()
+    }
+}
+
+// MARK: - Small primitives
+
+/// `.lbl` — the 10pt tracked micro-cap that labels a region.
+struct FleetLabel: View {
+    let text: String
+    var size: CGFloat = 10
+    var color: Color = FleetV6.fg3
+
+    var body: some View {
+        Text(text.uppercased())
+            .font(FleetV6.mono(size, .medium))
+            .tracking(size * 0.18)
+            .foregroundStyle(color)
+    }
+}
+
+/// The status dot used in channel heads, the panel head, and the feed.
+struct FleetDot: View {
+    var color: Color = FleetV6.fg3
+    var size: CGFloat = 6
+    var glow: Bool = false
+
+    var body: some View {
+        Circle()
+            .fill(color)
+            .frame(width: size, height: size)
+            .shadow(color: glow ? color.opacity(0.8) : .clear, radius: glow ? 5 : 0)
+    }
+}
+
+/// A dotted rule. The design uses `1px dotted` under every card head; SwiftUI
+/// needs the dash pattern spelled out.
+struct FleetDottedRule: View {
+    var color: Color = FleetV6.dotted
+
+    var body: some View {
+        Rectangle()
+            .fill(.clear)
+            .frame(height: 1)
+            .overlay {
+                GeometryReader { proxy in
+                    Path { path in
+                        path.move(to: CGPoint(x: 0, y: 0.5))
+                        path.addLine(to: CGPoint(x: proxy.size.width, y: 0.5))
+                    }
+                    .stroke(color, style: StrokeStyle(lineWidth: 1, dash: [1, 2]))
+                }
+            }
+    }
+}

--- a/apps/ios/Sources/FleetDeck/FleetDeckView.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckView.swift
@@ -1,0 +1,385 @@
+import DeckKit
+import SwiftUI
+
+// MARK: - Fleet Deck
+//
+// Native port of the design source `Lats Fleet Deck v6.html`
+// (claude.ai/design project e010d8da-5dd8-4f3f-bb3e-a24dd4c75532).
+//
+// The premise: this deck steers *agents*, not cursors. Four Macs sit across the
+// top as channels; whichever one needs a human decision sorts to the front and
+// its question is answerable inline. Below it, one enclosure holds the console,
+// the fleet feed, the command bay, and the key strip.
+
+struct FleetDeckView: View {
+    @ObservedObject var model: FleetDeckModel
+
+    var voicePhase: DeckVoicePhase?
+    var voiceTranscript: String = ""
+    var isBusy: Bool = false
+    var isOnline: Bool = true
+    var showsTrackpadStrip: Bool = false
+    /// Console buttons the Mac on deck can service; the rest render disabled.
+    var enabledConsoleActions: Set<FleetConsoleAction> = []
+
+    var onClose: (() -> Void)?
+    var onPushToTalk: () -> Void = {}
+    var onTile: (FleetCommandTile) -> Void = { _ in }
+    var onKey: (String, [String]) -> Void = { _, _ in }
+    var onChoose: (FleetDecisionOption) -> Void = { _ in }
+    var onConsoleAction: (FleetConsoleAction) -> Void = { _ in }
+    var onTrackpad: (DeckTrackpadEvent, Double, Double) -> Void = { _, _, _ in }
+
+    var body: some View {
+        VStack(spacing: FleetV6.M.stackGap) {
+            topBar
+
+            FleetChannelStrip(
+                channels: model.channels,
+                order: model.channelOrder,
+                currentIndex: model.currentIndex,
+                layout: model.layout,
+                onSelect: { index in withAnimation(.easeOut(duration: 0.18)) { model.select(index) } }
+            )
+
+            FleetVoiceBar(
+                phase: voicePhase,
+                transcript: voiceTranscript,
+                channels: model.channels,
+                routeIndex: model.routeIndex,
+                isBusy: isBusy,
+                onPushToTalk: onPushToTalk,
+                onRoute: { model.routeIndex = $0 }
+            )
+
+            deckPanel
+
+            statusBar
+        }
+        .padding(.horizontal, FleetV6.M.padH)
+        .padding(.top, FleetV6.M.padTop)
+        .padding(.bottom, FleetV6.M.padBottom)
+        .background(FleetV6.padBG)
+        .overlay(alignment: .top) {
+            // `#pad.bloom-on` — a soft wash off the top bezel.
+            LinearGradient(colors: [Color.white.opacity(0.06), .clear], startPoint: .top, endPoint: .bottom)
+                .frame(height: 220)
+                .allowsHitTesting(false)
+                .blendMode(.plusLighter)
+        }
+        .animation(.easeOut(duration: 0.25), value: model.layout)
+    }
+
+    // MARK: Top bar — `.fd-top`
+
+    private var topBar: some View {
+        HStack(spacing: 14) {
+            HStack(alignment: .firstTextBaseline, spacing: 7) {
+                Text("LATS").font(FleetV6.mono(11, .bold)).foregroundStyle(FleetV6.fg)
+                Text("·").font(FleetV6.mono(11)).foregroundStyle(FleetV6.fg4)
+                Text("OPS").font(FleetV6.mono(11, .medium)).foregroundStyle(FleetV6.fg3)
+            }
+            .tracking(1.76)
+
+            HStack(spacing: 6) {
+                FleetDot(color: FleetV6.green, size: 4)
+                Text(model.layout.label)
+                    .font(FleetV6.mono(9, .medium))
+                    .tracking(1.26)
+                    .foregroundStyle(FleetV6.fg3)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 2)
+            .background {
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(Color.white.opacity(0.03))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 5, style: .continuous)
+                            .strokeBorder(FleetV6.brk, lineWidth: 1)
+                    }
+            }
+
+            Spacer(minLength: 8)
+
+            Text("\(model.channels.count) MACS · \(agentCount) AGENTS")
+                .font(FleetV6.mono(9, .medium))
+                .tracking(1.08)
+                .monospacedDigit()
+                .foregroundStyle(FleetV6.fg3)
+
+            if let onClose {
+                Button(action: onClose) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(FleetV6.fg3)
+                        .frame(width: 18, height: 18)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Close deck")
+            }
+        }
+        .padding(.horizontal, 6)
+        .padding(.bottom, 6)
+        .frame(height: FleetV6.M.topBarHeight)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(Color.white.opacity(0.07)).frame(height: 1)
+        }
+    }
+
+    private var agentCount: Int {
+        model.channels.filter { $0.state != .idle }.count
+    }
+
+    // MARK: Deck panel — `.deck-panel`
+
+    private var deckPanel: some View {
+        VStack(spacing: 0) {
+            panelHead
+            panelBody
+            if showsTrackpadStrip {
+                FleetTrackpadStrip(onTrackpad: onTrackpad)
+                    .frame(height: FleetV6.M.trackpadHeight)
+            }
+            FleetCommandBay(
+                sets: model.sets,
+                setIndex: model.setIndex,
+                onSelectSet: { model.setIndex = $0 },
+                onTile: onTile
+            )
+            FleetKeyRow(onKey: onKey)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background {
+            ZStack {
+                FleetV6.deckPanelBG
+                FleetPanelGrid()
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: FleetV6.M.panelRadius, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: FleetV6.M.panelRadius, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.10), lineWidth: 1)
+        }
+        .shadow(color: .black.opacity(0.85), radius: 30, y: 26)
+    }
+
+    // `.panel-head`
+    private var panelHead: some View {
+        HStack(spacing: 8) {
+            FleetDot(color: FleetV6.agentHue(model.current?.hue ?? 0), size: 6)
+            Text(model.current?.deviceName ?? "No Mac on deck")
+                .font(FleetV6.mono(11.5))
+                .foregroundStyle(FleetV6.fg)
+                .lineLimit(1)
+
+            Spacer(minLength: 12)
+
+            if let channel = model.current {
+                (
+                    Text("\(channel.appName) · ").foregroundColor(FleetV6.fg3)
+                        + Text(channel.fileName).foregroundColor(FleetV6.fg2)
+                )
+                .font(FleetV6.mono(11.5))
+                .lineLimit(1)
+                .truncationMode(.head)
+            }
+        }
+        .padding(.horizontal, 15)
+        .padding(.vertical, 8)
+        .background(FleetV6.bezel)
+        .overlay(alignment: .top) {
+            Rectangle().fill(Color.white.opacity(0.10)).frame(height: 1)
+        }
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(FleetV6.seam).frame(height: 1)
+        }
+    }
+
+    // `.panel-body`
+    private var panelBody: some View {
+        GeometryReader { proxy in
+            Group {
+                if let channel = model.current {
+                    switch model.layout {
+                    case .ops:
+                        HStack(spacing: FleetV6.M.bodyGap) {
+                            console(channel, isRecent: model.lastResolvedIndex == model.currentIndex)
+                                .frame(width: consoleWidth(for: proxy.size.width, target: FleetV6.M.consoleWidth))
+                            FleetFeedPanel(
+                                events: model.visibleFeed,
+                                channels: model.channels,
+                                currentIndex: model.currentIndex,
+                                filter: model.feedFilter,
+                                attentionCount: model.attentionIndices.count,
+                                onFilter: { model.feedFilter = $0 },
+                                onSelect: { index in withAnimation(.easeOut(duration: 0.18)) { model.select(index) } }
+                            )
+                        }
+                    case .focus:
+                        HStack(spacing: FleetV6.M.bodyGap) {
+                            FleetFocusPane(channel: channel)
+                            console(channel, isRecent: false)
+                                .frame(width: consoleWidth(for: proxy.size.width, target: FleetV6.M.focusConsoleWidth))
+                        }
+                    }
+                } else {
+                    Text("No reachable Macs")
+                        .font(FleetV6.mono(12))
+                        .foregroundStyle(FleetV6.fg3)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+            .frame(width: proxy.size.width, height: proxy.size.height)
+        }
+        .padding(.horizontal, FleetV6.M.panelBodyPadH)
+        .padding(.vertical, FleetV6.M.panelBodyPadV)
+        .frame(maxHeight: .infinity)
+    }
+
+    /// The design's fixed column widths, held as a share on narrower iPads so
+    /// neither column collapses.
+    private func consoleWidth(for available: CGFloat, target: CGFloat) -> CGFloat {
+        guard available > 0 else { return target }
+        return min(target, max(260, available * 0.36))
+    }
+
+    private func console(_ channel: FleetChannel, isRecent: Bool) -> some View {
+        let queue = model.attentionIndices
+        let position = queue.firstIndex(of: model.currentIndex).map { $0 + 1 }
+        let nextBlocker = model.nextBlocker(from: model.currentIndex)
+
+        return FleetAgentConsole(
+            channel: channel,
+            queuePosition: position,
+            queueCount: queue.count,
+            nextBlockerLabel: nextBlocker.flatMap { index in
+                model.channels.indices.contains(index) ? model.channels[index].channelLabel : nil
+            },
+            justResolved: model.lastResolvedIndex == model.currentIndex,
+            isRecent: isRecent && channel.decision == nil,
+            enabledActions: enabledConsoleActions,
+            onChoose: { optionIndex in
+                withAnimation(.easeOut(duration: 0.2)) {
+                    model.resolve(channelIndex: model.currentIndex, optionIndex: optionIndex, dispatch: onChoose)
+                }
+            },
+            onDefer: { withAnimation(.easeOut(duration: 0.18)) { model.deferDecision() } },
+            onApprove: { onConsoleAction(.approve) },
+            onSteer: { onConsoleAction(.steer) },
+            onRecap: { onConsoleAction(.recap) }
+        )
+    }
+
+    // MARK: Status bar
+
+    private var statusBar: some View {
+        FleetStatusBar(
+            deviceName: model.current?.deviceName ?? "—",
+            routeLabel: model.routeLabel,
+            attentionCount: model.attentionIndices.count,
+            machineCount: model.channels.count,
+            agentCount: agentCount,
+            layout: model.layout,
+            isOnline: isOnline,
+            onAttention: { withAnimation(.easeOut(duration: 0.18)) { model.focusAttention() } },
+            onToggleLayout: {
+                withAnimation(.easeOut(duration: 0.25)) {
+                    model.layout = model.layout == .ops ? .focus : .ops
+                }
+            }
+        )
+        .padding(.horizontal, -FleetV6.M.padH)
+        .padding(.bottom, -FleetV6.M.padBottom)
+    }
+}
+
+/// The three console buttons that are not a decision — they act on the agent
+/// that is currently on deck.
+enum FleetConsoleAction: Hashable {
+    case approve, steer, recap
+}
+
+// MARK: - Trackpad strip
+//
+// `.deck-tp` — the optional pointer strip between the body and the command bay.
+// Corner brackets, a centred label, and a crosshair that tracks the finger.
+
+struct FleetTrackpadStrip: View {
+    let onTrackpad: (DeckTrackpadEvent, Double, Double) -> Void
+
+    @State private var crosshair: CGPoint?
+    @State private var lastPoint: CGPoint?
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack {
+                LinearGradient(
+                    colors: [FleetV6.rgb(0x111316), FleetV6.rgb(0x0E1013)],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+
+                ForEach(Array(brackets.enumerated()), id: \.offset) { _, alignment in
+                    Color.clear.overlay(alignment: alignment) {
+                        FleetBracket(alignment: alignment)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 10)
+                    }
+                }
+
+                Text("TRACKPAD")
+                    .font(FleetV6.mono(10))
+                    .tracking(4.2)
+                    .foregroundStyle(FleetV6.fg4)
+                    .opacity(0.45)
+
+                if let crosshair {
+                    Rectangle().fill(Color.white.opacity(0.14))
+                        .frame(width: 1)
+                        .position(x: crosshair.x, y: proxy.size.height / 2)
+                    Rectangle().fill(Color.white.opacity(0.14))
+                        .frame(height: 1)
+                        .position(x: proxy.size.width / 2, y: crosshair.y)
+                }
+            }
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        crosshair = value.location
+                        if let lastPoint {
+                            onTrackpad(.move, value.location.x - lastPoint.x, value.location.y - lastPoint.y)
+                        }
+                        lastPoint = value.location
+                    }
+                    .onEnded { _ in
+                        crosshair = nil
+                        lastPoint = nil
+                    }
+            )
+        }
+        .overlay(alignment: .top) { Rectangle().fill(FleetV6.seam).frame(height: 1) }
+        .clipped()
+        .accessibilityLabel("Trackpad")
+    }
+
+    private var brackets: [Alignment] { [.topLeading, .topTrailing, .bottomLeading, .bottomTrailing] }
+}
+
+/// `.tp-bk` — a 13pt corner bracket, open toward the middle of the strip.
+private struct FleetBracket: View {
+    let alignment: Alignment
+
+    private let size: CGFloat = 13
+    private let weight: CGFloat = 1.5
+
+    var body: some View {
+        ZStack(alignment: alignment) {
+            Color.clear.frame(width: size, height: size)
+            Rectangle().fill(Color.white.opacity(0.09)).frame(width: size, height: weight)
+            Rectangle().fill(Color.white.opacity(0.09)).frame(width: weight, height: size)
+        }
+        .frame(width: size, height: size)
+    }
+}

--- a/apps/ios/Sources/FleetDeck/FleetDeckVoiceBar.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckVoiceBar.swift
@@ -1,0 +1,172 @@
+import DeckKit
+import SwiftUI
+
+// MARK: - Voice bar
+//
+// `.vbar` — dictation is the steering wheel. Hold the pad to talk, then pick
+// which Mac's agent the words land on.
+
+struct FleetVoiceBar: View {
+    let phase: DeckVoicePhase?
+    let transcript: String
+    let channels: [FleetChannel]
+    let routeIndex: Int
+    let isBusy: Bool
+    let onPushToTalk: () -> Void
+    let onRoute: (Int) -> Void
+
+    private var isListening: Bool {
+        phase == .listening || phase == .transcribing
+    }
+
+    private var promptLabel: String {
+        switch phase {
+        case .listening:    return "LISTENING · RELEASE TO SEND"
+        case .transcribing: return "TRANSCRIBING"
+        case .reasoning:    return "THINKING"
+        case .speaking:     return "SPEAKING"
+        case .idle, .none:  return "HOLD TO TALK"
+        }
+    }
+
+    var body: some View {
+        FleetWell {
+            HStack(spacing: 16) {
+                pushToTalk
+                FleetVoiceWave(active: isListening)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    FleetLabel(text: promptLabel, size: 8.5, color: FleetV6.fg4)
+                    HStack(spacing: 6) {
+                        Text("›")
+                            .font(FleetV6.mono(13.5))
+                            .foregroundStyle(FleetV6.fg4)
+                        Text(transcript.isEmpty ? "—" : transcript)
+                            .font(FleetV6.mono(13.5))
+                            .foregroundStyle(FleetV6.fg)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                        if isListening {
+                            FleetCaret(width: 7, height: 13)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                HStack(spacing: 8) {
+                    FleetLabel(text: "ROUTE TO", size: 8.5, color: FleetV6.fg3)
+                    routeChips
+                }
+            }
+            .padding(.horizontal, 16)
+        }
+        .frame(height: FleetV6.M.voiceBarHeight)
+    }
+
+    // `.ptt`
+    private var pushToTalk: some View {
+        Button(action: onPushToTalk) {
+            Image(systemName: "mic")
+                .font(.system(size: 15, weight: .regular))
+                .foregroundStyle(isListening ? FleetV6.green : FleetV6.fg2)
+                .frame(width: 38, height: 38)
+                .background {
+                    Circle()
+                        .fill(FleetV6.dome)
+                        .overlay { Circle().strokeBorder(Color.white.opacity(0.11), lineWidth: 1) }
+                        .shadow(color: FleetV6.green.opacity(0.35), radius: 8)
+                        .shadow(color: .black.opacity(0.7), radius: 2, y: 1)
+                }
+        }
+        .buttonStyle(.plain)
+        .disabled(isBusy)
+        .accessibilityLabel("Push to talk")
+    }
+
+    // `.vroute-chips`
+    private var routeChips: some View {
+        HStack(spacing: 0) {
+            ForEach(Array(channels.enumerated()), id: \.element.id) { index, channel in
+                chip(
+                    title: channel.channelLabel.replacingOccurrences(of: " 0", with: " "),
+                    isOn: routeIndex == index,
+                    showsDivider: index > 0
+                ) { onRoute(index) }
+            }
+            chip(title: "ALL", isOn: routeIndex == channels.count, showsDivider: !channels.isEmpty) {
+                onRoute(channels.count)
+            }
+        }
+        .background {
+            RoundedRectangle(cornerRadius: 6, style: .continuous).fill(.clear)
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: 6, style: .continuous).strokeBorder(FleetV6.brk, lineWidth: 1)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+    }
+
+    private func chip(title: String, isOn: Bool, showsDivider: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(FleetV6.mono(10, .medium))
+                .tracking(1)
+                .foregroundStyle(isOn ? FleetV6.fg : FleetV6.fg4)
+                .padding(.horizontal, 11)
+                .padding(.vertical, 6)
+                .background(isOn ? Color.white.opacity(0.07) : .clear)
+                .overlay(alignment: .leading) {
+                    if showsDivider {
+                        Rectangle().fill(FleetV6.brk2).frame(width: 1)
+                    }
+                }
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(isOn ? [.isSelected, .isButton] : .isButton)
+    }
+}
+
+/// `.vwave` — nine bars at the design's fixed heights, breathing only while the
+/// mic is open.
+struct FleetVoiceWave: View {
+    var active: Bool
+
+    private let heights: [CGFloat] = [0.30, 0.60, 0.90, 0.45, 0.75, 0.35, 0.85, 0.50, 0.25]
+
+    var body: some View {
+        TimelineView(.animation(minimumInterval: active ? 1 / 20 : nil, paused: !active)) { context in
+            let phase = context.date.timeIntervalSinceReferenceDate
+            HStack(alignment: .center, spacing: 2.5) {
+                ForEach(Array(heights.enumerated()), id: \.offset) { index, base in
+                    let wobble = active
+                        ? 0.5 + 0.5 * abs(sin(phase * 2.2 + Double(index) * 0.55))
+                        : 1.0
+                    Capsule()
+                        .fill(Color.white.opacity(0.3))
+                        .frame(width: 2.5, height: max(2, 22 * base * wobble))
+                }
+            }
+            .frame(height: 22)
+        }
+        .accessibilityHidden(true)
+    }
+}
+
+/// The blinking block caret the design uses on the transcript and the log tail.
+struct FleetCaret: View {
+    var width: CGFloat = 6
+    var height: CGFloat = 11
+    var color: Color = Color.white.opacity(0.5)
+
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: 0.55)) { context in
+            let on = Int(context.date.timeIntervalSinceReferenceDate / 0.55) % 2 == 0
+            Rectangle()
+                .fill(color)
+                .frame(width: width, height: height)
+                .opacity(on ? 1 : 0)
+        }
+        .accessibilityHidden(true)
+    }
+}

--- a/apps/ios/Sources/Home/AddHostController.swift
+++ b/apps/ios/Sources/Home/AddHostController.swift
@@ -1,0 +1,211 @@
+import CryptoKit
+import DeckKit
+import Foundation
+
+/// Why pairing ended without a Mac joining the roster.
+enum AddHostFailure: Equatable {
+    /// The Mac declined. An answer, not an error — it gets no signal colour.
+    case denied
+    /// The question never got answered: the Mac was unreachable, asleep, or
+    /// stopped responding. This one *is* a failure — the system owes the
+    /// explanation, so it carries the error treatment.
+    case unreachable(String)
+}
+
+/// One sheet, five phases, one screen each.
+enum AddHostPhase: Equatable {
+    case picking
+    case confirming(BridgeEndpoint)
+    case waiting(BridgeEndpoint)
+    case added(BridgeEndpoint, withheld: [String])
+    case failed(BridgeEndpoint, AddHostFailure)
+}
+
+@MainActor
+final class AddHostController: ObservableObject {
+    @Published private(set) var phase: AddHostPhase = .picking
+    /// Seconds spent waiting. A clock rather than a spinner: see `AddHostSheet`.
+    @Published private(set) var waitedSeconds: Int = 0
+
+    /// Typed by hand when Bonjour can't see the Mac.
+    @Published var manualHost = ""
+    @Published var manualPort = "5287"
+
+    private let client = DeckBridgeClient()
+    private var pairingTask: Task<Void, Never>?
+
+    /// How long before the wait is worth explaining rather than just showing.
+    static let patienceThreshold = 25
+
+    /// This iPad's own code, the same string the Mac's approval alert leads
+    /// with. The user compares the two; that comparison is the only part of the
+    /// exchange an impostor on the network cannot fake, because every other
+    /// field in that alert — the device's name, its id, its platform — is
+    /// chosen by whoever sent the request.
+    let deviceCode = DeckBridgeSecurityStore.shared.deviceFingerprint
+
+    var isWaitingLongerThanExpected: Bool {
+        waitedSeconds >= Self.patienceThreshold
+    }
+
+    // MARK: - Navigation
+
+    func choose(_ endpoint: BridgeEndpoint) {
+        phase = .confirming(endpoint)
+    }
+
+    /// Returns to the list, abandoning anything in flight.
+    ///
+    /// Cancelling stops the iPad waiting; it cannot retract the alert already
+    /// on the Mac. If the user approves after cancelling, the Mac holds a trust
+    /// record this device doesn't — which heals on the next attempt, because
+    /// the Mac answers `alreadyTrusted` and we store it then.
+    func backToPicking() {
+        cancelPairing()
+        phase = .picking
+    }
+
+    func cancelPairing() {
+        pairingTask?.cancel()
+        pairingTask = nil
+        waitedSeconds = 0
+    }
+
+    /// The manually-typed endpoint, or nil when the fields aren't usable yet.
+    var manualEndpoint: BridgeEndpoint? {
+        let host = manualHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !host.isEmpty, let port = Int(manualPort), port > 0 else { return nil }
+        return BridgeEndpoint(name: host, host: host, port: port, source: "Manual")
+    }
+
+    // MARK: - The handshake
+
+    /// Pair with a Mac, then hand the trusted endpoint back to the caller.
+    ///
+    /// The order is the design: trust is stored *before* any session exists, so
+    /// the new Mac satisfies the fleet's existing trust check on its own terms.
+    /// Nothing has to be kept alive across the discovery churn that happens
+    /// while a human is deciding.
+    func pair(
+        with endpoint: BridgeEndpoint,
+        onPaired: @escaping (BridgeEndpoint) -> Void
+    ) {
+        pairingTask?.cancel()
+        waitedSeconds = 0
+        phase = .waiting(endpoint)
+
+        pairingTask = Task { [weak self] in
+            guard let self else { return }
+
+            let clock = Task { [weak self] in
+                while !Task.isCancelled {
+                    try? await Task.sleep(for: .seconds(1))
+                    guard !Task.isCancelled else { return }
+                    self?.waitedSeconds += 1
+                }
+            }
+            defer { clock.cancel() }
+
+            // Reach the Mac first, so an unreachable host is reported as
+            // unreachable rather than as a pairing that mysteriously never
+            // returns — and so a hand-typed address picks up the Mac's real
+            // identity before anything is written down about it.
+            let health: BridgeHealthResponse
+            do {
+                health = try await self.client.health(endpoint: endpoint)
+            } catch {
+                guard !Task.isCancelled else { return }
+                self.phase = .failed(endpoint, .unreachable(error.localizedDescription))
+                return
+            }
+            guard !Task.isCancelled else { return }
+
+            let canonical = endpoint.adoptingIdentity(from: health)
+
+            do {
+                let response = try await self.client.pair(endpoint: canonical)
+                guard !Task.isCancelled else { return }
+
+                switch response.disposition {
+                case .approved, .alreadyTrusted:
+                    DeckBridgeSecurityStore.shared.storePairing(
+                        response,
+                        lastKnownHost: canonical.host,
+                        lastKnownPort: canonical.port
+                    )
+                    onPaired(canonical)
+                    self.phase = .added(canonical, withheld: Self.withheld(from: response))
+                case .denied:
+                    self.phase = .failed(canonical, .denied)
+                }
+            } catch DeckBridgeClientError.badStatus(403, _) {
+                guard !Task.isCancelled else { return }
+                self.phase = .failed(canonical, .denied)
+            } catch {
+                guard !Task.isCancelled else { return }
+                self.phase = .failed(canonical, .unreachable(error.localizedDescription))
+            }
+        }
+    }
+
+    /// Capabilities we asked for and did not get. Said once, on the way in,
+    /// rather than surfacing as `insufficientCapability` mid-gesture days later.
+    private static func withheld(from response: DeckPairingResponse) -> [String] {
+        let granted = Set(response.grantedCapabilities)
+        return DeckBridgeCapability.defaultCompanionCapabilities.filter { !granted.contains($0) }
+    }
+}
+
+// MARK: - Candidates
+
+extension AddHostController {
+    /// Hosts Bonjour can currently see that this device has never paired with.
+    ///
+    /// Trusted hosts are deliberately absent: they are already in the roster,
+    /// and a list of "things to add" that includes what you already have is a
+    /// list that invites a second, pointless pairing.
+    ///
+    /// Passive discovery only — Home uses this for its count, and Home should
+    /// never be sweeping the network on its own.
+    static func candidates(from store: DeckStore) -> [BridgeEndpoint] {
+        store.discoveredBridges.filter { !DeckBridgeSecurityStore.shared.isTrusted(endpoint: $0) }
+    }
+
+    /// What the picker offers: everything Bonjour found, plus anything a sweep
+    /// turned up, minus what is already paired.
+    ///
+    /// Bonjour entries win on collision. A scan result knows an address and a
+    /// fingerprint; a Bonjour record knows the service name the Mac chose for
+    /// itself, which is what the user recognises in a list.
+    static func candidates(from store: DeckStore, including scanned: [BridgeEndpoint]) -> [BridgeEndpoint] {
+        var result = candidates(from: store)
+        var seen = Set(result.map(\.id))
+
+        for endpoint in scanned {
+            guard !DeckBridgeSecurityStore.shared.isTrusted(endpoint: endpoint) else { continue }
+            // A Mac found both ways is one Mac. Match on fingerprint where
+            // there is one, since the same host answers on two names often
+            // enough that address comparison alone would double it up.
+            let duplicate = result.contains { existing in
+                if let a = existing.bridgeFingerprint, let b = endpoint.bridgeFingerprint, !a.isEmpty {
+                    return a.caseInsensitiveCompare(b) == .orderedSame
+                }
+                return false
+            }
+            guard !duplicate, seen.insert(endpoint.id).inserted else { continue }
+            result.append(endpoint)
+        }
+
+        return result
+    }
+
+    /// A human label for a capability the Mac withheld.
+    static func capabilityLabel(_ capability: String) -> String {
+        switch capability {
+        case DeckBridgeCapability.deckRead:     return "reading this host's state"
+        case DeckBridgeCapability.deckPerform:  return "running commands"
+        case DeckBridgeCapability.inputTrackpad: return "trackpad control"
+        default:                                 return capability
+        }
+    }
+}

--- a/apps/ios/Sources/Home/AddHostSheet.swift
+++ b/apps/ios/Sources/Home/AddHostSheet.swift
@@ -1,0 +1,513 @@
+import DeckKit
+import SwiftUI
+
+/// Adding a Mac. Five phases, one screen each, one decision per screen.
+///
+/// Written directly in `DeckTheme` rather than the older `Lats*` components:
+/// this is new surface, so it starts where the type and colour system is going
+/// instead of where it has been.
+struct AddHostSheet: View {
+    @ObservedObject var store: DeckStore
+    /// Called once the Mac is trusted, so the caller can seat it in the fleet.
+    let onPaired: (BridgeEndpoint) -> Void
+    /// Called when the user wants to go straight to the Mac they just added.
+    let onOpen: (BridgeEndpoint) -> Void
+
+    @StateObject private var controller = AddHostController()
+    @StateObject private var scanner = LocalNetworkScanner()
+    @Environment(\.dismiss) private var dismiss
+    @State private var isEnteringManually = false
+
+    var body: some View {
+        ZStack {
+            DeckTheme.canvas.ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                titleBar
+                ScrollView {
+                    phaseBody
+                        .padding(.horizontal, DeckTheme.Space.margin)
+                        .padding(.vertical, DeckTheme.Space.x24)
+                        .frame(maxWidth: 480)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+        }
+        .animation(.easeInOut(duration: 0.18), value: controller.phase)
+    }
+
+    // MARK: - Chrome
+
+    private var titleBar: some View {
+        HStack {
+            Text(titleText)
+                .font(DeckTheme.title())
+                .foregroundStyle(DeckTheme.text)
+            Spacer(minLength: 0)
+            Button {
+                controller.cancelPairing()
+                dismiss()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(DeckTheme.textSecondary)
+                    .frame(width: 30, height: 30)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close")
+        }
+        .padding(.horizontal, DeckTheme.Space.margin)
+        .padding(.vertical, DeckTheme.Space.x12)
+    }
+
+    private var titleText: String {
+        switch controller.phase {
+        case .picking:                    return isEnteringManually ? "Enter an address" : "Add a Host"
+        case .confirming(let endpoint):   return "Add \(endpoint.displayName)?"
+        case .waiting(let endpoint):      return "Waiting for \(endpoint.displayName)"
+        case .added(let endpoint, _):     return "\(endpoint.displayName) added"
+        case .failed(let endpoint, _):    return endpoint.displayName
+        }
+    }
+
+    // MARK: - Phases
+
+    @ViewBuilder
+    private var phaseBody: some View {
+        switch controller.phase {
+        case .picking:
+            if isEnteringManually { manualEntry } else { picking }
+        case .confirming(let endpoint):
+            confirming(endpoint)
+        case .waiting(let endpoint):
+            waiting(endpoint)
+        case .added(let endpoint, let withheld):
+            added(endpoint, withheld: withheld)
+        case .failed(let endpoint, let failure):
+            failed(endpoint, failure)
+        }
+    }
+
+    // MARK: Picking
+
+    private var candidates: [BridgeEndpoint] {
+        AddHostController.candidates(from: store, including: scanner.found)
+    }
+
+    private var picking: some View {
+        VStack(alignment: .leading, spacing: DeckTheme.Space.x12) {
+            if candidates.isEmpty {
+                VStack(alignment: .leading, spacing: DeckTheme.Space.x8) {
+                    Text("Nothing found yet.")
+                        .font(DeckTheme.body())
+                        .foregroundStyle(DeckTheme.text)
+                    // The thing people actually get stuck on. A host runs
+                    // Lattices and still stays invisible until its bridge is
+                    // switched on, and nothing on the network can tell us that
+                    // is the reason — so the copy has to.
+                    Text("On the Mac, open Lattices → Settings → Companion and turn on the local bridge. It stays off until you do.")
+                        .font(DeckTheme.secondary())
+                        .foregroundStyle(DeckTheme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text("Both devices also need to be on the same Wi‑Fi.")
+                        .font(DeckTheme.secondary())
+                        .foregroundStyle(DeckTheme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(.vertical, DeckTheme.Space.x8)
+            } else {
+                ForEach(candidates) { endpoint in
+                    Button { controller.choose(endpoint) } label: {
+                        candidateRow(endpoint)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            scanSection
+
+            Divider().overlay(DeckTheme.hairline).padding(.vertical, DeckTheme.Space.x4)
+
+            HStack(spacing: DeckTheme.Space.x12) {
+                Button { isEnteringManually = true } label: {
+                    Text("Enter an address manually")
+                        .font(DeckTheme.secondary())
+                        .foregroundStyle(DeckTheme.textSecondary)
+                }
+                .buttonStyle(.plain)
+
+                Spacer(minLength: 0)
+
+                Button {
+                    scanner.reset()
+                    store.refreshDiscovery()
+                } label: {
+                    Text("Refresh")
+                        .font(DeckTheme.secondary())
+                        .foregroundStyle(DeckTheme.textSecondary)
+                }
+                .buttonStyle(.plain)
+                .disabled(scanner.isScanning)
+            }
+        }
+    }
+
+    // MARK: Sweep
+    //
+    // Bonjour stays the default and runs on its own. This is the fallback for
+    // networks that drop multicast, so it is a deliberate act with a visible
+    // cost rather than something the app does quietly in the background.
+
+    @ViewBuilder
+    private var scanSection: some View {
+        if scanner.isScanning {
+            VStack(alignment: .leading, spacing: DeckTheme.Space.x8) {
+                Text("Looking for hosts…")
+                    .font(DeckTheme.secondary())
+                    .foregroundStyle(DeckTheme.textSecondary)
+                // The one determinate indicator in this flow, because unlike
+                // waiting on a person this work really is finite and countable.
+                ProgressView(value: scanner.progress)
+                    .tint(DeckTheme.accent)
+            }
+            .padding(.vertical, DeckTheme.Space.x4)
+        } else {
+            VStack(alignment: .leading, spacing: DeckTheme.Space.x8) {
+                Button {
+                    Task { await scanner.scan() }
+                } label: {
+                    HStack(spacing: DeckTheme.Space.x8) {
+                        Image(systemName: "dot.radiowaves.left.and.right")
+                            .font(.system(size: 13, weight: .medium))
+                        Text(scanner.outcome == nil ? "Look for hosts" : "Look again")
+                            .font(DeckTheme.secondary(.medium))
+                    }
+                    .foregroundStyle(DeckTheme.textSecondary)
+                    .padding(.horizontal, DeckTheme.Space.x12)
+                    .padding(.vertical, DeckTheme.Space.x8)
+                    .background(
+                        RoundedRectangle(cornerRadius: DeckTheme.radiusCard, style: .continuous)
+                            .fill(DeckTheme.control)
+                    )
+                }
+                .buttonStyle(.plain)
+
+                if let note = scanNote {
+                    Text(note)
+                        .font(DeckTheme.caption())
+                        .foregroundStyle(DeckTheme.textTertiary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+    }
+
+    private var scanNote: String? {
+        switch scanner.outcome {
+        case .none:
+            return nil
+        case .swept:
+            return scanner.found.isEmpty
+                ? "Nothing answered. Check the bridge is on in Lattices on the Mac."
+                : nil   // They're in the list above; a count would just repeat it.
+        case .networkTooLarge:
+            return "This network is too big to check host by host. Enter the address instead."
+        case .noNetwork:
+            return "Not on a Wi‑Fi network."
+        }
+    }
+
+    /// Name and address only. The Mac's own fingerprint used to sit here, but
+    /// there is nothing on the Mac to check it against, so it was a number that
+    /// looked like security without being any.
+    private func candidateRow(_ endpoint: BridgeEndpoint) -> some View {
+        HStack(spacing: DeckTheme.Space.x12) {
+            Image(systemName: endpoint.deviceIcon)
+                .font(.system(size: 17, weight: .regular))
+                .foregroundStyle(DeckTheme.textSecondary)
+                .frame(width: 26)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(endpoint.displayName)
+                    .font(DeckTheme.body(.medium))
+                    .foregroundStyle(DeckTheme.text)
+                    .lineLimit(1)
+                Text(endpoint.host)
+                    .font(DeckTheme.secondary())
+                    .foregroundStyle(DeckTheme.textSecondary)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 0)
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(DeckTheme.textTertiary)
+        }
+        .padding(.horizontal, DeckTheme.Space.cardPadH)
+        .padding(.vertical, DeckTheme.Space.cardPadV)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: DeckTheme.radiusCard, style: .continuous)
+                .fill(DeckTheme.card)
+        )
+    }
+
+    private var manualEntry: some View {
+        VStack(alignment: .leading, spacing: DeckTheme.Space.x12) {
+            Text("Use this when the host doesn't appear on its own — usually because the network blocks discovery.")
+                .font(DeckTheme.secondary())
+                .foregroundStyle(DeckTheme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            field("Host", text: $controller.manualHost, keyboard: .URL)
+            field("Port", text: $controller.manualPort, keyboard: .numberPad)
+
+            primaryButton("Continue", enabled: controller.manualEndpoint != nil) {
+                guard let endpoint = controller.manualEndpoint else { return }
+                controller.choose(endpoint)
+            }
+
+            quietButton("Back") { isEnteringManually = false }
+        }
+    }
+
+    // MARK: Confirming
+
+    private func confirming(_ endpoint: BridgeEndpoint) -> some View {
+        VStack(alignment: .leading, spacing: DeckTheme.Space.x16) {
+            Text("\(endpoint.displayName) will ask whether to allow this iPad. Check that it shows this code:")
+                .font(DeckTheme.body())
+                .foregroundStyle(DeckTheme.text)
+                .fixedSize(horizontal: false, vertical: true)
+
+            // The one thing on this screen an impostor cannot fake. Given its
+            // own line and a size step above everything else, because the whole
+            // instruction above is "compare these".
+            Text(controller.deviceCode.replacingOccurrences(of: "-", with: " - "))
+                .font(DeckTheme.title())
+                .foregroundStyle(DeckTheme.text)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.vertical, DeckTheme.Space.x24)
+                .accessibilityLabel(controller.deviceCode.map(String.init).joined(separator: " "))
+
+            Text("If the codes don't match, deny it — something else on your network is asking.")
+                .font(DeckTheme.secondary())
+                .foregroundStyle(DeckTheme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text("\(endpoint.displayName) · \(endpoint.host):\(endpoint.port)")
+                .font(DeckTheme.caption())
+                .foregroundStyle(DeckTheme.textTertiary)
+
+            primaryButton("Ask to pair") {
+                controller.pair(with: endpoint, onPaired: onPaired)
+            }
+            quietButton("Cancel") { controller.backToPicking() }
+        }
+    }
+
+    // MARK: Waiting
+
+    /// Deliberately still. Everything else in this app moves at machine pace;
+    /// this is the one state paced by a person walking to a desk. A repeating
+    /// animation would promise imminent change, which is exactly the lie that
+    /// makes half a minute feel broken — so there is nothing to watch but a
+    /// clock, which says only that time is passing and that this is expected.
+    private func waiting(_ endpoint: BridgeEndpoint) -> some View {
+        VStack(alignment: .leading, spacing: DeckTheme.Space.x16) {
+            Text("Approve the prompt on \(endpoint.displayName).")
+                .font(DeckTheme.body())
+                .foregroundStyle(DeckTheme.text)
+
+            Text(elapsedLabel)
+                .font(DeckTheme.caption())
+                .foregroundStyle(DeckTheme.textTertiary)
+                .monospacedDigit()
+
+            if controller.isWaitingLongerThanExpected {
+                Text("Still waiting. Make sure \(endpoint.displayName) is awake.")
+                    .font(DeckTheme.secondary())
+                    .foregroundStyle(DeckTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            quietButton("Cancel") { controller.backToPicking() }
+        }
+    }
+
+    private var elapsedLabel: String {
+        let seconds = controller.waitedSeconds
+        return String(format: "Waiting — %d:%02d", seconds / 60, seconds % 60)
+    }
+
+    // MARK: Added
+
+    private func added(_ endpoint: BridgeEndpoint, withheld: [String]) -> some View {
+        VStack(alignment: .leading, spacing: DeckTheme.Space.x16) {
+            Text("It's in your roster and ready to use.")
+                .font(DeckTheme.body())
+                .foregroundStyle(DeckTheme.text)
+
+            if !withheld.isEmpty {
+                // Said now, once, rather than surfacing as a failed gesture in
+                // three days' time when nobody remembers pairing this Mac.
+                VStack(alignment: .leading, spacing: DeckTheme.Space.x4) {
+                    Text("\(endpoint.displayName) didn't grant \(listed(withheld)).")
+                        .font(DeckTheme.secondary())
+                        .foregroundStyle(DeckTheme.text)
+                    Text("You can change this in Lattices on \(endpoint.displayName).")
+                        .font(DeckTheme.secondary())
+                        .foregroundStyle(DeckTheme.textSecondary)
+                }
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(DeckTheme.Space.wellPad)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: DeckTheme.radiusCard, style: .continuous)
+                        .fill(DeckTheme.card)
+                )
+            }
+
+            // Adding does not move the Mac you were looking at — but you just
+            // spent four screens thinking about this one, so getting to it is
+            // one tap rather than a hunt back through Home.
+            primaryButton("Open \(endpoint.displayName)") {
+                onOpen(endpoint)
+                dismiss()
+            }
+            quietButton("Done") { dismiss() }
+        }
+    }
+
+    private func listed(_ capabilities: [String]) -> String {
+        let names = capabilities.map { AddHostController.capabilityLabel($0) }
+        guard names.count > 1 else { return names.first ?? "" }
+        return names.dropLast().joined(separator: ", ") + " or " + (names.last ?? "")
+    }
+
+    // MARK: Failed
+
+    @ViewBuilder
+    private func failed(_ endpoint: BridgeEndpoint, _ failure: AddHostFailure) -> some View {
+        VStack(alignment: .leading, spacing: DeckTheme.Space.x16) {
+            switch failure {
+            case .denied:
+                // The Mac answered. Nothing failed, so nothing is coloured:
+                // red would claim a fault and amber would claim it still needs
+                // something. It is set in the serif because this is the one
+                // moment in the flow where the Mac is talking back.
+                Text("\(endpoint.displayName) declined the request.")
+                    .font(DeckTheme.saidSecondary)
+                    .foregroundStyle(DeckTheme.text)
+                    .fixedSize(horizontal: false, vertical: true)
+
+            case .unreachable(let reason):
+                // This one *is* a failure — the question went unanswered, and
+                // the explanation is owed by the system rather than by a person.
+                VStack(alignment: .leading, spacing: DeckTheme.Space.x4) {
+                    Text("Couldn't reach \(endpoint.displayName).")
+                        .font(DeckTheme.body(.medium))
+                        .foregroundStyle(DeckTheme.text)
+                    Text(reason)
+                        .font(DeckTheme.secondary())
+                        .foregroundStyle(DeckTheme.textSecondary)
+                }
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(DeckTheme.Space.wellPad)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: DeckTheme.radiusCard, style: .continuous)
+                        .fill(DeckTheme.errorFill)
+                )
+
+                Text("Check that Lattices is running on \(endpoint.displayName), and that both devices are on the same Wi‑Fi.")
+                    .font(DeckTheme.secondary())
+                    .foregroundStyle(DeckTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            // Never automatic: a retry raises a fresh alert on the Mac
+            // immediately, and doing that on the user's behalf after they were
+            // just told no is how an app becomes something you turn off.
+            primaryButton("Try again") {
+                controller.pair(with: endpoint, onPaired: onPaired)
+            }
+            quietButton("Back") { controller.backToPicking() }
+        }
+    }
+
+    // MARK: - Controls
+
+    private func primaryButton(
+        _ title: String,
+        enabled: Bool = true,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(DeckTheme.body(.semibold))
+                .foregroundStyle(enabled ? DeckTheme.canvas : DeckTheme.textDisabled)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, DeckTheme.Space.x12)
+                .background(
+                    RoundedRectangle(cornerRadius: DeckTheme.radiusCard, style: .continuous)
+                        .fill(enabled ? DeckTheme.accent : DeckTheme.control)
+                )
+        }
+        .buttonStyle(.plain)
+        .disabled(!enabled)
+    }
+
+    private func quietButton(_ title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(DeckTheme.body())
+                .foregroundStyle(DeckTheme.textSecondary)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, DeckTheme.Space.x8)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func field(
+        _ placeholder: String,
+        text: Binding<String>,
+        keyboard: UIKeyboardType
+    ) -> some View {
+        TextField(placeholder, text: text)
+            .keyboardType(keyboard)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+            .font(DeckTheme.body())
+            .foregroundStyle(DeckTheme.text)
+            .tint(DeckTheme.accent)
+            .padding(.horizontal, DeckTheme.Space.x12)
+            .frame(height: 44)
+            .background(
+                RoundedRectangle(cornerRadius: DeckTheme.radiusCard, style: .continuous)
+                    .fill(DeckTheme.control)
+            )
+    }
+}
+
+// MARK: - Endpoint presentation
+
+extension BridgeEndpoint {
+    var displayName: String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return host }
+        return trimmed
+    }
+
+    var deviceIcon: String {
+        let hint = (displayName + " " + host).lowercased()
+        if hint.contains("mini")   { return "macmini" }
+        if hint.contains("studio") { return "macstudio" }
+        if hint.contains("imac")   { return "desktopcomputer" }
+        if hint.contains("air") || hint.contains("book") || hint.contains("pro") {
+            return "laptopcomputer"
+        }
+        return "macwindow"
+    }
+}

--- a/apps/ios/Sources/Home/HomeBottomBar.swift
+++ b/apps/ios/Sources/Home/HomeBottomBar.swift
@@ -64,10 +64,18 @@ extension HomeBottomMachineTelemetry {
 /// cluster expands an accordion with per-machine rows.
 ///
 /// Surface follows the Talkie BottomTrayBackground pattern: the dark surface
-/// extends into the bottom safe area while content sits above the home
-/// indicator via internal padding. The hairline lives only at the top edge.
+/// extends into the bottom safe area while content stays above the home
+/// indicator. The hairline lives only at the top edge.
 ///
-/// Size budget: ~40pt collapsed, ~96pt expanded (excluding safe-area extension).
+/// **The safe area does the lifting, not a padding constant.** This bar is the
+/// last child of a container that already respects the safe area, so its
+/// content is above the home indicator before any padding is applied — the
+/// `padding(.bottom, 16)` that used to sit here was stacked *on top of* the
+/// real ~20pt inset, spending 70pt of screen on 30pt of text. Chrome should
+/// cost what it renders; the surface reaching the physical bottom edge is the
+/// `ignoresSafeArea` below, not height.
+///
+/// Size budget: ~34pt collapsed, ~90pt expanded (excluding safe-area extension).
 struct HomeBottomBar: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
@@ -150,9 +158,8 @@ struct HomeBottomBar: View {
             }
         }
         .padding(.horizontal, 14)
-        .padding(.bottom, 16)   // lift content above home indicator
-        .frame(height: 54, alignment: .top)
-        .padding(.top, 0)
+        .frame(height: 30)
+        .padding(.bottom, 4)
     }
 
     private var compactCollapsedBar: some View {
@@ -189,8 +196,8 @@ struct HomeBottomBar: View {
             }
         }
         .padding(.horizontal, 12)
-        .padding(.bottom, 15)
-        .frame(height: 58, alignment: .top)
+        .frame(height: 34)
+        .padding(.bottom, 4)
     }
 
     private func compactAction(icon: String, label: String, action: @escaping () -> Void) -> some View {
@@ -198,7 +205,7 @@ struct HomeBottomBar: View {
             Image(systemName: icon)
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(LatsPalette.text)
-                .frame(width: 30, height: 30)
+                .frame(width: 28, height: 28)
                 .background(RoundedRectangle(cornerRadius: 6).fill(Color.white.opacity(0.055)))
                 .overlay(RoundedRectangle(cornerRadius: 6).stroke(LatsPalette.hairline2, lineWidth: 1))
         }

--- a/apps/ios/Sources/Home/HomeDataAdapter.swift
+++ b/apps/ios/Sources/Home/HomeDataAdapter.swift
@@ -14,8 +14,16 @@ import Foundation
 @MainActor
 enum HomeDataAdapter {
 
+    /// Build the roster.
+    ///
+    /// `secondaryStores` matters: without it this could only ever describe the
+    /// primary Mac in any detail, because a discovered endpoint carries an
+    /// address and nothing else. Every other host rendered as a name with no
+    /// scene, no focused app and no gauges — not because the data was missing,
+    /// but because the adapter was never handed the session that had it.
     static func machines(
         store: DeckStore,
+        secondaryStores: [DeckStore] = [],
         trustedBridges: [StoredBridgeTrust]
     ) -> [HomeMachine] {
         var result: [HomeMachine] = []
@@ -27,11 +35,33 @@ enum HomeDataAdapter {
             result.append(makeActive(endpoint: endpoint, snapshot: store.snapshot))
         }
 
+        // Only Macs this device has paired with. An unpaired Mac that merely
+        // happens to be on the network is a *candidate*, and it belongs in the
+        // add flow — putting it in the roster made a tap on it re-point the
+        // primary connection and raise an approval prompt on someone's desk,
+        // which is the swap-plus-unsolicited-prompt behaviour the add flow
+        // exists to replace.
         for bridge in store.discoveredBridges {
+            guard DeckBridgeSecurityStore.shared.isTrusted(endpoint: bridge) else { continue }
             let key = nameKey(bridge.name, host: bridge.host)
             if seen.contains(key) { continue }
             seen.insert(key)
-            result.append(makeDiscovered(endpoint: bridge))
+
+            // Match by fingerprint first — it is the Mac's identity — and fall
+            // back to address, which is all a manually-added host has.
+            let session = secondaryStores.first { candidate in
+                guard let active = candidate.activeEndpoint else { return false }
+                if let a = active.bridgeFingerprint, let b = bridge.bridgeFingerprint, !a.isEmpty {
+                    return a.caseInsensitiveCompare(b) == .orderedSame
+                }
+                return active.host == bridge.host && active.port == bridge.port
+            }
+
+            if let session, session.snapshot != nil {
+                result.append(makeActive(endpoint: bridge, snapshot: session.snapshot, isForeground: false))
+            } else {
+                result.append(makeDiscovered(endpoint: bridge))
+            }
         }
 
         for trust in trustedBridges {
@@ -144,7 +174,8 @@ private extension HomeDataAdapter {
 
     static func makeActive(
         endpoint: BridgeEndpoint,
-        snapshot: DeckRuntimeSnapshot?
+        snapshot: DeckRuntimeSnapshot?,
+        isForeground: Bool = true
     ) -> HomeMachine {
         let displayName = endpoint.name.isEmpty ? endpoint.host : endpoint.name
         let host = displayHost(endpoint.host)
@@ -159,8 +190,8 @@ private extension HomeDataAdapter {
             name: displayName,
             host: host,
             icon: iconFor(displayName + " " + host),
-            status: .active,
-            isForeground: true,                     // assume the connected Mac is foreground
+            status: isForeground ? .active : .online,
+            isForeground: isForeground,
             scene: nonEmpty(desktop?.activeLayerName),
             focusedApp: nonEmpty(desktop?.activeAppName),
             focusedWindow: nonEmpty(frontTitle),

--- a/apps/ios/Sources/Home/HomeDataAdapter.swift
+++ b/apps/ios/Sources/Home/HomeDataAdapter.swift
@@ -200,8 +200,22 @@ private extension HomeDataAdapter {
             agentState: agentState(for: voice),
             attentionCount: snapshot?.questions.count ?? 0,
             latencyMs: nil,
-            metrics: metrics(from: snapshot?.telemetry)
+            metrics: metrics(from: snapshot?.telemetry),
+            voice: voiceActivity(for: voice)
         )
+    }
+
+    /// Reduce the wire phase to what the roster card renders.
+    ///
+    /// Only `.listening` means a microphone is actually open. The rest are the
+    /// Mac working on something you already said, which is worth showing but is
+    /// not the state that needs to be impossible to miss.
+    static func voiceActivity(for voice: DeckVoiceState?) -> HomeVoiceActivity {
+        switch voice?.phase {
+        case .listening:                            return .listening
+        case .transcribing, .reasoning, .speaking:  return .working
+        case .idle, nil:                            return .off
+        }
     }
 
     /// Map `DeckSystemTelemetry` onto the gauge struct. Returns nil if no
@@ -233,7 +247,8 @@ private extension HomeDataAdapter {
             lastActionAgo: nil,
             agentState: .idle,
             attentionCount: 0,
-            latencyMs: nil
+            latencyMs: nil,
+            hasLiveSession: false
         )
     }
 
@@ -254,7 +269,8 @@ private extension HomeDataAdapter {
                 : agoLabel(from: trust.pairedAt),
             agentState: .idle,
             attentionCount: 0,
-            latencyMs: nil
+            latencyMs: nil,
+            hasLiveSession: false
         )
     }
 }

--- a/apps/ios/Sources/Home/HomeMockData.swift
+++ b/apps/ios/Sources/Home/HomeMockData.swift
@@ -71,6 +71,29 @@ struct HomeMachine: Identifiable, Equatable {
     /// Live load gauges. nil when the machine isn't reporting telemetry
     /// (offline / standby / discovered-but-not-paired).
     var metrics: HomeMachineMetrics? = nil
+    /// Whether this host's microphone is open right now. Per-machine because
+    /// with a fleet, "a mic is live" is not useful without "on which one".
+    var voice: HomeVoiceActivity = .off
+    /// Whether there is a live authenticated session behind this card.
+    /// A host can be trusted and visible on the network without one, and
+    /// offering a mic we cannot actually route to is worse than offering
+    /// none — the tap would look accepted and do nothing.
+    var hasLiveSession: Bool = true
+}
+
+/// What a host's voice runtime is doing, reduced to what the roster needs.
+///
+/// Deliberately not `DeckVoicePhase` — the card only needs to distinguish
+/// "your microphone is open on that machine" from "it is busy thinking" from
+/// "nothing". Keeping the view model free of the wire enum also keeps the
+/// mock fixtures free of DeckKit.
+enum HomeVoiceActivity: Equatable {
+    /// Nothing running.
+    case off
+    /// The microphone is open. This is the state that must never be subtle.
+    case listening
+    /// Captured, now transcribing / reasoning / speaking. Mic is closed.
+    case working
 }
 
 /// Per-machine load metrics surfaced as gauges. All fields are 0…100

--- a/apps/ios/Sources/Home/HomeMockData.swift
+++ b/apps/ios/Sources/Home/HomeMockData.swift
@@ -223,7 +223,7 @@ enum HomeMock {
             name: "arach-mini",
             host: "mini.local",
             icon: "macmini",
-            status: .standby,
+            status: .online,
             isForeground: false,
             scene: "Wind Down",
             focusedApp: "Music",

--- a/apps/ios/Sources/Home/HomeTargetsRow.swift
+++ b/apps/ios/Sources/Home/HomeTargetsRow.swift
@@ -29,6 +29,10 @@ struct HomeTargetsRow: View {
     var onEnterFleet: (() -> Void)? = nil
     var onAddHost: (() -> Void)? = nil
     var onAttention: ((HomeMachine) -> Void)? = nil
+    /// Start or stop dictation on one specific host. The mic lives on the
+    /// card because with a fleet, the target has to be chosen at the moment
+    /// you speak rather than configured ahead of time.
+    var onVoice: ((HomeMachine) -> Void)? = nil
 
     /// Measured width of the roster. Zero until first layout, which is why
     /// every fit test below treats zero as "assume it fits" — the first frame
@@ -140,7 +144,8 @@ struct HomeTargetsRow: View {
                     emphasis: m.isForeground ? .deemphasized : .full,
                     density: .compact,
                     onEnterDeck: onEnterDeck,
-                    onAttention: onAttention
+                    onAttention: onAttention,
+                    onVoice: onVoice
                 )
             }
         }
@@ -154,7 +159,8 @@ struct HomeTargetsRow: View {
                 emphasis: machine.isForeground ? .deemphasized : .full,
                 density: density,
                 onEnterDeck: onEnterDeck,
-                onAttention: onAttention
+                onAttention: onAttention,
+                onVoice: onVoice
             )
         }
     }
@@ -378,6 +384,7 @@ private struct HomeTargetCard: View {
     var density: HomeTargetDensity = .full
     var onEnterDeck: ((HomeMachine) -> Void)? = nil
     var onAttention: ((HomeMachine) -> Void)? = nil
+    var onVoice: ((HomeMachine) -> Void)? = nil
 
     /// Shared minimum card height per density. Picked so the gauges have room
     /// to breathe and offline cards reserve the same space — geometry stays
@@ -428,6 +435,7 @@ private struct HomeTargetCard: View {
     private var leftColumn: some View {
         VStack(alignment: .leading, spacing: 10) {
             nameRow
+            voiceLine
             identityBlock
             metadataBlock
             Spacer(minLength: 0)
@@ -445,6 +453,75 @@ private struct HomeTargetCard: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
                 .frame(maxWidth: .infinity, alignment: .leading)
+            micButton
+        }
+    }
+
+    // MARK: Per-host mic
+    //
+    // Talking to a fleet needs the target chosen at the moment you speak, not
+    // configured somewhere ahead of time — so the mic lives on the host, and
+    // "which Mac is listening" stops being a question.
+    //
+    // It is also the live indicator, which is the point: an open microphone on
+    // a machine in another room was previously announced only by a panel
+    // sliding up, and dismissing that panel left the mic open with nothing on
+    // screen to say so. Here the affordance and the state are the same object,
+    // so it cannot be dismissed away from its own indicator.
+
+    @ViewBuilder
+    private var micButton: some View {
+        if machine.status != .offline, machine.hasLiveSession {
+            Button { onVoice?(machine) } label: {
+                ZStack {
+                    Circle()
+                        .fill(micFill)
+                        .frame(width: 30, height: 30)
+                    if machine.voice == .listening {
+                        // Colour alone can't carry "your mic is open".
+                        Circle()
+                            .stroke(DeckTheme.accent, lineWidth: 1.5)
+                            .frame(width: 30, height: 30)
+                        MicPulseRing()
+                    }
+                    Image(systemName: micGlyph)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(micTint)
+                }
+                .frame(width: 44, height: 44)   // touch target, not visual size
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(onVoice == nil)
+            .accessibilityLabel(micAccessibilityLabel)
+        }
+    }
+
+    private var micGlyph: String {
+        switch machine.voice {
+        case .listening: return "mic.fill"
+        case .working:   return "waveform"
+        case .off:       return "mic"
+        }
+    }
+
+    private var micFill: Color {
+        machine.voice == .listening ? DeckTheme.accentFill : DeckTheme.control
+    }
+
+    private var micTint: Color {
+        switch machine.voice {
+        case .listening: return DeckTheme.accent
+        case .working:   return DeckTheme.text
+        case .off:       return DeckTheme.textSecondary
+        }
+    }
+
+    private var micAccessibilityLabel: String {
+        switch machine.voice {
+        case .listening: return "\(machine.name) is listening. Tap to stop."
+        case .working:   return "\(machine.name) is working on what you said."
+        case .off:       return "Talk to \(machine.name)"
         }
     }
 
@@ -493,6 +570,7 @@ private struct HomeTargetCard: View {
     private var compactBody: some View {
         VStack(alignment: .leading, spacing: 8) {
             compactNameRow
+            voiceLine
             identityBlock
             metadataBlock
             Spacer(minLength: 0)
@@ -505,7 +583,7 @@ private struct HomeTargetCard: View {
     }
 
     private var compactNameRow: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 6) {
             iconTile(size: 30, glyph: 15)
             Text(machine.name)
                 .font(DeckTheme.body(.medium))
@@ -516,6 +594,39 @@ private struct HomeTargetCard: View {
             if machine.attentionCount > 0 {
                 attentionDot
             }
+            micButton
+        }
+    }
+
+    /// A word, not just a colour. The complaint that started this was that a
+    /// live microphone was "a little bit too subtle" — a tinted glyph alone
+    /// repeats that mistake for anyone glancing at the roster from a metre away.
+    @ViewBuilder
+    private var voiceLine: some View {
+        switch machine.voice {
+        case .listening:
+            HStack(spacing: 6) {
+                Image(systemName: "mic.fill")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(DeckTheme.accent)
+                Text("Listening")
+                    .font(DeckTheme.secondary(.medium))
+                    .foregroundStyle(DeckTheme.accent)
+                Spacer(minLength: 0)
+            }
+        case .working:
+            HStack(spacing: 6) {
+                Image(systemName: "waveform")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(DeckTheme.textSecondary)
+                Text("Working on what you said")
+                    .font(DeckTheme.secondary())
+                    .foregroundStyle(DeckTheme.textSecondary)
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+            }
+        case .off:
+            EmptyView()
         }
     }
 
@@ -721,6 +832,27 @@ private struct HomeTargetCard: View {
 }
 
 // MARK: - Agent pulse
+
+/// Expanding ring behind a live mic. Motion carries "right now" in peripheral
+/// vision in a way a static tint does not — which is the whole complaint this
+/// answers.
+private struct MicPulseRing: View {
+    @State private var pulse = false
+
+    var body: some View {
+        Circle()
+            .stroke(DeckTheme.accent.opacity(0.55), lineWidth: 1.5)
+            .frame(width: 30, height: 30)
+            .scaleEffect(pulse ? 1.55 : 1.0)
+            .opacity(pulse ? 0.0 : 0.8)
+            .onAppear {
+                withAnimation(.easeOut(duration: 1.5).repeatForever(autoreverses: false)) {
+                    pulse = true
+                }
+            }
+            .allowsHitTesting(false)
+    }
+}
 
 private struct AgentPulseDot: View {
     let color: Color

--- a/apps/ios/Sources/Home/HomeTargetsRow.swift
+++ b/apps/ios/Sources/Home/HomeTargetsRow.swift
@@ -1,25 +1,79 @@
 import SwiftUI
 
-/// Adaptive grid of paired Macs. Each card carries live per-machine state
-/// (scene, focused app, last action, agent, attention) so the user can
-/// pick a target meaningfully — not just by name.
+/// The roster of paired hosts. Each card carries live per-machine state
+/// (scene, focused app, last action, agent, attention) so the user can pick a
+/// target meaningfully — not just by name.
 ///
-/// Adaptive: 1 = single rich card, 2 = split, 3-4 = 2x2 grid, 5+ = compact.
+/// **The roster wants to be one row.** It is a rank of things you choose
+/// between, and a rank reads as a rank when you can take it in at a glance.
+/// So the layout holds the row and spends *density*: cards thin from the full
+/// two-column card into a single-column one as the fleet grows, and only wrap
+/// when even the compact card would be too narrow to say anything.
+///
+/// The previous rule did the opposite — a fixed 260pt minimum per card, which
+/// on a 690pt row meant two columns and a third host stranded on its own line.
+/// Holding card width constant and spending rows is the wrong trade for a
+/// roster: three hosts on two rows reads as two groups.
+///
 /// Tap → enter Deck for that machine.
-///
-/// Size budget: ~150-220pt depending on machine count.
 struct HomeTargetsRow: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     let machines: [HomeMachine]
+    /// How many unpaired Macs discovery can currently see. Shown on the add
+    /// cell — this line is the whole replacement for the app auto-connecting to
+    /// whatever it found: it still tells you it can see something, it just no
+    /// longer acts on that by itself.
+    var nearbyCandidateCount: Int = 0
     var onEnterDeck: ((HomeMachine) -> Void)? = nil
+    var onEnterFleet: (() -> Void)? = nil
+    var onAddHost: (() -> Void)? = nil
     var onAttention: ((HomeMachine) -> Void)? = nil
+
+    /// Measured width of the roster. Zero until first layout, which is why
+    /// every fit test below treats zero as "assume it fits" — the first frame
+    /// should not flash a wrapped grid on its way to a row.
+    @State private var rowWidth: CGFloat = 0
+
+    /// On a narrow screen there is no room beside the cards, so the slot lies
+    /// down into a thin strip rather than claiming a card's worth of height.
+    private var slotIsHorizontal: Bool { horizontalSizeClass == .compact }
+
+    // MARK: Fit thresholds
+    //
+    // Both are the width at which the card in question stops being able to say
+    // what it is for, measured against its own contents rather than picked
+    // round: `full` needs room for the 110pt gauge column plus a machine name
+    // beside it; `compact` needs room for a name and a focused-app line.
+
+    private let cardGap: CGFloat = 12
+    private let uprightSlotWidth: CGFloat = 84
+    private let fullCardMin: CGFloat = 268
+    private let compactCardMin: CGFloat = 168
+
+    /// Width each card gets if the whole roster sits on a single row.
+    private var perCardWidth: CGFloat {
+        guard !machines.isEmpty, rowWidth > 0 else { return .infinity }
+        let slot = (onAddHost != nil && !slotIsHorizontal) ? uprightSlotWidth + cardGap : 0
+        let gaps = CGFloat(machines.count - 1) * cardGap
+        return (rowWidth - slot - gaps) / CGFloat(machines.count)
+    }
+
+    private var density: HomeTargetDensity {
+        perCardWidth >= fullCardMin ? .full : .compact
+    }
+
+    private var fitsOneRow: Bool {
+        perCardWidth >= compactCardMin
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             header
             content
+            fleetDoor
         }
+        .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { rowWidth = $0 }
     }
 
     // MARK: - Header
@@ -34,45 +88,60 @@ struct HomeTargetsRow: View {
 
     // MARK: - Content
 
+    /// Machines, with the add slot alongside them.
+    ///
+    /// The slot sits *beside* the roster rather than under it: an empty bay is
+    /// not worth a card's worth of height, and standing it up next to the real
+    /// hosts is also what it means — there is room here for one more.
     @ViewBuilder
     private var content: some View {
-        switch machines.count {
-        case 0:
-            LatsEmptyState(
-                title: "No paired machines",
-                subtitle: "Pair a Mac to see its live state here.",
-                icon: "laptopcomputer.slash"
-            )
-        case 1:
-            HomeTargetCard(
-                machine: machines[0],
-                emphasis: .full,
-                onEnterDeck: onEnterDeck,
-                onAttention: onAttention
-            )
-        case 2:
-            if horizontalSizeClass == .compact {
-                VStack(spacing: 10) {
-                    targetCards
-                }
-            } else {
-                HStack(spacing: 12) {
-                    targetCards
-                }
+        if machines.isEmpty {
+            addSlot
+        } else if fitsOneRow {
+            singleRow
+        } else if slotIsHorizontal {
+            VStack(spacing: 12) {
+                machineGrid
+                addSlot
             }
-        default:
-            LazyVGrid(
-                columns: [GridItem(.adaptive(minimum: 280, maximum: 420), spacing: 12)],
-                spacing: 12
-            ) {
-                ForEach(machines) { m in
-                    HomeTargetCard(
-                        machine: m,
-                        emphasis: m.isForeground ? .deemphasized : .full,
-                        onEnterDeck: onEnterDeck,
-                        onAttention: onAttention
-                    )
-                }
+        } else {
+            HStack(alignment: .top, spacing: cardGap) {
+                machineGrid
+                addSlot
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var singleRow: some View {
+        if slotIsHorizontal {
+            VStack(spacing: 10) {
+                HStack(alignment: .top, spacing: cardGap) { targetCards }
+                addSlot
+            }
+        } else {
+            HStack(alignment: .top, spacing: cardGap) {
+                targetCards
+                addSlot
+            }
+        }
+    }
+
+    /// Fallback for a fleet too large to rank on one row at this width. Cards
+    /// are already at compact density here, so the grid minimum matches it.
+    private var machineGrid: some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: compactCardMin, maximum: 420), spacing: cardGap)],
+            spacing: cardGap
+        ) {
+            ForEach(machines) { m in
+                HomeTargetCard(
+                    machine: m,
+                    emphasis: m.isForeground ? .deemphasized : .full,
+                    density: .compact,
+                    onEnterDeck: onEnterDeck,
+                    onAttention: onAttention
+                )
             }
         }
     }
@@ -83,10 +152,206 @@ struct HomeTargetsRow: View {
             HomeTargetCard(
                 machine: machine,
                 emphasis: machine.isForeground ? .deemphasized : .full,
+                density: density,
                 onEnterDeck: onEnterDeck,
                 onAttention: onAttention
             )
         }
+    }
+
+    @ViewBuilder
+    private var addSlot: some View {
+        if onAddHost != nil {
+            HomeAddHostSlot(
+                nearbyCount: nearbyCandidateCount,
+                isHorizontal: slotIsHorizontal,
+                onTap: onAddHost
+            )
+        }
+    }
+
+    // MARK: - The second door
+
+    /// With one Mac there is nothing to switch between, so the fleet view only
+    /// earns its place once there is a fleet.
+    @ViewBuilder
+    private var fleetDoor: some View {
+        if machines.count >= 2, let onEnterFleet {
+            HomeFleetDoor(machines: machines, onTap: onEnterFleet)
+        }
+    }
+}
+
+// MARK: - Fleet door
+
+/// The way into the multi-host deck.
+///
+/// This used to be a 6pt-padded capsule in the section header, which is where
+/// you put a filter — and it is not a filter, it is the surface where the whole
+/// fleet is operable at once. A door that leads somewhere bigger than the page
+/// it sits on should not be smaller than the page's smallest control.
+///
+/// It gets the app's one accent, applied twice (tile fill, hairline) and
+/// nowhere else on Home, so it reads as *the* destination without the band
+/// having to shout. The subtitle names what is behind the door rather than
+/// repeating the title, because "Fleet Deck" alone does not tell a first-time
+/// reader that it is where they act on every host at once.
+private struct HomeFleetDoor: View {
+    let machines: [HomeMachine]
+    var onTap: () -> Void
+
+    private var liveCount: Int {
+        machines.filter { $0.status != .offline }.count
+    }
+
+    private var subtitle: String {
+        let n = machines.count
+        if liveCount == n {
+            return "Watch and drive all \(n) hosts on one surface"
+        }
+        return "Watch and drive all \(n) hosts — \(liveCount) reachable now"
+    }
+
+    private var attentionTotal: Int {
+        machines.reduce(0) { $0 + $1.attentionCount }
+    }
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: DeckTheme.Space.x12) {
+                tile
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Fleet Deck")
+                        .font(DeckTheme.title())
+                        .foregroundStyle(DeckTheme.text)
+                    Text(subtitle)
+                        .font(DeckTheme.secondary())
+                        .foregroundStyle(DeckTheme.textSecondary)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 0)
+
+                if attentionTotal > 0 {
+                    Text("\(attentionTotal) waiting")
+                        .font(DeckTheme.caption(.medium))
+                        .foregroundStyle(DeckTheme.accent)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Capsule().fill(DeckTheme.accentFill))
+                }
+
+                Image(systemName: "arrow.up.right")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(DeckTheme.accent)
+            }
+            .padding(.horizontal, DeckTheme.Space.cardPadH)
+            .padding(.vertical, DeckTheme.Space.cardPadV)
+            .frame(maxWidth: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: DeckTheme.radiusCard, style: .continuous)
+                    .fill(DeckTheme.card)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: DeckTheme.radiusCard, style: .continuous)
+                    .stroke(DeckTheme.accent.opacity(0.30), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Open Fleet Deck for all \(machines.count) machines")
+    }
+
+    private var tile: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: DeckTheme.radiusCard, style: .continuous)
+                .fill(DeckTheme.accentFill)
+            Image(systemName: "square.grid.2x2.fill")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(DeckTheme.accent)
+        }
+        .frame(width: 40, height: 40)
+    }
+}
+
+// MARK: - Add slot
+
+/// The way into pairing: an empty bay at the end of the roster.
+///
+/// Deliberately not a card. A card announces a host; this announces *room for*
+/// one, so it takes a slot's width and none of a card's detail. It stands
+/// upright beside the hosts where there is width for it, and lies down into a
+/// thin strip where there isn't.
+private struct HomeAddHostSlot: View {
+    let nearbyCount: Int
+    let isHorizontal: Bool
+    var onTap: (() -> Void)? = nil
+
+    /// Width of the upright slot — wide enough to tap, narrow enough that it
+    /// never reads as a host that failed to load.
+    private let slotWidth: CGFloat = 84
+
+    private var nearbyLabel: String {
+        switch nearbyCount {
+        case 0:  return "none nearby"
+        case 1:  return "1 nearby"
+        default: return "\(nearbyCount) nearby"
+        }
+    }
+
+    var body: some View {
+        Button { onTap?() } label: {
+            if isHorizontal { strip } else { upright }
+        }
+        .buttonStyle(.plain)
+        .disabled(onTap == nil)
+        .accessibilityLabel("Add a host. \(nearbyLabel).")
+    }
+
+    private var upright: some View {
+        VStack(spacing: 8) {
+            plus
+            Text("Add")
+                .font(DeckTheme.caption(.medium))
+                .foregroundStyle(DeckTheme.textSecondary)
+            Text(nearbyLabel)
+                .font(DeckTheme.caption())
+                .foregroundStyle(DeckTheme.textTertiary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(.vertical, 12)
+        .frame(width: slotWidth)
+        .frame(minHeight: 140, maxHeight: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(DeckTheme.card)
+        )
+    }
+
+    private var strip: some View {
+        HStack(spacing: 10) {
+            plus
+            Text("Add a host")
+                .font(DeckTheme.secondary(.medium))
+                .foregroundStyle(DeckTheme.textSecondary)
+            Spacer(minLength: 0)
+            Text(nearbyLabel)
+                .font(DeckTheme.caption())
+                .foregroundStyle(DeckTheme.textTertiary)
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 44)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(DeckTheme.card)
+        )
+    }
+
+    private var plus: some View {
+        Image(systemName: "plus")
+            .font(.system(size: 15, weight: .medium))
+            .foregroundStyle(DeckTheme.textSecondary)
+            .frame(width: 26, height: 26)
     }
 }
 
@@ -97,29 +362,46 @@ private enum HomeTargetEmphasis {
     case deemphasized  // foreground machine — same card, lower contrast body
 }
 
+/// How much card there is room for.
+///
+/// Not a style choice — a fit. `full` is the two-column card with the tall
+/// gauge stack beside the text; `compact` folds it into one column and lays the
+/// gauges flat, which is what fits once three or more hosts share a row.
+enum HomeTargetDensity {
+    case full
+    case compact
+}
+
 private struct HomeTargetCard: View {
     let machine: HomeMachine
     var emphasis: HomeTargetEmphasis = .full
+    var density: HomeTargetDensity = .full
     var onEnterDeck: ((HomeMachine) -> Void)? = nil
     var onAttention: ((HomeMachine) -> Void)? = nil
 
-    /// Shared minimum card height. Picked so the gauge column has room to
-    /// breathe (status badge + tall gauges + latency) and offline cards
-    /// reserve the same space — keeps geometry identical regardless of state.
-    private var cardMinHeight: CGFloat { 156 }
+    /// Shared minimum card height per density. Picked so the gauges have room
+    /// to breathe and offline cards reserve the same space — geometry stays
+    /// identical regardless of state, so a host going dark never reflows the row.
+    private var cardMinHeight: CGFloat {
+        density == .full ? 156 : 140
+    }
 
     var body: some View {
         Button(action: { onEnterDeck?(machine) }) {
             LatsCard(padding: 12, radius: 8) {
-                HStack(alignment: .top, spacing: 14) {
-                    leftColumn
-                    rightColumn
+                Group {
+                    switch density {
+                    case .full:    fullBody
+                    case .compact: compactBody
+                    }
                 }
                 .frame(minHeight: cardMinHeight)
             }
         }
         .buttonStyle(.plain)
         .opacity(emphasis == .deemphasized ? 0.78 : 1.0)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(machine.name), \(machine.status.label)")
     }
 
     private func hasGaugeContent(_ m: HomeMachineMetrics) -> Bool {
@@ -129,7 +411,19 @@ private struct HomeTargetCard: View {
             || m.thermalPercent != nil
     }
 
-    // MARK: Left column — name, identity, metadata, agent
+    private var gauges: HomeMachineMetrics? {
+        guard let m = machine.metrics, hasGaugeContent(m) else { return nil }
+        return m
+    }
+
+    // MARK: Full — two columns
+
+    private var fullBody: some View {
+        HStack(alignment: .top, spacing: 14) {
+            leftColumn
+            rightColumn
+        }
+    }
 
     private var leftColumn: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -144,9 +438,9 @@ private struct HomeTargetCard: View {
 
     private var nameRow: some View {
         HStack(spacing: 10) {
-            iconTile
+            iconTile(size: 38, glyph: 18)
             Text(machine.name)
-                .font(LatsFont.mono(13, weight: .semibold))
+                .font(DeckTheme.body(.medium))
                 .foregroundStyle(bodyText)
                 .lineLimit(1)
                 .truncationMode(.tail)
@@ -154,13 +448,11 @@ private struct HomeTargetCard: View {
         }
     }
 
-    // MARK: Right column — status badge above the gauge stack
-
     private var rightColumn: some View {
         VStack(alignment: .trailing, spacing: 10) {
             statusStack
 
-            if let metrics = machine.metrics, hasGaugeContent(metrics) {
+            if let metrics = gauges {
                 Spacer(minLength: 4)
                 HomeMachineGauges(metrics: metrics, barHeight: 80)
                 Spacer(minLength: 0)
@@ -185,10 +477,60 @@ private struct HomeTargetCard: View {
             }
             if let lat = machine.latencyMs, machine.status != .offline {
                 Text("\(lat)ms")
-                    .font(LatsFont.mono(9))
-                    .tracking(0.4)
-                    .foregroundStyle(LatsPalette.textFaint)
+                    .font(DeckTheme.caption())
+                    .foregroundStyle(DeckTheme.textTertiary)
             }
+        }
+    }
+
+    // MARK: Compact — one column
+    //
+    // The status badge moves down to the footer rather than competing with the
+    // name for a ~170pt row, and the gauges lie flat under the text where the
+    // full card stands them up beside it. Nothing is dropped except the latency
+    // line, which has no producer yet anyway.
+
+    private var compactBody: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            compactNameRow
+            identityBlock
+            metadataBlock
+            Spacer(minLength: 0)
+            if let metrics = gauges {
+                HomeMachineGauges(metrics: metrics, barHeight: 26)
+            }
+            compactFooterRow
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+    }
+
+    private var compactNameRow: some View {
+        HStack(spacing: 8) {
+            iconTile(size: 30, glyph: 15)
+            Text(machine.name)
+                .font(DeckTheme.body(.medium))
+                .foregroundStyle(bodyText)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            if machine.attentionCount > 0 {
+                attentionDot
+            }
+        }
+    }
+
+    private var compactFooterRow: some View {
+        HStack(spacing: 8) {
+            LatsBadge(
+                text: machine.status.label,
+                tint: machine.status.tint,
+                dot: machine.status == .active
+            )
+            agentChip
+            Spacer(minLength: 0)
+            Image(systemName: "arrow.up.right")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(emphasis == .deemphasized ? DeckTheme.textTertiary : DeckTheme.textSecondary)
         }
     }
 
@@ -199,33 +541,30 @@ private struct HomeTargetCard: View {
         switch machine.status {
         case .offline:
             HStack(alignment: .firstTextBaseline, spacing: 6) {
-                Text("PAIRED")
-                    .font(LatsFont.mono(9, weight: .bold))
-                    .tracking(0.8)
-                    .foregroundStyle(LatsPalette.textFaint)
-                    .frame(width: 50, alignment: .leading)
-                Text(machine.lastActionAgo ?? "—")
-                    .font(LatsFont.mono(11))
-                    .foregroundStyle(bodyDim)
+                Text("Paired \(machine.lastActionAgo ?? "—") ago")
+                    .font(DeckTheme.secondary())
+                    .foregroundStyle(DeckTheme.textTertiary)
                 Spacer(minLength: 0)
             }
         default:
             VStack(alignment: .leading, spacing: 6) {
                 focusedRow
-                lastActionRow
+                if density == .full {
+                    lastActionRow
+                }
             }
         }
     }
 
-    private var iconTile: some View {
+    private func iconTile(size: CGFloat, glyph: CGFloat) -> some View {
         let tint = machine.status.tint
         return ZStack {
             RoundedRectangle(cornerRadius: 8).fill(tint.opacity(0.15))
             Image(systemName: machine.icon)
-                .font(.system(size: 18, weight: .regular))
+                .font(.system(size: glyph, weight: .regular))
                 .foregroundStyle(tint)
         }
-        .frame(width: 38, height: 38)
+        .frame(width: size, height: size)
         .overlay(
             RoundedRectangle(cornerRadius: 8).stroke(tint.opacity(0.4), lineWidth: 1)
         )
@@ -234,8 +573,8 @@ private struct HomeTargetCard: View {
     private var attentionDot: some View {
         Button(action: { onAttention?(machine) }) {
             Text("\(machine.attentionCount)")
-                .font(LatsFont.mono(9, weight: .bold))
-                .foregroundStyle(LatsPalette.text)
+                .font(DeckTheme.caption(.semibold))
+                .foregroundStyle(DeckTheme.text)
                 .padding(.horizontal, 5)
                 .frame(minWidth: 16, minHeight: 14)
                 .background(
@@ -256,10 +595,10 @@ private struct HomeTargetCard: View {
         if let scene = machine.scene {
             HStack(spacing: 6) {
                 Image(systemName: "rectangle.3.group")
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(LatsPalette.teal)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(DeckTheme.textSecondary)
                 Text(scene)
-                    .font(LatsFont.ui(12, weight: .medium))
+                    .font(DeckTheme.secondary(.medium))
                     .foregroundStyle(bodyText)
                     .lineLimit(1)
                 Spacer(minLength: 0)
@@ -269,9 +608,9 @@ private struct HomeTargetCard: View {
                 Image(systemName: "moon.zzz")
                     .font(.system(size: 10, weight: .regular))
                     .foregroundStyle(LatsPalette.textFaint)
-                Text("unreachable")
-                    .font(LatsFont.mono(10))
-                    .foregroundStyle(LatsPalette.textFaint)
+                Text("Unreachable")
+                    .font(DeckTheme.secondary())
+                    .foregroundStyle(DeckTheme.textTertiary)
                 Spacer(minLength: 0)
             }
         }
@@ -282,30 +621,25 @@ private struct HomeTargetCard: View {
     @ViewBuilder
     private var focusedRow: some View {
         HStack(alignment: .firstTextBaseline, spacing: 6) {
-            Text("FOCUS")
-                .font(LatsFont.mono(9, weight: .bold))
-                .tracking(0.8)
-                .foregroundStyle(LatsPalette.textFaint)
-                .frame(width: 44, alignment: .leading)
             if let app = machine.focusedApp {
                 Text(app)
-                    .font(LatsFont.mono(11, weight: .semibold))
+                    .font(DeckTheme.secondary(.medium))
                     .foregroundStyle(bodyText)
                     .lineLimit(1)
-                if let win = machine.focusedWindow {
+                if let win = machine.focusedWindow, density == .full {
                     Text("·")
-                        .font(LatsFont.mono(11))
-                        .foregroundStyle(LatsPalette.textFaint)
+                        .font(DeckTheme.secondary())
+                        .foregroundStyle(DeckTheme.textTertiary)
                     Text(win)
-                        .font(LatsFont.mono(11))
+                        .font(DeckTheme.secondary())
                         .foregroundStyle(bodyDim)
                         .lineLimit(1)
                         .truncationMode(.middle)
                 }
             } else {
-                Text("—")
-                    .font(LatsFont.mono(11))
-                    .foregroundStyle(LatsPalette.textFaint)
+                Text("Nothing focused")
+                    .font(DeckTheme.secondary())
+                    .foregroundStyle(DeckTheme.textTertiary)
             }
             Spacer(minLength: 0)
         }
@@ -314,29 +648,17 @@ private struct HomeTargetCard: View {
     @ViewBuilder
     private var lastActionRow: some View {
         HStack(alignment: .firstTextBaseline, spacing: 6) {
-            Text("LAST")
-                .font(LatsFont.mono(9, weight: .bold))
-                .tracking(0.8)
-                .foregroundStyle(LatsPalette.textFaint)
-                .frame(width: 44, alignment: .leading)
             if let action = machine.lastAction {
                 Text(action)
-                    .font(LatsFont.mono(11))
-                    .foregroundStyle(bodyText)
+                    .font(DeckTheme.caption())
+                    .foregroundStyle(DeckTheme.textTertiary)
                     .lineLimit(1)
                     .truncationMode(.tail)
                 if let ago = machine.lastActionAgo {
-                    Text("·")
-                        .font(LatsFont.mono(11))
-                        .foregroundStyle(LatsPalette.textFaint)
-                    Text(ago)
-                        .font(LatsFont.mono(10))
-                        .foregroundStyle(bodyDim)
+                    Text("· \(ago)")
+                        .font(DeckTheme.caption())
+                        .foregroundStyle(DeckTheme.textTertiary)
                 }
-            } else {
-                Text(machine.lastActionAgo ?? "—")
-                    .font(LatsFont.mono(11))
-                    .foregroundStyle(LatsPalette.textFaint)
             }
             Spacer(minLength: 0)
         }
@@ -350,7 +672,7 @@ private struct HomeTargetCard: View {
             Spacer(minLength: 0)
             Image(systemName: "arrow.up.right")
                 .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(emphasis == .deemphasized ? LatsPalette.textFaint : LatsPalette.textDim)
+                .foregroundStyle(emphasis == .deemphasized ? DeckTheme.textTertiary : DeckTheme.textSecondary)
         }
     }
 
@@ -366,17 +688,13 @@ private struct HomeTargetCard: View {
         let tint = machine.agentState.tint
 
         return HStack(spacing: 6) {
-            Text("AGENT")
-                .font(LatsFont.mono(9, weight: .bold))
-                .tracking(0.8)
-                .foregroundStyle(LatsPalette.textFaint)
             if isRunning {
                 AgentPulseDot(color: tint)
             } else {
                 Circle().fill(tint.opacity(isWaiting ? 0.85 : 0.55)).frame(width: 5, height: 5)
             }
             Text(agentLabel)
-                .font(LatsFont.mono(10, weight: isRunning ? .semibold : .regular))
+                .font(DeckTheme.caption(isRunning ? .medium : .regular))
                 .foregroundStyle(isRunning ? tint : (isWaiting ? tint : LatsPalette.textDim))
                 .lineLimit(1)
                 .truncationMode(.tail)
@@ -386,19 +704,19 @@ private struct HomeTargetCard: View {
     private var agentLabel: String {
         switch machine.agentState {
         case .idle: return "idle"
-        case .running(let task): return "running · \(task)"
-        case .waiting(let msg): return "waiting · \(msg)"
+        case .running(let task): return density == .full ? "running · \(task)" : "running"
+        case .waiting(let msg):  return density == .full ? "waiting · \(msg)"  : "waiting"
         }
     }
 
     // MARK: Emphasis-aware foregrounds
 
     private var bodyText: Color {
-        emphasis == .deemphasized ? LatsPalette.textDim : LatsPalette.text
+        emphasis == .deemphasized ? DeckTheme.textSecondary : DeckTheme.text
     }
 
     private var bodyDim: Color {
-        emphasis == .deemphasized ? LatsPalette.textFaint : LatsPalette.textDim
+        emphasis == .deemphasized ? DeckTheme.textTertiary : DeckTheme.textSecondary
     }
 }
 
@@ -431,7 +749,7 @@ private struct AgentPulseDot: View {
 #Preview("Targets · 1") {
     LatsBackground {
         ScrollView {
-            HomeTargetsRow(machines: HomeMock.fleetOne) { _ in }
+            HomeTargetsRow(machines: HomeMock.fleetOne, onEnterDeck: { _ in }, onEnterFleet: {}, onAddHost: {})
                 .padding(14)
         }
     }
@@ -441,8 +759,21 @@ private struct AgentPulseDot: View {
 #Preview("Targets · 2") {
     LatsBackground {
         ScrollView {
-            HomeTargetsRow(machines: HomeMock.fleetTwo) { _ in }
+            HomeTargetsRow(machines: HomeMock.fleetTwo, onEnterDeck: { _ in }, onEnterFleet: {}, onAddHost: {})
                 .padding(14)
+        }
+    }
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Targets · 3") {
+    LatsBackground {
+        ScrollView {
+            HomeTargetsRow(
+                machines: Array(HomeMock.fleetFour.prefix(3)),
+                onEnterDeck: { _ in }, onEnterFleet: {}, onAddHost: {}
+            )
+            .padding(14)
         }
     }
     .preferredColorScheme(.dark)
@@ -451,7 +782,7 @@ private struct AgentPulseDot: View {
 #Preview("Targets · 4") {
     LatsBackground {
         ScrollView {
-            HomeTargetsRow(machines: HomeMock.fleetFour) { _ in }
+            HomeTargetsRow(machines: HomeMock.fleetFour, onEnterDeck: { _ in }, onEnterFleet: {}, onAddHost: {})
                 .padding(14)
         }
     }
@@ -461,7 +792,7 @@ private struct AgentPulseDot: View {
 #Preview("Targets · empty") {
     LatsBackground {
         ScrollView {
-            HomeTargetsRow(machines: HomeMock.fleetEmpty)
+            HomeTargetsRow(machines: HomeMock.fleetEmpty, onAddHost: {})
                 .padding(14)
         }
     }

--- a/apps/ios/Sources/Home/HomeView.swift
+++ b/apps/ios/Sources/Home/HomeView.swift
@@ -40,6 +40,8 @@ struct HomeView: View {
     /// Opens the multi-host deck. Only offered when there is more than one Mac.
     var onEnterFleet: (() -> Void)? = nil
     var onAddHost: (() -> Void)? = nil
+    /// Toggle dictation on one specific host, from its roster card.
+    var onMachineVoice: ((HomeMachine) -> Void)? = nil
     /// Unpaired Macs discovery can see right now. Surfaced on the add cell.
     var nearbyCandidateCount: Int = 0
     var onScene: ((HomeScene) -> Void)? = nil
@@ -149,7 +151,8 @@ struct HomeView: View {
                         nearbyCandidateCount: nearbyCandidateCount,
                         onEnterDeck: onEnterDeck,
                         onEnterFleet: onEnterFleet,
-                        onAddHost: onAddHost
+                        onAddHost: onAddHost,
+                        onVoice: onMachineVoice
                     )
 
                     HomeScenesGrid(scenes: scenes, onScene: onScene)
@@ -184,7 +187,20 @@ struct HomeView: View {
                         onVoiceCancel?()
                         voicePanelOpen = false
                     },
-                    onClose: { voicePanelOpen = false },
+                    onClose: {
+                        // Dismissing the panel must not leave a microphone open
+                        // on a machine you can no longer see. The chevron reads
+                        // as "close voice" and used to close only the *panel* —
+                        // capture kept running on the remote Mac with nothing on
+                        // screen to say so, and no way back to a stop button
+                        // except re-opening the panel.
+                        //
+                        // Only `.listening` holds the mic open; the later phases
+                        // are the Mac thinking, and silently cancelling that
+                        // would throw away a turn the user already spoke.
+                        if voiceState?.phase == .listening { onVoiceStop?() }
+                        voicePanelOpen = false
+                    },
                     onRemediate: { onVoiceRemediate?($0) }
                 )
                 .transition(.move(edge: .bottom).combined(with: .opacity))

--- a/apps/ios/Sources/Home/HomeView.swift
+++ b/apps/ios/Sources/Home/HomeView.swift
@@ -37,6 +37,11 @@ struct HomeView: View {
     var bottomTelemetry: HomeBottomTelemetry = .empty
 
     var onEnterDeck: ((HomeMachine) -> Void)? = nil
+    /// Opens the multi-host deck. Only offered when there is more than one Mac.
+    var onEnterFleet: (() -> Void)? = nil
+    var onAddHost: (() -> Void)? = nil
+    /// Unpaired Macs discovery can see right now. Surfaced on the add cell.
+    var nearbyCandidateCount: Int = 0
     var onScene: ((HomeScene) -> Void)? = nil
     var onRoutine: ((HomeRoutine) -> Void)? = nil
     var onBroadcast: ((HomeSyncAction, [HomeMachine]) -> Void)? = nil
@@ -139,7 +144,13 @@ struct HomeView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
-                    HomeTargetsRow(machines: machines, onEnterDeck: onEnterDeck)
+                    HomeTargetsRow(
+                        machines: machines,
+                        nearbyCandidateCount: nearbyCandidateCount,
+                        onEnterDeck: onEnterDeck,
+                        onEnterFleet: onEnterFleet,
+                        onAddHost: onAddHost
+                    )
 
                     HomeScenesGrid(scenes: scenes, onScene: onScene)
 

--- a/apps/ios/Sources/Home/HomeZeroState.swift
+++ b/apps/ios/Sources/Home/HomeZeroState.swift
@@ -148,7 +148,7 @@ struct HomeZeroState: View {
     private var cta: some View {
         VStack(spacing: 14) {
             LatsButton(
-                title: "Pair a Mac",
+                title: "Add a host",
                 icon: "plus.circle",
                 style: .primary(.green)
             ) {

--- a/apps/ios/Sources/LatsDeckScreen.swift
+++ b/apps/ios/Sources/LatsDeckScreen.swift
@@ -4,26 +4,33 @@ import UIKit
 
 // MARK: - Design System
 
+/// Home and the single-host cockpit speak through these names; they now resolve
+/// to the one token layer in `DeckTheme.swift`. Kept as an alias rather than a
+/// find-and-replace so ~5,600 lines of call sites move in one step instead of
+/// one risky sweep.
 enum LatsPalette {
-    static let bgEdge   = Color(hue: 0.62, saturation: 0.05, brightness: 0.08)
-    static let bg       = Color(hue: 0.62, saturation: 0.05, brightness: 0.13)
-    static let surface  = Color(hue: 0.62, saturation: 0.06, brightness: 0.18)
-    static let surface2 = Color(hue: 0.62, saturation: 0.07, brightness: 0.22)
+    static let bgEdge   = DeckTheme.canvas
+    static let bg       = DeckTheme.canvas
+    static let surface  = DeckTheme.card
+    static let surface2 = DeckTheme.raised
 
-    static let hairline  = Color.white.opacity(0.06)
-    static let hairline2 = Color.white.opacity(0.10)
+    static let hairline  = DeckTheme.hairline
+    static let hairline2 = DeckTheme.hairlineStrong
 
-    static let text      = Color(white: 0.96)
-    static let textDim   = Color(white: 0.96).opacity(0.55)
-    static let textFaint = Color(white: 0.96).opacity(0.32)
+    static let text      = DeckTheme.text
+    static let textDim   = DeckTheme.textSecondary
+    static let textFaint = DeckTheme.textTertiary
 
-    static let red    = Color(red: 0.95, green: 0.40, blue: 0.42)
-    static let amber  = Color(red: 0.96, green: 0.74, blue: 0.36)
-    static let green  = Color(red: 0.43, green: 0.86, blue: 0.55)
-    static let teal   = Color(red: 0.43, green: 0.83, blue: 0.84)
-    static let blue   = Color(red: 0.49, green: 0.71, blue: 0.97)
-    static let violet = Color(red: 0.74, green: 0.59, blue: 0.99)
-    static let pink   = Color(red: 0.97, green: 0.58, blue: 0.81)
+    // Two hues for the whole app. Everything that used to carry a decorative
+    // tint resolves to a grey, so the only saturation left is something that
+    // actually wants you.
+    static let red    = DeckTheme.error
+    static let amber  = DeckTheme.accent
+    static let green  = DeckTheme.textSecondary
+    static let teal   = DeckTheme.textSecondary
+    static let blue   = DeckTheme.textSecondary
+    static let violet = DeckTheme.textSecondary
+    static let pink   = DeckTheme.textSecondary
 }
 
 enum LatsTint: String, CaseIterable {
@@ -47,12 +54,15 @@ enum LatsTint: String, CaseIterable {
     }
 }
 
+/// Both faces are now the system face. See `DeckTheme` — the app operates
+/// agents and dictation, not terminals, so chrome has no reason to wear
+/// monospace. The serif is reserved for utterances and lives on `DeckTheme`.
 enum LatsFont {
     static func mono(_ size: CGFloat, weight: Font.Weight = .regular) -> Font {
-        .system(size: size, weight: weight, design: .monospaced)
+        .system(size: size, weight: weight)
     }
     static func ui(_ size: CGFloat, weight: Font.Weight = .regular) -> Font {
-        .system(size: size, weight: weight, design: .default)
+        .system(size: size, weight: weight)
     }
 }
 
@@ -630,27 +640,17 @@ struct LatsTrackpadTopBezel: View {
     }
 }
 
+/// The blueprint grid, retired.
+///
+/// Both design systems independently reached for an engineering grid, which is
+/// what made that the shared tell rather than a coincidence — it is a costume
+/// that makes even neutral content read as technical, and it adds moiré behind
+/// text for nothing. Flat near-black is what lets a two-hue palette read as
+/// deliberate instead of empty.
+///
+/// Kept as an empty view so its call sites can stay put.
 struct LatsGridBackground: View {
-    var body: some View {
-        Canvas { context, size in
-            let step: CGFloat = 20
-            let lineColor = Color.white.opacity(0.025)
-            var path = Path()
-            var x: CGFloat = 0
-            while x < size.width {
-                path.move(to: CGPoint(x: x, y: 0))
-                path.addLine(to: CGPoint(x: x, y: size.height))
-                x += step
-            }
-            var y: CGFloat = 0
-            while y < size.height {
-                path.move(to: CGPoint(x: 0, y: y))
-                path.addLine(to: CGPoint(x: size.width, y: y))
-                y += step
-            }
-            context.stroke(path, with: .color(lineColor), lineWidth: 1)
-        }
-    }
+    var body: some View { EmptyView() }
 }
 
 struct LatsInsetSlice<Content: View>: View {
@@ -2537,13 +2537,10 @@ struct FleetDeckScreen: View {
     }
 
     var body: some View {
-        Group {
-            if stores.count == 1, let store = stores.first, store.snapshot != nil {
-                singleDeck(store)
-            } else {
-                fleetLayout
-            }
-        }
+        // No auto-deciding by host count: Home already chose this surface. A
+        // single-Mac focus environment is reached through `DeckDestination.host`,
+        // which presents `LatsDeckScreen` directly.
+        fleetLayout
         .preferredColorScheme(.dark)
         .statusBarHidden(true)
         .onAppear {
@@ -2556,6 +2553,11 @@ struct FleetDeckScreen: View {
         .onChange(of: primaryStore.discoveredBridges) { _, _ in
             guard previewStores == nil else { return }
             fleetStore.synchronize(with: primaryStore)
+            // `synchronize` mints new sessions at the default ambient rate. The
+            // deck is open, so anything joining the roster now has to keep up
+            // with it — otherwise a Mac that appears mid-session updates at
+            // background cadence while sitting on screen.
+            fleetStore.setUIPriority(.fast, primaryStore: primaryStore)
             selectInitialSessionIfNeeded()
         }
         .onChange(of: fleetStore.secondaryStores.map(\.sessionID)) { _, _ in
@@ -2568,33 +2570,32 @@ struct FleetDeckScreen: View {
         }
     }
 
-    @ViewBuilder
-    private func singleDeck(_ store: DeckStore) -> some View {
-        LatsDeckScreen(
-            liveSnapshot: store.snapshot,
-            connectionLabel: store.connectionLabel,
-            onAction: { actionID, payload, label in
-                store.perform(actionID: actionID, pageID: "cockpit", payload: payload, label: label)
-            },
-            onTrackpadEvent: { event, dx, dy in
-                store.sendTrackpad(event: event, dx: dx, dy: dy)
-            }
-        )
-    }
-
     private var fleetLayout: some View {
         GeometryReader { proxy in
             let isLandscape = proxy.size.width > proxy.size.height
+            // The Fleet Deck design is authored on a 1376×1032 iPad-landscape
+            // canvas. Give it the screen whenever there is room for its fixed
+            // rows; anything shorter (iPhone landscape) keeps the lane layout.
+            let fitsDeck = isLandscape && proxy.size.height >= 700 && !stores.isEmpty
 
-            LatsBackground(grid: true) {
-                VStack(spacing: 0) {
-                    fleetTopBar(isLandscape: isLandscape)
-                    if stores.isEmpty {
-                        fleetEmptyState
-                    } else if isLandscape {
-                        landscapeDecks(size: proxy.size)
-                    } else {
-                        portraitDecks
+            if fitsDeck {
+                FleetDeckHost(
+                    stores: stores,
+                    initialMachineID: initialMachineID,
+                    onClose: { dismiss() }
+                )
+                .ignoresSafeArea(.container, edges: .bottom)
+            } else {
+                LatsBackground(grid: true) {
+                    VStack(spacing: 0) {
+                        fleetTopBar(isLandscape: isLandscape)
+                        if stores.isEmpty {
+                            fleetEmptyState
+                        } else if isLandscape {
+                            landscapeDecks(size: proxy.size)
+                        } else {
+                            portraitDecks
+                        }
                     }
                 }
             }
@@ -2754,26 +2755,42 @@ struct FleetDeckScreen: View {
 }
 
 #if DEBUG
+/// Renders the Fleet Deck against four canned Macs, which exercises the whole
+/// live path — `DeckStore` snapshots through `FleetDeckAdapter` — without a
+/// network. Pass `useDesignFixture` to render the design source's own data
+/// instead, for comparison against the artifact.
 struct FleetDeckPreviewHost: View {
     @StateObject private var primaryStore: DeckStore
     @StateObject private var fleetStore = DeckFleetStore()
     private let previewStores: [DeckStore]
+    private let useDesignFixture: Bool
+    private let fixtureLayout: FleetDeckLayout
 
-    init(machineCount: Int = 4) {
+    init(machineCount: Int = 4, useDesignFixture: Bool = false, fixtureLayout: FleetDeckLayout = .ops) {
+        self.fixtureLayout = fixtureLayout
         let names = ["Arach MacBook Pro", "Studio", "Mac mini", "Build Mac"]
         let stores = (0..<max(1, min(machineCount, names.count))).map {
             DeckStore.fleetPreview(name: names[$0], index: $0)
         }
         previewStores = stores
+        self.useDesignFixture = useDesignFixture
         _primaryStore = StateObject(wrappedValue: stores[0])
     }
 
     var body: some View {
-        FleetDeckScreen(
-            primaryStore: primaryStore,
-            fleetStore: fleetStore,
-            previewStores: previewStores
-        )
+        Group {
+            if useDesignFixture {
+                FleetDeckFixtureHost(initialLayout: fixtureLayout)
+            } else {
+                FleetDeckScreen(
+                    primaryStore: primaryStore,
+                    fleetStore: fleetStore,
+                    previewStores: previewStores
+                )
+            }
+        }
+        .preferredColorScheme(.dark)
+        .statusBarHidden(true)
     }
 }
 #endif

--- a/apps/ios/Sources/LatticesCompanionApp.swift
+++ b/apps/ios/Sources/LatticesCompanionApp.swift
@@ -5,7 +5,15 @@ struct LatticesCompanionApp: App {
     var body: some Scene {
         WindowGroup {
             #if DEBUG
-            if ProcessInfo.processInfo.arguments.contains("--fleet-preview") {
+            if ProcessInfo.processInfo.arguments.contains("--fleet-design") {
+                // The design source's own data, for comparison against the artifact.
+                // Add --fleet-focus to boot into the design's second layout.
+                FleetDeckPreviewHost(
+                    machineCount: 4,
+                    useDesignFixture: true,
+                    fixtureLayout: ProcessInfo.processInfo.arguments.contains("--fleet-focus") ? .focus : .ops
+                )
+            } else if ProcessInfo.processInfo.arguments.contains("--fleet-preview") {
                 FleetDeckPreviewHost(machineCount: 4)
             } else {
                 ContentView()

--- a/apps/ios/Sources/LocalNetworkScanner.swift
+++ b/apps/ios/Sources/LocalNetworkScanner.swift
@@ -1,0 +1,221 @@
+import Darwin
+import Foundation
+
+/// Finds bridges by asking every address on this device's own subnet, for the
+/// networks where Bonjour never arrives.
+///
+/// Bonjour is the right default and stays the default: it is cheap, passive,
+/// and it tells you a service's name and fingerprint without anyone having to
+/// look for it. But plenty of real networks drop multicast — guest Wi‑Fi, most
+/// corporate networks, anything with client isolation half-configured — and on
+/// those the only route in was typing an address by hand, which means knowing
+/// it. Sweeping the subnet is how the app finds a host it can plainly reach.
+///
+/// This only ever runs when the user asks. It is a burst of a few hundred
+/// short-lived requests, which is fine as a deliberate act and would be rude on
+/// a timer.
+@MainActor
+final class LocalNetworkScanner: ObservableObject {
+
+    enum Outcome: Equatable {
+        /// Swept the subnet and this is what answered.
+        case swept(checked: Int)
+        /// The subnet is too big to walk politely — see `maxHosts`.
+        case networkTooLarge(hosts: Int)
+        /// No usable IPv4 interface, so there is no subnet to sweep.
+        case noNetwork
+    }
+
+    @Published private(set) var isScanning = false
+    /// 0…1 across the sweep, for a determinate bar — the one place in this flow
+    /// where a progress indicator is honest, because the work really is finite
+    /// and really is countable.
+    @Published private(set) var progress: Double = 0
+    @Published private(set) var found: [BridgeEndpoint] = []
+    @Published private(set) var outcome: Outcome?
+
+    /// Refuse to walk anything bigger than a /23. A /16 is 65,534 probes; at
+    /// that size this stops being a scan and starts being a nuisance to every
+    /// other device on the network.
+    private let maxHosts = 512
+    /// How many probes are in the air at once. High enough to finish a /24 in a
+    /// few seconds, low enough not to exhaust the socket budget.
+    private let concurrency = 24
+
+    func reset() {
+        found = []
+        outcome = nil
+        progress = 0
+    }
+
+    func scan(port: Int = 5287) async {
+        guard !isScanning else { return }
+
+        guard let interface = LocalNetworkProbe.primaryIPv4Interface() else {
+            outcome = .noNetwork
+            return
+        }
+
+        let hosts = interface.hostAddresses
+        guard hosts.count <= maxHosts else {
+            outcome = .networkTooLarge(hosts: hosts.count)
+            return
+        }
+
+        isScanning = true
+        progress = 0
+        found = []
+        outcome = nil
+        defer { isScanning = false }
+
+        let targets = hosts.filter { $0 != interface.address }
+        var completed = 0
+
+        await withTaskGroup(of: BridgeEndpoint?.self) { group in
+            var next = 0
+            let window = min(concurrency, targets.count)
+
+            while next < window {
+                let address = targets[next]
+                group.addTask { await LocalNetworkProbe.probe(address: address, port: port) }
+                next += 1
+            }
+
+            while let result = await group.next() {
+                completed += 1
+                progress = targets.isEmpty ? 1 : Double(completed) / Double(targets.count)
+
+                if let result, !found.contains(where: { $0.host == result.host }) {
+                    found.append(result)
+                }
+
+                if next < targets.count {
+                    let address = targets[next]
+                    group.addTask { await LocalNetworkProbe.probe(address: address, port: port) }
+                    next += 1
+                }
+            }
+        }
+
+        progress = 1
+        outcome = .swept(checked: targets.count)
+    }
+}
+
+// MARK: - Probing
+//
+// Deliberately outside the actor: each probe is network work and has no reason
+// to touch the main thread.
+
+enum LocalNetworkProbe {
+
+    struct IPv4Interface {
+        let name: String
+        /// Host byte order throughout — the bit arithmetic below is unreadable
+        /// otherwise.
+        let address: UInt32
+        let netmask: UInt32
+
+        /// Every address on this subnet except the network and broadcast ones.
+        var hostAddresses: [UInt32] {
+            let network = address & netmask
+            let broadcast = network | ~netmask
+            guard broadcast > network + 1 else { return [] }
+            return Array((network + 1)...(broadcast - 1))
+        }
+    }
+
+    /// The interface this device would actually reach a Mac over. Wi‑Fi wins
+    /// when present, because that is where a companion bridge lives; anything
+    /// else usable is a fallback rather than a guess.
+    static func primaryIPv4Interface() -> IPv4Interface? {
+        var head: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&head) == 0, let first = head else { return nil }
+        defer { freeifaddrs(head) }
+
+        var fallback: IPv4Interface?
+
+        for pointer in sequence(first: first, next: { $0.pointee.ifa_next }) {
+            let flags = Int32(pointer.pointee.ifa_flags)
+            guard flags & IFF_UP != 0, flags & IFF_LOOPBACK == 0 else { continue }
+            guard let addressPointer = pointer.pointee.ifa_addr,
+                  addressPointer.pointee.sa_family == UInt8(AF_INET),
+                  let maskPointer = pointer.pointee.ifa_netmask else { continue }
+
+            let name = String(cString: pointer.pointee.ifa_name)
+            let address = addressPointer.withMemoryRebound(to: sockaddr_in.self, capacity: 1) {
+                UInt32(bigEndian: $0.pointee.sin_addr.s_addr)
+            }
+            let netmask = maskPointer.withMemoryRebound(to: sockaddr_in.self, capacity: 1) {
+                UInt32(bigEndian: $0.pointee.sin_addr.s_addr)
+            }
+            guard netmask != 0 else { continue }
+
+            let interface = IPv4Interface(name: name, address: address, netmask: netmask)
+            if name == "en0" { return interface }
+            if fallback == nil { fallback = interface }
+        }
+
+        return fallback
+    }
+
+    /// Sessions are per-probe-batch rather than shared, so a sweep can't leave
+    /// a pile of idle connections behind it.
+    private static let session: URLSession = {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 1.5
+        configuration.timeoutIntervalForResource = 2
+        configuration.httpMaximumConnectionsPerHost = 1
+        configuration.waitsForConnectivity = false
+        configuration.allowsCellularAccess = false
+        return URLSession(configuration: configuration)
+    }()
+
+    /// Ask one address whether it is a Lattices bridge.
+    ///
+    /// The answer has to be a bridge health payload, not merely an open port —
+    /// plenty of things listen on plenty of ports, and a scan that reported
+    /// them would fill the picker with everything on the network.
+    static func probe(address: UInt32, port: Int) async -> BridgeEndpoint? {
+        let host = ipv4String(address)
+
+        var components = URLComponents()
+        components.scheme = "http"
+        components.host = host
+        components.port = port
+        components.path = "/health"
+        guard let url = components.url else { return nil }
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 1.5
+        request.httpMethod = "GET"
+
+        guard
+            let (data, response) = try? await session.data(for: request),
+            let http = response as? HTTPURLResponse,
+            http.statusCode == 200,
+            let health = try? JSONDecoder().decode(BridgeHealthResponse.self, from: data),
+            health.ok
+        else {
+            return nil
+        }
+
+        let name = health.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return BridgeEndpoint(
+            // The address is where it actually answered, so that is what we
+            // keep — `health.hostName` may be a name this network can't resolve,
+            // which is very often exactly why Bonjour failed here too.
+            name: name.isEmpty ? host : name,
+            host: host,
+            port: port,
+            source: "Scan",
+            bridgeFingerprint: health.bridgeFingerprint,
+            securityMode: health.mode,
+            capabilities: health.capabilities ?? []
+        )
+    }
+
+    static func ipv4String(_ address: UInt32) -> String {
+        "\((address >> 24) & 0xFF).\((address >> 16) & 0xFF).\((address >> 8) & 0xFF).\(address & 0xFF)"
+    }
+}

--- a/apps/mac/Sources/Core/Actions/VoiceIntentResolver.swift
+++ b/apps/mac/Sources/Core/Actions/VoiceIntentResolver.swift
@@ -414,7 +414,32 @@ final class VoiceIntentResolver {
         return nil
     }
 
+    /// True when some intent other than `search` declares this exact utterance
+    /// as one of its own examples.
+    ///
+    /// The search shortcuts below are *shape* heuristics — "starts with find",
+    /// "ends in windows" — and they run inside `directMatch`, which fires before
+    /// any intent gets to compete. So a heuristic about a suffix outranked
+    /// intents that had spelled the phrase out, and it did so at 0.98
+    /// confidence: `search` claimed nine of the resolver's own declared
+    /// examples, including "where's my mouse" (find_mouse), "organize the
+    /// windows" (distribute), and "show me all windows" (list_windows). A
+    /// confident wrong answer is worse than no answer, because nothing
+    /// downstream second-guesses 0.98.
+    ///
+    /// Yielding here doesn't hand the utterance to the other intent — it just
+    /// stops short-circuiting, and lets the semantic scorer below decide on the
+    /// merits.
+    private func isDeclaredByOtherIntent(_ input: String) -> Bool {
+        IntentEngine.shared.definitions().contains { def in
+            def.name != "search"
+                && def.examples.contains { normalizeUtterance($0) == input }
+        }
+    }
+
     private func exactSearchQuery(for input: String) -> String? {
+        guard !isDeclaredByOtherIntent(input) else { return nil }
+
         if let query = extractSearchQuery(from: input), !query.isEmpty,
            searchPrefixes.contains(where: input.hasPrefix) {
             return cleanQuery(query)

--- a/apps/mac/Sources/Core/Companion/LatticesCompanionBridgeServer.swift
+++ b/apps/mac/Sources/Core/Companion/LatticesCompanionBridgeServer.swift
@@ -11,6 +11,13 @@ final class LatticesCompanionBridgeServer: NSObject {
     static let maxBodyBytes = 512 * 1024
 
     private let queue = DispatchQueue(label: "lattices.companion.bridge", qos: .userInitiated)
+    /// Pairing is the one request that waits on a human, so it gets its own
+    /// queue. Answering it on `queue` — which is serial, and carries every
+    /// snapshot, action, and trackpad event from every paired device — would
+    /// freeze the entire bridge for as long as the approval alert is up.
+    /// Serial on purpose: two devices asking at once should queue, not stack
+    /// two modal alerts on top of each other.
+    private let pairingQueue = DispatchQueue(label: "lattices.companion.bridge.pairing", qos: .userInitiated)
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
 
@@ -162,8 +169,16 @@ private extension LatticesCompanionBridgeServer {
         }
     }
 
+    /// Whether `route` answered the request itself, or handed the socket to
+    /// another queue that will answer and close it later.
+    enum RouteOutcome {
+        case answered
+        case handedOff
+    }
+
     func handleClient(fd: Int32) {
-        defer { close(fd) }
+        var ownsSocket = true
+        defer { if ownsSocket { close(fd) } }
 
         guard let request = readRequest(from: fd) else {
             sendError(status: 400, message: "Invalid HTTP request", to: fd)
@@ -171,7 +186,9 @@ private extension LatticesCompanionBridgeServer {
         }
 
         do {
-            try route(request, to: fd)
+            if try route(request, to: fd) == .handedOff {
+                ownsSocket = false
+            }
         } catch let error as LatticesCompanionSecurityError {
             let status: Int
             switch error {
@@ -186,7 +203,8 @@ private extension LatticesCompanionBridgeServer {
         }
     }
 
-    func route(_ request: HTTPRequest, to fd: Int32) throws {
+    @discardableResult
+    func route(_ request: HTTPRequest, to fd: Int32) throws -> RouteOutcome {
         switch (request.method, request.path) {
         case ("GET", "/health"):
             let security = LatticesDeckHost.shared.securityConfiguration
@@ -213,20 +231,36 @@ private extension LatticesCompanionBridgeServer {
         case ("GET", "/deck-builder"):
             guard sendDeckBuilderAsset(path: "index.html", to: fd) else {
                 sendError(status: 404, message: "Deck Builder asset is unavailable", to: fd)
-                return
+                return .answered
             }
 
         case ("GET", let path) where path.hasPrefix("/_next/static/"):
             guard sendDeckBuilderAsset(path: String(path.dropFirst()), to: fd) else {
                 sendError(status: 404, message: "Deck Builder asset is unavailable", to: fd)
-                return
+                return .answered
             }
 
         case ("POST", "/pairing/request"):
+            // Decode on the bridge queue so a malformed body still fails fast,
+            // but answer on `pairingQueue`: `handlePairingRequest` blocks until
+            // a human clicks, and the companion has to keep serving everyone
+            // else meanwhile.
             let pairingRequest = try decoder.decode(DeckPairingRequest.self, from: request.body)
-            let response = LatticesCompanionSecurityCoordinator.shared.handlePairingRequest(pairingRequest)
-            let status = response.disposition == .denied ? 403 : 200
-            try sendJSON(status: status, value: response, to: fd)
+            pairingQueue.async { [weak self] in
+                defer { close(fd) }
+                guard let self else { return }
+                let response = LatticesCompanionSecurityCoordinator.shared.handlePairingRequest(pairingRequest)
+                let status = response.disposition == .denied ? 403 : 200
+                do {
+                    try self.sendJSON(status: status, value: response, to: fd)
+                } catch {
+                    // The companion may well have given up waiting and closed
+                    // the socket. The trust decision still stands on this side;
+                    // a retry resolves as `alreadyTrusted`.
+                    DiagnosticLog.shared.warn("CompanionPairing: could not deliver response — \(error.localizedDescription)")
+                }
+            }
+            return .handedOff
 
         case ("GET", "/deck/snapshot"):
             let auth = try authorizeProtectedRequest(request, requiredCapability: DeckBridgeCapability.deckRead)
@@ -278,6 +312,8 @@ private extension LatticesCompanionBridgeServer {
         default:
             sendError(status: 404, message: "Unknown route", to: fd)
         }
+
+        return .answered
     }
 
     func authorizeProtectedRequest(_ request: HTTPRequest, requiredCapability: String) throws -> AuthorizedBridgeRequest {

--- a/apps/mac/Sources/Core/Companion/LatticesCompanionSecurityCoordinator.swift
+++ b/apps/mac/Sources/Core/Companion/LatticesCompanionSecurityCoordinator.swift
@@ -559,15 +559,26 @@ private extension LatticesCompanionSecurityCoordinator {
     func runPairingAlert(_ request: DeckPairingRequest) -> Bool {
         NSApp.activate(ignoringOtherApps: true)
 
+        // Everything a device tells us about itself — its name, its id, its
+        // platform — is chosen by whoever sent the request, so a machine on
+        // the same network can raise a prompt that looks exactly like the one
+        // the user is expecting. The fingerprint is the only field here that
+        // is derived from a key the sender must actually hold, so it leads,
+        // and the forgeable fields are labelled as claims rather than facts.
+        let code = Self.fingerprint(forPublicKeyBase64: request.devicePublicKey)
+
         let alert = NSAlert()
         alert.alertStyle = .warning
-        alert.messageText = "Allow \(request.deviceName) to pair with Lattices?"
+        alert.messageText = "Allow a device to control this Mac?"
         alert.informativeText = """
-        This device is asking for encrypted local-network control of your Mac.
+        Check that this code matches the one on the device asking:
 
-        Device ID: \(request.deviceID)
-        Device Fingerprint: \(Self.fingerprint(forPublicKeyBase64: request.devicePublicKey))
-        Platform: \(request.platform)
+            \(code)
+
+        The device calls itself “\(request.deviceName)” (\(request.platform)). \
+        That name is chosen by the device and is not verified — only the code is.
+
+        If the codes do not match, deny: something else on your network is asking.
         """
         alert.addButton(withTitle: "Allow Pairing")
         alert.addButton(withTitle: "Deny")

--- a/design/fleet-deck/add-host-logic.md
+++ b/design/fleet-deck/add-host-logic.md
@@ -1,0 +1,307 @@
+# Add a Mac — the logic
+
+**Status:** implementation-ready design · 2026-07-30
+**Companion to:** [add-host-workflow.md](add-host-workflow.md) (the why, the screens)
+
+Deliberately small: one new file, one new sheet, four edits to existing files.
+
+---
+
+## 0. The simplification
+
+The workflow doc proposed `DeckFleetStore.adopt(endpoint:)` that **bypasses** the `guard isTrusted else { continue }` in `synchronize`, so a Mac could be adopted while still untrusted. That created a hard problem — keeping an in-flight adoptee alive across the `discoveredBridges` churn that happens *during* pairing, when `synchronize` rebuilds `secondaryStores` wholesale and reaps by key diff.
+
+The problem disappears if you **pair first and adopt second**:
+
+```
+health → pair → store trust → adopt
+                    ↑
+            endpoint is trusted from here on
+```
+
+By the time anything is adopted, the Mac *is* trusted, so it passes the existing guard unchanged. No bypass, no holding area, no flag. `adopt` shrinks to "insert this now-trusted endpoint immediately instead of waiting for the next discovery tick" — which is still worth having, because a manually-entered Mac may never appear on Bonjour at all.
+
+This also moves pairing out of `loadConnection`, where it is currently an invisible side effect (`ensurePairing`), and into a place where each step has a name and a screen.
+
+---
+
+## 1. New file: `apps/ios/Sources/Home/AddHostController.swift`
+
+```swift
+import DeckKit
+import SwiftUI
+
+/// Why pairing ended without a Mac being added.
+enum AddHostFailure: Equatable {
+    /// The Mac declined. An answer, not an error — no red.
+    case denied
+    /// We never got far enough to be declined.
+    case unreachable(String)
+}
+
+/// One sheet, five phases. Each has exactly one screen.
+enum AddHostPhase: Equatable {
+    case picking
+    case confirming(BridgeEndpoint)
+    case waiting(BridgeEndpoint)
+    case added(BridgeEndpoint, withheld: [String])
+    case failed(BridgeEndpoint, AddHostFailure)
+}
+
+@MainActor
+final class AddHostController: ObservableObject {
+    @Published private(set) var phase: AddHostPhase = .picking
+    /// Set while `.waiting` has run long enough to be worth explaining.
+    @Published private(set) var isTakingAWhile = false
+
+    private let client = DeckBridgeClient()
+    private var pairingTask: Task<Void, Never>?
+
+    /// This iPad's own fingerprint, in the derivation the Mac's approval alert
+    /// prints (`LatticesCompanionSecurityCoordinator.swift:357`). The same
+    /// string appears on both screens — that is the entire point of showing it.
+    let deviceCode = DeckBridgeSecurityStore.shared.deviceFingerprint
+
+    // MARK: Navigation
+
+    func choose(_ endpoint: BridgeEndpoint) { phase = .confirming(endpoint) }
+
+    func backToPicking() {
+        pairingTask?.cancel()
+        pairingTask = nil
+        isTakingAWhile = false
+        phase = .picking
+    }
+
+    // MARK: The handshake
+
+    /// Pair, then hand the trusted endpoint to `onPaired`.
+    ///
+    /// Order matters: trust is stored *before* any session is created, so the
+    /// new Mac passes `DeckFleetStore`'s existing trust guard on its own and
+    /// nothing has to be held open across discovery churn.
+    func pair(
+        with endpoint: BridgeEndpoint,
+        onPaired: @escaping (BridgeEndpoint) -> Void
+    ) {
+        phase = .waiting(endpoint)
+        isTakingAWhile = false
+
+        pairingTask = Task {
+            // Explain the wait before the user starts inventing reasons for it.
+            let nudge = Task {
+                try? await Task.sleep(for: .seconds(25))
+                if !Task.isCancelled { self.isTakingAWhile = true }
+            }
+            defer { nudge.cancel() }
+
+            let health: BridgeHealthResponse
+            do {
+                health = try await client.health(endpoint: endpoint)
+            } catch {
+                guard !Task.isCancelled else { return }
+                phase = .failed(endpoint, .unreachable(error.localizedDescription))
+                return
+            }
+
+            // Carry the Mac's identity onto the endpoint. A manually-typed
+            // endpoint has no Bonjour `fp` record, and without this it would
+            // never match a trust record or dedupe against the same Mac
+            // discovered over Bonjour.
+            let canonical = endpoint.adoptingIdentity(from: health)
+
+            do {
+                let response = try await client.pair(endpoint: canonical)
+                guard !Task.isCancelled else { return }
+
+                switch response.disposition {
+                case .approved, .alreadyTrusted:
+                    DeckBridgeSecurityStore.shared.storePairing(
+                        response,
+                        lastKnownHost: canonical.host,
+                        lastKnownPort: canonical.port
+                    )
+                    onPaired(canonical)
+                    phase = .added(canonical, withheld: withheld(from: response))
+                case .denied:
+                    phase = .failed(canonical, .denied)
+                }
+            } catch let DeckBridgeClientError.badStatus(status, detail) where status == 403 {
+                guard !Task.isCancelled else { return }
+                phase = .failed(canonical, .denied)
+                _ = detail
+            } catch {
+                guard !Task.isCancelled else { return }
+                phase = .failed(canonical, .unreachable(error.localizedDescription))
+            }
+        }
+    }
+
+    /// Capabilities we asked for and did not get. Told once, here, rather than
+    /// surfacing as `insufficientCapability` mid-gesture three days later.
+    private func withheld(from response: DeckPairingResponse) -> [String] {
+        let granted = Set(response.grantedCapabilities ?? DeckBridgeCapability.defaultCompanionCapabilities)
+        return DeckBridgeCapability.defaultCompanionCapabilities
+            .filter { !granted.contains($0) }
+    }
+}
+
+// MARK: - Candidates
+
+extension AddHostController {
+    /// Macs on the network this device has never paired with. Trusted Macs are
+    /// deliberately absent — they are already in the roster.
+    static func candidates(from store: DeckStore) -> [BridgeEndpoint] {
+        store.discoveredBridges.filter { !DeckBridgeSecurityStore.shared.isTrusted(endpoint: $0) }
+    }
+}
+```
+
+**Cancel semantics.** `backToPicking` cancels the task, which abandons the request on the iPad. It cannot retract the alert on the Mac — if the user approves after cancelling, the Mac holds a trust record the iPad does not. That state is self-healing: a retry gets `.alreadyTrusted` and the iPad stores it then. Worth one line of copy, not a protocol.
+
+---
+
+## 2. Edit: `DeckBridgeSecurityStore.swift`
+
+Three additions.
+
+```swift
+/// This device's fingerprint, derived exactly as the Mac derives it for its
+/// approval alert, so the two screens show the same string.
+var deviceFingerprint: String {
+    let digest = SHA256.hash(data: Data(devicePublicKeyBase64.utf8))
+    let hex = digest.map { String(format: "%02x", $0) }.joined()
+    return String(hex.prefix(12)).uppercased().chunked(into: 4).joined(separator: "-")
+}
+
+/// One definition of "have we paired with this Mac". The same fingerprint
+/// comparison is currently written out by hand in `ContentView.prepareConnection`
+/// and `DeckFleetStore.synchronize`; both should call this.
+func isTrusted(endpoint: BridgeEndpoint) -> Bool {
+    guard let fingerprint = endpoint.bridgeFingerprint, !fingerprint.isEmpty else { return false }
+    return trustedBridges.values.contains {
+        $0.bridgeFingerprint.caseInsensitiveCompare(fingerprint) == .orderedSame
+    }
+}
+```
+
+And `StoredBridgeTrust` remembers where the Mac was:
+
+```swift
+struct StoredBridgeTrust: Codable, Equatable, Sendable {
+    …
+    var lastKnownHost: String?
+    var lastKnownPort: Int?
+}
+```
+
+Both optional, so the JSON already in `UserDefaults` decodes unchanged — no migration. This is what turns a paired-but-offline Mac from a dead card into a Reconnect. `storePairing` gains the two parameters; every successful `loadConnection` should also refresh them, since Macs change address.
+
+---
+
+## 3. Edit: `DeckStore.swift`
+
+**Auto-connect only to Macs we already trust.** `handleDiscoveryUpdate:310` becomes:
+
+```swift
+// Discovery is an observation, not an intent. Reconnecting to a Mac this
+// device already paired with is silent and correct; pairing with a stranger
+// raises a modal alert on someone's desk and must be the user's decision.
+if activeEndpoint == nil,
+   let known = bridges.first(where: { DeckBridgeSecurityStore.shared.isTrusted(endpoint: $0) }) {
+    connect(to: known)
+    return
+}
+```
+
+Note `first(where:)`, not `first`: with three Macs on the network and one paired, the paired one is picked regardless of alphabetical order.
+
+**`DeckFleetStore.adopt(endpoint:)`** — for responsiveness and for manual endpoints Bonjour will never report:
+
+```swift
+/// Insert a just-paired Mac as a secondary session immediately, rather than
+/// waiting for the next discovery tick. Safe against the trust guard in
+/// `synchronize` because the caller stores trust before adopting.
+func adopt(_ endpoint: BridgeEndpoint) {
+    let key = Self.endpointKey(endpoint)
+    guard storesByEndpointKey[key] == nil else { return }
+    let store = DeckStore(endpoint: endpoint, discoversBridges: false)
+    storesByEndpointKey[key] = store
+    secondaryStores.append(store)
+}
+```
+
+One caveat to carry: `synchronize` rebuilds `secondaryStores` from `discoveredBridges`, so a manually-added Mac that Bonjour never reports gets reaped on the next tick. Either `synchronize` preserves keys it did not create, or manual Macs are re-seeded from `lastKnownHost`/`lastKnownPort`. **The second is better** — it is the same mechanism state 3 (trusted, not discovered) needs anyway, so one fix serves both.
+
+---
+
+## 4. Edit: `ContentView.swift`
+
+```swift
+@State private var showAddHost = false
+```
+
+```swift
+onAddHost: { showAddHost = true },
+```
+
+```swift
+.sheet(isPresented: $showAddHost) {
+    AddHostSheet(store: store) { endpoint in
+        // Additive: the Mac you are looking at does not move. The only
+        // exception is having nothing to look at.
+        if store.activeEndpoint == nil {
+            store.connect(to: endpoint)
+        } else {
+            fleetStore.adopt(endpoint)
+        }
+    }
+    .preferredColorScheme(.dark)
+}
+```
+
+That `if` is the whole "adding is additive" decision, and it is three lines. Everything else in this document exists to make those three lines safe.
+
+Also: `prepareConnection` should drop its hand-rolled fingerprint comparison in favour of `isTrusted(endpoint:)`.
+
+---
+
+## 5. Edit: `HomeTargetsRow.swift`
+
+`onAddHost: (() -> Void)?`, and an add cell rendered as the last item of the grid — peer of the machine cards, same geometry, `card` surface, no accent. Subtitle is live:
+
+```swift
+let nearby = AddHostController.candidates(from: store).count
+// "2 found nearby" / "Nothing found nearby"
+```
+
+That subtitle is the entire replacement for auto-connect: the app still tells you it can see something, it just no longer acts on it.
+
+Open (kimi ruling requested): whether the cell belongs in the grid or in the section header beside the Fleet Deck door.
+
+---
+
+## 6. Blocking bugs
+
+Neither is caused by this design; both prevent it from working. Verification requested from codex.
+
+**Pairing times out in 10s, not 90s.** `DeckBridgeClient.swift:88` sets `request.timeoutInterval = 90`; the shared session config at line 71 sets `timeoutIntervalForResource = 10`, which caps the entire transfer. `.waiting` cannot outlive ten seconds until `/pairing/request` gets its own session:
+
+```swift
+private let pairingSession: URLSession = {
+    let configuration = URLSessionConfiguration.default
+    configuration.timeoutIntervalForRequest = 120
+    configuration.timeoutIntervalForResource = 180
+    return URLSession(configuration: configuration)
+}()
+```
+
+**Rescan destroys the fleet.** `BridgeDiscovery.refresh()` publishes `[]` before restarting the browser, which drives `synchronize` to drop every secondary store; rediscovery mints new `DeckStore`s with new `sessionID`s, and `FleetChannel.id` is that UUID, so channel identity resets. Rescan is exactly what a user taps while adding a Mac. Fix: re-browse without publishing the empty roster.
+
+---
+
+## 7. Scope
+
+**In:** the five phases, the additive add, trusted-only auto-connect, the device code, `lastKnownHost`/`Port`, both bug fixes.
+
+**Out:** QR pairing, pairing from the Fleet Deck, mutual SAS verification, reconnect-to-offline-Mac (needs `lastKnownHost` first, then it is a small follow-up).

--- a/design/fleet-deck/add-host-workflow-review.md
+++ b/design/fleet-deck/add-host-workflow-review.md
@@ -1,0 +1,74 @@
+# Add-host workflow — adversarial review
+
+**Reviewer:** session-ms7uslma-sl5cki · 2026-07-30
+**Target:** [add-host-workflow.md](add-host-workflow.md)
+**Method:** every code claim in the doc was checked against source. All of them hold (bug 1, bug 2, the fingerprint derivation, the `isTrusted` guard, the `FleetChannel.id` churn). The problems below are things the doc *missed*, plus rulings on the five questions asked.
+
+---
+
+## Verdicts, one line each
+
+1. **Fingerprint step:** not theater — it is the only unforgeable field in the approval alert — but as specified it doesn't work; it needs three conditions or it should be cut to plain copy.
+2. **Additive:** correct, and the objection dissolves if the success screen offers "Open Studio" as its primary action.
+3. **Five hosts:** the design's change list keeps the fleet roster *discovery-driven*; at five hosts that's the thing that breaks, and Change 1–5 don't fix it. Manual-entry Macs can't survive in the fleet at all.
+4. **Waiting state:** pairing legitimately requires proving control of the Mac, but "control" ≠ "standing at it" — a CLI approval path (`lattices companion approve`) covers the couch case with zero new protocol.
+5. **Biggest miss:** the doc claims "two small Mac-side notes." False. The Mac's pairing handler **blocks the entire bridge on a serial queue and holds the app's main thread in a modal session** for the whole wait. The design stretches that wait to minutes by intent. This is the finding that changes the design.
+
+---
+
+## F1 — The Mac side is not "two small notes" (blocking)
+
+`LatticesCompanionBridgeServer` handles **every** connection on one serial queue (`LatticesCompanionBridgeServer.swift:13`, `:159`). `route()` calls `handlePairingRequest` synchronously (`:227`), which blocks on a semaphore until the human answers the modal alert (`LatticesCompanionSecurityCoordinator.swift:547-556`), and `runModal()` holds the Mac's **main thread** in a modal session the whole time (`:559-574`).
+
+Consequences, all made worse by the design's own (correct) premise that waiting lasts minutes:
+
+- **The whole bridge freezes while the alert is up.** `/health`, `/deck/snapshot`, `/deck/perform` from *already-trusted* devices stall behind the blocked queue. If any other device is paired to that Mac (an iPhone, a second iPad), its session goes red for the duration of the add.
+- **Waiting manufactures "unreachable."** If the add flow (or roster liveness) pings `/health` on the candidate during step 3, that ping hangs — the iPad will read the Mac as unreachable *because* it is waiting. Implementation must use Bonjour presence only during waiting, and the doc should say so.
+- **The Mac itself degrades.** Lattices is a window manager; hotkeys, tiling, HUD all live on the main thread. A modal session parked for minutes is a real cost on the machine being added.
+- **Unauthenticated DoS.** `/pairing/request` requires no auth. Any LAN device can spam it; each request queues a modal alert *and* wedges the serial queue. The doc hardens the iPad's auto-connect and does nothing about the actual exposed surface. Also: after a **deny**, a queued retry from the iPad immediately raises the *next* alert — denial becomes whack-a-mole if the waiting state ever auto-retries.
+
+**Required Mac-side changes** (this is Change 0, before any iPad work): handle pairing asynchronously off the route path with a pending-approval registry; dedupe concurrent requests per `deviceID` (concurrent requests join one pending decision instead of queueing alerts); rate-limit the endpoint. The bug-1 fix (minutes-long iPad timeout) is *harmful* until this lands — it converts a 10s wedge into a minutes-long one.
+
+## F2 — A second add-path exists and the change list doesn't touch it
+
+The doc says the only manual path is Settings → macsCard. Not true. `HomeDataAdapter.machines` puts **untrusted discovered Macs into the Home roster** with no trust filter (`HomeDataAdapter.swift:30-35`), and tapping one runs `ContentView.prepareConnection` (`ContentView.swift:165-181`), which calls `store.connect(to:)` on the untrusted endpoint — re-pointing the primary *and* firing the pairing prompt. That is exactly the swap-plus-unsolicited-prompt behavior the design exists to kill, one accidental tap away, and no Change 1–5 removes it. The §2 state table says state-1 Macs belong in the Add sheet only; the change list must include: filter untrusted out of `HomeDataAdapter.machines` (or render them as inert "candidate" cards that open the add sheet) and delete the pairing branch of `prepareConnection`.
+
+Same door, different room: Settings "reconnect" presumably remains `store.connect(to:)` — which swaps the primary for a *trusted* Mac too. If reconnect doesn't route through `adopt()`, the swap bug survives in Settings after being fixed everywhere else.
+
+## F3 — Q1: the fingerprint is not theater, but as specced it won't do its job
+
+What the code says: the alert's headline and body are built from `deviceName`, `deviceID`, `platform` — **all attacker-chosen** (`LatticesCompanionSecurityCoordinator.swift:562-571`). An attacker on the LAN can raise "Allow Art's iPad to pair?" that is pixel-identical to the real one *except* the fingerprint, which they cannot forge: replaying the iPad's public key produces a trust record only the real iPad can use, so a matching fingerprint genuinely proves the request came from the device in your hand. The threat it defends is precise and realistic: the user initiates an add, an attacker's request lands at the same moment, the user approves reflexively. With auto-connect killed, *unexpected* prompts become self-evidently suspicious — the fingerprint is the tiebreaker for *expected* ones. That's a real outcome change, in a narrow but load-bearing scenario. Keep it — under three conditions:
+
+1. **The Mac alert must be redesigned** so the fingerprint is the primary element and the forgeable fields are demoted (today it's one line buried between Device ID and Platform in `informativeText`). Without this, "check that it shows this code" points the user at small grey text under a big bold attacker-controlled title. This is a third Mac-side change — the doc's "no Mac change needed" claim is what's theater.
+2. **The confirm screen must say what to do on mismatch** ("If the code is different, tap Deny — another device is asking"). A comparison with no failure action is ritual by definition.
+3. **Note the limit:** 12 hex = 48 bits, and the fingerprint is `SHA256` of the *base64 string* (`:357-361`) sent in a plaintext POST — an observer can learn the target value and grind ~2^47 keys offline for a colliding prefix. Acceptable for v1; it makes the SAS upgrade path a real item, not a someday. (Also fragile: hashing the encoding rather than key bytes means any future re-encoding silently changes every displayed fingerprint.)
+
+If the team won't fund condition 1, cut the code display and keep only the plain-language line ("Your Mac will ask you to allow this iPad") — an unprominent code teaches users that hex is skippable, which is worse than no code.
+
+## F4 — Q2: additive is right; give intent its one tap
+
+Auto-switching would violate the host-ownership invariant the rest of the app is built on, and it punishes the user who was mid-task on Mac 1. But the counter-argument ("you just spent four screens on Studio") is real and cheaply satisfied: the **approved** state's primary action should be **"Open Studio"** (enter its deck / make it the hot host), secondary "Done" → Home. Intent continues in one tap; nothing is stolen. This also closes §8's first open question without a policy fight.
+
+The deeper smell: the design keeps entrenching the primary/secondary asymmetry (primary owns discovery, Home renders from it, secondaries live in `DeckFleetStore`). At five hosts "primary" is a load-bearing accident — primary goes offline and Home error-states while four healthy Macs sit in the fleet; "forget the primary" is undefined. The end-state model is N peer sessions + a selection pointer + one discovery service owned by nobody. The doc doesn't have to build that now, but it should *name* it, or `adopt()` becomes another buttress on the wrong spine.
+
+## F5 — Q3: what actually breaks at five hosts
+
+- **The roster is discovery-driven and must become trust-driven.** `DeckFleetStore.synchronize` builds the fleet from `primaryStore.discoveredBridges` and **reaps any store not currently discovered** (`DeckStore.swift:535-538`). mDNS at five hosts flaps routinely; every transient disappearance tears down a live session and rebuilds it with a fresh `sessionID`, so `FleetChannel.id` churns (`FleetDeckAdapter.swift:49`) and the deck's channels shuffle. Bug 2 is just the loudest instance of this; fixing `refresh()` while keeping reap-on-absence fixes the symptom and keeps the disease. The fix the doc's own §2 table implies but the change list never states: **trust records are the roster; discovery only annotates address and liveness.**
+- **Manual-entry Macs cannot exist in this fleet at all.** A state-4 Mac (Bonjour blocked — the doc's own justification for manual entry) is never in `discoveredBridges`, so `synchronize` reaps it on the next discovery update, forever. Change 1's "don't reap while pairing is in flight" is too weak — adopted stores must survive on trust, permanently. As written, the manual path adds a Mac that evaporates seconds later.
+- **Polling doesn't scale as wired.** Deck open → `setUIPriority(.fast)` on *all* stores → five 1 Hz snapshot streams of fat payloads; and `currentPollInterval` pins any Mac with a pending question at 1 Hz even ambient (`DeckStore.swift:383-391`) — five agent-running Macs means several permanent 1 Hz pollers on Home. Each transient failure writes `errorMessage` → red cards flapping. Needs a visibility budget (focused host fast, rest slow). Not add-flow scope, but the add flow is what makes five hosts reachable, so it belongs in the doc as a named follow-up, not silence.
+- **Old-build edge:** a trusted Mac whose Bonjour TXT lacks `fp` fails the fingerprint match → shows up as a *candidate* in the add sheet → user re-adds → `alreadyTrusted`. Harmless but confusing; worth one line of copy or a version gate.
+
+## F6 — Q4: pairing must prove control of the Mac, not proximity to it
+
+Approving from the iPad would be self-approval — no. But this is a developer tool: the couch user almost certainly has SSH or screen sharing to that Mac already, and *that is the same trust anchor* (you can run commands on it). The cheap, in-grain escape hatch is a CLI: `lattices companion pending` / `lattices companion approve <fingerprint>` — approve over SSH, fingerprint comparison intact, zero new protocol, and it fixes the fact that a modal NSAlert is invisible over SSH today. Bonus: it survives the alert being unanswerable (locked screen, other Space). Reject the "accept pairings for 10 minutes" pre-auth window — it reopens the exact reflexive-approval hole the fingerprint closes. Also reframe expectations: the natural pairing moment is Mac setup — the user is already there installing Lattices; the empty-state copy already assumes it.
+
+## F7 — Smaller kills
+
+- **Pick-step rows show the Mac's fingerprint** — §5 argues at length that the user has nothing to compare it against; then don't print it. It's noise that trains users to skim hex, which F3 needs them not to do. Name + host is enough; fingerprints live in Settings.
+- **"The prompt may be behind another window" is the wrong 25s hint.** The alert code calls `NSApp.activate(ignoringOtherApps: true)` before `runModal` (`:560`) — it fronts itself. The actual stall modes: Mac asleep/locked, alert on another Space, or the queue wedged behind an earlier pairing alert (F1). Copy should say "Make sure the Mac is awake."
+- **First-run regression, unowned.** Change 2 means a fresh install shows an empty Home instead of auto-connecting. Right trade, but the doc must own it: on an empty roster the add cell is the hero state, not one cell among none.
+- **Cancel/deny race copy.** Serialization on the Mac means a retry sent after a deny raises a fresh alert immediately. The denied state's "Try again" is fine; any *automatic* retry in waiting is not. Say explicitly: waiting never auto-retries.
+
+---
+
+*Verified in code this pass: bug 1 (`DeckBridgeClient.swift:71` vs `:88`), bug 2 (`BridgeDiscovery.swift:21-27` → `ContentView.swift:152-155`), fingerprint derivation match (`LatticesCompanionSecurityCoordinator.swift:357-362` vs alert `:569`), serial bridge queue (`LatticesCompanionBridgeServer.swift:13,159,227`), semaphore/modal blocking (`:542-575`), untrusted-in-roster path (`HomeDataAdapter.swift:30-35`, `ContentView.swift:165-181`), fleet reap (`DeckStore.swift:502-541`), channel-id churn (`FleetDeckAdapter.swift:49`).*

--- a/design/fleet-deck/add-host-workflow.md
+++ b/design/fleet-deck/add-host-workflow.md
@@ -1,0 +1,185 @@
+# Adding a Mac — workflow design
+
+**Status:** design, not built · 2026-07-30
+**Scope:** iPad companion (`apps/ios`), with two small Mac-side notes
+**Related:** [token-spec-v7.md](token-spec-v7.md) for type/colour, `ContentView.swift` for the entry model
+
+---
+
+## 1. What exists today
+
+There is no add-host workflow. There is a side effect that sometimes produces one.
+
+**The only automatic path** is in `DeckStore.handleDiscoveryUpdate` (`DeckStore.swift:310`):
+
+```swift
+if activeEndpoint == nil, let first = bridges.first {
+    connect(to: first)
+    return
+}
+```
+
+On first launch the iPad browses Bonjour, sorts by name, takes `[0]`, and pairs with it. `connect` → `loadConnection` → `ensurePairing` → `POST /pairing/request` → the Mac raises a **modal `NSAlert`** asking the human to approve. The user chose nothing. If three Macs are on the network, the alphabetically-first one gets the prompt.
+
+**The only manual path** is Settings → `macsCard` → tap an online row → `store.connect(to:)`. That is the *primary* store, the one Home renders from. So adding a second Mac **re-points the surface you are looking at**: Mac 1 leaves Home, Mac 2 arrives. Adding is a swap.
+
+**The fleet can't add.** `DeckFleetStore.synchronize` (`DeckStore.swift:511`) has
+
+```swift
+guard isTrusted else { continue }
+```
+
+which is correct as an automatic policy — Fleet Deck must not spray approval prompts across every Bonjour peer — but it means an untrusted Mac can *only* enter the fleet by first hijacking the primary store. The bottleneck is structural.
+
+**Nothing on the iPad acknowledges pairing.** No "waiting for approval" state, no fingerprint, no denial copy, no cancel. `loadConnection` awaits, and on failure writes `error.localizedDescription` into a red card.
+
+---
+
+## 2. Four states, three of them actionable
+
+Every Mac the app can know about is in exactly one of these. Today the UI conflates them.
+
+| # | State | Known by | Where it belongs | Action |
+|---|---|---|---|---|
+| 1 | Discovered, untrusted | Bonjour, no matching trust record | **Add sheet** | Add |
+| 2 | Discovered, trusted | Bonjour + fingerprint match | **Home roster** | Open |
+| 3 | Trusted, not discovered | Trust record only | **Home roster**, dimmed | Reconnect |
+| 4 | Unknown | Nothing | **Add sheet**, manual | Enter address |
+
+State 3 is currently a dead card: `makeTrustedOffline` builds it with `host: "paired"` and `status: .offline`, and `onEnterDeck` bails on `.offline`. `StoredBridgeTrust` stores no address, so there is nothing to reconnect *to*. Fixing that is a one-field change (§6).
+
+---
+
+## 3. Principles
+
+**Adding is additive.** Pairing a Mac must never move the Mac you are currently on. This is the same host-ownership property that governs the deck: the surface you are looking at answers to the machine you picked. A new Mac joins the roster; it does not take the throne. Only exception: if there is no primary at all, the first Mac you add becomes it.
+
+**Discovery is not intent.** Finding a Mac on the network is an observation. Pairing with it is a decision, and it fires a modal alert on someone's desk. The app should never make that decision on the user's behalf.
+
+**Both screens show the same number.** Right now the Mac's alert shows the *iPad's* device fingerprint and the iPad (if it showed anything) would have the *Mac's* bridge fingerprint. Different values — nothing to compare. See §5.
+
+**Pairing is slow and that is normal.** The human has to walk to the Mac, find the alert, and read it. The waiting state should be built for minutes, not for a spinner.
+
+---
+
+## 4. The flow
+
+### Entry point: Home, not Settings
+
+Home is the roster. The roster gets one more cell.
+
+```
+Machines                          [ Fleet Deck ↗ ]  3
+
+┌───────────────┐ ┌───────────────┐ ┌───────────────┐
+│ Mac mini      │ │ Studio        │ │ ⊕             │
+│ …             │ │ …             │ │ Add a Mac     │
+│               │ │               │ │ 1 found       │
+└───────────────┘ └───────────────┘ └───────────────┘
+```
+
+The add cell is a peer of the machine cards, same geometry, same `card` surface, no accent. Its subtitle is live: `1 found nearby` / `Nothing found nearby`. That subtitle is the entire replacement for auto-connect — the app still tells you it sees something, it just doesn't act.
+
+Settings keeps only *management*: forget a Mac, review granted capabilities, see fingerprints. Adding leaves Settings.
+
+### Step 1 — Pick
+
+A sheet (`raised`), listing state-1 Macs only. Each row: name, `host` in `textSecondary`, and the Mac's short fingerprint in `textTertiary`. Trusted Macs are deliberately absent — they are already home.
+
+Below the list, one quiet row: **Enter an address manually** → host + port fields, for state 4 and for networks where Bonjour is blocked.
+
+Empty case: *"No new Macs nearby. Open Lattices on the Mac and put both devices on the same Wi-Fi."* — plus a Rescan button that must not clear the roster (§6, bug 2).
+
+### Step 2 — Confirm
+
+The step that does not exist today, and the reason the whole flow is worth building.
+
+```
+        Add Studio?
+
+  Your Mac will ask you to allow this iPad.
+  Check that it shows this code:
+
+           A3F2-9B41-C0DE
+
+  Studio · studio.local:5287
+
+        [ Ask to pair ]   Cancel
+```
+
+That code is **this iPad's own device fingerprint** — `SHA256(devicePublicKeyBase64).prefix(12)`, chunked in fours, exactly the derivation at `LatticesCompanionSecurityCoordinator.swift:357`. The Mac's alert already prints it as `Device Fingerprint`. Showing it here costs no protocol change and no Mac change, and it answers the question the user actually has when an alert pops: *is this me?*
+
+Type: `DeckTheme.title()` at 17pt for the code, grouped in fours. Three groups of four hex characters compare fine chunk-by-chunk in SF Pro; if it reads badly on device, this is the one screen in the app where a mono exception would be earned — comparing a checksum across two devices is columnar data, not terminal cosplay. Judge it on the iPad, not here.
+
+### Step 3 — Waiting
+
+```
+        Waiting for Studio
+
+     Approve the prompt on your Mac.
+
+              ● ● ●
+
+              Cancel
+```
+
+Patient by construction: a slow three-dot cycle, no progress bar, no percentage. After ~25 seconds add one line — *"Still waiting. The prompt may be behind another window."* — because that is the actual failure mode of a modal `NSAlert` on a busy desktop.
+
+Cancel abandons the request on the iPad. Note honestly: it cannot retract the alert on the Mac. If the user approves after cancelling, the Mac holds a trust record the iPad doesn't — recoverable, because a retry returns `.alreadyTrusted` and the iPad stores it then. Worth a line of copy on the pick step for a Mac in that state, not worth a protocol.
+
+### Step 4 — Outcome
+
+Three distinct endings. They are currently one red card.
+
+**Approved.** Store the trust, keep the session as a **secondary**, dismiss to Home with the new card present. Do not steal the primary. If `grantedCapabilities` is narrower than requested, say it once, here: *"Trackpad control wasn't granted. You can change this on the Mac."* — better than surfacing `insufficientCapability` mid-gesture three days later.
+
+**Denied.** *"Studio declined the request."* with **Try again**. This is an answer, not an error — no red, no warning triangle.
+
+**Unreachable.** *"Couldn't reach Studio."* + *"Make sure Lattices is running and both devices are on the same Wi-Fi."* Distinct from denied, and it must be reachable — see bug 1.
+
+---
+
+## 5. Why the fingerprint is the iPad's, not the Mac's
+
+The instinct is to show the Mac's fingerprint (it's right there in the Bonjour `fp` TXT record and in `health.bridgeFingerprint`). But the user has nothing to check it against — the Mac's alert doesn't print its own fingerprint, and even if it did, an attacker impersonating the Mac would simply print theirs.
+
+Showing the iPad's own fingerprint verifies the direction that actually matters here: *this alert on my Mac was raised by the device in my hand.* It defends the realistic case — a second device on the network triggering a prompt the user approves reflexively.
+
+Proper mutual verification is a short authentication string over both public keys, and it needs Mac-side work. Not now; noted as the upgrade path.
+
+---
+
+## 6. What has to change
+
+Ordered by whether it blocks the flow.
+
+**Bug 1 — pairing times out in 10s, not 90s.** `DeckBridgeClient.pair` sets `request.timeoutInterval = 90` (`DeckBridgeClient.swift:88`), but the shared session config sets `timeoutIntervalForResource = 10` (line 71). The resource timeout caps the whole transfer, so it wins. Today the iPad gives up ten seconds into a human decision. **This makes step 3 impossible as designed** and probably explains any "pairing failed but the Mac says it worked" behaviour already seen. Fix: a dedicated `URLSession` for `/pairing/request` with a resource timeout in the minutes.
+
+**Bug 2 — rescan destroys the fleet.** `BridgeDiscovery.refresh()` calls `onUpdate?([])` before restarting the browser. That fires `ContentView.onChange(of: store.discoveredBridges)` → `synchronize` with zero endpoints → every secondary store is disconnected and dropped. Rediscovery then builds **new** `DeckStore`s with new `sessionID`s, and since `FleetChannel.id = store.sessionID.uuidString` (`FleetDeckAdapter.swift:49`), the deck's channel identity resets. Rescan is exactly what a user taps while adding a Mac. Fix: re-browse without publishing an empty roster, or debounce the empty publish.
+
+**Change 1 — `DeckFleetStore.adopt(endpoint:)`.** A deliberate add mints a secondary store for an *untrusted* endpoint, bypassing the `isTrusted` guard, and `synchronize` must not reap it while pairing is in flight. This is the change that makes adding additive instead of a swap. The `isTrusted` guard stays exactly as-is for the automatic path — it is doing its job.
+
+**Change 2 — auto-connect only to trusted Macs.** In `handleDiscoveryUpdate`, qualify the `activeEndpoint == nil` branch with a fingerprint match against `trustedBridgeList()`. A previously-paired Mac still reconnects silently on launch, which is right. An unknown Mac lands in the roster as a candidate.
+
+**Change 3 — `StoredBridgeTrust` remembers where.** Add `lastKnownHost: String?` and `lastKnownPort: Int?`, written on every successful connection. Both optional, so existing persisted JSON decodes unchanged — no migration. This turns state 3 from a dead card into a Reconnect.
+
+**Change 4 — a pairing state machine.** Something like `enum PairingPhase { idle, confirming(BridgeEndpoint), waiting(BridgeEndpoint), approved(…), denied(String), unreachable(String) }`, owned by whatever backs the add sheet. Today the outcome is inferred from a thrown error's `localizedDescription`, which is why denied and unreachable look identical.
+
+**Change 5 — manual connects inherit identity.** `connectManually` builds an endpoint with no fingerprint, so `DeckFleetStore.endpointKey` falls back to `service:<host>:<port>` and can never dedupe against the same Mac seen over Bonjour. `canonicalEndpoint(from:health:)` already backfills the fingerprint from `health` — the manual path just needs to persist the canonical endpoint rather than the typed one.
+
+---
+
+## 7. Deliberately not doing
+
+- **QR / camera pairing.** Faster, but it needs a Mac-side display surface and it removes the moment where the user reads what they are approving. Revisit if manual entry proves painful.
+- **Pairing from the Fleet Deck.** The deck is for operating machines that are already yours. Roster management belongs to Home.
+- **Auto-adding every trusted Mac to the fleet.** Already the behaviour, already correct.
+- **Mutual SAS verification.** The right endpoint, gated on Mac-side work.
+
+---
+
+## 8. Open
+
+- Should a newly added Mac ever become the primary when one already exists? Designed as no. The counter-argument is that you just expressed intent about that machine — but you expressed intent to *add* it, and the deck is one tap away.
+- Does the add cell belong in the roster grid, or in the section header next to Fleet Deck? Grid, because it's a machine-shaped thing; but the header keeps the grid honest at 4+ machines.
+- Fingerprint face — SF Pro or the one mono exception. On-device call.

--- a/design/fleet-deck/app-aware-controls-critique.md
+++ b/design/fleet-deck/app-aware-controls-critique.md
@@ -1,0 +1,115 @@
+# App-aware deck controls — direction critique
+
+Requested by fleetdeck-coordinator (fleet-deck channel, ask f-ms86kqof-4brj). Brief: find what is
+wrong with "detect the frontmost app, swap the deck's buttons" + spatial minimap, before it is built.
+
+## The structural flaw first: frontmost is the wrong dispatch key
+
+The proposal binds both *which buttons show* and *what a press does* to the Mac's frontmost app.
+Surfacing on frontmost is fine. **Dispatching on frontmost is not**, and it is wrong in a way
+specific to this product.
+
+The race: the deck snapshot says Chrome is frontmost; the operator taps "next tab"; between
+snapshot and tap, focus moved — and on this Mac, focus moves *by itself*, because the product's
+premise is autonomous agents running unattended, opening windows, spawning dialogs. On an ordinary
+remote control, focus changes when the user changes it. Here, frontmost is the least stable state
+on the machine, and the operator is by definition not looking at it. A keystroke synthesized at
+the focused app (`CompanionKeyboardController.typeText`, dispatch via `frontmostWindowTarget()` —
+`apps/mac/Sources/Core/Companion/LatticesDeckHost.swift:423,1060,1095,1333`) lands wherever focus
+is *now*. Misdirected input on an unwatched machine is silent and destructive — picture ⌘W arriving
+in the wrong app.
+
+Rule: every app-aware action must carry the target's identity (wid / session name) captured from
+the snapshot the operator was actually looking at. The Mac verifies the target still exists —
+raising it first if needed — or refuses and reports. If the deck can't name the target, the button
+doesn't exist.
+
+Side note: the snapshot has two notions of "active app" (`layout.frontmostWindow.appName` vs
+`desktop.activeAppName`, built at `LatticesDeckHost.swift:631` with its own fallback chain). They
+can disagree. Pick one authority before building anything that swaps on it.
+
+## 1. Maintenance trap — split the proposal into three tiers
+
+- **Tier A — platform conventions, not per-app contracts.** ⌘1–⌘8, ⌘9-last-tab, ⌘T, ⌘⇧[/],
+  ctrl-tab are macOS-wide tabbing conventions shared by Chrome, Safari, iTerm, Slack, Ghostty.
+  One "tabbed app" control set, zero per-app code, no treadmill. But note: fire-and-forget
+  keystrokes **cannot degrade honestly**, because the deck has no read-back — the snapshot carries
+  no tab state (`.tab` declared at `swift/Sources/DeckKit/DeckRuntimeSnapshot.swift:279`, never
+  emitted; only `.task/.application/.window/.session` at `LatticesDeckHost.swift:947–1018`).
+  Success is unverifiable from the iPad. Tier A is tolerable only for low-stakes, idempotent-ish
+  actions, and only with target-carrying dispatch per the rule above.
+- **Tier B — apps with a real automation API.** tmux (CLI/control mode), iTerm2 (Python/
+  AppleScript API), Chrome/Safari (scriptable tab enumeration). Readable state means the deck can
+  display truth and confirm effects. This is per-app work, but it's a contract with an API —
+  versioned, testable, fails loudly — not a contract with someone else's UI. This tier is where
+  app-awareness earns its keep.
+- **Tier C — apps with neither** (Ghostty: no scripting interface, minimal AX). Nothing to build
+  on. Skip entirely rather than faking it with keystrokes.
+
+The treadmill only starts if Tier B work is done by synthesizing keystrokes against UI assumptions.
+Smallest set that earns per-app support: **tmux** (the daemon already indexes it — `terminals.search`,
+`[lattices:session-name]` window tags) and **one scriptable browser** for tab lists. Stop there.
+
+## 2. "Jump to the seventh tab" is a demo
+
+The ordinal is only knowable by looking at the Mac's screen. If the operator can see the screen,
+they are within reach of a keyboard, and ⌘7 beats picking up an iPad. If they can't see the screen
+— the app's entire premise — the ordinal is unknowable and the button is dead weight. The feature
+does not survive the blind case *as specified*.
+
+The version that survives: build the `.tab` **producer** and put tab *titles* in the switcher, so
+the iPad is the source of tab knowledge rather than requiring it. Tap the tab by name; "seventh"
+becomes an implementation detail of a list row, not a feature. The protocol slot has been waiting
+for exactly this. Cut ordinal voice/buttons outright.
+
+## 3. Minimap: situational awareness yes, precision navigation no
+
+For *finding a window you can name*, the honest ranking at 15 windows / 2 displays is:
+text list > voice > minimap. Spatial memory covers the three or four deliberately placed windows —
+which are precisely the ones easiest to name, so the minimap's theoretical win ("know where, not
+what") is thinnest exactly where it's claimed. The rest of a 15-window desktop renders as
+overlapping slivers; a tap on 8pt targets (Apple floor: 44pt) is ambiguous between three stacked
+rectangles, and ambiguity in a *focus* action means focusing the wrong window on a machine you
+can't see.
+
+What the minimap uniquely provides is **state, not navigation**: "what does the Mac look like right
+now — did the agent open something, did a dialog appear." A list can't show that; for this product
+it's genuinely valuable, and it's nearly free because it already exists (`LatsLayoutSurface.previewCard`,
+tap-to-focus working, buried in the legacy surfaces screen). Keep it glanceable, coarse. Where a
+tap is ambiguous, disambiguate *into* the list (pop the windows near the tap point) rather than
+pretending the map has precision it lacks. Do not invest in zoom, per-window labels at strip size,
+or making it the primary switcher. (Adjacent: grieg holds the design ruling on trackpad/minimap
+fusion — this argues against map-as-trackpad, but that ruling is theirs.)
+
+## 4. Multiplexer: only address layers that have an address
+
+"Which layer does the button hit" has one clean answer: a button may only target a layer with an
+addressable API, and it names its target explicitly.
+
+- **tmux layer**: never send Ctrl-b keystrokes through the emulator through the window system. The
+  Mac runs `tmux select-window -t <session>:<n>` against the socket. Unambiguous by construction,
+  works even when the Ghostty window isn't focused, and `list-windows` gives read-back so the deck
+  shows truth. tmux is the *good* case in the whole proposal.
+- **Emulator layer** (Ghostty splits/tabs): no API → no buttons, deliberately, until one exists.
+- **OS window layer**: already has first-class deck controls (focus by wid, layout actions).
+
+The user knows the target because the strip is **labeled with and pinned to a session name**, not
+because they reason about focus. Framing rule: if a control's effect depends on state the iPad
+cannot display, the control is forbidden.
+
+## 5. Cut list and build-order correction
+
+Cut outright:
+- Frontmost-swapping as **dispatch** semantics (keep it only for choosing which set to surface).
+- Ordinal tab jumping, voice or button.
+- Anything Ghostty-specific.
+- A generic "app profiles" framework/config format. Build exactly two concrete sets — tabbed-app
+  conventions with target-carrying dispatch, and a tmux session strip — and abstract only if a
+  third genuinely appears.
+
+Build-order correction: **read path before write path.** Every deck surface that works today
+(windows, sessions, tasks) is snapshot-backed; the proposal jumps straight to write-only buttons
+acting on state the iPad can't see. First make the Mac emit tab/tmux state into the snapshot
+(the `.tab` producer, a tmux session feed from the daemon's existing index). Buttons that act on
+what the iPad already displays are a small, safe increment. Buttons acting on invisible state are
+the entire risk of this feature.

--- a/design/fleet-deck/connection-lifecycle-review.md
+++ b/design/fleet-deck/connection-lifecycle-review.md
@@ -1,0 +1,189 @@
+# Connection lifecycle — review
+
+**Scope:** connect · disconnect · refresh · status · remote logs
+**Date:** 2026-07-30 · iPad companion + Mac bridge
+**Occasion:** a revoked pairing left the iPad permanently stuck with no way out from the iPad alone. That class of bug — *a state the user cannot escape* — is what this review is looking for.
+
+Findings are ordered by that test first, then by severity.
+
+---
+
+## 0. The one that already bit
+
+Fixed today, recorded because the shape recurs below.
+
+Trust is **two records, one per device**, and either side can drop its own silently. When the Mac revoked the iPad:
+
+- `ensurePairing` opens `guard security.isTrusted(health: health) == false else { return }` — so the iPad never re-pairs while it holds a record. The record that would let it recover was the record blocking recovery.
+- `disconnect()` cleared the session but not the trust, and `handleDiscoveryUpdate` reconnects to any trusted host whenever `activeEndpoint == nil`. Disconnect was undone by the next Bonjour update.
+- Forget was `.swipeActions` on a `Button` inside a `VStack`. That modifier only works inside a `List`. Dead UI.
+
+Three independent bugs, each survivable alone; together, a dead end. The Mac's own trusted-device store showed the iPad's last successful auth was two days before the user noticed.
+
+---
+
+## 1. Connect
+
+### 1.1 Connect is fire-and-forget and can resolve out of order — **host ownership**
+
+`DeckStore.connect(to:)` sets published state, then launches an **untracked** `Task { await loadConnection(...) }`. Nothing cancels a previous one.
+
+`loadConnection` then mutates shared state at six points with `await`s between them: `health`, `activeEndpoint`, `manualHost/Port`, `manifest`, `snapshot`, `startPolling`. Two connects in flight interleave freely, and the **later-finishing** one wins — not the later-*requested* one.
+
+Consequences: tap Mac A, then Mac B, and you can end up driving A. Worse, you can end up with A's `health` and B's `manifest`, because there is no atomicity across the sequence. Every protected request signs against `health.bridgePublicKey`, so a mismatched pair silently authenticates to the wrong Mac or fails in a way that reads as a network fault.
+
+This is the same property the deck entry model was built to protect. It is unguarded one layer down.
+
+**Fix:** a generation token checked after every `await`, or a retained `connectTask` cancelled on entry. The token is cheaper and survives cancellation races.
+
+### 1.2 `performWithFallback` reassigns `activeEndpoint` from inside an action
+
+`candidateEndpoints(for:)` walks alternatives and, on success, writes `activeEndpoint`, `manualHost`, `manualPort`. So a routine action can silently re-point the session while a connect is in flight. Combined with 1.1 there is no single owner of `activeEndpoint`.
+
+### 1.3 Snapshot polling has no address fallback, but actions do
+
+`performWithFallback` tries every candidate endpoint. `refreshSnapshot(endpoint:)` takes `preferredEndpoint(fallback:)` and nothing else. So when a Mac changes address, **actions keep working and the snapshot goes stale** — the UI freezes while the buttons still fire. Asymmetric by accident, and the wrong way round: stale state is more dangerous than a failed action, because it looks fine.
+
+### 1.4 There is no reconnect path at all
+
+If `/health` succeeded once and later fails, nothing ever re-runs `loadConnection`. `startPolling` only ever calls `refreshSnapshot`, which only calls `client.snapshot`. A Mac that restarts its bridge, changes address, or re-keys is never re-handshaked — the session just fails forever at 1–5s intervals.
+
+---
+
+## 2. Disconnect
+
+### 2.1 `autoConnectSuppressed` does not survive relaunch — **escapable, but only just**
+
+The flag added today is in-memory. Quit the app and the iPad reconnects to a host the user deliberately disconnected. Disconnect currently means "until you next launch."
+
+If a deliberate disconnect is meant to be durable it should persist, keyed on `bridgePublicKey` — the same identity trust uses, not host:port.
+
+### 2.2 Forgetting a Mac does not stop its secondary session — **leak**
+
+`DeckStore.forget(publicKey:)` removes the trust record and disconnects *the primary* if it matches. Secondary stores are untouched.
+
+`DeckFleetStore.synchronize` is what reaps untrusted stores, and it only runs from `ContentView.onChange(of: store.discoveredBridges)` / `.onChange(of: store.activeEndpoint)`. Forgetting changes neither. So **a forgotten secondary Mac keeps polling on its 1–5s loop** until discovery happens to change — signing requests against a Mac the user just told us to drop.
+
+### 2.3 `DeckFleetStore.release(_:)` is dead code
+
+Written this morning, never called. Either wire it to forget or delete it; an unused disconnect path is a maintenance trap.
+
+### 2.4 Secondary Macs cannot be disconnected individually
+
+Settings manages the primary only. The only way to drop a fleet member is Forget, which is a heavier action (it destroys the pairing). There is no "disconnect this one for now."
+
+---
+
+## 3. Refresh
+
+### 3.1 No backoff — a dead host is hammered forever
+
+```swift
+while !Task.isCancelled {
+    try? await Task.sleep(for: .seconds(interval))
+    await self.refreshSnapshot(endpoint: endpoint)
+}
+```
+
+`currentPollInterval` is 1–5s and derived only from *desired liveness*, never from *observed health*. An unreachable Mac is retried every 1–5 seconds indefinitely, each attempt paying a 6s connect timeout.
+
+Worse: `currentPollInterval` returns **1.0** when `snapshot?.questions` is non-empty. A snapshot that went stale while holding a question pins the loop at 1Hz against a host that is not answering — the failure state is the most expensive state.
+
+### 3.2 Every failure overwrites one shared `errorMessage`
+
+Eight write sites, every severity into one `String?`. A rejected trackpad gesture overwrites "the bridge is unreachable." This is also what made the revocation invisible: a 403 read the same as any transient error.
+
+`FleetDeckAdapter` already had to work around it — it routes `errorMessage` to `fault` precisely so a bad swipe cannot masquerade as a channel needing attention.
+
+### 3.3 `refreshDiscovery` is the only user-facing recovery, and it is indirect
+
+The user's lever for "something is wrong" is Refresh, which restarts the Bonjour browse. It does not re-handshake, re-pair, or reset a session. For every failure in §1 and §2 it is the wrong tool, but it is the only one offered.
+
+---
+
+## 4. Status
+
+### 4.1 The model cannot express what actually goes wrong
+
+`HomeMachineStatus` is `active / online / standby / offline`.
+
+- **`.standby` is never produced.** `HomeDataAdapter` emits only `.active`, `.online`, `.offline`.
+- **`latencyMs` is hardcoded `nil`** at all three construction sites, while `HomeTargetCard` has a rendering branch for it.
+- There is no **connecting**, **retrying**, **degraded**, or **trust lost**.
+
+`isLoading` exists on the store and Home never reads it.
+
+### 4.2 Status is derived from presence, not from health
+
+`makeDiscovered` returns `.online` for anything Bonjour can see. A Mac that is advertising happily and 403ing every request shows as **ONLINE**. That is precisely today's failure rendered as a green light.
+
+The honest minimum:
+
+| State | Means |
+|---|---|
+| `active` | authenticated, snapshot fresh, foreground |
+| `online` | authenticated, snapshot fresh |
+| `connecting` | handshake in flight |
+| `degraded` | authenticated once, last N polls failed |
+| `untrusted` | reachable, but it refused us — **actionable: add again** |
+| `offline` | paired, not reachable |
+
+`untrusted` is the one that would have made today visible in a glance instead of a two-day silence.
+
+### 4.3 There is no per-host error surface
+
+`errorMessage` belongs to the store. Home shows machine cards. A secondary Mac's failure has nowhere to appear on Home at all.
+
+---
+
+## 5. Remote logs — what is actually possible
+
+**Better than expected: the data already exists and is already structured.**
+
+`DiagnosticLog` (`apps/mac/Sources/Core/System/DiagnosticLog.swift`) is a `HudLogStore` facade holding `Entry { id, time, message, level }` with levels info/success/warning/error. It is in-memory, published, and already carries exactly the events this review cares about — `CompanionPairing: approved device id=…`, `CompanionBridge: accept() failed`, and so on.
+
+**It is not exposed over the bridge.** `LatticesCompanionBridgeServer` references `DiagnosticLog` only to *write* to it. There is no route.
+
+The iPad's only view of the Mac is `snapshot.activityLog`, which is written in exactly one place — `LatticesDeckHost.swift:1493`, `tag: "DECK"`, `text: outcome.summary`. So it narrates deck actions and nothing else. (It is also why `FleetDeckAdapter.swift:59` names every channel "DECK": `agentName: log.first?.tag.uppercased()`.)
+
+**Proposal — `GET /deck/diagnostics`, protected:**
+
+- Under a **new capability**, `diagnostics.read`, not `deck.read`. Reading a Mac's internal log is a different grant from reading its deck state, and the capability mechanism already exists to say so — including letting a Mac withhold it.
+- **Cursor semantics**: `?since=<entry id or ISO timestamp>&limit=200`, returning newest-first with a `nextCursor`. The ring is small but polling it whole every second would be silly.
+- **Redaction before it leaves the Mac.** The log today carries device ids, key fingerprints, and host names. Pairing lines print the full device UUID. A companion showing a log should see events, not identifiers — truncate ids to the same 12-hex form the pairing code uses, and drop public keys entirely.
+- **Not on the snapshot poll.** A separate, explicitly-opened surface, fetched only while a log view is on screen. Otherwise every iPad drags the Mac's log across the network at 1Hz forever.
+
+This is worth doing precisely because of §0: when the connection is broken, `snapshot` is exactly what you cannot get. A diagnostics read that works while the deck is failing is the difference between "it doesn't work" and "the Mac revoked you at 21:13."
+
+---
+
+## 6. Ranked
+
+**Escapability — a user stuck with no iPad-side way out:**
+1. §2.2 forgotten secondary keeps polling and signing (leak, silent)
+2. §1.4 no reconnect path — a session can only die, never recover
+3. §2.1 disconnect does not survive relaunch
+
+**Correctness:**
+4. §1.1 connect races — wrong Mac, or a spliced session
+5. §1.3 snapshot has no address fallback while actions do — stale UI that looks live
+6. §1.2 actions re-point `activeEndpoint`
+
+**Honesty:**
+7. §4.2 `.online` for a Mac that is refusing us
+8. §3.2 one `errorMessage` for every severity
+9. §4.1 dead `.standby`, always-nil `latencyMs`
+
+**Capability:**
+10. §5 remote diagnostics — the thing that would have made §0 self-service
+
+---
+
+## 7. Proposed order
+
+1. **403 coverage + disambiguation.** Wire revocation detection into `perform` and `sendTrackpad`. But `untrustedDevice` and `insufficientCapability` are *both* 403 on the Mac, so naive handling would delete a good pairing over a capability shortfall — needs a discriminator before it is safe to broaden. Fail closed: only forget on 403 when the request was `deck.read`, which every pairing grants.
+2. **Forget must stop secondaries** — call `DeckFleetStore.release` and re-synchronize.
+3. **Backoff** on consecutive failures, and stop letting a stale question pin a dead host at 1Hz.
+4. **Connection generation token** in `loadConnection`.
+5. **Status model** — add `connecting` / `degraded` / `untrusted`; delete `.standby` or produce it.
+6. **`/deck/diagnostics`** behind `diagnostics.read`.

--- a/design/fleet-deck/deck-next-layer.md
+++ b/design/fleet-deck/deck-next-layer.md
@@ -1,0 +1,82 @@
+# Deck — the next layer
+
+**Direction from the operator, 2026-07-30.** Three things: bigger touch targets and tighter chrome; application-aware controls (Chrome tabs, Ghostty/iTerm and the multiplexer class); and a spatial window map projected into the trackpad region so you can *see* a window and jump to it.
+
+This document establishes what already exists before anything gets designed on top of it, because the answer turns out to change the plan.
+
+---
+
+## 1. What is already there
+
+Checked, not assumed.
+
+| Capability | Status |
+|---|---|
+| Frontmost app on the Mac | **Live** — `layout.frontmostWindow.appName`, `desktop.activeAppName` |
+| Window geometry, normalized | **Live** — `DeckLayoutPreviewWindow`, emitted at `LatticesDeckHost.swift:900` |
+| Tapping a window to focus it | **Built** — `LatsLayoutSurface.previewCard` → `switch.focusItem` |
+| Tabs | **Protocol slot, no producer** — `DeckSwitcherItemKind.tab` is declared and the Mac never emits it |
+| Terminal / tmux knowledge on the Mac | **Exists, unreachable** — lives in OmniSearch / CommandMode / assistant layers, nothing reaches the bridge |
+| Control sizing knobs | `minimumControlHeight = 80` (`:1485`), positioned-grid `rowHeight = 96` (`:1504`), grid spacing 10 |
+
+### The finding that matters
+
+**The window map is roughly 80% built and is in the wrong place.**
+
+`DeckLayoutPreviewWindow` already carries `normalizedFrame`, `title`, `subtitle`, `appCategory`, `appCategoryTint`, `isFrontmost`, `displayIndex`, and `itemID`. The Mac emits it on every snapshot. And `LatsSurfaceDetailView` → `LatsLayoutSurface.previewCard` *already draws it* — normalized frames as rectangles, tinted by app category, frontmost highlighted, each one tappable to focus via `switch.focusItem`.
+
+It works today. It is buried in a legacy "surfaces" list that the deck entry model no longer routes anyone to. The work is not building this feature; it is **moving it into the deck and making it small enough to live there**.
+
+That reorders the three asks by cost: density is cheap, the map is cheap-and-already-working, and app-awareness is the only one that needs new protocol.
+
+---
+
+## 2. Density
+
+Nothing here is blocked. Knobs exist; the numbers are simply phone numbers on a desk device.
+
+Current: control min height 80, positioned rows 96, grid spacing 10, chrome strips 26.
+
+The 44pt guidance everyone quotes is a *floor for a phone held in one hand*. A 13" iPad on a desk, operated with a thumb while looking at a different screen, wants targets well above it — and the deck has the room, currently spent on chrome.
+
+Squeeze candidates, in order: the 26pt chrome strips, inter-tile spacing, and the trackpad (the operator explicitly offered this one back). Awaiting kimi's target numbers rather than inventing them, since this is exactly the call that spec exists to make.
+
+---
+
+## 3. The window map
+
+**Design question is not "can we" but "where does it live and how does it read at 8 points wide".**
+
+Open, with kimi:
+
+- **Does the map share the trackpad's rectangle?** Tempting, and I suspect wrong: one surface that means both *relative pointer* and *absolute window position* is two mental models on one control. Alternatives are stacked regions, or the map as the default with the trackpad as a mode.
+- **Colour.** `appCategoryTint` is live data and reintroduces a palette the v7 spec deliberately removed. A window map may be the one place a category palette earns its way back — or identity has to come from position and frontmost-ness alone.
+- **Multi-display.** `displayIndex` and `displayCount` exist. Two displays side by side halve an already tiny window.
+
+---
+
+## 4. Application-aware controls
+
+The only one of the three that needs new protocol, and the only one with a real design risk.
+
+**What exists:** the frontmost app name, on every snapshot. That is enough to *switch* a control set. It is not enough to *populate* one.
+
+**What is missing:**
+
+- **Tabs.** `.tab` is declared in `DeckSwitcherItemKind` and never produced. Chrome tab navigation needs the Mac to enumerate tabs and expose a focus-by-index action. Nothing in the deck host does this today.
+- **Terminal/multiplexer state.** The Mac knows about tmux sessions and terminal tabs — the CLI's `terminals.search` exposes cwd, tab titles, tmux sessions, running commands — but that lives in the daemon and assistant layers. The companion deck host does not surface any of it.
+
+**The risk I want challenged before building** (out with fable): every special-cased app is a contract with somebody else's UI. Chrome renames a menu item, iTerm changes a binding, and a button on the iPad silently does the wrong thing to a live session. There is also a targeting problem specific to the multiplexer case — tmux inside Ghostty inside a window means a keystroke has three possible recipients, chosen by state the iPad cannot see.
+
+And one question about the premise itself: "jump to the seventh tab" requires already knowing it is seventh, which implies looking at the Mac — while the app's whole premise is operating a Mac you are not looking at. The feature may be real, but the framing that makes it real is probably *"show me the tabs, let me pick one"* rather than *"go to tab seven"*.
+
+---
+
+## 5. Order
+
+1. **Density.** No dependencies, immediate benefit, reversible.
+2. **Window map into the deck.** The renderer exists; this is placement, scale, and legibility.
+3. **Tabs as a producer.** `.tab` already exists in the protocol — emit it, render a list, focus by `itemID`. This gets the Chrome and terminal cases *without* per-app keybinding contracts, because picking from a list the Mac supplied is app-agnostic.
+4. **Per-app control sets** — only if 3 proves insufficient, and only for a set small enough to maintain honestly.
+
+Step 3 before step 4 is the important ordering: it may make step 4 unnecessary, and it cannot rot the way a keybinding table can.

--- a/design/fleet-deck/design-analysis.md
+++ b/design/fleet-deck/design-analysis.md
@@ -1,0 +1,257 @@
+# Lats Fleet Deck — Design → Native implementation analysis
+
+**Scope:** analysis only. No repo files were modified. Written 2026-07-19 outside the
+repo, filed here 2026-07-29.
+
+**Design source:** claude.ai/design project `e010d8da-…`, file `Lats Fleet Deck.html`
+(read via the claude_design MCP `get_file`; returned untruncated, `truncated:false`).
+
+**Native source:** `/Users/art/dev/lattices/apps/ios/Sources/` —
+`LatsDeckScreen.swift` (Fleet types at 2519–4103), `DeckStore.swift`, `ContentView.swift`.
+
+---
+
+## 1. Revision visibility — what I can and cannot see
+
+The claude_design MCP surface is file-oriented (`list_files` / `get_file`), **not**
+revision-oriented: there is no per-file diff/history method. So I read the *current
+published state* of `Lats Fleet Deck.html` and can describe it exactly, but I cannot
+render a literal revision-over-revision diff. What I *can* establish about lineage from
+internal evidence:
+
+- The project contains a **separate, older sibling** `Lats Cockpit - iPad.html` — the
+  single-Mac cockpit that the native `LatsDeckScreen` was originally ported from
+  (per project memory). `Lats Fleet Deck.html` is the newer multi-Mac artifact; the
+  project's `screenshots/` now carries a `fd-*` set (`fd-full`, `fd-deck`, `fd-lower`,
+  `fd-now`, `fd-check`) that are Fleet-Deck reference captures.
+- **Strong internal signal that the fader was recently re-purposed:** the CSS comment
+  on the crossfader still reads *"one slot per host channel, aligned to the channel
+  grid,"* but the live JS wires the fader to **command SETS** (`SETS` = 5 entries:
+  WINDOW/AGENT/DEV/VOICE/SYSTEM), not to host channels. `selectSet()` re-renders the
+  tile bay and the LCD. That stale comment vs. live behavior is the fingerprint of the
+  latest change: **the crossfader moved from "route a Mac" to "select a command set."**
+
+That single change is the most consequential delta vs. the native build, because the
+current native Fleet Deck implements the *older* model (fader = channel router). See §3
+and §5.
+
+---
+
+## 2. Design file — exact visual system
+
+Root `#stage` centers a fixed **`.pad` 1376×1032** (iPad-landscape canvas) and JS
+`fit()` scales it to the viewport. Everything is `var(--mono)`, 12px base.
+
+**Vertical stack inside `.pad`** (gap 9px, padding `12 16 9`):
+
+1. **`.fd-top`** (h 26) — brand `LATS · DECK` (700 + faint dot + `DECK`), right group
+   `4 MACS` + close ✕. Bottom hairline `rgba(255,255,255,.07)` + shadow seam.
+2. **`.fd-channels`** (h **252**) — CSS grid `repeat(4,1fr)`, radius `10px 10px 0 0`,
+   one `.chan` per Mac, left hairline between columns. Per channel:
+   - `.chan-head` (border-bottom dotted): `CH 0x` cap, device SVG icon, device name.
+   - `.chan-ctx`: left `CURRENT APP` label (10.5px, tracked) + app name **16px** +
+     sub file (ellipsized); right `.chan-metrics` CPU/MEM/WIN (`em` label + `b` value,
+     tabular-nums).
+   - `.chan-tape`: `AGENT LOG` + `IDLE`, then rows `[dot color][AGENT label 52px][text]`.
+   - `.chan-foot` (border-top): `ON DECK` / `STANDBY` with dot; active channel's foot
+     turns green + glowing dot.
+   - `.chan.active` = subtle top-down white gradient wash.
+3. **`.fd-route`** (radius `0 0 10px 10px`, pulled up `-9px` to fuse with channels) —
+   the LCD/mixer:
+   - `.route-top` grid `1fr auto 1fr`: left cap, center **`.led-win` LCD** panel
+     (`SET 01 — WINDOW`, black inset, `text-shadow` glow), right `SET 1 / 5`.
+   - `.f-track` **crossfader**: `grid-template-columns:repeat(N,1fr)` (N = 5 sets),
+     `.f-rail` recessed bar, one `.f-slot` per set (tick dot + label), and a **machined
+     aluminum `.f-handle`** (28×28, radius 5): layered `linear-gradient` +
+     `repeating-linear-gradient` knurling + inset highlight/shadow, plus a `::before`
+     recessed groove and `::after` bright center scribe line. Slides with
+     `transition:left .3s cubic-bezier(.22,1,.36,1)`.
+4. **`.fd-deck` → `.deck-panel`** (radius 12, embossed, 30px grid texture background,
+   deep inset shadow) — a *single enclosure* containing:
+   - **`.panel-head`** (embossed ledge, inset top highlight): left Mac name
+     `Arach MacBook Pro`, right `Xcode · FleetDeckScreen.swift`.
+   - **`.panel-body`** grid **`250px 1fr 320px`**, gap 16, inset shadow (well):
+     - left `.panel-col.left`: `.mcard.mstats.recent` (host + `14ms` + CPU/MEM/GPU
+       `.mbar` bars) and `.mcard.mdisp` (displays `D1/D2` toggle + `.dviz` 2×2 window
+       grid). `.mcard.recent` draws white **corner-bracket ticks** via 8 layered
+       gradients.
+     - center `.panel-center`: `.pc-status` ghosted (**opacity .66**) two lines —
+       `LIVE <task>` (18px) and `NEXT <task>` (16px, dimmer). A JS-injected
+       **`.tp-cross` crosshair** (vertical + horizontal 1px lines, green dot, live
+       `X … Y …` readout) tracks `pointermove` over `.panel-body`.
+     - right `.panel-col.right`: `.mcard.mtx` transcript quote, `.mcard.mact` activity
+       (`CODEX`/`SCOUT`/`BUILD` rows, `52px 1fr`).
+   - **`.deck-tiles`** command bay: grid `repeat(3,1fr)` × 2 rows = **6 tiles**, h 162.
+     Each `.tile`: `auto 1fr` grid, **34×34 icon** (radius 9, radial gradient, inset
+     emboss), title **14px**, meta `NN · <verb>` (9px uppercase). Hover/active lift.
+   - **`.deck-keys`** keyboard strip (embossed ledge, mirrors panel-head): groups
+     `esc ⌘C ⌘V ⌘Z ⇥→ space` / arrow cluster / `⌃ ⌥ ⇧ ⌘ ↵enter`. Keys are molded caps
+     (radius 7, inset highlight, press translateY).
+5. **`.fd-status`** (h 26, full-bleed `margin:0 -16px -9px`) — status bar: green
+   `● ONLINE`, Mac name, spacer, then `MACS 4`, `AGENTS 7`, `CPU 24%`, `MEM 52%`,
+   `NET 14ms`, `SET · WINDOW` (green). Grouped by left hairlines.
+6. **`.tweaks`** dev panel (Motion still/alive, Bloom off/on) — persisted to
+   localStorage; drives `#pad.motion-alive` sweep/breathe animations and
+   `#pad.bloom-on` overhead radial. Developer toy, not product chrome.
+
+**Tokens / lighting / texture:**
+- Colors: `--grn` = `--acc` (system.css green), `--vio` `oklch(.70 .15 300)`,
+  `--blu` `oklch(.73 .11 250)`, `--amb` `oklch(.80 .12 82)`, `--red` `oklch(.68 .16 25)`.
+  Cards `#0b0c0e`; breaks white `.08`/`.05`.
+- Type: `var(--mono)` (JetBrains Mono in the design system) at 9–18px; uppercase labels
+  tracked `.1–.24em`; `font-variant-numeric:tabular-nums` on all metrics/LCD.
+- Radii: pad 14 · channels/route 10 · deck-panel 12 · mcard 5 · tiles 9 · keys 7.
+- Lighting: radial page + pad gradients; embossed ledges (`inset 0 1px 0 rgba(255,…)`
+  over dark) on panel-head/keys; machined-metal fader; LED glow via `text-shadow`;
+  bloom overlay; 30px grid on the deck well.
+- Motion (only when `motion-alive`): `barsweep` on `.mbar` fills, `livebreathe` on the
+  transcript live dot, `actbreathe` on an activity row; all gated by
+  `prefers-reduced-motion`.
+
+---
+
+## 3. Intended interaction model (Design)
+
+- **Channels row = a 4-Mac monitor.** Each channel shows that Mac's context (current
+  app/file), vitals (CPU/MEM/WIN), and its agent log. Exactly **one** channel is
+  *active / ON DECK* (CH 01 in the mock); the others are STANDBY. (Note: the mock JS
+  does not wire channel clicks — the active channel is fixed — but the `.chan.active`
+  styling + `ON DECK/STANDBY` semantics make clear that **tapping a channel = choose
+  which Mac feeds the common deck**.)
+- **Crossfader = command-set mixer.** The fader parks on one of **5 command sets**
+  (WINDOW · AGENT · DEV · VOICE · SYSTEM). Moving it (`selectSet`) swaps the tile bay to
+  that set's 6 buttons, updates the LCD (`SET 0i — NAME`), the counter (`SET i/5`), and
+  the status-bar `SET · NAME`. The handle animates to the chosen slot.
+- **Common deck = the active Mac's live surface:** header names the Mac + frontmost app,
+  the body is its trackpad (crosshair + ghosted LIVE/NEXT agent status) flanked by
+  stats/displays (left) and transcript/activity (right), the tile bay is the selected
+  command set, and the keyboard strip sends raw keys.
+
+So the Design separates the two axes cleanly: **channel (which Mac)** is chosen in the
+top lanes; **command set (which 6 actions)** is chosen on the fader/LCD.
+
+---
+
+## 4. Section-by-section map: Design → native SwiftUI
+
+| Design section | Native type / member | File · approx lines |
+|---|---|---|
+| Presentation / router | `FleetDeckScreen` in `.fullScreenCover` | ContentView.swift:99–105 |
+| `.pad` shell, landscape vs portrait | `FleetDeckScreen.fleetLayout` / `landscapeDecks` / `portraitDecks` | LatsDeckScreen.swift:2525, 2585, 2625, 2699 |
+| `.fd-top` topbar | `fleetTopBar` (LATS·DECK, `N-UP` badge, `N MACS`) | 2604–2623 |
+| `.fd-channels` (one `.chan`) | `FleetLanePicker` (header / contextStrip / agentTape / routeFooter) | 2896–3163 |
+| `.chan-head` | `laneHeader` (`CH 0x`, machine icon, label, LIVE/LINK) | 2964–2994 |
+| `.chan-ctx` (CURRENT APP + metrics) | `contextStrip` (CONTEXT + activeApp/Window + CPU/MEM/WIN) | 2996–3029, 3141 |
+| `.chan-tape` (AGENT LOG) | `agentTape` + `agentEntries` (activityLog → cockpit agentRows) | 3051–3139 |
+| `.chan-foot` ON DECK/STANDBY | `routeFooter` (ROUTED TO DECK / TAP TO ROUTE) | 3031–3049 |
+| `.fd-route` fader + `.f-handle` | `FleetLaneFader` (**but routes channels, not sets**) | 2781–2886 |
+| `.led-win` LCD / `SET i/5` / status SET | **no native equivalent** | — |
+| `.deck-panel` enclosure | `FleetSharedDeck` (landscape) / `FleetMachineDeck` (portrait) | 3165–3514, 3516–~4100 |
+| `.panel-head` (Mac · file) | `FleetSharedDeck.deckHeader` (+ page tabs) | 3281–3334 |
+| `.panel-body` grid 250/1fr/320 | `LatsTrackpadSurface` (left cols / center / right cols / bezels) | 374–535 |
+| left `.mstats` / `.mdisp` | `CompactSystemPanel` / `CompactDisplaysPanel` | 676–894 |
+| center `.pc-status` + crosshair | `LatsTrackpadModeVisual` (idle/rec/replay/agent) | 998–1129 |
+| right `.mtx` / `.mact` | `CompactTranscriptPanel` / `CompactActivityLogPanel` | 896–994 |
+| `.deck-tiles` command bay | `LatsShortcutGrid` of `LatsShortcutTile` (from `activePage.tiles`) | 1475–1556, 1661–1792, 3231–3251 |
+| `.deck-keys` keyboard strip | `LatsActionKeyboardRow` (+ `ModifierKey` sticky chords) | 1164–1471 |
+| `.fd-status` status bar | **no native equivalent** (per-deck `deckFooter` instead) | 3336–3363 |
+| `.tweaks` / bloom / motion | not ported (dev toy) | — |
+| Data source | `DeckStore` snapshot; `DeckFleetStore` secondary sessions; `fleetPreview` mock | DeckStore.swift:13, 497, 576–712 |
+
+---
+
+## 5. Prioritized delta list
+
+### MUST match (product-model / identity)
+1. **Fader semantics — decide the model (owner call).** Design's latest fader is a
+   **command-set mixer** (WINDOW/AGENT/DEV/VOICE/SYSTEM) with an LCD readout; native's
+   `FleetLaneFader` is a **channel router** (which Mac → deck), with command sets
+   surfaced instead as small **page tabs** in `deckHeader` (2307–2329). These are
+   different mental models. This is the one delta that changes structure and must be
+   resolved before anything else.
+2. **LCD route/set readout** (`.led-win` `SET 0i — NAME`, `SET i/5`) — the signature
+   element of the route strip; absent natively.
+3. **Bottom status bar** (`.fd-status`: ONLINE · Mac · MACS/AGENTS/CPU/MEM/NET · SET).
+   Native shows a *per-deck* footer (`OUTPUT · CPU · LANE READY`) — a different object.
+   Note `AGENTS 7` implies a **fleet-aggregate agent count** native does not compute.
+
+### SHOULD match (visual fidelity)
+4. **Single deck enclosure vs. split.** Design is one `.deck-panel` (head→body→tiles→
+   keys) as a unit; native splits it into `LatsCockpitShell{ trackpad }` (h 280) + a
+   separate scrolling `LatsShortcutGrid`, and the keyboard lives *inside* the trackpad
+   bottom bezel, not on an embossed strip under the tiles. Consider unifying to the
+   enclosure + embossed ledges (panel-head/keys `inset` highlight).
+5. **Machined-aluminum fader handle** (knurled multi-gradient cap + center scribe +
+   `.3s cubic-bezier` slide). Native knob (2844–2862) is a simpler rounded-rect.
+6. **Trackpad crosshair with live X/Y** and **ghosted LIVE/NEXT** status (opacity .66).
+   Native has a mode visual but no crosshair/coordinate readout.
+7. **`.mcard.recent` corner-bracket ticks**, 30px grid on the deck well, embossed
+   ledges — texture cues currently softened natively.
+8. **Command tile fidelity:** Design icon **34px** + meta `NN · <verb>`; native
+   `LatsShortcutTile` icon **25px** + meta `act.NN · category` (1687). Tile grid is
+   fixed **3×2 / 6** in Design; native derives columns from live tile count (3232).
+9. **Typography:** Design uses `--mono` (JetBrains Mono) + oklch accents; native uses
+   system `.monospaced` (LatsFont.mono, 51) + sRGB approximations (LatsPalette, 7–27).
+
+### Intentional / acceptable native deviations
+10. **SF Symbols instead of inline SVG** icon sets — correct for a native app.
+11. **Live, data-driven tiles** from `store.snapshot.cockpit.pages` with real
+    `actionID`s (3466–3480) instead of the Design's fixed 5×6 static set — functionally
+    superior; keep.
+12. **Portrait pager** (`FleetMachineDeck` in a `TabView`, 2699–2710) — a native
+    responsive affordance the single fixed-canvas Design doesn't cover; keep.
+13. **`N-UP` badge + horizontal scroll** of lanes for >4 Macs — native scale handling
+    beyond the Design's fixed 4 columns; keep.
+
+---
+
+## 6. Effects / assets / data assumptions not represented natively
+
+- **CSS effects absent natively:** knurled aluminum fader gradients; LED `text-shadow`
+  glow; `.mcard.recent` corner brackets; embossed ledges (`inset` highlight over dark);
+  30px deck-well grid; bloom radial overlay; `barsweep`/`livebreathe`/`actbreathe`
+  animations (+ `prefers-reduced-motion` gating); crosshair overlay + live X/Y.
+- **Data the Design assumes that native fleet chrome doesn't compute:** fleet-aggregate
+  `AGENTS` count; a global `NET 14ms` latency figure in the status bar; a fixed
+  **5-set** command model (`SET i/5`); per-Mac `WIN` count in the LCD context (native
+  has WIN in the lane picker but not in a route LCD).
+- **Assets:** Design ships inline `DEV` SVGs (laptop/studio/mini) + ~30 command SVGs and
+  `system.css` tokens. Native substitutes SF Symbols + `LatsPalette`/`LatsFont` — fine.
+  The `screenshots/fd-*.png` in the project are reference captures, not shipping assets.
+- **Fonts:** if parity matters, the app must bundle JetBrains Mono; otherwise accept the
+  system-monospaced deviation and match sizes/tracking only.
+
+---
+
+## 7. Recommended sequence + verification rubric
+
+**Sequence (gated on the model decision):**
+1. **Decide the fader model** (owner). If Design wins → introduce a command-set concept:
+   either map live `cockpit.pages` onto the 5 named sets, or add a set layer above pages;
+   move set-selection onto the fader and re-home channel-selection to the lane taps.
+2. Add the **LCD route/set readout** to the route strip.
+3. Add the **bottom `.fd-status` bar** (incl. a fleet agent-count aggregate + net RTT);
+   reconcile with the current per-deck footer.
+4. Fidelity pass: unify the **deck enclosure** + embossed ledges; upgrade the **fader
+   handle**; add **crosshair X/Y** + ghosted LIVE/NEXT; restore corner ticks + deck-well
+   grid; bump tile icon to 34px and align meta text.
+5. Typography pass (JetBrains Mono + oklch-matched accents) if the font is bundled.
+
+**Verification rubric (side-by-side at iPad landscape ≈ 1376×1032):**
+- Channels: 4 equal columns, one ON DECK, CPU/MEM/WIN + agent tape present.
+- Route: fader travel matches slot count; LCD + counter + status-bar set label agree.
+- Deck body: proportions read as `250 / 1fr / 320`; left stats+displays, center
+  trackpad w/ crosshair, right transcript+activity.
+- Command bay: 3×2 grid, 34px icons, `NN · verb` meta.
+- Keyboard: esc/⌘C/⌘V/⌘Z/⇥/space · arrows · ⌃⌥⇧⌘ · enter.
+- Status bar groups render and update.
+- Dark-load with no flicker (matches the recent web-view background fix); respects
+  reduced-motion.
+
+---
+
+### Owner / next move
+The fader-semantics decision (§5.1) is a product-model choice for the deck-builder owner
+(`lattices.deck-builder-mac.arts-mac-mini-local`), not something to resolve unilaterally.
+Everything else is fidelity work that can proceed once that axis is fixed. No repository
+changes were made.

--- a/design/fleet-deck/design-review.md
+++ b/design/fleet-deck/design-review.md
@@ -1,0 +1,131 @@
+# Lats Fleet Deck — design review vs. native iPad app
+
+**Reviewer:** senior FE/product-design pass (SwiftUI + high-fidelity control surfaces)
+**Scope:** analysis only — no repo files edited/built/committed. Written 2026-07-19 outside the repo, filed here 2026-07-29.
+**Baseline:** merged `63aab23`. DEBUG fixture: `--fleet-preview` → `FleetDeckPreviewHost(machineCount:4)` (LatsDeckScreen.swift:2756–2779).
+**Sources read:** `artifacts/Lats-Fleet-Deck.html`, `artifacts/system.css`, `artifacts/PROVENANCE.md`, prior `design-analysis.md`; native `LatsDeckScreen.swift` (fleet 2519–4101), `DeckStore.swift`, `ContentView.swift`.
+
+---
+
+## 1. Recommendation: **SYNTHESIZE** (lean Design on the fader's *job*, keep Native's routing + data truth)
+
+The central decision is really about **removing a redundancy**, not choosing a winner:
+
+- **Design (latest HTML):** lanes conceptually pick the Mac (ON DECK / STANDBY — but the mock never wires channel clicks; CH 01 is hardcoded `active:true`, HTML 486). The **physical fader is the only wired control** and it selects one of **5 command sets** (WINDOW/AGENT/DEV/VOICE/SYSTEM, HTML 560–576) → swaps the 6-tile bank, drives the LCD (`SET 01 — WINDOW`) and the status-bar SET label.
+- **Native:** lane taps **really** route a Mac to the deck (`FleetLanePicker.onSelect` → `selectedSessionID`, 2629–2659). But `FleetLaneFader` (2781–2886) *also* routes the Mac — **so the fader duplicates the lane taps.** Command sets are demoted to small header page-tabs (`deckHeader` 3307–3329).
+
+**The native fader has no unique job.** The operator explicitly wants to *keep* a tactile physical fader ("bottom-aligned controls… one stable tactile common deck"), so deleting it is off the table. The clean resolution is the Design's division of labor:
+
+> **Route the Mac by tapping its lane. Select the command bank with the fader.**
+
+This gives the fader the one job it lacks, and it creates a tight cause→effect adjacency: the fader sits directly above the tile bay it now controls — slide it, the bank right below re-banks, the deck enclosure itself stays put ("one stable tactile common deck"; only the bank content swaps, exactly as the HTML's `selectSet()` re-renders only `#tiles` + LCD, HTML 605–613).
+
+**Two deliberate departures from the Design (keep Native's strengths):**
+1. **Command sets stay data-driven** from `store.snapshot.cockpit.pages` (2 pages / 6+4 tiles in the fixture, DeckStore 602–625) — *not* the Design's hardcoded 5 sets × 6 tiles. The fader slot count adapts to the routed Mac's page count.
+2. **The LCD names both axes** — routed Mac (`CH 0i`) *and* active bank (`SET 0i — NAME`) — reconciling the two controls into one readout.
+
+### Exact operator workflow (post-synthesis)
+
+1. Enter Fleet Deck (`.fullScreenCover`, ContentView 99–105). Landscape → 4 Mac lanes on top.
+2. **Tap a lane** → routes that Mac to the common deck (ON DECK/STANDBY; accent border). Deck header names the Mac + frontmost file. *(unchanged native behavior)*
+3. **Slide the fader** (route strip, above the deck) → parks on a command bank. LCD updates `CH 0i · SET 0j — NAME`, the tile bay re-banks, status-bar SET label updates, handle animates ≤0.3s. *(fader's new job)*
+4. **Tap a tile** → fires on the routed Mac (`perform`, 3493–3508). **Keyboard strip / trackpad** → raw input. *(unchanged)*
+5. **Re-route to another Mac** → fader re-populates with that Mac's banks, parks on bank 1; LCD shows new CH + SET.
+6. **Portrait** → keep the pager + page strip (a horizontal fader is awkward on a narrow single-deck pager; intentional deviation, see §5).
+
+---
+
+## 2. Highest-impact ideas, ordered by value
+
+1. **Fader → command-bank selector; route Macs by lane tap** *(model — do first)*. Kills the fader/lane redundancy; gives the tactile control a real job; keeps sets truthful/adaptive. Touches `FleetLaneFader` (2781–2886) + `landscapeDecks` (2625–2677) + lift `selectedPageID` out of `FleetSharedDeck` (3170).
+2. **LCD route/set readout** (`.led-win`, HTML 118–124): recessed black inset, tabular-nums, text-glow via `.shadow`. Signature element; gives the fader semantic feedback. No native equivalent today.
+3. **Unify the deck into one enclosure** (`.deck-panel` head→body→tile-bay→keys as a single bordered unit, HTML 163–277). Native currently splits it: `LatsCockpitShell{trackpad}` at fixed h=280 (3193–3225) + a *separate scrolling* `LatsShortcutGrid` (3237–3251), with the keyboard buried in the trackpad bezel. Unifying with embossed head/keys ledges is the single biggest "stable tactile deck" win.
+4. **Machined-aluminum fader handle** (HTML 139–149: layered `linear`+`repeating-linear` knurl, recessed `::before` groove, bright `::after` scribe, `.3s cubic-bezier(.22,1,.36,1)` slide). Current knob is a plain rounded-rect + center bar (2844–2862).
+5. **Bottom fleet status bar** (`.fd-status`, HTML 326–335 / 445–455): full-bleed, hairline-grouped: `● ONLINE · <Mac> · MACS N · AGENTS Σ · CPU% · MEM% · SET·NAME`. **Truthful subset only** — MACS=`stores.count`, AGENTS=Σ live agent rows across stores, CPU/MEM from the routed Mac's telemetry, SET from the fader. **Omit `NET 14ms`** (no truthful source — see §5). Native only has a per-deck footer (`deckFooter` 3336–3363), a different object.
+6. **Trackpad crosshair + live X/Y + ghosted LIVE/NEXT** (HTML 226–238, 630–646): 1px cross, 7px green dot, `X … Y …` 9px readout; `pc-status` LIVE (18px) / NEXT (16px) at opacity .66. Adds precision cue + agent status on the control surface.
+7. **Command-tile fidelity bump**: icon **25→34px** (`iconBadge` 1732 → HTML `.tile-ic` 317), keep `NN · verb` meta (already at 1687), and lock the bank to a fixed **3×2 / 6** where the page supplies ≥6 tiles (native derives columns from count, 3232).
+8. **Texture cues**: `.mcard.recent` corner-bracket ticks (HTML 185–195), 30px deck-well grid (HTML 166–168), embossed `inset 0 1px 0 rgba(255,255,255,.09)` ledges on panel-head/keys (HTML 173, 260). Mostly folds into #3.
+9. **Adaptive fader slot count** (2..N): render N=page-count slots, degrade labels gracefully past ~5 (abbreviate; rely on LCD for the full name). Keeps the control truthful where the Design hardcodes 5.
+10. **Typography parity**: bundle **JetBrains Mono** + oklch-matched accents (HTML 11–14), or accept the system-`.monospaced` deviation (`LatsFont.mono`) and match sizes/tracking only. Lowest priority.
+
+---
+
+## 3. Section-by-section Design → native SwiftUI map
+
+| Design section | Native type / member | File · lines |
+|---|---|---|
+| Presentation / router | `FleetDeckScreen` in `.fullScreenCover` | ContentView.swift:99–105 |
+| `.pad` shell; landscape vs portrait | `FleetDeckScreen.fleetLayout` / `landscapeDecks` / `portraitDecks` | LatsDeckScreen.swift:2585, 2625, 2699 |
+| `.fd-top` topbar (`LATS·DECK`, `N MACS`, ✕) | `fleetTopBar` (+ `N-UP`/`SWIPE` badge) | 2604–2623 |
+| `.fd-channels` → one `.chan` | `FleetLanePicker` | 2896–3163 |
+| `.chan-head` (`CH 0x`, dev icon, LIVE) | `laneHeader` | 2964–2994 |
+| `.chan-ctx` (CURRENT APP + CPU/MEM/WIN) | `contextStrip` / `laneMetric` | 2996–3029, 3141–3150 |
+| `.chan-tape` (AGENT LOG rows) | `agentTape` / `agentEntries` | 3051–3139 |
+| `.chan-foot` ON DECK / STANDBY | `routeFooter` | 3031–3049 |
+| `.fd-route` fader + `.f-handle` | `FleetLaneFader` **(routes Macs — repurpose to banks)** | 2781–2886; knob 2844–2862 |
+| `.led-win` LCD / `SET i/5` / status SET | **none — build new** | — |
+| `.deck-panel` enclosure | `FleetSharedDeck` (landscape) / `FleetMachineDeck` (portrait) | 3165–3514 / 3516–3976 |
+| `.panel-head` (Mac · file) | `FleetSharedDeck.deckHeader` (**holds page tabs — move to fader**) | 3281–3334 |
+| `.panel-body` 250 / 1fr / 320 | `LatsTrackpadSurface` (via `LatsCockpitShell`) | 374–535; shell 3193–3225 |
+| left `.mstats` / `.mdisp` | `CompactSystemPanel` / `CompactDisplaysPanel` | ~676–894 |
+| center `.pc-status` + crosshair | `LatsTrackpadModeVisual` (idle/rec/replay/agent) | ~998–1129 |
+| right `.mtx` / `.mact` | `CompactTranscriptPanel` / `CompactActivityLogPanel` | ~896–994 |
+| `.deck-tiles` command bay | `LatsShortcutGrid` of `LatsShortcutTile` | grid 1475–1556; tile 1661–1792; wired 3231–3251 |
+| `.deck-keys` keyboard strip | `LatsActionKeyboardRow` (+ `ModifierKey`) | 1164–1471 |
+| `.fd-status` status bar | **none — per-deck `deckFooter` instead** | 3336–3363 |
+| `.tweaks` / bloom / motion | not ported (dev toy) | — |
+| Data | `DeckStore` snapshot; `DeckFleetStore`; `fleetPreview` fixture | DeckStore.swift:576–712 |
+
+---
+
+## 4. Minimal implementation slices (each independently shippable + verifiable under `--fleet-preview`)
+
+- **Slice A — model (smallest fix).** Lift `selectedPageID` from `FleetSharedDeck` (3170) up to `FleetDeckScreen`. Repoint `FleetLaneFader` from `selectedIndex=channel` to `selectedIndex=pageIndex` of the routed store; `onSelect(i)` → set that page. Relabel `"CHANNEL ROUTE"` / `"DECK OUT · CH"` (2811, 2821) → `"COMMAND BANK"` / `"SET · <NAME>"`. Mac routing stays on lane taps (already there). Remove the header page-tabs in landscape (3307–3329); reclaim that space for the frontmost-file `ph-r` readout. *No new chrome — resolves the redundancy alone.*
+- **Slice B — LCD.** New `FleetRouteLCD` subview in the route strip: `CH 0i` + `SET 0j — NAME` + `SET j / N`, recessed inset + `.shadow` glow. Pure presentation; `accessibilityHidden` (fader carries the value).
+- **Slice C — handle craft.** Replace the knob (2844–2862) with a machined cap (layered gradients + 2×14 center scribe); animate `knobX` with `.spring`/`.easeOut(0.28)` as the cubic-bezier analog.
+- **Slice D — enclosure.** Wrap header/trackpad/tile-bay/keyboard into one bordered `.deck-panel`; move `LatsActionKeyboardRow` out of the trackpad bezel onto a dedicated embossed ledge under the tile bay; add embossed head/keys ledges + 30px well grid. *(Higher effort — after A–C.)*
+- **Slice E — status bar.** `fleetStatusBar` at the bottom of `fleetLayout` (below the deck, above safe area): ONLINE · routed Mac · `MACS N` · `AGENTS Σ` · `CPU%` · `MEM%` · `SET·NAME`. Truthful data only; reconcile with (or replace) `deckFooter`.
+- **Slice F — fidelity.** Tile icon 25→34; crosshair overlay + ghosted LIVE/NEXT; `.mcard.recent` corner ticks. Lowest risk; last.
+
+---
+
+## 5. Risks & intentional deviations
+
+- **Truthful data — `NET ms` has no source.** `DeckSystemTelemetry` (DeckStore 662–668) has CPU/MEM/GPU/windowCount/sessionCount, **no latency**. `latencyMs` exists only in the Home model and its adapter hard-codes `nil` (HomeDataAdapter 171/205/226); only `HomeMockData` (213) shows `14`. → **Omit NET from the status bar** (or gate it on a real `health` RTT if/when one lands). Do **not** fabricate. `AGENTS Σ` *is* truthful (sum live `agentRows`/`activityLog` across stores).
+- **Variable banks vs. fixed 5×6.** Design hardcodes 5 sets × 6 tiles; native pages vary (fixture: 2 pages, 6 & 4 tiles). Fader slot count and the tile bay must adapt (don't force empty 3×2 cells). *Intentional.*
+- **Portrait keeps the page strip.** A horizontal fader on a narrow single-deck pager is poor ergonomics; retain `FleetMachineDeck.deckPageStrip` (3709–3733) in portrait. *Intentional.*
+- **Touch targets.** Design handle is 28×28; iOS HIG wants ≥44pt hit area. The fader gesture already spans the whole track (`minimumDistance:0`, 2865–2873) and the row is 58pt (2660) — keep the *hit* region ≥44pt even if the visual cap is smaller.
+- **Accessibility.** Preserve `accessibilityAdjustableAction` on the fader (2877–2883) — repoint value to "Command set n of N". Keep `FleetLanePicker`'s route label (2961). Mark the LCD decorative.
+- **Safe areas.** The full-bleed `.fd-status` maps to a bottom bar inset **above** the home indicator — don't let it slide under the safe area.
+- **Reduced motion.** Gate the handle slide + any bar-sweep on `@Environment(\.accessibilityReduceMotion)` (Design already gates its motion via `prefers-reduced-motion`, CSS 294–295).
+- **Keep, don't "fix":** SF Symbols over inline SVG (correct native choice); data-driven live tiles/pages over static sets; `N-UP` badge + horizontal lane scroll for >4 Macs; portrait pager. These are native affordances the fixed 1376×1032 Design doesn't cover.
+
+---
+
+## 6. Simulator visual rubric (exact sizes / states)
+
+**Harness:** launch `--fleet-preview` (`FleetDeckPreviewHost(machineCount:4)`); iPad **landscape ≈ 1366×1024** (matches the DEBUG `#Preview`, 4112–4116; Design pad is 1376×1032). Verify `.preferredColorScheme(.dark)`, no flash.
+
+- **Lanes:** 4 equal columns; lane width ≥245pt (`laneWidth` clamp 2692–2697); row height `min(255, max(225, h·0.25))` (2647). Exactly **one ON DECK** (accent border 1pt + 2pt top bar; 2947–2952), rest STANDBY. Per lane: `CH 0x` 8pt-bold, machine icon 11pt, LIVE/LINK dot 5pt, CONTEXT app 11pt, CPU/MEM/WIN values 9pt, AGENT TAPE ≤3 rows (label 6pt / 42pt-wide, 3081–3099).
+- **Fader (route strip):** row 58pt (2660); N slots = **routed Mac's page count** (fixture: 2); handle parked on the active bank; slide ≤0.3s; center LCD `SET 0j — NAME` 13pt w/ glow; right `SET j / N`; left `CH 0i`. Handle hit-region ≥44pt.
+- **Deck enclosure:** single bordered panel, radius 12; header 42pt (Mac left, `Xcode · <file>` right); body proportions read **250 / 1fr / 320**; trackpad center shows crosshair (1px lines, 7px green dot, `X…Y…` 9pt) + ghosted LIVE (18pt) / NEXT (16pt) at opacity .66; tile bay **3×2 = 6**, icon **34px**, title 14pt, meta `0i · verb` 9pt; keyboard ledge: `esc ⌘C ⌘V ⌘Z ⇥ space / ← ↑ ↓ → / ⌃ ⌥ ⇧ ⌘ ↵enter`, keys 31pt tall / ≥42pt wide.
+- **Status bar:** 26pt; hairline-grouped `● ONLINE`(green) · Mac · `MACS 4` · `AGENTS Σ` · `CPU%` · `MEM%` · `SET·NAME`(green); sits above the home-indicator safe area; **no NET group**.
+- **Interaction states to capture:**
+  (a) route Mac A→B — lane ON DECK moves, deck header + LCD `CH` update;
+  (b) slide fader bank1→bank2 — tile bay re-banks, LCD `SET` + status SET update, handle animates;
+  (c) tile press — scale 0.985 + shadow drop (1713–1720);
+  (d) trackpad drag — crosshair follows, X/Y updates; tap → click;
+  (e) **reduced-motion ON** — no slide/sweep;
+  (f) **portrait** — pager + page strip, one deck per page;
+  (g) **empty** — "No reachable Macs" (2719–2727);
+  (h) **1-up** — single `LatsDeckScreen` path (2541–2542).
+
+---
+
+## 7. Product decision memo
+
+- **Decision:** **Synthesize.** Fader becomes the **command-bank selector** (adopt Design's division of labor + its signature LCD/machined handle). **Mac routing stays on lane taps** (keep Native's real, direct interaction). One **LCD** reconciles both axes (`CH 0i · SET 0j — NAME`). Command banks remain **data-driven** from `cockpit.pages`, not the Design's hardcoded 5.
+- **Why:** eliminates the current fader↔lane-tap redundancy; keeps the tactile fader the operator wants and gives it a real job with tight fader→tile-bay adjacency; the deck enclosure stays stable while only the bank swaps; adopts the highest-craft Design elements without sacrificing truthful or adaptive data.
+- **Guardrails:** omit `NET ms` (no truthful source); compute `AGENTS` from live rows; portrait keeps the page strip; preserve ≥44pt touch targets, the adjustable-fader a11y, safe-area insets, and reduced-motion gating.
+- **Sequence:** Slice **A** (model) first, behind `--fleet-preview`; verify against the §6 rubric in Simulator; then **B→F**.
+- **Owner / next move:** greenlighting the **fader repurpose** is the deck-builder-mac owner's product call — it changes the interaction model, so it should be their explicit yes before implementation. Everything after is fidelity work gated on that yes. **No repo changes were made in this review.**

--- a/design/fleet-deck/token-spec-v7.md
+++ b/design/fleet-deck/token-spec-v7.md
@@ -1,0 +1,141 @@
+# Fleet Deck — Token Spec v7
+
+**Author:** kimi (taste), via #fleet-deck · 2026-07-30
+**Brief (Arach, verbatim):** "full font sizes, smaller is better, fewest possible colors, no mono / technical vibe across the board"
+**Replaces:** `LatsPalette`/`LatsFont` (`apps/ios/Sources/LatsDeckScreen.swift:7-57`) and `FleetV6` (`apps/ios/Sources/FleetDeck/FleetDeckTheme.swift`) with one enum — `DeckTheme`. One Swift file, no gradients, no per-component one-offs.
+
+Framing: the app is a remote control, and should look like the OS it lives on rather than the thing it points at.
+
+**Corrected 2026-07-30 (Arach):** kimi's original framing was "operates terminals". It doesn't. This app operates *agents* (Scout-brokered), *dictation*, and the Mac's window/input surface. Nothing here is a terminal.
+
+That removes the spec's only mono exception. `LatticesDeckHost.swift:1493` is the single record site for the activity log — `tag: "DECK"`, `text: outcome.summary` — so every line is a prose summary of an action, never columnar output. Prose set in mono is the terminal-cosplay this spec exists to kill. **The iPad companion has no mono face at all.** See §6.
+
+## 1. Surfaces — five levels, all opaque
+
+v6 had six named surfaces plus five machined gradients. The real count is five, and only three are structural.
+
+| Token | Hex | Role |
+|---|---|---|
+| `canvas` | `#0D0F12` | root background |
+| `well` | `#0A0B0D` | **recessed group** (channel strip, log screen, voice bar). Depth −1 |
+| `card` | `#131518` | **flush item** (card, tile, list row). Depth +1 |
+| `raised` | `#181B1F` | focused/hero console, popovers, sheets. Never ordinary cards |
+| `control` | `#1E2126` | buttons, keycaps, inputs, chips — anything tappable inside a card |
+
+`well`/`card` around `canvas` *is* the two-level depth model: down for groups, up for items, nothing between. Steps are ~4–5% luminance apart. If two adjacent surfaces don't need a visible seam, they are the same level — don't invent a sixth.
+
+**Deleted:** `padBG`, `deckPanelBG`, `statusBG`, `tilesWrapBG` → `canvas`/`well`. `heroBG` gradient → `raised`. `bezel`, `keycap`, `keycapHover`, `tileFace`, `dome` → flat `control`/`card`. `FleetPanelGrid` dies with the engineering grid. `FleetCornerTicks` dies — a recently-changed card gets a `hairlineStrong` stroke.
+
+## 2. Text ramp — keep v6's four, renamed
+
+| Token | Hex | Role |
+|---|---|---|
+| `text` | `#E2E2DF` | titles, names, primary values |
+| `textSecondary` | `#A0A09B` | metadata, secondary rows, icons |
+| `textTertiary` | `#71716C` | captions, timestamps, quiet content |
+| `textDisabled` | `#4A4A4D` | disabled |
+
+Values unchanged. Warm-neutral is why the amber doesn't vibrate on it; already opaque; four steps matches the four roles the UI actually has.
+
+**Deleted:** `LatsPalette.text/textDim/textFaint` (alpha whites), `tileIcon #CEC6B9` → `textSecondary`.
+
+## 3. Hairlines — two, mostly forbidden
+
+- `hairline` — white 8%. Stroke on a flush card; separator between sibling rows when gap < 8pt.
+- `hairlineStrong` — white 14%. Focused/selected/recently-changed card stroke. The only "look at me" that isn't amber.
+
+**Not allowed:** between well and canvas (spacing does the recess), between sections inside one card, under card heads. No dotted rules, no black seams.
+
+**Deleted:** `dotted`, `seam`, `cardBR`, `heroBR`, `FleetDottedRule`, the keycap black stroke. `brk`/`brk2` and `hairline`/`hairline2` collapse into the two above.
+
+## 4. Radii — 4 / 8 / 12, continuous
+
+`radiusSmall` 4 (chips, badges) · `radiusCard` 8 (cards, tiles, controls) · `radiusWell` 12 (wells, panels, sheets). All `.continuous`; concentric rule outer = inner + padding. Resolves the 8/6 vs 10/12/5 disagreement.
+
+## 5. The two hues
+
+- `accent` `#E4B65C` — attention **and** selection
+- `accentPressed` `#C29B4E` (× 0.85 brightness)
+- `accentFill` — accent @ 14%, selected-row / active-toggle fill
+- `error` `#EA6A64`
+- `errorPressed` `#C85A55` (× 0.85)
+- `errorFill` — error @ 14%
+
+Disabled accent = accent @ 35%, but prefer `textDisabled` for disabled controls.
+
+**Deleted:** green, teal, blue, violet, pink (both files), the entire `LatsTint` enum, `agentHues`/`agentHue(_:)`. Where a tint string arrives over the wire, drop the colour, keep the icon.
+
+## 6. Type — four sizes, SF Pro, no tracking, no uppercase
+
+| Token | Spec | Role |
+|---|---|---|
+| `title` | 17 semibold | console names, the decision question, sheet titles |
+| `body` | 15 regular | primary rows, channel names, input text |
+| `secondary` | 13 regular | metadata, descriptions |
+| `caption` | 11 regular | timestamps, status words, former micro-labels (sentence case) |
+
+**No `log` token.** kimi's draft carved out `12 regular monospaced` for "log/terminal content". Corrected: there is no terminal content. The activity log is prose (`outcome.summary`), so it renders in `secondary` like any other narrative row. Mono appears nowhere in the iPad app.
+
+### Two faces, split by voice — not by data type
+
+**Arach, 2026-07-30:** a distinction between the system face and a user-communication face is wanted.
+
+The split is *who is speaking*, not *what shape the data is*:
+
+| Face | Token prefix | Used for |
+|---|---|---|
+| **SF Pro** (system) | `title` / `body` / `secondary` / `caption` | all chrome — names, labels, metadata, buttons, status, counts |
+| **Serif** (communication) | `said` / `saidSecondary` | utterances: the agent's decision question, voice transcript, agent messages |
+
+- `said` — 17 regular serif. The decision question; anything an agent is asking you.
+- `saidSecondary` — 15 regular serif. Voice transcript, agent message bodies.
+
+This reinstates the serif kimi first flagged as "the one warm, non-technical gesture in v6" and then cut under "fewest possible". With the axis named it earns its place: the serif is not decoration, it marks *someone is talking to you* — which is the entire point of a surface whose signature state is an agent blocked on a human.
+
+Chrome never uses it. Two faces, one job each.
+
+Fifth/sixth sizes today: `FleetLabel`'s 10pt tracked caps → `caption` in `textTertiary`; stray 12pt chrome → `secondary`/`caption`; 26pt status numerals → `title`.
+
+**Deleted:** `LatsFont.mono`/`ui`, `FleetV6.mono` as a chrome face, `FleetV6.serif` — the decision question becomes `title`. *"The serif was the design performing thoughtfulness; the OS doesn't do that."*
+
+## 7. States without green
+
+Running is default-healthy, so running looks like **nothing**.
+
+- **Running** — no dot, no colour. Icon `textSecondary`, name `text`. Health is absence of signal.
+- **Idle** — row demoted to `textTertiary`; 6pt hollow dot (1pt `textTertiary` stroke, no fill).
+- **Needs you** — 6pt filled `accent` dot, soft amber glow (radius 4 @ 60%), plus an `accent` caption word where a reason fits ("reply?", "approval"). Never amber the whole row.
+- **Error** — same construction in `error`, with `errorFill` behind the row only while unresolved.
+- **Selected/focused** — structural, not chromatic: `raised` fill or `hairlineStrong` stroke. **Selection is not attention.**
+
+## 8. Spacing — 8pt grid
+
+`space2 · space4 · space8 · space12 · space16 · space24 · space32`
+
+Screen margins 16 · card padding 16h/14v (the 14 is v6's own interior rhythm — keep) · well inner padding 12 · sibling card gap 8 · section gap in a card 12 · icon↔label 8 · between major regions 16.
+
+`FleetV6.M` heights (topBar 26, channels 158, voiceBar 58, …) stay as layout constants where used — geometry, not theme. Don't port them into the enum.
+
+## Migration map (no orphans)
+
+- `LatsPalette.bgEdge/bg` → `canvas`; `surface`/`surface2` → `card`/`raised` by role
+- `LatsPalette.hairline/2`, `FleetV6.brk/brk2` → `hairline`/`hairlineStrong`
+- `wellBG` → `well`; `cardBG`, `tilesWrapBG` → `card`
+- all gradients (`heroBG`, `padBG`, `deckPanelBG`, `statusBG`, `bezel`, `keycap(+Hover)`, `tileFace`, `dome`) → flat `canvas`/`raised`/`control`
+- `fg`…`fg4` → `text`…`textDisabled`
+- `LatsTint`, `agentHues`, green/teal/blue/violet/pink, `tileIcon` → deleted
+- `FleetLabel`, chrome `mono`, `serif` → `title`/`body`/`secondary`/`caption`; log `mono` → `log`
+- `FleetPanelGrid`, `FleetDottedRule`, `FleetCornerTicks` → deleted
+- `FleetWell`/`FleetCard` survive as components, re-skinned: flat fills, hairline on cards only, wells defined by fill alone
+
+## Open question: mono on the Mac command bar
+
+**Flagged assumption:** this spec governs the iPad companion; the Mac's locked JetBrains Mono command bar is untouched.
+
+kimi's view, verbatim:
+
+> It holds. The companion reads as a companion through shared surfaces, the grey ramp, the amber, the spacing rhythm, and the channel-strip IA — none of which is a typeface. The Mac's mono command bar is a keyboard-platform power affordance; the iPad is glance-and-tap, and SF Pro is correct there. The two are never on screen at once, so forcing one face buys invisible consistency at the cost of making one platform worse.
+>
+> The thread worth keeping: log/terminal content is mono on both (SF Mono on iPad is fine — content, not chrome). Chrome speaks each OS's native voice; the data is what sounds the same.
+>
+> If Arach rules one typeface everywhere, the cost is iPad chrome going mono — the terminal-cosplay this spec exists to kill. I'd push back.


### PR DESCRIPTION
## Summary
- add the multi-host iPad companion foundation, host discovery, add-host flow, and connection lifecycle
- introduce the shared DeckKit transport/runtime surface used by the Mac and iOS companion
- scope voice state and actions per host while preserving the existing Talkie integration

## Verification
- clean checkout `swift test --package-path swift` — 9 tests passed
- clean checkout `LATTICES_HUDSON_SOURCE=git HUDSONKIT_WITH_VOICE=1 swift test --package-path apps/mac` — 29 tests passed, 13 Stage Manager tests skipped because Stage Manager was disabled
- clean checkout iOS Simulator `xcodebuild` — build succeeded
- resolved Hudson main at `8c02727` during clean verification

## Stack
1 of 4. #82, #83, and #84 build on this foundation.