### PR TITLE
Add native companion remote and desktop preview

### DIFF
--- a/apps/ios/LatticesCompanion.xcodeproj/project.pbxproj
+++ b/apps/ios/LatticesCompanion.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		02DFEEC584B5BE76F4E0EF59 /* Icon-App-29x29@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = AB70174A80BDBEF97964B1D1 /* Icon-App-29x29@3x.png */; };
 		0B62E8780B2EF68BB75DCB77 /* DeckKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1D4FCB5C53FAA6DC26531C63 /* DeckKit */; };
 		0F0698A95BD07D14D89D5BA1 /* HomeRoutinesList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23261457659049EF7D390F0E /* HomeRoutinesList.swift */; };
+		1F06EA84AB51D9E228FBBBCB /* DesktopPreviewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD01DA0D87BAD6328C48DE8 /* DesktopPreviewScreen.swift */; };
 		2495F9FA74E60FE3935AF9AB /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6008CE13AA2719DE4CFEFBA5 /* ContentView.swift */; };
 		29EB1F420B2143258D6BE3E6 /* HomeVoiceOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F80BAECD547AFCAF6FB4487 /* HomeVoiceOverlay.swift */; };
 		303C0ED6FF5A801009E72EBD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E0A62477A93C15EBE3917B2E /* LaunchScreen.storyboard */; };
@@ -131,6 +132,7 @@
 		E8CF4F00C46E366B32EC05B6 /* FleetDeckConsole.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDeckConsole.swift; sourceTree = "<group>"; };
 		EDEBF60950520605C2AFCAB6 /* FleetDeckFocusPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDeckFocusPane.swift; sourceTree = "<group>"; };
 		EE5C0AF5BDF4BE3A05157A33 /* HomeVoicePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeVoicePanel.swift; sourceTree = "<group>"; };
+		EFD01DA0D87BAD6328C48DE8 /* DesktopPreviewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopPreviewScreen.swift; sourceTree = "<group>"; };
 		EFEA84FACFEF2BC028E68125 /* FleetDeckVoiceBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDeckVoiceBar.swift; sourceTree = "<group>"; };
 		F48879BE5FDAA5E9B1F69EB2 /* LocalNetworkScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNetworkScanner.swift; sourceTree = "<group>"; };
 		F6F62141EE310B1E14C10F6D /* FleetDeckHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FleetDeckHost.swift; sourceTree = "<group>"; };
@@ -261,6 +263,7 @@
 				CE3829B428DD890399011344 /* DeckSkeleton.swift */,
 				11238FFB50336470B6A97CE0 /* DeckStore.swift */,
 				33D07069EDC1FC31F2D17855 /* DeckTheme.swift */,
+				EFD01DA0D87BAD6328C48DE8 /* DesktopPreviewScreen.swift */,
 				0A0454EF94BCB42389D5B90B /* Info.plist */,
 				0AE37E6C4302786080981EE9 /* LatsDeckScreen.swift */,
 				E5BE58AB3627168981D1D91F /* LatsDesignSystem.swift */,
@@ -374,6 +377,7 @@
 				702E0CE9E43B03A228EB124B /* DeckSkeleton.swift in Sources */,
 				015334E9F01E2EC8CE7C6C77 /* DeckStore.swift in Sources */,
 				A554A5F6BEE7A1D19133D7E3 /* DeckTheme.swift in Sources */,
+				1F06EA84AB51D9E228FBBBCB /* DesktopPreviewScreen.swift in Sources */,
 				E49DB476A1AF62CF00A48A94 /* FleetDeckAdapter.swift in Sources */,
 				E28369386027FFF51101E239 /* FleetDeckChannelStrip.swift in Sources */,
 				3A1671AC9709B03CC97F9D13 /* FleetDeckCommandBay.swift in Sources */,

--- a/apps/ios/Sources/ContentView.swift
+++ b/apps/ios/Sources/ContentView.swift
@@ -1,5 +1,6 @@
 import DeckKit
 import SwiftUI
+import UIKit
 
 // MARK: - Router
 
@@ -199,7 +200,15 @@ struct ContentView: View {
                 // opened it. Left standing, it would keep vouching for the
                 // primary store long after the primary had been pointed at some
                 // other Mac — which is the exact confusion it exists to prevent.
-                if destination == nil { repointedMachineID = nil }
+                if destination == nil {
+                    repointedMachineID = nil
+                    // A protected request can discover that the saved pairing
+                    // no longer matches while the deck is covering Home. Pull
+                    // the roster again as the cover closes so the stale card is
+                    // replaced by the Add flow immediately.
+                    trustedBridges = DeckBridgeSecurityStore.shared.trustedBridgeList()
+                    fleetStore.releaseUntrusted()
+                }
             }
             .onChange(of: showSettings) { _, isOpen in
                 store.setUIPriority(isOpen ? .fast : .ambient)
@@ -213,6 +222,14 @@ struct ContentView: View {
         .onChange(of: store.activeEndpoint) { _, _ in
             fleetStore.synchronize(with: store)
             promoteNewSessionsIfPresenting()
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(
+                for: DeckBridgeSecurityStore.trustDidChangeNotification
+            )
+        ) { _ in
+            trustedBridges = DeckBridgeSecurityStore.shared.trustedBridgeList()
+            fleetStore.releaseUntrusted()
         }
     }
 
@@ -299,6 +316,8 @@ private struct HostDeckHost: View {
     @State private var transitionSettled = false
     /// Only true once waiting has gone on long enough to deserve an explanation.
     @State private var waitIsWorthExplaining = false
+    @State private var showsDesktopPreview = false
+    @State private var trackpadWindowPreviewImage: UIImage?
 
     /// Roughly the length of a `fullScreenCover` presentation.
     private let settleDelay = Duration.milliseconds(300)
@@ -337,6 +356,9 @@ private struct HostDeckHost: View {
         .animation(.easeInOut(duration: 0.22), value: isReady)
         .preferredColorScheme(.dark)
         .statusBarHidden(true)
+        .fullScreenCover(isPresented: $showsDesktopPreview) {
+            DesktopPreviewScreen(store: store)
+        }
         .task {
             // Data goes in flight immediately; the tree is built after the
             // animation lands. The two costs stop overlapping.
@@ -345,6 +367,9 @@ private struct HostDeckHost: View {
             transitionSettled = true
             try? await Task.sleep(for: narrationDelay)
             if store.snapshot == nil { waitIsWorthExplaining = true }
+        }
+        .task(id: trackpadPreviewTaskID) {
+            await updateTrackpadWindowPreview()
         }
     }
 
@@ -359,14 +384,59 @@ private struct HostDeckHost: View {
         LatsDeckScreen(
             liveSnapshot: store.snapshot,
             connectionLabel: store.connectionLabel,
+            trackpadWindowPreviewImage: trackpadWindowPreviewImage,
             onAction: { actionID, payload, label in
                 store.perform(actionID: actionID, pageID: "cockpit", payload: payload, label: label)
             },
             onTrackpadEvent: { event, dx, dy in
                 store.sendTrackpad(event: event, dx: dx, dy: dy)
-            }
+            },
+            onDesktopPreview: { showsDesktopPreview = true }
         )
     }
+
+    private var trackpadPreviewTaskID: TrackpadWindowPreviewTaskID {
+        TrackpadWindowPreviewTaskID(
+            windowID: store.snapshot?.layout?.frontmostWindow?.id,
+            isEnabled: isReady && !showsDesktopPreview
+        )
+    }
+
+    private func updateTrackpadWindowPreview() async {
+        trackpadWindowPreviewImage = nil
+        guard trackpadPreviewTaskID.isEnabled,
+              trackpadPreviewTaskID.windowID != nil else {
+            return
+        }
+
+        while !Task.isCancelled {
+            do {
+                let preview = try await store.desktopPreview(
+                    maxPixelWidth: 960,
+                    scope: .frontmostWindow
+                )
+                try Task.checkCancellation()
+                guard
+                    let jpeg = Data(base64Encoded: preview.jpegBase64),
+                    let image = UIImage(data: jpeg)
+                else {
+                    return
+                }
+                trackpadWindowPreviewImage = image
+            } catch {
+                // The full Desktop Preview surface owns permission and pairing
+                // guidance. The trackpad thumbnail stays quiet and optional.
+                return
+            }
+
+            try? await Task.sleep(for: .seconds(4))
+        }
+    }
+}
+
+private struct TrackpadWindowPreviewTaskID: Hashable {
+    let windowID: String?
+    let isEnabled: Bool
 }
 
 // MARK: - Home (no Mac connected)

--- a/apps/ios/Sources/DeckBridgeClient.swift
+++ b/apps/ios/Sources/DeckBridgeClient.swift
@@ -168,6 +168,14 @@ struct DeckBridgeClient {
     ) async throws -> DeckTrackpadEventResult {
         try await protectedPost(path: "/deck/trackpad", endpoint: endpoint, health: health, body: request)
     }
+
+    func desktopPreview(
+        endpoint: BridgeEndpoint,
+        health: BridgeHealthResponse,
+        request: DeckDesktopPreviewRequest
+    ) async throws -> DeckDesktopPreviewFrame {
+        try await protectedPost(path: "/deck/preview", endpoint: endpoint, health: health, body: request)
+    }
 }
 
 private extension DeckBridgeClient {

--- a/apps/ios/Sources/DeckBridgeSecurityStore.swift
+++ b/apps/ios/Sources/DeckBridgeSecurityStore.swift
@@ -43,7 +43,7 @@ struct StoredBridgeTrust: Codable, Equatable, Sendable {
     var lastKnownPort: Int?
 
     var effectiveCapabilities: [String] {
-        grantedCapabilities ?? DeckBridgeCapability.defaultCompanionCapabilities
+        grantedCapabilities ?? DeckBridgeCapability.legacyCompanionCapabilities
     }
 }
 
@@ -55,6 +55,7 @@ struct PreparedBridgeRequest {
 
 final class DeckBridgeSecurityStore {
     static let shared = DeckBridgeSecurityStore()
+    static let trustDidChangeNotification = Notification.Name("DeckBridgeSecurityStore.trustDidChange")
 
     private enum DefaultsKey {
         static let deviceID = "companion.security.deviceID"
@@ -145,8 +146,9 @@ final class DeckBridgeSecurityStore {
 
     /// Forget a previously paired bridge by its public key.
     func forgetBridge(publicKey: String) {
-        trustedBridges.removeValue(forKey: publicKey)
+        guard trustedBridges.removeValue(forKey: publicKey) != nil else { return }
         persistTrustedBridges()
+        NotificationCenter.default.post(name: Self.trustDidChangeNotification, object: nil)
     }
 
     func pairingRequest() -> DeckPairingRequest {
@@ -181,6 +183,7 @@ final class DeckBridgeSecurityStore {
             lastKnownPort: lastKnownPort ?? existing?.lastKnownPort
         )
         persistTrustedBridges()
+        NotificationCenter.default.post(name: Self.trustDidChangeNotification, object: nil)
     }
 
     /// Remember where a Mac answered, so it stays reconnectable once it stops
@@ -392,6 +395,8 @@ private extension DeckBridgeSecurityStore {
             required = DeckBridgeCapability.deckPerform
         case "/deck/trackpad":
             required = DeckBridgeCapability.inputTrackpad
+        case "/deck/preview":
+            required = DeckBridgeCapability.screenPreview
         default:
             required = nil
         }

--- a/apps/ios/Sources/DeckStore.swift
+++ b/apps/ios/Sources/DeckStore.swift
@@ -33,7 +33,7 @@ final class DeckStore: ObservableObject {
     private let client = DeckBridgeClient()
     private let discovery = BridgeDiscovery()
     private var pollingTask: Task<Void, Never>?
-    private var trackpadEventInFlight = false
+    private var trackpadEventInFlightGeneration: Int?
     private var queuedTrackpadEvents: [QueuedTrackpadEvent] = []
     private let maxQueuedTrackpadEvents = 8
 
@@ -41,6 +41,7 @@ final class DeckStore: ObservableObject {
         var event: DeckTrackpadEvent
         var dx: Double
         var dy: Double
+        var connectionGeneration: Int
 
         var canCoalesce: Bool {
             switch event {
@@ -137,6 +138,7 @@ final class DeckStore: ObservableObject {
         // previous explicit disconnect.
         autoConnectSuppressed = false
         connectionGeneration += 1
+        resetTrackpadPipeline()
         consecutivePollFailures = 0
         let generation = connectionGeneration
         activeEndpoint = endpoint
@@ -179,6 +181,8 @@ final class DeckStore: ObservableObject {
     func disconnect(suppressAutoReconnect: Bool = true) {
         pollingTask?.cancel()
         pollingTask = nil
+        connectionGeneration += 1
+        resetTrackpadPipeline()
         activeEndpoint = nil
         health = nil
         manifest = nil
@@ -217,6 +221,28 @@ final class DeckStore: ObservableObject {
     /// callers don't need to be perfect.
     func setUIPriority(_ priority: DeckPollPriority) {
         uiPriority = priority
+    }
+
+    /// Pull one current desktop frame from the paired Mac. Callers await each
+    /// frame before requesting another so capture work cannot pile up when the
+    /// iPad is backgrounded or the local network slows down.
+    func desktopPreview(
+        displayIndex: Int? = nil,
+        maxPixelWidth: Int = 1_440,
+        scope: DeckDesktopPreviewScope = .display
+    ) async throws -> DeckDesktopPreviewFrame {
+        guard let endpoint = preferredEndpoint(), let health else {
+            throw DeckBridgeClientError.badStatus(503, "The Mac is not connected.")
+        }
+        return try await client.desktopPreview(
+            endpoint: endpoint,
+            health: health,
+            request: DeckDesktopPreviewRequest(
+                displayIndex: displayIndex,
+                maxPixelWidth: maxPixelWidth,
+                scope: scope
+            )
+        )
     }
 
     func perform(
@@ -292,15 +318,21 @@ final class DeckStore: ObservableObject {
         dy: Double = 0
     ) {
         guard let endpoint = preferredEndpoint(), let health else { return }
-        let queued = QueuedTrackpadEvent(event: event, dx: dx, dy: dy)
+        let generation = connectionGeneration
+        let queued = QueuedTrackpadEvent(
+            event: event,
+            dx: dx,
+            dy: dy,
+            connectionGeneration: generation
+        )
 
-        guard !trackpadEventInFlight else {
+        guard trackpadEventInFlightGeneration == nil else {
             enqueueTrackpadEvent(queued)
             return
         }
 
-        trackpadEventInFlight = true
-        sendTrackpadEvent(queued, endpoint: endpoint, health: health)
+        trackpadEventInFlightGeneration = generation
+        sendTrackpadEvent(queued, endpoint: endpoint, health: health, generation: generation)
     }
 }
 
@@ -309,6 +341,7 @@ private extension DeckStore {
         if event.canCoalesce,
            let last = queuedTrackpadEvents.last,
            last.event == event.event,
+           last.connectionGeneration == event.connectionGeneration,
            last.canCoalesce {
             queuedTrackpadEvents[queuedTrackpadEvents.count - 1].coalesce(event)
         } else {
@@ -327,7 +360,8 @@ private extension DeckStore {
     func sendTrackpadEvent(
         _ queued: QueuedTrackpadEvent,
         endpoint: BridgeEndpoint,
-        health: BridgeHealthResponse
+        health: BridgeHealthResponse,
+        generation: Int
     ) {
         Task {
             do {
@@ -336,31 +370,48 @@ private extension DeckStore {
                     health: health,
                     request: DeckTrackpadEventRequest(event: queued.event, dx: queued.dx, dy: queued.dy)
                 )
+                guard generation == connectionGeneration else { return }
                 if !result.ok {
                     errorMessage = "Trackpad input was rejected. Check that the Mac bridge is enabled and has Accessibility permission."
+                } else if var currentSnapshot = snapshot,
+                          var trackpad = currentSnapshot.trackpad {
+                    trackpad.pointerX = result.pointerX
+                    trackpad.pointerY = result.pointerY
+                    currentSnapshot.trackpad = trackpad
+                    snapshot = currentSnapshot
                 }
             } catch {
+                guard generation == connectionGeneration else { return }
                 errorMessage = error.localizedDescription
                 await probeTrustIfRefused(error, endpoint: endpoint)
             }
-            finishTrackpadEvent()
+            finishTrackpadEvent(generation: generation)
         }
     }
 
-    func finishTrackpadEvent() {
+    func finishTrackpadEvent(generation: Int) {
+        guard generation == connectionGeneration,
+              trackpadEventInFlightGeneration == generation else { return }
+
+        queuedTrackpadEvents.removeAll { $0.connectionGeneration != generation }
         guard let next = queuedTrackpadEvents.first else {
-            trackpadEventInFlight = false
+            trackpadEventInFlightGeneration = nil
             return
         }
 
         queuedTrackpadEvents.removeFirst()
         guard let endpoint = preferredEndpoint(), let health else {
-            trackpadEventInFlight = false
+            trackpadEventInFlightGeneration = nil
             queuedTrackpadEvents.removeAll()
             return
         }
 
-        sendTrackpadEvent(next, endpoint: endpoint, health: health)
+        sendTrackpadEvent(next, endpoint: endpoint, health: health, generation: generation)
+    }
+
+    func resetTrackpadPipeline() {
+        queuedTrackpadEvents.removeAll()
+        trackpadEventInFlightGeneration = nil
     }
 
     func handleDiscoveryUpdate(_ bridges: [BridgeEndpoint]) {
@@ -460,7 +511,7 @@ private extension DeckStore {
         }
     }
 
-    /// Notice that a Mac has stopped trusting this device, and let go.
+    /// Notice that the two devices no longer agree on this pairing, and let go.
     ///
     /// Trust lives in two records — one per device — and the Mac can drop its
     /// own at any time. When it does, every protected request comes back 403
@@ -469,10 +520,24 @@ private extension DeckStore {
     /// never recover on its own: it reconnects, gets refused, reconnects, and
     /// reports a different flavour of the same failure forever.
     ///
-    /// Dropping our half breaks the loop. The host leaves the roster and turns
-    /// back into something you can add, which is the one action that fixes it.
+    /// The same deadlock happens when the iPad's private key changes while its
+    /// UserDefaults trust record survives (for example, after restoring app
+    /// data without its Keychain item). The Mac still knows the old public key,
+    /// so it correctly rejects every signature with a 401.
+    ///
+    /// Dropping our half breaks either loop. The host leaves the roster and
+    /// turns back into something you can add, which is the one action that can
+    /// safely replace a mismatched key with explicit approval on the Mac.
     private func handleRevokedTrust(_ error: Error) -> Bool {
-        guard case DeckBridgeClientError.badStatus(403, _) = error,
+        guard case DeckBridgeClientError.badStatus(let status, let detail) = error else {
+            return false
+        }
+
+        let macRevokedTrust = status == 403
+        let signingKeyChanged = status == 401
+            && detail.localizedCaseInsensitiveContains("signature could not be verified")
+
+        guard (macRevokedTrust || signingKeyChanged),
               let publicKey = health?.bridgePublicKey,
               DeckBridgeSecurityStore.shared.trust(forPublicKey: publicKey) != nil else {
             return false
@@ -481,7 +546,11 @@ private extension DeckStore {
         let name = connectionLabel
         DeckBridgeSecurityStore.shared.forgetBridge(publicKey: publicKey)
         disconnect(suppressAutoReconnect: true)
-        errorMessage = "\(name) no longer trusts this iPad. Add it again to reconnect."
+        if signingKeyChanged {
+            errorMessage = "\(name)'s saved pairing no longer matches this iPad. Go back and add it again to reconnect."
+        } else {
+            errorMessage = "\(name) no longer trusts this iPad. Add it again to reconnect."
+        }
         return true
     }
 

--- a/apps/ios/Sources/DesktopPreviewScreen.swift
+++ b/apps/ios/Sources/DesktopPreviewScreen.swift
@@ -1,0 +1,463 @@
+import DeckKit
+import SwiftUI
+import UIKit
+
+/// A read-only, couch-friendly view of the paired Mac's current display.
+///
+/// Frames are intentionally pulled one at a time. The next request starts only
+/// after the current JPEG has arrived and decoded, so a weak Wi-Fi connection
+/// cannot build up a stale queue of screen captures.
+struct DesktopPreviewScreen: View {
+    @ObservedObject var store: DeckStore
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.scenePhase) private var scenePhase
+
+    @State private var image: UIImage?
+    @State private var frame: DeckDesktopPreviewFrame?
+    @State private var requestedDisplayIndex: Int?
+    @State private var isAutoRefreshing = true
+    @State private var isFetching = false
+    @State private var errorMessage: String?
+    @State private var refreshGeneration = 0
+
+    private let refreshInterval = Duration.seconds(2)
+
+    private var previewTaskID: PreviewTaskID {
+        PreviewTaskID(
+            displayIndex: requestedDisplayIndex,
+            isAutoRefreshing: isAutoRefreshing,
+            refreshGeneration: refreshGeneration,
+            isSceneActive: scenePhase == .active
+        )
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            previewStage
+            footer
+        }
+        .background(DeckTheme.canvas.ignoresSafeArea())
+        .preferredColorScheme(.dark)
+        .statusBarHidden(true)
+        .task(id: previewTaskID) {
+            await runPreviewLoop()
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: DeckTheme.Space.x12) {
+            PreviewIconButton(
+                systemName: "xmark",
+                label: "Close Desktop Preview",
+                action: { dismiss() }
+            )
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Desktop Preview")
+                    .font(DeckTheme.title())
+                    .foregroundStyle(DeckTheme.text)
+                Text(store.connectionLabel)
+                    .font(DeckTheme.caption())
+                    .foregroundStyle(DeckTheme.textTertiary)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 8)
+
+            if let frame, frame.displays.count > 1 {
+                displayPicker(frame.displays)
+            }
+
+            PreviewIconButton(
+                systemName: isAutoRefreshing ? "pause.fill" : "play.fill",
+                label: isAutoRefreshing ? "Pause automatic refresh" : "Resume automatic refresh",
+                action: { isAutoRefreshing.toggle() }
+            )
+
+            PreviewIconButton(
+                systemName: "arrow.clockwise",
+                label: "Refresh now",
+                isBusy: isFetching,
+                action: { refreshGeneration += 1 }
+            )
+        }
+        .padding(.horizontal, DeckTheme.Space.margin)
+        .padding(.vertical, DeckTheme.Space.x12)
+        .background(DeckTheme.well)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(DeckTheme.hairline)
+                .frame(height: 1)
+        }
+    }
+
+    private var previewStage: some View {
+        ZStack {
+            Color.black
+
+            if let image {
+                DesktopPreviewImageView(image: image)
+                    .accessibilityLabel("Current screen on \(store.connectionLabel)")
+                    .accessibilityHint("Pinch or double-tap to zoom, then drag to inspect the screen.")
+
+                if let errorMessage {
+                    staleFrameBanner(errorMessage)
+                        .padding(DeckTheme.Space.margin)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+                }
+            } else if let errorMessage {
+                initialErrorState(errorMessage)
+            } else {
+                loadingState
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .clipped()
+    }
+
+    private var loadingState: some View {
+        VStack(spacing: DeckTheme.Space.x16) {
+            ProgressView()
+                .controlSize(.large)
+                .tint(DeckTheme.accent)
+            Text("Reading \(store.connectionLabel)'s screen…")
+                .font(DeckTheme.body(.medium))
+                .foregroundStyle(DeckTheme.textSecondary)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Reading \(store.connectionLabel)'s screen")
+    }
+
+    private func initialErrorState(_ message: String) -> some View {
+        let presentation = errorPresentation(for: message)
+        return VStack(spacing: DeckTheme.Space.x16) {
+            Image(systemName: presentation.icon)
+                .font(.system(size: 34, weight: .regular))
+                .foregroundStyle(DeckTheme.error)
+
+            VStack(spacing: DeckTheme.Space.x8) {
+                Text(presentation.title)
+                    .font(DeckTheme.title())
+                    .foregroundStyle(DeckTheme.text)
+                    .multilineTextAlignment(.center)
+                Text(presentation.detail)
+                    .font(DeckTheme.secondary())
+                    .foregroundStyle(DeckTheme.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(2)
+            }
+
+            Button {
+                refreshGeneration += 1
+            } label: {
+                Label("Try Again", systemImage: "arrow.clockwise")
+                    .font(DeckTheme.body(.semibold))
+                    .foregroundStyle(Color.black)
+                    .padding(.horizontal, DeckTheme.Space.x16)
+                    .frame(minHeight: 44)
+                    .background(DeckTheme.accent, in: RoundedRectangle(cornerRadius: DeckTheme.radiusCard))
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(DeckTheme.Space.x32)
+        .frame(maxWidth: 480)
+    }
+
+    private func staleFrameBanner(_ message: String) -> some View {
+        let presentation = errorPresentation(for: message)
+        return HStack(spacing: DeckTheme.Space.x12) {
+            Image(systemName: presentation.icon)
+                .foregroundStyle(DeckTheme.error)
+            Text(presentation.detail)
+                .font(DeckTheme.secondary(.medium))
+                .foregroundStyle(DeckTheme.text)
+                .lineLimit(2)
+            Spacer(minLength: DeckTheme.Space.x8)
+            Button("Retry") { refreshGeneration += 1 }
+                .font(DeckTheme.secondary(.semibold))
+                .foregroundStyle(DeckTheme.accent)
+                .frame(minWidth: 44, minHeight: 44)
+        }
+        .padding(.leading, DeckTheme.Space.x16)
+        .padding(.trailing, DeckTheme.Space.x8)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: DeckTheme.radiusWell))
+        .overlay {
+            RoundedRectangle(cornerRadius: DeckTheme.radiusWell)
+                .stroke(DeckTheme.error.opacity(0.35), lineWidth: 1)
+        }
+        .frame(maxWidth: 680)
+    }
+
+    private var footer: some View {
+        HStack(spacing: DeckTheme.Space.x12) {
+            HStack(spacing: DeckTheme.Space.x8) {
+                Circle()
+                    .fill(errorMessage == nil ? DeckTheme.accent : DeckTheme.error)
+                    .frame(width: 7, height: 7)
+
+                if let frame {
+                    TimelineView(.periodic(from: .now, by: 1)) { _ in
+                        Text("Captured \(Text(frame.capturedAt, style: .relative))")
+                    }
+                    .font(DeckTheme.caption(.medium))
+                    .foregroundStyle(DeckTheme.textSecondary)
+
+                    Text("\(frame.pixelWidth) × \(frame.pixelHeight)")
+                        .font(DeckTheme.caption())
+                        .foregroundStyle(DeckTheme.textTertiary)
+                } else {
+                    Text(isFetching ? "Connecting…" : "Waiting for screen")
+                        .font(DeckTheme.caption(.medium))
+                        .foregroundStyle(DeckTheme.textSecondary)
+                }
+            }
+
+            Spacer()
+
+            Label(
+                isAutoRefreshing ? "Refreshes every 2 seconds" : "Refresh paused",
+                systemImage: isAutoRefreshing ? "arrow.triangle.2.circlepath" : "pause.circle"
+            )
+            .font(DeckTheme.caption())
+            .foregroundStyle(DeckTheme.textTertiary)
+
+            Label("Encrypted on your local connection", systemImage: "lock.fill")
+                .font(DeckTheme.caption())
+                .foregroundStyle(DeckTheme.textTertiary)
+        }
+        .padding(.horizontal, DeckTheme.Space.margin)
+        .frame(minHeight: 44)
+        .background(DeckTheme.well)
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(DeckTheme.hairline)
+                .frame(height: 1)
+        }
+    }
+
+    private func displayPicker(_ displays: [DeckDesktopPreviewDisplay]) -> some View {
+        Menu {
+            ForEach(displays) { display in
+                Button {
+                    requestedDisplayIndex = display.displayIndex
+                } label: {
+                    Label(display.name, systemImage: display.displayIndex == currentDisplayIndex ? "checkmark" : "display")
+                }
+            }
+        } label: {
+            HStack(spacing: 7) {
+                Image(systemName: "display.2")
+                Text(currentDisplayName(in: displays))
+                    .lineLimit(1)
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+            }
+            .font(DeckTheme.secondary(.medium))
+            .foregroundStyle(DeckTheme.textSecondary)
+            .padding(.horizontal, DeckTheme.Space.x12)
+            .frame(minHeight: 44)
+            .background(DeckTheme.control, in: RoundedRectangle(cornerRadius: DeckTheme.radiusCard))
+        }
+        .accessibilityLabel("Choose Mac display")
+    }
+
+    private var currentDisplayIndex: Int? {
+        requestedDisplayIndex ?? frame?.displayIndex
+    }
+
+    private func currentDisplayName(in displays: [DeckDesktopPreviewDisplay]) -> String {
+        displays.first(where: { $0.displayIndex == currentDisplayIndex })?.name ?? "Display"
+    }
+
+    private func runPreviewLoop() async {
+        guard scenePhase == .active else { return }
+
+        while !Task.isCancelled {
+            let succeeded = await fetchFrame()
+            guard succeeded, isAutoRefreshing, !Task.isCancelled else { return }
+            try? await Task.sleep(for: refreshInterval)
+        }
+    }
+
+    private func fetchFrame() async -> Bool {
+        isFetching = true
+        defer { isFetching = false }
+
+        do {
+            let nextFrame = try await store.desktopPreview(displayIndex: requestedDisplayIndex)
+            try Task.checkCancellation()
+            guard
+                let jpeg = Data(base64Encoded: nextFrame.jpegBase64),
+                let nextImage = UIImage(data: jpeg)
+            else {
+                throw DesktopPreviewDecodeError.invalidJPEG
+            }
+
+            frame = nextFrame
+            image = nextImage
+            errorMessage = nil
+            return true
+        } catch is CancellationError {
+            return false
+        } catch {
+            errorMessage = error.localizedDescription
+            return false
+        }
+    }
+
+    private func errorPresentation(for message: String) -> PreviewErrorPresentation {
+        let lowercased = message.lowercased()
+        if lowercased.contains("screen.preview") || lowercased.contains("pair again") {
+            return PreviewErrorPresentation(
+                icon: "lock.trianglebadge.exclamationmark",
+                title: "Screen Preview needs approval",
+                detail: "Forget and add this Mac again to approve Screen Preview for this iPad."
+            )
+        }
+        if lowercased.contains("screen recording") {
+            return PreviewErrorPresentation(
+                icon: "rectangle.inset.filled.and.person.filled",
+                title: "Allow Screen Recording on the Mac",
+                detail: message
+            )
+        }
+        return PreviewErrorPresentation(
+            icon: "wifi.exclamationmark",
+            title: "Can't refresh the Mac screen",
+            detail: message
+        )
+    }
+}
+
+private struct PreviewTaskID: Hashable {
+    let displayIndex: Int?
+    let isAutoRefreshing: Bool
+    let refreshGeneration: Int
+    let isSceneActive: Bool
+}
+
+private struct PreviewErrorPresentation {
+    let icon: String
+    let title: String
+    let detail: String
+}
+
+private enum DesktopPreviewDecodeError: LocalizedError {
+    case invalidJPEG
+
+    var errorDescription: String? {
+        "The Mac returned a screen image that this iPad could not display."
+    }
+}
+
+private struct PreviewIconButton: View {
+    let systemName: String
+    let label: String
+    var isBusy = false
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            ZStack {
+                Image(systemName: systemName)
+                    .opacity(isBusy ? 0 : 1)
+                if isBusy {
+                    ProgressView()
+                        .controlSize(.small)
+                        .tint(DeckTheme.textSecondary)
+                }
+            }
+            .font(.system(size: 14, weight: .semibold))
+            .foregroundStyle(DeckTheme.textSecondary)
+            .frame(width: 44, height: 44)
+            .background(DeckTheme.control, in: RoundedRectangle(cornerRadius: DeckTheme.radiusCard))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+    }
+}
+
+/// UIScrollView supplies native pinch, pan, and double-tap zoom behavior while
+/// SwiftUI owns the surrounding controls and state.
+private struct DesktopPreviewImageView: UIViewRepresentable {
+    let image: UIImage
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeUIView(context: Context) -> UIScrollView {
+        let scrollView = UIScrollView()
+        scrollView.delegate = context.coordinator
+        scrollView.minimumZoomScale = 1
+        scrollView.maximumZoomScale = 4
+        scrollView.bouncesZoom = true
+        scrollView.decelerationRate = .fast
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.backgroundColor = .black
+
+        let imageView = context.coordinator.imageView
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFit
+        imageView.clipsToBounds = true
+        scrollView.addSubview(imageView)
+
+        NSLayoutConstraint.activate([
+            imageView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+            imageView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            imageView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            imageView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
+            imageView.heightAnchor.constraint(equalTo: scrollView.frameLayoutGuide.heightAnchor),
+        ])
+
+        let doubleTap = UITapGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.handleDoubleTap(_:))
+        )
+        doubleTap.numberOfTapsRequired = 2
+        scrollView.addGestureRecognizer(doubleTap)
+        context.coordinator.scrollView = scrollView
+        return scrollView
+    }
+
+    func updateUIView(_ scrollView: UIScrollView, context: Context) {
+        let sizeChanged = context.coordinator.imageView.image?.size != image.size
+        context.coordinator.imageView.image = image
+        if sizeChanged {
+            scrollView.setZoomScale(1, animated: false)
+        }
+    }
+
+    final class Coordinator: NSObject, UIScrollViewDelegate {
+        let imageView = UIImageView()
+        weak var scrollView: UIScrollView?
+
+        func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+            imageView
+        }
+
+        @objc func handleDoubleTap(_ gesture: UITapGestureRecognizer) {
+            guard let scrollView else { return }
+            if scrollView.zoomScale > scrollView.minimumZoomScale {
+                scrollView.setZoomScale(scrollView.minimumZoomScale, animated: true)
+                return
+            }
+
+            let location = gesture.location(in: imageView)
+            let targetScale = min(2, scrollView.maximumZoomScale)
+            let width = scrollView.bounds.width / targetScale
+            let height = scrollView.bounds.height / targetScale
+            let rect = CGRect(
+                x: location.x - width / 2,
+                y: location.y - height / 2,
+                width: width,
+                height: height
+            )
+            scrollView.zoom(to: rect, animated: true)
+        }
+    }
+}

--- a/apps/ios/Sources/Home/AddHostController.swift
+++ b/apps/ios/Sources/Home/AddHostController.swift
@@ -205,6 +205,7 @@ extension AddHostController {
         case DeckBridgeCapability.deckRead:     return "reading this host's state"
         case DeckBridgeCapability.deckPerform:  return "running commands"
         case DeckBridgeCapability.inputTrackpad: return "trackpad control"
+        case DeckBridgeCapability.screenPreview: return "viewing this Mac's screen"
         default:                                 return capability
         }
     }

--- a/apps/ios/Sources/LatsDeckScreen.swift
+++ b/apps/ios/Sources/LatsDeckScreen.swift
@@ -191,8 +191,8 @@ struct LatsWindow: Identifiable {
 
 struct CommandDeck {
     static let accent: LatsTint = .green
-    static let name = "command"
-    static let hint = "core"
+    static let name = "remote"
+    static let hint = "control"
 
     static let shortcuts: [LatsShortcut] = [
         .init(label: "Dictate",     icon: "mic.fill",                 tint: .red,    category: .voice,  hint: "F1",  sim: .rec),
@@ -382,6 +382,11 @@ struct LatsCockpitShell<Content: View>: View {
 // MARK: - Trackpad Surface
 
 struct LatsTrackpadSurface: View {
+    private enum TrackpadInteractionMode {
+        case pointer
+        case scroll
+    }
+
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     let mode: CockpitMode
@@ -399,16 +404,18 @@ struct LatsTrackpadSurface: View {
     let activityLog: [DeckActivityLogEntry]
     let hostLabel: String
     let trackpadState: DeckTrackpadState?
+    var windowPreviewImage: UIImage? = nil
     var spaceDisplays: [DeckSpaceDisplay] = []
     var frontmostApp: String? = nil
     var frontmostTitle: String? = nil
     var onSendKey: ((String, [String]) -> Void)? = nil
     var onReplayUndo: (() -> Void)? = nil
     var onTrackpadEvent: ((DeckTrackpadEvent, Double, Double) -> Void)? = nil
-    var onSpaceTap: ((Int) -> Void)? = nil
+    var onSpaceTap: ((_ display: Int, _ index: Int) -> Void)? = nil
     var onMonitorSwipe: ((_ display: Int, _ direction: Int) -> Void)? = nil
 
     @State private var lastTrackpadLocation: CGPoint?
+    @State private var trackpadInteractionMode: TrackpadInteractionMode = .pointer
 
     var body: some View {
         ZStack {
@@ -419,6 +426,12 @@ struct LatsTrackpadSurface: View {
                 .gesture(trackpadDragGesture)
                 .simultaneousGesture(trackpadTapGesture)
                 .allowsHitTesting(isTrackpadReady)
+                .accessibilityLabel("Mac trackpad")
+                .accessibilityHint(
+                    trackpadInteractionMode == .pointer
+                        ? "Drag to move the pointer. Tap to click."
+                        : "Drag to scroll the current Mac window. Tap to click."
+                )
 
             // Top bezel: useful state — Mac name (left), live mode (center), frontmost app/title (right).
             // Symmetric with the bottom action bezel; together they frame the touch surface.
@@ -436,6 +449,19 @@ struct LatsTrackpadSurface: View {
             }
             .allowsHitTesting(false)
 
+            if let windowPreviewImage {
+                LatsTrackpadWindowPreview(
+                    image: windowPreviewImage,
+                    appName: frontmostApp,
+                    windowTitle: frontmostTitle,
+                    isDeemphasized: mode != .idle
+                )
+                .padding(.horizontal, horizontalSizeClass == .compact ? 24 : 270)
+                .padding(.top, 38)
+                .padding(.bottom, 92)
+                .allowsHitTesting(false)
+            }
+
             // Center mode visual
             LatsTrackpadModeVisual(
                 mode: mode,
@@ -447,6 +473,12 @@ struct LatsTrackpadSurface: View {
                 onReplayUndo: onReplayUndo
             )
             .allowsHitTesting(mode == .replay && onReplayUndo != nil)
+
+            if let pointerX = trackpadState?.pointerX,
+               let pointerY = trackpadState?.pointerY {
+                LatsTrackpadPointerGuides(x: pointerX, y: pointerY)
+                    .allowsHitTesting(false)
+            }
 
             if horizontalSizeClass != .compact {
                 // LEFT column — system on top, displays bottom; equal share of vertical space
@@ -495,14 +527,19 @@ struct LatsTrackpadSurface: View {
             // Bottom bezel: keyboard buttons sit on a quiet ledge that mirrors the top bezel.
             VStack(spacing: 0) {
                 Spacer()
+                trackpadControlRow
+                    .padding(.horizontal, 12)
+                    .padding(.top, 5)
                 LatsActionKeyboardRow(onSendKey: onSendKey)
                     .padding(.horizontal, 12)
-                    .padding(.vertical, 6)
+                    .padding(.top, 4)
+                    .padding(.bottom, 6)
                     .frame(maxWidth: .infinity)
                     .background(Color.black.opacity(0.32))
-                    .overlay(alignment: .top) {
-                        Rectangle().fill(LatsPalette.hairline).frame(height: 1)
-                    }
+            }
+            .background(Color.black.opacity(0.32))
+            .overlay(alignment: .top) {
+                Rectangle().fill(LatsPalette.hairline).frame(height: 1)
             }
         }
         .background(LatsPalette.bgEdge)
@@ -527,8 +564,17 @@ struct LatsTrackpadSurface: View {
                 lastTrackpadLocation = value.location
 
                 guard abs(dx) > 0.2 || abs(dy) > 0.2 else { return }
-                let scale = trackpadState?.pointerScale ?? 1.6
-                onTrackpadEvent?(.move, Double(dx) * scale, Double(dy) * scale)
+                let event: DeckTrackpadEvent
+                let scale: Double
+                switch trackpadInteractionMode {
+                case .pointer:
+                    event = .move
+                    scale = trackpadState?.pointerScale ?? 1.6
+                case .scroll:
+                    event = .scroll
+                    scale = trackpadState?.scrollScale ?? 1
+                }
+                onTrackpadEvent?(event, Double(dx) * scale, Double(dy) * scale)
             }
             .onEnded { _ in
                 lastTrackpadLocation = nil
@@ -541,6 +587,173 @@ struct LatsTrackpadSurface: View {
                 guard isTrackpadReady else { return }
                 onTrackpadEvent?(.click, 0, 0)
             }
+    }
+
+    private var trackpadControlRow: some View {
+        HStack(spacing: 5) {
+            trackpadModeButton(
+                title: "Pointer",
+                icon: "cursorarrow.motionlines",
+                mode: .pointer
+            )
+            trackpadModeButton(
+                title: "Scroll",
+                icon: "arrow.up.and.down",
+                mode: .scroll
+            )
+
+            Spacer(minLength: 8)
+
+            trackpadActionButton(title: "Click", icon: "cursorarrow.click") {
+                onTrackpadEvent?(.click, 0, 0)
+            }
+            trackpadActionButton(title: "Right Click", icon: "cursorarrow.rays") {
+                onTrackpadEvent?(.rightClick, 0, 0)
+            }
+        }
+        .disabled(!isTrackpadReady)
+    }
+
+    private func trackpadModeButton(
+        title: String,
+        icon: String,
+        mode: TrackpadInteractionMode
+    ) -> some View {
+        let isActive = trackpadInteractionMode == mode
+        return Button {
+            trackpadInteractionMode = mode
+        } label: {
+            trackpadControlLabel(title: title, icon: icon, isActive: isActive)
+        }
+        .buttonStyle(.plain)
+        .accessibilityHint("Use drags on the trackpad to \(title.lowercased()).")
+    }
+
+    private func trackpadActionButton(
+        title: String,
+        icon: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            trackpadControlLabel(title: title, icon: icon, isActive: false)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func trackpadControlLabel(title: String, icon: String, isActive: Bool) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: icon)
+            Text(title)
+                .lineLimit(1)
+        }
+        .font(LatsFont.mono(9, weight: .semibold))
+        .foregroundStyle(isActive ? LatsPalette.green : LatsPalette.textDim)
+        .padding(.horizontal, 9)
+        .frame(minHeight: 30)
+        .background(
+            RoundedRectangle(cornerRadius: 4)
+                .fill(isActive ? LatsPalette.green.opacity(0.14) : Color.white.opacity(0.035))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 4)
+                .stroke(isActive ? LatsPalette.green.opacity(0.48) : LatsPalette.hairline2, lineWidth: 1)
+        )
+    }
+}
+
+/// The frontmost window is subdued enough to remain a touch surface, but clear
+/// enough that someone away from the Mac can see what the pointer is acting on.
+private struct LatsTrackpadWindowPreview: View {
+    let image: UIImage
+    let appName: String?
+    let windowTitle: String?
+    let isDeemphasized: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Image(uiImage: image)
+                .resizable()
+                .scaledToFit()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color.black)
+
+            if let appName, !appName.isEmpty {
+                HStack(spacing: 5) {
+                    Image(systemName: "macwindow")
+                    Text(appName)
+                        .font(LatsFont.ui(9, weight: .semibold))
+                    if let windowTitle, !windowTitle.isEmpty {
+                        Text("·")
+                            .foregroundStyle(LatsPalette.textFaint)
+                        Text(windowTitle)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                }
+                .font(LatsFont.ui(9))
+                .foregroundStyle(LatsPalette.textDim)
+                .padding(.horizontal, 8)
+                .frame(maxWidth: .infinity, minHeight: 24, alignment: .leading)
+                .background(Color.black.opacity(0.78))
+            }
+        }
+        .background(Color.black)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay {
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(LatsPalette.hairline2, lineWidth: 1)
+        }
+        .shadow(color: Color.black.opacity(0.5), radius: 10, y: 5)
+        .opacity(isDeemphasized ? 0.20 : 0.62)
+        .accessibilityHidden(true)
+    }
+}
+
+/// Actual normalized Mac cursor position, updated directly from joystick event
+/// responses. The crossing lines make X and Y legible even when the preview is
+/// visually busy or the pointer itself is tiny.
+private struct LatsTrackpadPointerGuides: View {
+    let x: Double
+    let y: Double
+
+    var body: some View {
+        GeometryReader { proxy in
+            let topInset: CGFloat = 31
+            let bottomInset: CGFloat = 57
+            let usableHeight = max(1, proxy.size.height - topInset - bottomInset)
+            let point = CGPoint(
+                x: min(max(CGFloat(x), 0), 1) * proxy.size.width,
+                y: topInset + min(max(CGFloat(y), 0), 1) * usableHeight
+            )
+
+            ZStack(alignment: .topLeading) {
+                Path { path in
+                    path.move(to: CGPoint(x: point.x, y: topInset))
+                    path.addLine(to: CGPoint(x: point.x, y: proxy.size.height - bottomInset))
+                    path.move(to: CGPoint(x: 0, y: point.y))
+                    path.addLine(to: CGPoint(x: proxy.size.width, y: point.y))
+                }
+                .stroke(LatsPalette.green.opacity(0.46), style: StrokeStyle(lineWidth: 1, dash: [5, 5]))
+
+                Circle()
+                    .fill(LatsPalette.green.opacity(0.18))
+                    .overlay(Circle().stroke(LatsPalette.green, lineWidth: 1.5))
+                    .frame(width: 18, height: 18)
+                    .position(point)
+
+                Text("X \(Int((min(max(x, 0), 1) * 100).rounded()))  Y \(Int((min(max(y, 0), 1) * 100).rounded()))")
+                    .font(LatsFont.mono(8, weight: .semibold))
+                    .foregroundStyle(LatsPalette.green)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 3)
+                    .background(Color.black.opacity(0.72), in: RoundedRectangle(cornerRadius: 3))
+                    .position(
+                        x: min(max(point.x + 48, 52), proxy.size.width - 52),
+                        y: min(max(point.y - 18, topInset + 12), proxy.size.height - bottomInset - 12)
+                    )
+            }
+        }
+        .accessibilityHidden(true)
     }
 }
 
@@ -738,7 +951,7 @@ struct CompactDisplaysPanel: View {
     let spaceCount: Int
     let spaceName: String?
     var spaceDisplays: [DeckSpaceDisplay] = []
-    var onSpaceTap: ((Int) -> Void)? = nil
+    var onSpaceTap: ((_ display: Int, _ index: Int) -> Void)? = nil
     var onMonitorSwipe: ((_ display: Int, _ direction: Int) -> Void)? = nil
 
     @State private var selectedDisplay: Int = 0
@@ -761,9 +974,19 @@ struct CompactDisplaysPanel: View {
 
     private var spacesForActiveDisplay: [Int] {
         if activeDisplay < spaceDisplays.count {
-            return spaceDisplays[activeDisplay].spaces.map(\.index)
+            // The bridge reports one-based display-local indices. The rest of
+            // the iPad cockpit uses zero-based indices for state and actions.
+            return spaceDisplays[activeDisplay].spaces.map { max(0, $0.index - 1) }
         }
         return Array(0..<max(spaceCount, 1))
+    }
+
+    private var activeSpaceIndex: Int {
+        guard activeDisplay < spaceDisplays.count,
+              let current = spaceDisplays[activeDisplay].spaces.first(where: \.isCurrent) else {
+            return space
+        }
+        return max(0, current.index - 1)
     }
 
     var body: some View {
@@ -868,7 +1091,7 @@ struct CompactDisplaysPanel: View {
     }
 
     private func spaceCell(index: Int) -> some View {
-        let isActive = index == space
+        let isActive = index == activeSpaceIndex
         let label = Text("\(index + 1)")
             .font(LatsFont.mono(8, weight: isActive ? .semibold : .regular))
             .foregroundStyle(isActive ? LatsPalette.green : LatsPalette.textDim)
@@ -885,7 +1108,7 @@ struct CompactDisplaysPanel: View {
 
         return Group {
             if let onSpaceTap {
-                Button { onSpaceTap(index) } label: { label }.buttonStyle(.plain)
+                Button { onSpaceTap(activeDisplay, index) } label: { label }.buttonStyle(.plain)
             } else {
                 label
             }
@@ -1542,6 +1765,7 @@ struct LatsShortcutGrid: View {
                 index: index,
                 isRecent: recentlyPressed == shortcut.id
             ) {
+                guard shortcut.isEnabled else { return }
                 onTap(shortcut)
                 withAnimation { recentlyPressed = shortcut.id }
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) {
@@ -1551,6 +1775,26 @@ struct LatsShortcutGrid: View {
                 }
             }
         }
+    }
+}
+
+private struct LatsEmptyDeckState: View {
+    var body: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "square.dashed")
+                .font(.system(size: 24, weight: .medium))
+                .foregroundStyle(LatsPalette.textFaint)
+            Text("THIS PAGE IS EMPTY")
+                .font(LatsFont.mono(10, weight: .bold))
+                .foregroundStyle(LatsPalette.text)
+                .tracking(1)
+            Text("Add controls in Lattices on your Mac.")
+                .font(LatsFont.mono(9))
+                .foregroundStyle(LatsPalette.textDim)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .combine)
     }
 }
 
@@ -1590,6 +1834,29 @@ struct LatsJoystickControl: View {
                     Circle()
                         .fill(shortcut.tint.color.opacity(0.07))
                         .overlay(Circle().stroke(shortcut.tint.color.opacity(0.30), lineWidth: 1))
+                    GeometryReader { geometry in
+                        let center = CGPoint(x: geometry.size.width / 2, y: geometry.size.height / 2)
+                        let knobPoint = CGPoint(
+                            x: center.x + knobOffset.width,
+                            y: center.y + knobOffset.height
+                        )
+                        Path { path in
+                            path.move(to: CGPoint(x: center.x, y: 0))
+                            path.addLine(to: CGPoint(x: center.x, y: geometry.size.height))
+                            path.move(to: CGPoint(x: 0, y: center.y))
+                            path.addLine(to: CGPoint(x: geometry.size.width, y: center.y))
+                        }
+                        .stroke(LatsPalette.hairline2, lineWidth: 1)
+
+                        Path { path in
+                            path.move(to: CGPoint(x: knobPoint.x, y: 0))
+                            path.addLine(to: CGPoint(x: knobPoint.x, y: geometry.size.height))
+                            path.move(to: CGPoint(x: 0, y: knobPoint.y))
+                            path.addLine(to: CGPoint(x: geometry.size.width, y: knobPoint.y))
+                        }
+                        .stroke(shortcut.tint.color.opacity(0.48), style: StrokeStyle(lineWidth: 1, dash: [4, 4]))
+                    }
+                    .clipShape(Circle())
                     Circle()
                         .stroke(LatsPalette.hairline, style: StrokeStyle(lineWidth: 1, dash: [3, 4]))
                         .padding(diameter * 0.22)
@@ -1720,6 +1987,9 @@ struct LatsShortcutTile: View {
             )
         }
         .buttonStyle(.plain)
+        .disabled(!shortcut.isEnabled)
+        .opacity(shortcut.isEnabled ? 1 : 0.46)
+        .accessibilityHint(shortcut.isEnabled ? shortcut.hint : "\(shortcut.hint) Unavailable.")
         .onLongPressGesture(minimumDuration: 0, maximumDistance: .infinity, perform: {}, onPressingChanged: { pressing in
             withAnimation(.easeOut(duration: 0.08)) { isPressed = pressing }
         })
@@ -1989,14 +2259,22 @@ struct LatsDeckScreen: View {
     /// Active bridge label supplied by the connection store.
     var connectionLabel: String?
 
+    /// Periodically captured frontmost Mac window shown beneath the trackpad's
+    /// pointer guides. Nil keeps offline previews and fleet lanes lightweight.
+    var trackpadWindowPreviewImage: UIImage? = nil
+
     /// When connected, tile presses and keyboard sends route through this callback.
     var onAction: ((_ actionID: String, _ payload: [String: DeckValue], _ label: String?) -> Void)?
 
     /// When connected, the full-screen cockpit surface forwards pointer events here.
     var onTrackpadEvent: ((_ event: DeckTrackpadEvent, _ dx: Double, _ dy: Double) -> Void)?
 
-    /// Which deck to render. Defaults to "command".
-    var deckID: String = "command"
+    /// Opens the native, read-only Mac screen viewer. This is navigation on the
+    /// iPad, not an action to perform on the Mac.
+    var onDesktopPreview: (() -> Void)?
+
+    /// Which deck to render. Defaults to the stable remote surface.
+    var deckID: String = "remote"
 
     // ── Mock-mode state (only used when liveSnapshot is nil) ──
     @State private var selectedDeckID: String?
@@ -2131,7 +2409,7 @@ struct LatsDeckScreen: View {
     }
 
     private var shortcuts: [LatsShortcut] {
-        if let live = liveShortcuts(), !live.isEmpty { return live }
+        if let live = liveShortcuts() { return live }
         return CommandDeck.shortcuts
     }
 
@@ -2152,7 +2430,7 @@ struct LatsDeckScreen: View {
         let liveNames = liveSnapshot?.cockpit?.pages
             .map { $0.title.lowercased() }
             .filter { !$0.isEmpty } ?? []
-        return liveNames.isEmpty ? ["command", "dev", "media", "windows", "voice"] : liveNames
+        return liveNames.isEmpty ? ["remote", "move", "speak & run"] : liveNames
     }
 
     var body: some View {
@@ -2194,6 +2472,7 @@ struct LatsDeckScreen: View {
                                     activityLog: activityLog,
                                     hostLabel: hostLabel,
                                     trackpadState: liveSnapshot?.trackpad,
+                                    windowPreviewImage: trackpadWindowPreviewImage,
                                     spaceDisplays: spaceDisplays,
                                     frontmostApp: liveSnapshot?.layout?.frontmostWindow?.appName
                                         ?? liveSnapshot?.desktop?.activeAppName,
@@ -2216,33 +2495,40 @@ struct LatsDeckScreen: View {
                         }
 
                         // Shortcut grid (deck keys) — horizontal swipe cycles decks
-                        ScrollView {
-                            LatsShortcutGrid(
-                                shortcuts: shortcuts,
-                                columns: gridColumns,
-                                rows: hSize == .compact ? nil : activeCockpitPage()?.rows,
-                                onTap: handleTilePress,
-                                onJoystickMove: { dx, dy in
-                                    onTrackpadEvent?(.move, dx, dy)
-                                },
-                                onJoystickInteractionChanged: { active in
-                                    isUsingJoystick = active
-                                    if !active {
-                                        joystickSwipeSuppressedUntil = Date().addingTimeInterval(0.25)
-                                    }
-                                },
-                                joystickEnabled: joystickReady,
-                                joystickScale: liveSnapshot?.trackpad?.pointerScale ?? 1.6
-                            )
-                            .padding(14)
-                            .id(effectiveDeckID)
-                            .transition(.opacity.combined(with: .move(edge: .leading)))
+                        Group {
+                            if isConnected, activeCockpitPage() != nil, shortcuts.isEmpty {
+                                LatsEmptyDeckState()
+                                    .padding(14)
+                            } else {
+                                ScrollView {
+                                    LatsShortcutGrid(
+                                        shortcuts: shortcuts,
+                                        columns: gridColumns,
+                                        rows: hSize == .compact ? nil : activeCockpitPage()?.rows,
+                                        onTap: handleTilePress,
+                                        onJoystickMove: { dx, dy in
+                                            onTrackpadEvent?(.move, dx, dy)
+                                        },
+                                        onJoystickInteractionChanged: { active in
+                                            isUsingJoystick = active
+                                            if !active {
+                                                joystickSwipeSuppressedUntil = Date().addingTimeInterval(0.25)
+                                            }
+                                        },
+                                        joystickEnabled: joystickReady,
+                                        joystickScale: liveSnapshot?.trackpad?.pointerScale ?? 1.6
+                                    )
+                                    .padding(14)
+                                    .id(effectiveDeckID)
+                                    .transition(.opacity.combined(with: .move(edge: .leading)))
+                                }
+                                .contentShape(Rectangle())
+                                // simultaneousGesture so the ScrollView's vertical scroll
+                                // and the horizontal deck-cycle swipe can both recognize.
+                                .simultaneousGesture(deckSwipeGesture)
+                            }
                         }
                         .frame(maxHeight: .infinity)
-                        .contentShape(Rectangle())
-                        // simultaneousGesture so the ScrollView's vertical scroll
-                        // and the horizontal deck-cycle swipe can both recognize.
-                        .simultaneousGesture(deckSwipeGesture)
                     }
                 }
                 .safeAreaInset(edge: .bottom, spacing: 0) {
@@ -2340,6 +2626,12 @@ struct LatsDeckScreen: View {
     // MARK: - Behaviour
 
     private func handleTilePress(_ shortcut: LatsShortcut) {
+        guard shortcut.isEnabled else { return }
+        if shortcut.actionID == "desktop.preview.open" {
+            onDesktopPreview?()
+            return
+        }
+
         if let onAction, let actionID = shortcut.actionID {
             var payload = shortcut.payload
             if actionID == "clipboard.pasteFromDevice",
@@ -2407,24 +2699,25 @@ struct LatsDeckScreen: View {
         }
     }
 
-    private func handleSpaceTap(_ index: Int) {
+    private func handleSpaceTap(_ display: Int, _ index: Int) {
         if let onAction {
-            // Mac-side gap: bridge needs a "spaces.focusIndex" handler to honor this.
-            onAction("spaces.focusIndex", ["index": .int(index)], "Switch to space \(index + 1)")
+            onAction(
+                "spaces.focusIndex",
+                ["displayIndex": .int(display), "index": .int(index)],
+                "Switch display \(display + 1) to space \(index + 1)"
+            )
         } else {
             mockSpace = index
         }
     }
 
-    /// Swipe a monitor to the next/previous space. Falls back to Ctrl+Left/Right via
-    /// keys.send when the bridge has no per-display swipe action.
+    /// Swipe a monitor to the next/previous space on that display.
     private func handleMonitorSwipe(_ display: Int, _ direction: Int) {
         if let onAction {
-            let key = direction > 0 ? "right" : "left"
             let label = direction > 0 ? "Next space" : "Previous space"
             onAction(
-                "keys.send",
-                ["key": .string(key), "modifiers": .array([.string("⌃")])],
+                "spaces.focusRelative",
+                ["displayIndex": .int(display), "direction": .int(direction)],
                 label
             )
         } else {
@@ -2449,7 +2742,7 @@ struct LatsDeckScreen: View {
 
     private func cycleDeck(forward: Bool = true) {
         let liveIDs = liveSnapshot?.cockpit?.pages.map(\.id).filter { !$0.isEmpty } ?? []
-        let ids = liveIDs.isEmpty ? ["command", "dev", "media", "windows", "voice"] : liveIDs
+        let ids = liveIDs.isEmpty ? ["remote", "move", "speak-run"] : liveIDs
         guard !ids.isEmpty else { return }
         guard let currentIndex = ids.firstIndex(of: effectiveDeckID) else {
             withAnimation(.easeOut(duration: 0.22)) { selectedDeckID = ids.first }
@@ -3185,6 +3478,7 @@ private struct FleetSharedDeck: View {
     let laneNumber: Int
 
     @State private var selectedPageID: String?
+    @State private var showsDesktopPreview = false
 
     private var pages: [DeckCockpitPage] {
         store.snapshot?.cockpit?.pages ?? []
@@ -3245,26 +3539,37 @@ private struct FleetSharedDeck: View {
 
             LatsHairlineDivider()
 
-            GeometryReader { proxy in
-                let columns = max(1, min(3, shortcuts.count))
-                let rows = max(1, Int(ceil(Double(shortcuts.count) / Double(columns))))
-                let availableHeight = max(96, proxy.size.height - 24 - CGFloat(max(0, rows - 1)) * 10)
-                let controlHeight = availableHeight / CGFloat(rows)
+            Group {
+                if store.snapshot != nil, shortcuts.isEmpty {
+                    LatsEmptyDeckState()
+                        .padding(12)
+                } else {
+                    GeometryReader { proxy in
+                        let authoredRows = activePage?.rows
+                        let columns = authoredRows == nil
+                            ? max(1, min(3, shortcuts.count))
+                            : max(1, activePage?.columns ?? 4)
+                        let flowRows = max(1, Int(ceil(Double(shortcuts.count) / Double(columns))))
+                        let availableHeight = max(96, proxy.size.height - 24 - CGFloat(max(0, flowRows - 1)) * 10)
+                        let controlHeight = availableHeight / CGFloat(flowRows)
 
-                ScrollView {
-                    LatsShortcutGrid(
-                        shortcuts: shortcuts,
-                        columns: columns,
-                        onTap: perform,
-                        onJoystickMove: { dx, dy in store.sendTrackpad(event: .move, dx: dx, dy: dy) },
-                        joystickEnabled: joystickReady,
-                        joystickScale: store.snapshot?.trackpad?.pointerScale ?? 1.6,
-                        minimumControlHeight: controlHeight
-                    )
-                    .padding(12)
-                    .frame(minHeight: proxy.size.height, alignment: .bottom)
+                        ScrollView {
+                            LatsShortcutGrid(
+                                shortcuts: shortcuts,
+                                columns: columns,
+                                rows: authoredRows,
+                                onTap: perform,
+                                onJoystickMove: { dx, dy in store.sendTrackpad(event: .move, dx: dx, dy: dy) },
+                                joystickEnabled: joystickReady,
+                                joystickScale: store.snapshot?.trackpad?.pointerScale ?? 1.6,
+                                minimumControlHeight: controlHeight
+                            )
+                            .padding(12)
+                            .frame(minHeight: proxy.size.height, alignment: .bottom)
+                        }
+                        .scrollIndicators(.hidden)
+                    }
                 }
-                .scrollIndicators(.hidden)
             }
 
             deckFooter
@@ -3291,6 +3596,9 @@ private struct FleetSharedDeck: View {
             .padding(.horizontal, 8)
         }
         .shadow(color: Color.black.opacity(0.60), radius: 9, x: 0, y: 5)
+        .fullScreenCover(isPresented: $showsDesktopPreview) {
+            DesktopPreviewScreen(store: store)
+        }
         .onAppear(perform: selectFirstPageIfNeeded)
         .onChange(of: pages.map(\.id)) { _, _ in selectFirstPageIfNeeded() }
     }
@@ -3461,21 +3769,20 @@ private struct FleetSharedDeck: View {
         store.perform(actionID: actionID, pageID: activePage?.id ?? "cockpit", label: "Undo last action")
     }
 
-    private func focusSpace(_ index: Int) {
+    private func focusSpace(_ display: Int, _ index: Int) {
         store.perform(
             actionID: "spaces.focusIndex",
             pageID: activePage?.id ?? "cockpit",
-            payload: ["index": .int(index)],
-            label: "Switch to space \(index + 1)"
+            payload: ["displayIndex": .int(display), "index": .int(index)],
+            label: "Switch display \(display + 1) to space \(index + 1)"
         )
     }
 
     private func swipeMonitor(_ display: Int, _ direction: Int) {
-        let key = direction > 0 ? "right" : "left"
         store.perform(
-            actionID: "keys.send",
+            actionID: "spaces.focusRelative",
             pageID: activePage?.id ?? "cockpit",
-            payload: ["key": .string(key), "modifiers": .array([.string("⌃")])],
+            payload: ["displayIndex": .int(display), "direction": .int(direction)],
             label: direction > 0 ? "Next space" : "Previous space"
         )
     }
@@ -3492,6 +3799,10 @@ private struct FleetSharedDeck: View {
             actionID: tile.actionID,
             payload: tile.payload,
             controlKind: tile.controlKind,
+            col: tile.col,
+            row: tile.row,
+            colSpan: tile.colSpan,
+            rowSpan: tile.rowSpan,
             isEnabled: tile.isEnabled
         )
     }
@@ -3509,6 +3820,10 @@ private struct FleetSharedDeck: View {
 
     private func perform(_ shortcut: LatsShortcut) {
         guard shortcut.isEnabled, let actionID = shortcut.actionID else { return }
+        if actionID == "desktop.preview.open" {
+            showsDesktopPreview = true
+            return
+        }
         var payload = shortcut.payload
         if actionID == "clipboard.pasteFromDevice",
            let text = UIPasteboard.general.string,
@@ -3535,6 +3850,7 @@ private struct FleetMachineDeck: View {
     var accentOverride: Color? = nil
 
     @State private var selectedPageID: String?
+    @State private var showsDesktopPreview = false
 
     private var pages: [DeckCockpitPage] {
         store.snapshot?.cockpit?.pages ?? []
@@ -3630,6 +3946,9 @@ private struct FleetMachineDeck: View {
                 Group {
                     if !shortcuts.isEmpty {
                         shortcutGrid(width: proxy.size.width)
+                    } else if store.snapshot != nil {
+                        LatsEmptyDeckState()
+                            .padding(10)
                     } else {
                         connectionState
                     }
@@ -3662,6 +3981,9 @@ private struct FleetMachineDeck: View {
                     .padding(.horizontal, 5)
             }
             .shadow(color: Color.black.opacity(0.50), radius: 6, x: 0, y: 3)
+        }
+        .fullScreenCover(isPresented: $showsDesktopPreview) {
+            DesktopPreviewScreen(store: store)
         }
         .onAppear(perform: selectFirstPageIfNeeded)
         .onChange(of: pages.map(\.id)) { _, _ in selectFirstPageIfNeeded() }
@@ -3754,7 +4076,10 @@ private struct FleetMachineDeck: View {
             ScrollView {
                 LatsShortcutGrid(
                     shortcuts: shortcuts,
-                    columns: width >= 560 ? 3 : 2,
+                    columns: activePage?.rows == nil
+                        ? (width >= 560 ? 3 : 2)
+                        : max(1, activePage?.columns ?? 4),
+                    rows: activePage?.rows,
                     onTap: perform,
                     onJoystickMove: { dx, dy in store.sendTrackpad(event: .move, dx: dx, dy: dy) },
                     joystickEnabled: joystickReady,
@@ -3917,21 +4242,20 @@ private struct FleetMachineDeck: View {
         store.perform(actionID: actionID, pageID: activePage?.id ?? "cockpit", label: "Undo last action")
     }
 
-    private func focusSpace(_ index: Int) {
+    private func focusSpace(_ display: Int, _ index: Int) {
         store.perform(
             actionID: "spaces.focusIndex",
             pageID: activePage?.id ?? "cockpit",
-            payload: ["index": .int(index)],
-            label: "Switch to space \(index + 1)"
+            payload: ["displayIndex": .int(display), "index": .int(index)],
+            label: "Switch display \(display + 1) to space \(index + 1)"
         )
     }
 
     private func swipeMonitor(_ display: Int, _ direction: Int) {
-        let key = direction > 0 ? "right" : "left"
         store.perform(
-            actionID: "keys.send",
+            actionID: "spaces.focusRelative",
             pageID: activePage?.id ?? "cockpit",
-            payload: ["key": .string(key), "modifiers": .array([.string("⌃")])],
+            payload: ["displayIndex": .int(display), "direction": .int(direction)],
             label: direction > 0 ? "Next space" : "Previous space"
         )
     }
@@ -3948,6 +4272,10 @@ private struct FleetMachineDeck: View {
             actionID: tile.actionID,
             payload: tile.payload,
             controlKind: tile.controlKind,
+            col: tile.col,
+            row: tile.row,
+            colSpan: tile.colSpan,
+            rowSpan: tile.rowSpan,
             isEnabled: tile.isEnabled
         )
     }
@@ -3965,6 +4293,10 @@ private struct FleetMachineDeck: View {
 
     private func perform(_ shortcut: LatsShortcut) {
         guard shortcut.isEnabled, let actionID = shortcut.actionID else { return }
+        if actionID == "desktop.preview.open" {
+            showsDesktopPreview = true
+            return
+        }
         var payload = shortcut.payload
         if actionID == "clipboard.pasteFromDevice",
            let text = UIPasteboard.general.string,

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -31,10 +31,13 @@ targets:
         excludes:
           - Contents.json
           - AppIcon.appiconset/Contents.json
+          # Alternate design review artifact; intentionally not part of the app
+          # bundle until it is selected as the shipping icon.
+          - AppIconV2.appiconset
     info:
       path: Sources/Info.plist
       properties:
-        CFBundleDisplayName: Lattices
+        CFBundleDisplayName: Lattices Deck
         NSAppTransportSecurity:
           NSAllowsLocalNetworking: true
         NSBonjourServices:

--- a/apps/mac/Lattices.app/Contents/Info.plist
+++ b/apps/mac/Lattices.app/Contents/Info.plist
@@ -30,13 +30,18 @@
     <key>CFBundleShortVersionString</key>
     <string>0.9.0</string>
     <key>LSMinimumSystemVersion</key>
-    <string>13.0</string>
+    <string>26.0</string>
     <key>LSUIElement</key>
     <true/>
     <key>NSHighResolutionCapable</key>
     <true/>
     <key>NSMicrophoneUsageDescription</key>
     <string>Lattices uses the microphone for Hudson Voice dictation and voice commands.</string>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsLocalNetworking</key>
+        <true/>
+    </dict>
     <key>NSSupportsAutomaticTermination</key>
     <true/>
 </dict>

--- a/apps/mac/Sources/AppShell/Preferences.swift
+++ b/apps/mac/Sources/AppShell/Preferences.swift
@@ -32,7 +32,7 @@ class Preferences: ObservableObject {
         static let cockpitLayoutVersion = "companion.cockpit.layoutVersion"
     }
 
-    private static let currentCockpitLayoutVersion = 2
+    private static let currentCockpitLayoutVersion = 4
 
     private static let dismissedCapabilitiesKey = "permissions.dismissed"
 
@@ -311,21 +311,23 @@ class Preferences: ObservableObject {
     private static func loadCompanionCockpitLayout() -> LatticesCompanionCockpitLayout {
         if let data = UserDefaults.standard.data(forKey: CompanionDefaultsKey.cockpitLayout),
            let decoded = try? JSONDecoder().decode(LatticesCompanionCockpitLayout.self, from: data) {
-            let normalized = LatticesCompanionCockpitCatalog.normalized(decoded)
-            guard UserDefaults.standard.integer(forKey: CompanionDefaultsKey.cockpitLayoutVersion)
-                    < currentCockpitLayoutVersion else {
-                return normalized
+            let savedVersion = UserDefaults.standard.integer(
+                forKey: CompanionDefaultsKey.cockpitLayoutVersion
+            )
+            guard savedVersion < currentCockpitLayoutVersion else {
+                return LatticesCompanionCockpitCatalog.normalized(decoded)
             }
 
-            let migrated = migrateCompanionCockpitLayout(normalized)
-            if let encoded = try? JSONEncoder().encode(migrated) {
+            let migrated = migrateCompanionCockpitLayout(decoded, fromVersion: savedVersion)
+            let normalized = LatticesCompanionCockpitCatalog.normalized(migrated)
+            if let encoded = try? JSONEncoder().encode(normalized) {
                 UserDefaults.standard.set(encoded, forKey: CompanionDefaultsKey.cockpitLayout)
             }
             UserDefaults.standard.set(
                 currentCockpitLayoutVersion,
                 forKey: CompanionDefaultsKey.cockpitLayoutVersion
             )
-            return migrated
+            return normalized
         }
 
         // One-time migration from the original web-builder draft. Early builds
@@ -353,10 +355,31 @@ class Preferences: ObservableObject {
         return LatticesCompanionCockpitCatalog.defaultLayout
     }
 
-    /// Adds the phone-to-Mac gateway paste action to existing starter decks
-    /// without replacing the user's other placements. The schema version makes
-    /// this a one-time migration, so removing the tile later remains respected.
-    private static func migrateCompanionCockpitLayout(
+    /// Advances old deck layouts without replacing anything the user authored.
+    /// Only exact untouched starter layouts advance; every renamed, reordered,
+    /// added, removed, or repositioned page remains the user's layout.
+    static func migrateCompanionCockpitLayout(
+        _ layout: LatticesCompanionCockpitLayout,
+        fromVersion: Int
+    ) -> LatticesCompanionCockpitLayout {
+        var migrated = layout
+        if fromVersion < 2 {
+            migrated = migratePasteDeviceIntoCompanionCockpit(migrated)
+        }
+        if fromVersion < 3,
+           migrated == LatticesCompanionCockpitCatalog.legacyDefaultLayoutV2 {
+            migrated = LatticesCompanionCockpitCatalog.legacyDefaultLayoutV3
+        }
+        if fromVersion < 4,
+           migrated == LatticesCompanionCockpitCatalog.legacyDefaultLayoutV3 {
+            migrated = LatticesCompanionCockpitCatalog.defaultLayout
+        }
+        return migrated
+    }
+
+    /// Adds the phone-to-Mac gateway paste action to the v1 starter deck
+    /// without replacing the user's other placements.
+    private static func migratePasteDeviceIntoCompanionCockpit(
         _ layout: LatticesCompanionCockpitLayout
     ) -> LatticesCompanionCockpitLayout {
         var migrated = layout
@@ -419,14 +442,15 @@ class Preferences: ObservableObject {
                 "switch-window-prev", "switch-window-next", "switch-app-prev", "switch-app-next",
                 "layout-optimize", "mouse-find", "key-up", "key-down"
             ]
-            if page.slotIDs == legacyStarter,
-               let starter = LatticesCompanionCockpitCatalog.defaultLayout.pages.first(where: { $0.id == "dev" }) {
-                page = starter
+            if let starter = LatticesCompanionCockpitCatalog.legacyDefaultLayoutV2.pages.first(where: { $0.id == "dev" }) {
+                var exactLegacyPage = starter
+                exactLegacyPage.slotIDs = legacyStarter
+                if page == exactLegacyPage {
+                    page = starter
+                }
             }
         }
 
-        page.subtitle = LatticesCompanionCockpitCatalog.defaultLayout.pages
-            .first(where: { $0.id == "dev" })?.subtitle ?? page.subtitle
         migrated.pages[index] = page
         return migrated
     }

--- a/apps/mac/Sources/Core/Companion/CompanionDeckBuilderView.swift
+++ b/apps/mac/Sources/Core/Companion/CompanionDeckBuilderView.swift
@@ -22,9 +22,10 @@ struct CompanionDeckBuilderView: NSViewRepresentable {
         let config = WKWebViewConfiguration()
         let controller = WKUserContentController()
         controller.add(context.coordinator, name: "deck")
-        if let json = Self.builderJSON(for: layout) {
+        if let json = Self.builderJSON(for: layout),
+           let catalogJSON = Self.builderCatalogJSON() {
             controller.addUserScript(WKUserScript(
-                source: "window.__DECK_INIT__ = \(json);",
+                source: "window.__DECK_INIT__ = \(json); window.__DECK_CATALOG__ = \(catalogJSON);",
                 injectionTime: .atDocumentStart,
                 forMainFrameOnly: true
             ))
@@ -102,10 +103,11 @@ struct CompanionDeckBuilderView: NSViewRepresentable {
     }
 }
 
-private extension CompanionDeckBuilderView {
+extension CompanionDeckBuilderView {
     struct BuilderDeck: Codable {
         var id: String
         var name: String
+        var subtitle: String?
         var tint: String
         var columns: Int
         var rows: Int
@@ -119,10 +121,46 @@ private extension CompanionDeckBuilderView {
         var tint: String
         var category: String
         var actionID: String
+        var baseLabel: String?
+        var baseIcon: String?
+        var baseTint: String?
+        var baseCategory: String?
         var col: Int
         var row: Int
         var colSpan: Int
         var rowSpan: Int
+    }
+
+    struct BuilderCatalogGroup: Codable {
+        var group: String
+        var items: [BuilderCatalogItem]
+    }
+
+    struct BuilderCatalogItem: Codable {
+        var id: String
+        var label: String
+        var icon: String
+        var tint: String
+        var category: String
+    }
+
+    static func builderCatalogJSON() -> String? {
+        let groups = LatticesCompanionShortcutCategory.allCases.compactMap { category -> BuilderCatalogGroup? in
+            let items = LatticesCompanionCockpitCatalog.shortcuts.compactMap { definition -> BuilderCatalogItem? in
+                guard !definition.id.isEmpty, definition.category == category else { return nil }
+                return BuilderCatalogItem(
+                    id: definition.id,
+                    label: definition.title,
+                    icon: builderIcon(for: definition.id),
+                    tint: definition.category.tintToken,
+                    category: definition.category.rawValue
+                )
+            }
+            guard !items.isEmpty else { return nil }
+            return BuilderCatalogGroup(group: category.title, items: items)
+        }
+        guard let data = try? JSONEncoder().encode(groups) else { return nil }
+        return String(data: data, encoding: .utf8)
     }
 
     static func builderJSON(for layout: LatticesCompanionCockpitLayout) -> String? {
@@ -147,11 +185,15 @@ private extension CompanionDeckBuilderView {
                       !slot.shortcutID.isEmpty else { return nil }
                 return BuilderKey(
                     id: "\(page.id)-\(index)",
-                    label: definition.title,
-                    icon: builderIcon(for: slot.shortcutID),
-                    tint: definition.category.tintToken,
-                    category: definition.category.rawValue,
+                    label: slot.customLabel ?? definition.title,
+                    icon: slot.customBuilderIcon ?? builderIcon(for: slot.shortcutID),
+                    tint: slot.customTint ?? definition.category.tintToken,
+                    category: slot.customCategory ?? definition.category.rawValue,
                     actionID: slot.shortcutID,
+                    baseLabel: definition.title,
+                    baseIcon: builderIcon(for: slot.shortcutID),
+                    baseTint: definition.category.tintToken,
+                    baseCategory: definition.category.rawValue,
                     col: slot.col,
                     row: slot.row,
                     colSpan: slot.colSpan,
@@ -161,6 +203,7 @@ private extension CompanionDeckBuilderView {
             return BuilderDeck(
                 id: page.id,
                 name: page.title,
+                subtitle: page.subtitle,
                 tint: keys.first?.tint ?? "blue",
                 columns: page.columns,
                 rows: page.rows ?? max(1, Int(ceil(Double(max(1, page.slotIDs.count)) / Double(max(1, page.columns))))),
@@ -177,17 +220,23 @@ private extension CompanionDeckBuilderView {
             LatticesCompanionCockpitLayout.Page(
                 id: deck.id,
                 title: deck.name,
+                subtitle: deck.subtitle,
                 columns: min(5, max(2, deck.columns)),
                 rows: min(4, max(1, deck.rows)),
                 slots: deck.keys.prefix(LatticesCompanionCockpitCatalog.slotCount).compactMap { key in
                     let shortcutID = canonicalShortcutID(key.actionID)
-                    guard LatticesCompanionCockpitCatalog.definition(for: shortcutID) != nil else { return nil }
+                    guard let definition = LatticesCompanionCockpitCatalog.definition(for: shortcutID) else { return nil }
+                    let defaultIcon = builderIcon(for: shortcutID)
                     return .init(
                         shortcutID: shortcutID,
                         col: key.col,
                         row: key.row,
                         colSpan: max(1, key.colSpan),
-                        rowSpan: max(1, key.rowSpan)
+                        rowSpan: max(1, key.rowSpan),
+                        customLabel: key.label == (key.baseLabel ?? definition.title) ? nil : key.label,
+                        customBuilderIcon: key.icon == (key.baseIcon ?? defaultIcon) ? nil : key.icon,
+                        customTint: key.tint == (key.baseTint ?? definition.category.tintToken) ? nil : key.tint,
+                        customCategory: key.category == (key.baseCategory ?? definition.category.rawValue) ? nil : key.category
                     )
                 }
             )

--- a/apps/mac/Sources/Core/Companion/LatticesCompanionBridgeServer.swift
+++ b/apps/mac/Sources/Core/Companion/LatticesCompanionBridgeServer.swift
@@ -309,6 +309,37 @@ private extension LatticesCompanionBridgeServer {
             )
             try sendJSON(status: 200, value: response, to: fd)
 
+        case ("POST", "/deck/preview"):
+            let auth = try authorizeProtectedRequest(request, requiredCapability: DeckBridgeCapability.screenPreview)
+            let previewRequest = try LatticesCompanionSecurityCoordinator.shared.decodeProtectedBody(
+                DeckDesktopPreviewRequest.self,
+                body: request.body,
+                auth: auth,
+                method: request.method,
+                path: request.path
+            )
+
+            // ScreenCaptureKit is async. Hand the socket off so the serial bridge
+            // queue can keep serving trackpad, snapshot, and action requests while
+            // the frame is being captured and encoded.
+            Task { [weak self] in
+                defer { close(fd) }
+                guard let self else { return }
+                do {
+                    let frame = try await LatticesDesktopPreviewCapture.capture(previewRequest)
+                    let response = try LatticesCompanionSecurityCoordinator.shared.encodeProtectedResponse(
+                        frame,
+                        auth: auth,
+                        status: 200,
+                        path: request.path
+                    )
+                    try self.sendJSON(status: 200, value: response, to: fd)
+                } catch {
+                    self.sendError(status: 500, message: error.localizedDescription, to: fd)
+                }
+            }
+            return .handedOff
+
         default:
             sendError(status: 404, message: "Unknown route", to: fd)
         }

--- a/apps/mac/Sources/Core/Companion/LatticesCompanionCockpit.swift
+++ b/apps/mac/Sources/Core/Companion/LatticesCompanionCockpit.swift
@@ -10,13 +10,34 @@ struct LatticesCompanionCockpitLayout: Codable, Equatable {
         var row: Int
         var colSpan: Int
         var rowSpan: Int
+        /// Optional visual overrides authored in the Mac deck builder. The
+        /// action remains catalog-backed; these fields only customize how the
+        /// key is presented on companion devices.
+        var customLabel: String?
+        var customBuilderIcon: String?
+        var customTint: String?
+        var customCategory: String?
 
-        init(shortcutID: String, col: Int, row: Int, colSpan: Int = 1, rowSpan: Int = 1) {
+        init(
+            shortcutID: String,
+            col: Int,
+            row: Int,
+            colSpan: Int = 1,
+            rowSpan: Int = 1,
+            customLabel: String? = nil,
+            customBuilderIcon: String? = nil,
+            customTint: String? = nil,
+            customCategory: String? = nil
+        ) {
             self.shortcutID = shortcutID
             self.col = col
             self.row = row
             self.colSpan = colSpan
             self.rowSpan = rowSpan
+            self.customLabel = customLabel
+            self.customBuilderIcon = customBuilderIcon
+            self.customTint = customTint
+            self.customCategory = customCategory
         }
     }
 
@@ -140,7 +161,9 @@ enum LatticesCompanionCockpitCatalog {
 
     static let slotCount = 16
 
-    static let defaultLayout = LatticesCompanionCockpitLayout(
+    /// The original six-way starter is retained only so Preferences can tell an
+    /// untouched deck from a personalized one during the v3 migration.
+    static let legacyDefaultLayoutV2 = LatticesCompanionCockpitLayout(
         pages: [
             .init(
                 id: "command",
@@ -212,8 +235,130 @@ enum LatticesCompanionCockpitCatalog {
         ]
     )
 
+    /// The first job-based starter shipped briefly as v3. Retain it so an exact,
+    /// untouched copy can move forward without changing personalized decks.
+    static let legacyDefaultLayoutV3 = LatticesCompanionCockpitLayout(
+        pages: [
+            .init(
+                id: "remote",
+                title: "Remote",
+                subtitle: "See and directly control this Mac",
+                columns: 4,
+                rows: 3,
+                slots: [
+                    .init(shortcutID: "mac-windows", col: 0, row: 0, colSpan: 2, rowSpan: 2),
+                    .init(shortcutID: "mouse-joystick", col: 2, row: 0, colSpan: 2, rowSpan: 2),
+                    .init(shortcutID: "talkie-search", col: 0, row: 2, colSpan: 2),
+                    .init(shortcutID: "paste-device", col: 2, row: 2, colSpan: 2),
+                ]
+            ),
+            .init(
+                id: "move",
+                title: "Move",
+                subtitle: "Navigate apps and arrange the current window",
+                columns: 4,
+                rows: 4,
+                slots: [
+                    .init(shortcutID: "switch-app-prev", col: 0, row: 0, colSpan: 2),
+                    .init(shortcutID: "switch-app-next", col: 2, row: 0, colSpan: 2),
+                    .init(shortcutID: "switch-window-prev", col: 0, row: 1, colSpan: 2),
+                    .init(shortcutID: "switch-window-next", col: 2, row: 1, colSpan: 2),
+                    .init(shortcutID: "place-left", col: 0, row: 2),
+                    .init(shortcutID: "place-center", col: 1, row: 2),
+                    .init(shortcutID: "place-right", col: 2, row: 2),
+                    .init(shortcutID: "place-maximize", col: 3, row: 2),
+                    .init(shortcutID: "mouse-find", col: 0, row: 3),
+                    .init(shortcutID: "mouse-summon", col: 1, row: 3),
+                    .init(shortcutID: "layout-optimize", col: 2, row: 3, colSpan: 2),
+                ]
+            ),
+            .init(
+                id: "speak-run",
+                title: "Speak & Run",
+                subtitle: "Create, capture, and delegate",
+                columns: 4,
+                rows: 4,
+                slots: [
+                    .init(shortcutID: "talkie-dictate", col: 0, row: 0, colSpan: 2),
+                    .init(shortcutID: "talkie-settings", col: 2, row: 0, colSpan: 2),
+                    .init(shortcutID: "talkie-record", col: 0, row: 1, colSpan: 2),
+                    .init(shortcutID: "talkie-keyboard", col: 2, row: 1, colSpan: 2),
+                    .init(shortcutID: "voice-toggle", col: 0, row: 2),
+                    .init(shortcutID: "voice-cancel", col: 1, row: 2),
+                    .init(shortcutID: "talkie-memos", col: 2, row: 2),
+                    .init(shortcutID: "mac-sessions", col: 3, row: 2),
+                    .init(shortcutID: "mac-claude", col: 0, row: 3),
+                    .init(shortcutID: "talkie-agent", col: 1, row: 3),
+                    .init(shortcutID: "talkie-ssh", col: 2, row: 3),
+                    .init(shortcutID: "talkie-command", col: 3, row: 3),
+                ]
+            ),
+        ]
+    )
+
+    /// The companion is a remote for the Mac in front of the user, not a
+    /// catalog of the subsystems that happen to implement its commands. Keep
+    /// the starter deliberately small and job-based; the complete catalog
+    /// remains available in the Mac deck builder.
+    static let defaultLayout = LatticesCompanionCockpitLayout(
+        pages: [
+            .init(
+                id: "remote",
+                title: "Remote",
+                subtitle: "Couch controls that complement the live trackpad",
+                columns: 4,
+                rows: 2,
+                slots: [
+                    .init(shortcutID: "mac-windows", col: 0, row: 0, colSpan: 2),
+                    .init(shortcutID: "paste-device", col: 2, row: 0, colSpan: 2),
+                    .init(shortcutID: "mouse-find", col: 0, row: 1, colSpan: 2),
+                    .init(shortcutID: "mouse-summon", col: 2, row: 1, colSpan: 2),
+                ]
+            ),
+            .init(
+                id: "move",
+                title: "Move",
+                subtitle: "Navigate apps and arrange the current window",
+                columns: 4,
+                rows: 4,
+                slots: [
+                    .init(shortcutID: "switch-app-prev", col: 0, row: 0, colSpan: 2),
+                    .init(shortcutID: "switch-app-next", col: 2, row: 0, colSpan: 2),
+                    .init(shortcutID: "switch-window-prev", col: 0, row: 1, colSpan: 2),
+                    .init(shortcutID: "switch-window-next", col: 2, row: 1, colSpan: 2),
+                    .init(shortcutID: "place-left", col: 0, row: 2),
+                    .init(shortcutID: "place-center", col: 1, row: 2),
+                    .init(shortcutID: "place-right", col: 2, row: 2),
+                    .init(shortcutID: "place-maximize", col: 3, row: 2),
+                    .init(shortcutID: "resize-grow", col: 0, row: 3),
+                    .init(shortcutID: "resize-shrink", col: 1, row: 3),
+                    .init(shortcutID: "layout-optimize", col: 2, row: 3, colSpan: 2),
+                ]
+            ),
+            .init(
+                id: "speak-run",
+                title: "Speak & Run",
+                subtitle: "Voice, capture, and repeatable work",
+                columns: 4,
+                rows: 3,
+                slots: [
+                    .init(shortcutID: "voice-toggle", col: 0, row: 0, colSpan: 2),
+                    .init(shortcutID: "voice-cancel", col: 2, row: 0, colSpan: 2),
+                    .init(shortcutID: "talkie-dictate", col: 0, row: 1, colSpan: 2),
+                    .init(shortcutID: "talkie-record", col: 2, row: 1, colSpan: 2),
+                    .init(shortcutID: "talkie-settings", col: 0, row: 2, colSpan: 2),
+                    .init(shortcutID: "mac-sessions", col: 2, row: 2, colSpan: 2),
+                ]
+            ),
+        ]
+    )
+
     static let shortcuts: [LatticesCompanionShortcutDefinition] = [
         .init(id: "", title: "Empty", subtitle: "Leave this slot unused", iconSystemName: "square.dashed", accentToken: nil, category: .layout),
+        // Keep the legacy `mac-windows` slot id so saved deck layouts remain
+        // valid, but own the definition here. Desktop Preview is Lattices
+        // navigation and must never inherit Talkie's perform/open fallback.
+        .init(id: "mac-windows", title: "Desktop Preview", subtitle: "View this Mac's screen on your iPad", iconSystemName: "display", accentToken: "green", category: .layout),
     ] + TalkieDeckProvider.shortcuts.map {
         LatticesCompanionShortcutDefinition(
             id: $0.id,
@@ -270,24 +415,112 @@ enum LatticesCompanionCockpitCatalog {
     }
 
     static func normalized(_ layout: LatticesCompanionCockpitLayout) -> LatticesCompanionCockpitLayout {
-        let blueprintPages = defaultLayout.pages
-        let existing = Dictionary(uniqueKeysWithValues: layout.pages.map { ($0.id, $0) })
+        let sourcePages = layout.pages.isEmpty ? defaultLayout.pages : layout.pages
+        var usedPageIDs = Set<String>()
 
-        return LatticesCompanionCockpitLayout(
-            pages: blueprintPages.map { blueprint in
-                let current = existing[blueprint.id]
-                let flatSlots = normalizedSlots(current?.slotIDs ?? blueprint.slotIDs)
-                return .init(
-                    id: blueprint.id,
-                    title: current?.title ?? blueprint.title,
-                    subtitle: current?.subtitle ?? blueprint.subtitle,
-                    columns: max(2, current?.columns ?? blueprint.columns),
-                    rows: current?.rows ?? blueprint.rows,
-                    slotIDs: flatSlots,
-                    slots: current?.slots
-                )
+        let pages: [LatticesCompanionCockpitLayout.Page] = sourcePages.enumerated().map { index, page in
+            let columns = min(5, max(2, page.columns))
+            let inferredRows = page.slots?.map { $0.row + max(1, $0.rowSpan) }.max() ?? 1
+            let rows = min(4, max(1, page.rows ?? inferredRows))
+
+            let baseID = page.id.trimmingCharacters(in: .whitespacesAndNewlines)
+            let fallbackID = baseID.isEmpty ? "page-\(index + 1)" : baseID
+            var pageID = fallbackID
+            var suffix = 2
+            while usedPageIDs.contains(pageID) {
+                pageID = "\(fallbackID)-\(suffix)"
+                suffix += 1
             }
-        )
+            usedPageIDs.insert(pageID)
+
+            let positioned = page.slots.map { slots in
+                var occupied = Set<Int>()
+
+                func cells(col: Int, row: Int, colSpan: Int, rowSpan: Int) -> [Int] {
+                    (row..<(row + rowSpan)).flatMap { cellRow in
+                        (col..<(col + colSpan)).map { cellCol in
+                            cellRow * columns + cellCol
+                        }
+                    }
+                }
+
+                func firstOpenPosition(colSpan: Int, rowSpan: Int) -> (col: Int, row: Int)? {
+                    guard colSpan <= columns, rowSpan <= rows else { return nil }
+                    for row in 0...(rows - rowSpan) {
+                        for col in 0...(columns - colSpan) {
+                            if cells(col: col, row: row, colSpan: colSpan, rowSpan: rowSpan)
+                                .allSatisfy({ !occupied.contains($0) }) {
+                                return (col, row)
+                            }
+                        }
+                    }
+                    return nil
+                }
+
+                let normalizedSlots: [LatticesCompanionCockpitLayout.Slot] = slots
+                    .prefix(slotCount)
+                    .compactMap { slot -> LatticesCompanionCockpitLayout.Slot? in
+                    let preferredCol = min(columns - 1, max(0, slot.col))
+                    let preferredRow = min(rows - 1, max(0, slot.row))
+                    var colSpan = min(columns - preferredCol, max(1, slot.colSpan))
+                    var rowSpan = min(rows - preferredRow, max(1, slot.rowSpan))
+                    let preferredCells = cells(
+                        col: preferredCol,
+                        row: preferredRow,
+                        colSpan: colSpan,
+                        rowSpan: rowSpan
+                    )
+
+                    var position: (col: Int, row: Int)?
+                    if preferredCells.allSatisfy({ !occupied.contains($0) }) {
+                        position = (preferredCol, preferredRow)
+                    } else {
+                        position = firstOpenPosition(colSpan: colSpan, rowSpan: rowSpan)
+                    }
+
+                    // A custom layout can become denser when an oversized grid
+                    // is clamped to the supported 5×4 canvas. Keep every action
+                    // reachable by relaxing its span before ever overlapping it.
+                    if position == nil {
+                        colSpan = 1
+                        rowSpan = 1
+                        position = firstOpenPosition(colSpan: 1, rowSpan: 1)
+                    }
+                    guard let position else { return nil }
+
+                    occupied.formUnion(cells(
+                        col: position.col,
+                        row: position.row,
+                        colSpan: colSpan,
+                        rowSpan: rowSpan
+                    ))
+                    return LatticesCompanionCockpitLayout.Slot(
+                        shortcutID: slot.shortcutID,
+                        col: position.col,
+                        row: position.row,
+                        colSpan: colSpan,
+                        rowSpan: rowSpan,
+                        customLabel: slot.customLabel,
+                        customBuilderIcon: slot.customBuilderIcon,
+                        customTint: slot.customTint,
+                        customCategory: slot.customCategory
+                    )
+                }
+                return normalizedSlots
+            }
+
+            return .init(
+                id: pageID,
+                title: page.title,
+                subtitle: page.subtitle,
+                columns: columns,
+                rows: page.slots == nil ? page.rows : rows,
+                slotIDs: normalizedSlots(page.slotIDs),
+                slots: positioned
+            )
+        }
+
+        return LatticesCompanionCockpitLayout(pages: pages)
     }
 
     static func renderedState(
@@ -318,6 +551,9 @@ enum LatticesCompanionCockpitCatalog {
                             row: slot.row,
                             colSpan: slot.colSpan,
                             rowSpan: slot.rowSpan,
+                            customLabel: slot.customLabel,
+                            customBuilderIcon: slot.customBuilderIcon,
+                            customTint: slot.customTint,
                             voice: voice,
                             desktop: desktop,
                             layoutState: layoutState,
@@ -366,6 +602,9 @@ enum LatticesCompanionCockpitCatalog {
         row: Int? = nil,
         colSpan: Int? = nil,
         rowSpan: Int? = nil,
+        customLabel: String? = nil,
+        customBuilderIcon: String? = nil,
+        customTint: String? = nil,
         voice: DeckVoiceState?,
         desktop: DeckDesktopSummary?,
         layoutState: DeckLayoutState?,
@@ -386,12 +625,12 @@ enum LatticesCompanionCockpitCatalog {
         return DeckCockpitTile(
             id: id,
             shortcutID: shortcutID,
-            title: rendered.title,
+            title: nonBlank(customLabel) ?? rendered.title,
             subtitle: rendered.subtitle,
-            iconSystemName: rendered.iconSystemName,
+            iconSystemName: customBuilderIcon.map(builderSystemIcon) ?? rendered.iconSystemName,
             accentToken: rendered.accentToken,
             deckID: rendered.deckID ?? pageID,
-            categoryTint: rendered.categoryTint ?? definition(for: shortcutID)?.category.tintToken,
+            categoryTint: customTint ?? rendered.categoryTint ?? definition(for: shortcutID)?.category.tintToken,
             actionID: rendered.actionID,
             payload: rendered.payload,
             isEnabled: rendered.isEnabled,
@@ -402,6 +641,35 @@ enum LatticesCompanionCockpitCatalog {
             colSpan: colSpan,
             rowSpan: rowSpan
         )
+    }
+
+    private static func nonBlank(_ value: String?) -> String? {
+        guard let value, !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        return value
+    }
+
+    private static func builderSystemIcon(_ icon: String) -> String {
+        let icons: [String: String] = [
+            "Mic": "mic.fill", "X": "xmark", "CornerDownLeft": "return",
+            "ArrowLeft": "arrow.left", "ArrowRight": "arrow.right",
+            "ArrowUp": "arrow.up", "ArrowDown": "arrow.down",
+            "ChevronLeft": "chevron.left", "ChevronRight": "chevron.right",
+            "Search": "magnifyingglass", "Command": "command",
+            "LayoutGrid": "rectangle.3.group.fill", "Crosshair": "scope",
+            "MousePointer2": "cursorarrow", "SpaceIcon": "space",
+            "PanelLeft": "rectangle.leadinghalf.filled",
+            "PanelRight": "rectangle.trailinghalf.filled",
+            "SquareDashed": "square.dashed", "Maximize2": "macwindow",
+            "Monitor": "display", "Terminal": "terminal", "Play": "play.fill",
+            "Hammer": "hammer.fill", "GitBranch": "arrow.triangle.branch",
+            "Volume2": "speaker.wave.2.fill", "Sun": "sun.max.fill",
+            "Camera": "camera.fill", "Sparkles": "sparkles", "Home": "house.fill",
+            "Clock": "clock", "Joystick": "circle.circle.fill",
+            "ClipboardPaste": "rectangle.portrait.and.arrow.forward"
+        ]
+        return icons[icon] ?? "square.dashed"
     }
 
     private static func renderedShortcut(
@@ -416,6 +684,23 @@ enum LatticesCompanionCockpitCatalog {
 
         if let keyShortcut = keyboardShortcut(for: shortcutID) {
             return keyShortcut
+        }
+
+        // Desktop Preview belongs to the Lattices companion itself. It is a
+        // read-only view of this Mac's current screen, not a Talkie launch
+        // action, even though the slot originated in Talkie's deck layout.
+        if shortcutID == "mac-windows" {
+            return RenderedShortcut(
+                title: "Desktop Preview",
+                subtitle: "View this Mac's screen on your iPad",
+                iconSystemName: "display",
+                accentToken: "green",
+                categoryTint: LatticesCompanionShortcutCategory.layout.tintToken,
+                actionID: "desktop.preview.open",
+                payload: [:],
+                isEnabled: true,
+                isActive: false
+            )
         }
 
         if let talkieShortcut = talkieShortcut(for: shortcutID, snapshot: talkie) {
@@ -694,20 +979,21 @@ enum LatticesCompanionCockpitCatalog {
         } else if snapshot.isReachable {
             subtitle = shortcut.subtitle
         } else if snapshot.isRunning {
-            subtitle = snapshot.lastError ?? "Talkie is running; waiting for its bridge."
+            subtitle = snapshot.lastError ?? "Voice controls are starting."
         } else {
-            subtitle = "Open Talkie on this Mac."
+            subtitle = "Unavailable until the voice companion is running."
         }
 
+        let canOpenProvider = shortcut.id == "talkie-home"
         return RenderedShortcut(
-            title: shortcut.title,
+            title: !snapshot.isReachable && canOpenProvider ? "Open Talkie" : shortcut.title,
             subtitle: subtitle,
             iconSystemName: shortcut.iconSystemName,
             accentToken: shortcut.accentToken,
             categoryTint: shortcut.accentToken,
-            actionID: snapshot.isReachable ? "talkie.perform" : "talkie.open",
+            actionID: snapshot.isReachable ? "talkie.perform" : (canOpenProvider ? "talkie.open" : nil),
             payload: snapshot.isReachable ? ["shortcutID": .string(shortcut.id)] : [:],
-            isEnabled: true,
+            isEnabled: snapshot.isReachable || canOpenProvider,
             isActive: isActive
         )
     }

--- a/apps/mac/Sources/Core/Companion/LatticesCompanionSecurityCoordinator.swift
+++ b/apps/mac/Sources/Core/Companion/LatticesCompanionSecurityCoordinator.swift
@@ -59,7 +59,7 @@ struct LatticesCompanionTrustedDeviceRecord: Codable, Equatable, Identifiable, S
     }
 
     var effectiveCapabilities: [String] {
-        capabilities ?? DeckBridgeCapability.defaultCompanionCapabilities
+        capabilities ?? DeckBridgeCapability.legacyCompanionCapabilities
     }
 }
 
@@ -156,7 +156,18 @@ final class LatticesCompanionSecurityCoordinator {
 
         if var existing = trustedDevices[request.deviceID], existing.publicKey == request.devicePublicKey {
             existing.lastSeenAt = Date()
-            existing.capabilities = grantedCapabilities.isEmpty ? existing.effectiveCapabilities : grantedCapabilities
+            let existingCapabilities = existing.effectiveCapabilities
+            let additions = Self.additionalCapabilities(
+                existing: existingCapabilities,
+                requested: grantedCapabilities
+            )
+            let upgradeApproved = additions.isEmpty
+                || promptForCapabilityUpgrade(request, additions: additions)
+            existing.capabilities = Self.capabilitiesAfterPairingRequest(
+                existing: existingCapabilities,
+                requested: grantedCapabilities,
+                upgradeApproved: upgradeApproved
+            )
             trustedDevices[request.deviceID] = existing
             persistTrustedDevices()
             diag.success("CompanionPairing: device already trusted id=\(request.deviceID)")
@@ -310,7 +321,7 @@ final class LatticesCompanionSecurityCoordinator {
     }
 }
 
-private extension LatticesCompanionSecurityCoordinator {
+extension LatticesCompanionSecurityCoordinator {
     static func loadTrustedDevices() -> [String: LatticesCompanionTrustedDeviceRecord] {
         guard
             let data = UserDefaults.standard.data(forKey: DefaultsKey.trustedDevices),
@@ -367,6 +378,19 @@ private extension LatticesCompanionSecurityCoordinator {
         return requested
             .intersection(supported)
             .sorted()
+    }
+
+    static func additionalCapabilities(existing: [String], requested: [String]) -> [String] {
+        Array(Set(requested).subtracting(existing)).sorted()
+    }
+
+    static func capabilitiesAfterPairingRequest(
+        existing: [String],
+        requested: [String],
+        upgradeApproved: Bool
+    ) -> [String] {
+        guard upgradeApproved else { return Array(Set(existing)).sorted() }
+        return Array(Set(existing).union(requested)).sorted()
     }
 
     func persistTrustedDevices() {
@@ -556,6 +580,41 @@ private extension LatticesCompanionSecurityCoordinator {
         return approved
     }
 
+    func promptForCapabilityUpgrade(_ request: DeckPairingRequest, additions: [String]) -> Bool {
+        if Thread.isMainThread {
+            return runCapabilityUpgradeAlert(request, additions: additions)
+        }
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var approved = false
+        DispatchQueue.main.async {
+            approved = self.runCapabilityUpgradeAlert(request, additions: additions)
+            semaphore.signal()
+        }
+        semaphore.wait()
+        return approved
+    }
+
+    func runCapabilityUpgradeAlert(_ request: DeckPairingRequest, additions: [String]) -> Bool {
+        NSApp.activate(ignoringOtherApps: true)
+        let code = Self.fingerprint(forPublicKeyBase64: request.devicePublicKey)
+        let labels = additions.map(Self.userFacingCapabilityName)
+
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Allow more access for this device?"
+        alert.informativeText = """
+        “\(request.deviceName)” is already paired as \(code) and is asking for:
+
+            \(labels.joined(separator: "\n    "))
+
+        Existing access remains available if you keep the current permissions.
+        """
+        alert.addButton(withTitle: "Allow Access")
+        alert.addButton(withTitle: "Keep Current Access")
+        return alert.runModal() == .alertFirstButtonReturn
+    }
+
     func runPairingAlert(_ request: DeckPairingRequest) -> Bool {
         NSApp.activate(ignoringOtherApps: true)
 
@@ -566,6 +625,13 @@ private extension LatticesCompanionSecurityCoordinator {
         // is derived from a key the sender must actually hold, so it leads,
         // and the forgeable fields are labelled as claims rather than facts.
         let code = Self.fingerprint(forPublicKeyBase64: request.devicePublicKey)
+        // Disclose the same normalized set that pairing will actually grant.
+        // Older clients may send an empty list, which intentionally maps to
+        // the current supported companion capability set.
+        let requestedAccess = Self.grantedCapabilities(for: request.requestedCapabilities)
+            .map(Self.userFacingCapabilityName)
+            .map { "    • \($0)" }
+            .joined(separator: "\n")
 
         let alert = NSAlert()
         alert.alertStyle = .warning
@@ -578,11 +644,29 @@ private extension LatticesCompanionSecurityCoordinator {
         The device calls itself “\(request.deviceName)” (\(request.platform)). \
         That name is chosen by the device and is not verified — only the code is.
 
+        If allowed, this device can:
+        \(requestedAccess)
+
         If the codes do not match, deny: something else on your network is asking.
         """
         alert.addButton(withTitle: "Allow Pairing")
         alert.addButton(withTitle: "Deny")
         return alert.runModal() == .alertFirstButtonReturn
+    }
+
+    static func userFacingCapabilityName(_ capability: String) -> String {
+        switch capability {
+        case DeckBridgeCapability.screenPreview:
+            return "View this Mac's screen"
+        case DeckBridgeCapability.inputTrackpad:
+            return "Move, click, and scroll the pointer"
+        case DeckBridgeCapability.deckPerform:
+            return "Run companion deck actions"
+        case DeckBridgeCapability.deckRead:
+            return "Read the companion deck and Mac status"
+        default:
+            return capability
+        }
     }
 
     static func constantTimeEquals(_ lhs: String, _ rhs: String) -> Bool {

--- a/apps/mac/Sources/Core/Companion/LatticesCompanionTrackpadController.swift
+++ b/apps/mac/Sources/Core/Companion/LatticesCompanionTrackpadController.swift
@@ -8,6 +8,7 @@ final class LatticesCompanionTrackpadController {
     private init() {}
 
     func state(isEnabled: Bool) -> DeckTrackpadState {
+        let pointer = normalizedCursorPosition()
         guard isEnabled else {
             return DeckTrackpadState(
                 isEnabled: false,
@@ -16,7 +17,9 @@ final class LatticesCompanionTrackpadController {
                 statusDetail: "Enable the companion trackpad from the Mac Companion settings.",
                 pointerScale: 1.6,
                 scrollScale: 1.0,
-                supportsDragLock: true
+                supportsDragLock: true,
+                pointerX: pointer.x,
+                pointerY: pointer.y
             )
         }
 
@@ -30,7 +33,9 @@ final class LatticesCompanionTrackpadController {
                 : "Grant Accessibility permission to Lattices on your Mac to enable pointer control.",
             pointerScale: 1.6,
             scrollScale: 1.0,
-            supportsDragLock: true
+            supportsDragLock: true,
+            pointerX: pointer.x,
+            pointerY: pointer.y
         )
     }
 
@@ -57,13 +62,39 @@ final class LatticesCompanionTrackpadController {
             ok = performMouseDrag(dx: request.dx, dy: request.dy)
         }
 
-        return DeckTrackpadEventResult(ok: ok)
+        let pointer = normalizedCursorPosition()
+        return DeckTrackpadEventResult(ok: ok, pointerX: pointer.x, pointerY: pointer.y)
     }
 }
 
 private extension LatticesCompanionTrackpadController {
     func currentCursorPoint() -> CGPoint {
         CGEvent(source: nil)?.location ?? .zero
+    }
+
+    /// CGEvent and CGDisplayBounds share the same global coordinate space, so
+    /// this remains accurate across displays above, below, or left of the main
+    /// screen. The iPad renders the normalized point as full-surface X/Y guides.
+    func normalizedCursorPosition() -> (x: Double?, y: Double?) {
+        var displays = Array(repeating: CGDirectDisplayID(), count: 16)
+        var count: UInt32 = 0
+        guard CGGetActiveDisplayList(UInt32(displays.count), &displays, &count) == .success,
+              count > 0 else {
+            return (nil, nil)
+        }
+
+        let desktopBounds = displays.prefix(Int(count))
+            .map(CGDisplayBounds)
+            .reduce(CGRect.null) { $0.union($1) }
+        guard !desktopBounds.isNull, desktopBounds.width > 0, desktopBounds.height > 0 else {
+            return (nil, nil)
+        }
+
+        let point = currentCursorPoint()
+        return (
+            min(1, max(0, Double((point.x - desktopBounds.minX) / desktopBounds.width))),
+            min(1, max(0, Double((point.y - desktopBounds.minY) / desktopBounds.height)))
+        )
     }
 
     func clamp(delta: Double) -> CGFloat {

--- a/apps/mac/Sources/Core/Companion/LatticesDeckHost.swift
+++ b/apps/mac/Sources/Core/Companion/LatticesDeckHost.swift
@@ -85,6 +85,7 @@ final class LatticesDeckHost: DeckHost, @unchecked Sendable {
             .appSwitching,
             .taskSwitching,
             .historyFeed,
+            .screenPreview,
             .systemTelemetry,
             .spaces,
             .keyboardForwarding,
@@ -177,6 +178,21 @@ final class LatticesDeckHost: DeckHost, @unchecked Sendable {
     }
 }
 
+extension LatticesDeckHost {
+    static func resolveSpaceTarget(
+        displays: [DisplaySpaces],
+        displayIndex: Int,
+        index: Int
+    ) -> (display: DisplaySpaces, space: SpaceInfo)? {
+        guard index >= 0,
+              let display = displays.first(where: { $0.displayIndex == displayIndex }),
+              display.spaces.indices.contains(index) else {
+            return nil
+        }
+        return (display, display.spaces[index])
+    }
+}
+
 private extension LatticesDeckHost {
     enum ResizeDimension: String {
         case width
@@ -266,6 +282,17 @@ private extension LatticesDeckHost {
         case "talkie.perform":
             guard let shortcutID = request.payload["shortcutID"]?.stringValue else {
                 throw LatticesDeckHostError.missingPayload("shortcutID")
+            }
+            // Compatibility guard for an iPad holding a pre-preview snapshot.
+            // That older mapping called this Talkie route with `mac-windows`,
+            // which caused Talkie to open. A refreshed deck handles the slot as
+            // native iPad navigation and never sends a Mac action at all.
+            if shortcutID == "mac-windows" {
+                return ActionOutcome(
+                    summary: "Refresh Desktop Preview",
+                    detail: "Refresh the deck on your iPad, then open Desktop Preview again.",
+                    suggestedActions: []
+                )
             }
             do {
                 let result = try TalkieDeckProvider.shared.trigger(shortcutID: shortcutID)
@@ -429,7 +456,22 @@ private extension LatticesDeckHost {
 
         case "spaces.focusRelative":
             let direction = request.payload["direction"]?.intValue ?? 1
-            return try MainActorSync.run { self.switchActiveSpace(direction: direction > 0 ? 1 : -1) }
+            let displayIndex = request.payload["displayIndex"]?.intValue
+            return try MainActorSync.run {
+                self.switchActiveSpace(
+                    direction: direction > 0 ? 1 : -1,
+                    displayIndex: displayIndex
+                )
+            }
+
+        case "spaces.focusIndex":
+            guard let index = request.payload["index"]?.intValue else {
+                throw LatticesDeckHostError.missingPayload("index")
+            }
+            let displayIndex = request.payload["displayIndex"]?.intValue
+            return try MainActorSync.run {
+                self.switchActiveSpace(index: index, displayIndex: displayIndex)
+            }
 
         case "mouse.find":
             let result = try callAPI("mouse.find")
@@ -1085,7 +1127,7 @@ private extension LatticesDeckHost {
     }
 
     @MainActor
-    func switchActiveSpace(direction: Int) -> ActionOutcome {
+    func switchActiveSpace(direction: Int, displayIndex: Int? = nil) -> ActionOutcome {
         let displays = WindowTiler.getDisplaySpaces()
         guard !displays.isEmpty else {
             return ActionOutcome(summary: "No displays available", detail: nil, suggestedActions: [])
@@ -1100,7 +1142,9 @@ private extension LatticesDeckHost {
             return NSScreen.screens.first(where: { $0.frame.contains(mouse) }) ?? NSScreen.main
         }()
 
-        let preferredDisplayIndex = NSScreen.screens.firstIndex { activeScreen === $0 } ?? 0
+        let preferredDisplayIndex = displayIndex
+            ?? NSScreen.screens.firstIndex { activeScreen === $0 }
+            ?? 0
         let display = displays.first(where: { $0.displayIndex == preferredDisplayIndex }) ?? displays[0]
 
         guard let currentIdx = display.spaces.firstIndex(where: { $0.isCurrent }) else {
@@ -1125,6 +1169,53 @@ private extension LatticesDeckHost {
         return ActionOutcome(
             summary: direction > 0 ? "Next space" : "Previous space",
             detail: "Switched display \(display.displayIndex + 1) to space \(target.index).",
+            suggestedActions: []
+        )
+    }
+
+    @MainActor
+    func switchActiveSpace(index: Int, displayIndex: Int? = nil) -> ActionOutcome {
+        let displays = WindowTiler.getDisplaySpaces()
+        guard !displays.isEmpty else {
+            return ActionOutcome(summary: "No displays available", detail: nil, suggestedActions: [])
+        }
+
+        let activeScreen: NSScreen? = {
+            if let frontmost = frontmostWindowTarget(),
+               let entry = DesktopModel.shared.windows[frontmost.wid] {
+                return WindowTiler.screenForWindowFrame(entry.frame)
+            }
+            let mouse = NSEvent.mouseLocation
+            return NSScreen.screens.first(where: { $0.frame.contains(mouse) }) ?? NSScreen.main
+        }()
+        let preferredDisplayIndex = displayIndex
+            ?? NSScreen.screens.firstIndex { activeScreen === $0 }
+            ?? 0
+
+        guard let target = Self.resolveSpaceTarget(
+            displays: displays,
+            displayIndex: preferredDisplayIndex,
+            index: index
+        ) else {
+            return ActionOutcome(
+                summary: "Space unavailable",
+                detail: "Display \(preferredDisplayIndex + 1) does not have space \(index + 1).",
+                suggestedActions: []
+            )
+        }
+
+        if target.space.isCurrent {
+            return ActionOutcome(
+                summary: "Already on space \(target.space.index)",
+                detail: "Display \(target.display.displayIndex + 1) is already showing that space.",
+                suggestedActions: []
+            )
+        }
+
+        WindowTiler.switchToSpace(spaceId: target.space.id)
+        return ActionOutcome(
+            summary: "Space \(target.space.index)",
+            detail: "Switched display \(target.display.displayIndex + 1) to space \(target.space.index).",
             suggestedActions: []
         )
     }

--- a/apps/mac/Sources/Core/Companion/LatticesDesktopPreviewCapture.swift
+++ b/apps/mac/Sources/Core/Companion/LatticesDesktopPreviewCapture.swift
@@ -1,0 +1,196 @@
+import AppKit
+import DeckKit
+import Foundation
+import ScreenCaptureKit
+
+enum LatticesDesktopPreviewCaptureError: LocalizedError {
+    case permissionRequired
+    case noDisplays
+    case displayUnavailable
+    case frontmostWindowUnavailable
+    case encodingFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .permissionRequired:
+            return "Screen Recording is off on this Mac. Enable Lattices in System Settings → Privacy & Security → Screen & System Audio Recording."
+        case .noDisplays:
+            return "No Mac display is available to preview."
+        case .displayUnavailable:
+            return "That Mac display is no longer available. Choose another display."
+        case .frontmostWindowUnavailable:
+            return "No frontmost Mac window is available to preview."
+        case .encodingFailed:
+            return "The Mac captured the display but could not prepare the preview image."
+        }
+    }
+}
+
+/// Captures a deliberately bounded still frame for the paired iPad.
+///
+/// This is not a video stream. The iPad pulls a new encrypted JPEG after it
+/// finishes decoding the previous one, which naturally applies backpressure
+/// and keeps capture work bounded when the network or client slows down.
+@MainActor
+enum LatticesDesktopPreviewCapture {
+    static func capture(_ request: DeckDesktopPreviewRequest) async throws -> DeckDesktopPreviewFrame {
+        guard CGPreflightScreenCaptureAccess() else {
+            throw LatticesDesktopPreviewCaptureError.permissionRequired
+        }
+
+        let screens = NSScreen.screens
+        guard !screens.isEmpty else {
+            throw LatticesDesktopPreviewCaptureError.noDisplays
+        }
+
+        let content = try await SCShareableContent.excludingDesktopWindows(
+            false,
+            onScreenWindowsOnly: true
+        )
+        let selectedIndex: Int
+        let filter: SCContentFilter
+        let sourceWidth: Int
+        let sourceHeight: Int
+
+        switch request.scope {
+        case .display:
+            selectedIndex = resolvedDisplayIndex(request.displayIndex, screens: screens)
+            guard screens.indices.contains(selectedIndex),
+                  let selectedDisplayID = displayID(for: screens[selectedIndex]),
+                  let selectedDisplay = content.displays.first(where: { $0.displayID == selectedDisplayID }) else {
+                throw LatticesDesktopPreviewCaptureError.displayUnavailable
+            }
+            filter = SCContentFilter(display: selectedDisplay, excludingWindows: [])
+            sourceWidth = max(selectedDisplay.width, 1)
+            sourceHeight = max(selectedDisplay.height, 1)
+
+        case .frontmostWindow:
+            guard let selectedWindow = frontmostWindow(in: content) else {
+                throw LatticesDesktopPreviewCaptureError.frontmostWindowUnavailable
+            }
+            filter = SCContentFilter(desktopIndependentWindow: selectedWindow)
+            sourceWidth = max(Int(selectedWindow.frame.width.rounded()), 1)
+            sourceHeight = max(Int(selectedWindow.frame.height.rounded()), 1)
+            selectedIndex = displayIndex(containing: selectedWindow.frame.center, screens: screens)
+                ?? resolvedDisplayIndex(request.displayIndex, screens: screens)
+        }
+
+        let configuration = SCStreamConfiguration()
+        let requestedWidth = min(max(request.maxPixelWidth, 720), 1_920)
+        let outputWidth = min(sourceWidth, requestedWidth)
+        let outputHeight = max(1, Int((Double(sourceHeight) * Double(outputWidth) / Double(sourceWidth)).rounded()))
+
+        configuration.width = outputWidth
+        configuration.height = outputHeight
+        configuration.captureResolution = .nominal
+        configuration.scalesToFit = true
+        configuration.preservesAspectRatio = true
+        configuration.showsCursor = true
+        configuration.shouldBeOpaque = true
+
+        let image = try await SCScreenshotManager.captureImage(
+            contentFilter: filter,
+            configuration: configuration
+        )
+        let bitmap = NSBitmapImageRep(cgImage: image)
+        guard let jpeg = bitmap.representation(
+            using: .jpeg,
+            properties: [.compressionFactor: 0.64]
+        ) else {
+            throw LatticesDesktopPreviewCaptureError.encodingFailed
+        }
+
+        let displays = screens.enumerated().map { index, screen in
+            let screenID = displayID(for: screen)
+            let scDisplay = screenID.flatMap { id in
+                content.displays.first(where: { $0.displayID == id })
+            }
+            return DeckDesktopPreviewDisplay(
+                displayIndex: index,
+                name: screen.localizedName,
+                pixelWidth: scDisplay?.width ?? Int(screen.frame.width * screen.backingScaleFactor),
+                pixelHeight: scDisplay?.height ?? Int(screen.frame.height * screen.backingScaleFactor)
+            )
+        }
+
+        return DeckDesktopPreviewFrame(
+            capturedAt: .now,
+            displayIndex: selectedIndex,
+            displays: displays,
+            pixelWidth: image.width,
+            pixelHeight: image.height,
+            jpegBase64: jpeg.base64EncodedString()
+        )
+    }
+
+    private static func resolvedDisplayIndex(_ requested: Int?, screens: [NSScreen]) -> Int {
+        if let requested, screens.indices.contains(requested) {
+            return requested
+        }
+        let pointer = NSEvent.mouseLocation
+        return screens.firstIndex(where: { $0.frame.contains(pointer) })
+            ?? screens.firstIndex(where: { $0 === NSScreen.main })
+            ?? 0
+    }
+
+    private static func displayID(for screen: NSScreen) -> CGDirectDisplayID? {
+        let key = NSDeviceDescriptionKey("NSScreenNumber")
+        return (screen.deviceDescription[key] as? NSNumber).map { CGDirectDisplayID($0.uint32Value) }
+    }
+
+    private static func displayIndex(containing point: CGPoint, screens: [NSScreen]) -> Int? {
+        screens.firstIndex { screen in
+            guard let id = displayID(for: screen) else { return false }
+            return CGDisplayBounds(id).contains(point)
+        }
+    }
+
+    private static func frontmostWindow(in content: SCShareableContent) -> SCWindow? {
+        guard let application = NSWorkspace.shared.frontmostApplication else { return nil }
+        let pid = application.processIdentifier
+
+        if let windowID = frontmostWindowID(for: pid),
+           let exact = content.windows.first(where: { $0.windowID == windowID }) {
+            return exact
+        }
+
+        return content.windows.first { window in
+            window.owningApplication?.processID == pid
+                && window.isOnScreen
+                && window.frame.width >= 120
+                && window.frame.height >= 80
+        }
+    }
+
+    /// CGWindowList is ordered front-to-back. Matching the frontmost app's
+    /// first normal-layer window gives ScreenCaptureKit the exact window rather
+    /// than whichever same-process utility panel happens to enumerate first.
+    private static func frontmostWindowID(for pid: pid_t) -> CGWindowID? {
+        guard let info = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements],
+            kCGNullWindowID
+        ) as? [[String: Any]] else {
+            return nil
+        }
+
+        for window in info {
+            guard (window[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value == pid,
+                  (window[kCGWindowLayer as String] as? NSNumber)?.intValue == 0,
+                  let number = window[kCGWindowNumber as String] as? NSNumber,
+                  let boundsDictionary = window[kCGWindowBounds as String] as? NSDictionary,
+                  let bounds = CGRect(dictionaryRepresentation: boundsDictionary),
+                  bounds.width >= 120,
+                  bounds.height >= 80 else {
+                continue
+            }
+            return CGWindowID(number.uint32Value)
+        }
+        return nil
+    }
+}
+
+private extension CGRect {
+    var center: CGPoint {
+        CGPoint(x: midX, y: midY)
+    }
+}

--- a/apps/mac/Sources/Core/Companion/TalkieDeckProvider.swift
+++ b/apps/mac/Sources/Core/Companion/TalkieDeckProvider.swift
@@ -74,6 +74,8 @@ private struct TalkieLocalClientAccessResponse: Decodable {
 final class TalkieDeckProvider: @unchecked Sendable {
     static let shared = TalkieDeckProvider()
 
+    /// Slot order of the retired six-page starter. Kept only for exact-layout
+    /// migration and for decoding saved legacy Talkie pages.
     static let talkiePageSlotIDs: [String] = [
         "talkie-dictate", "talkie-record", "talkie-settings", "talkie-search",
         "deck-app-previous", "deck-app-next", "deck-window-previous", "deck-window-next",
@@ -82,18 +84,17 @@ final class TalkieDeckProvider: @unchecked Sendable {
     ]
 
     static let shortcuts: [TalkieDeckShortcutDefinition] = [
-        .init(id: "talkie-dictate", title: "Dictate", subtitle: "Start or stop Talkie dictation.", iconSystemName: "mic.fill", accentToken: "red"),
-        .init(id: "talkie-record", title: "Record Memo", subtitle: "Start or stop a Talkie memo.", iconSystemName: "square.and.pencil", accentToken: "violet"),
-        .init(id: "talkie-settings", title: "Voice Command", subtitle: "Start Talkie's voice command capture.", iconSystemName: "waveform.badge.mic", accentToken: "pink"),
-        .init(id: "talkie-search", title: "Search", subtitle: "Open Talkie search on the Mac.", iconSystemName: "magnifyingglass", accentToken: "blue"),
-        .init(id: "mac-claude", title: "Claude", subtitle: "Open Talkie's Claude console.", iconSystemName: "sparkles", accentToken: "violet"),
-        .init(id: "talkie-agent", title: "Pi", subtitle: "Open Talkie's Pi console.", iconSystemName: "circle.grid.cross", accentToken: "blue"),
-        .init(id: "talkie-ssh", title: "Shell", subtitle: "Open the Talkie Shell tab.", iconSystemName: "terminal", accentToken: "green"),
-        .init(id: "mac-sessions", title: "Workflows", subtitle: "Open Talkie's workflow picker.", iconSystemName: "wand.and.stars", accentToken: "teal"),
-        .init(id: "mac-windows", title: "Desktop Preview", subtitle: "Start Talkie's desktop capture flow.", iconSystemName: "display", accentToken: "green"),
-        .init(id: "talkie-keyboard", title: "Record Screen", subtitle: "Start Talkie's screen recording flow.", iconSystemName: "record.circle", accentToken: "red"),
-        .init(id: "talkie-command", title: "Palette", subtitle: "Open Talkie's command palette.", iconSystemName: "command", accentToken: "violet"),
-        .init(id: "talkie-memos", title: "Memos", subtitle: "Open Talkie's memo library.", iconSystemName: "waveform", accentToken: "pink"),
+        .init(id: "talkie-dictate", title: "Type by Voice", subtitle: "Dictate into the current Mac app.", iconSystemName: "mic.fill", accentToken: "red"),
+        .init(id: "talkie-record", title: "Record Note", subtitle: "Start or stop a voice note.", iconSystemName: "square.and.pencil", accentToken: "violet"),
+        .init(id: "talkie-settings", title: "Tell Mac", subtitle: "Speak a command for this Mac.", iconSystemName: "waveform.badge.mic", accentToken: "pink"),
+        .init(id: "talkie-search", title: "Search", subtitle: "Search apps and commands on the Mac.", iconSystemName: "magnifyingglass", accentToken: "blue"),
+        .init(id: "mac-claude", title: "Claude", subtitle: "Open the Claude console.", iconSystemName: "sparkles", accentToken: "violet"),
+        .init(id: "talkie-agent", title: "Agent Console", subtitle: "Open the secondary agent console.", iconSystemName: "circle.grid.cross", accentToken: "blue"),
+        .init(id: "talkie-ssh", title: "Shell", subtitle: "Open a remote shell.", iconSystemName: "terminal", accentToken: "green"),
+        .init(id: "mac-sessions", title: "Run Workflow", subtitle: "Choose a saved workflow.", iconSystemName: "wand.and.stars", accentToken: "teal"),
+        .init(id: "talkie-keyboard", title: "Record Screen", subtitle: "Start a screen recording.", iconSystemName: "record.circle", accentToken: "red"),
+        .init(id: "talkie-command", title: "Commands", subtitle: "Choose a command to run.", iconSystemName: "command", accentToken: "violet"),
+        .init(id: "talkie-memos", title: "Notes", subtitle: "Open recorded notes.", iconSystemName: "waveform", accentToken: "pink"),
         .init(id: "talkie-home", title: "Home", subtitle: "Bring Talkie home to the front.", iconSystemName: "house", accentToken: "violet"),
         .init(id: "talkie-pending", title: "Pending", subtitle: "Open Talkie's pending actions.", iconSystemName: "hourglass", accentToken: "amber"),
         .init(id: "talkie-recent", title: "Recents", subtitle: "Open Talkie's recent activity.", iconSystemName: "clock.arrow.circlepath", accentToken: "amber"),

--- a/apps/mac/Sources/Core/System/DiagnosticLog.swift
+++ b/apps/mac/Sources/Core/System/DiagnosticLog.swift
@@ -36,14 +36,13 @@ final class DiagnosticLog: ObservableObject {
 
     @Published private(set) var entries: [Entry] = []
 
-    private let store = HudLogStore.shared
     private let logger = HudLogger(subsystem: "dev.lattices.app", category: "diagnostic")
     private var cancellables = Set<AnyCancellable>()
 
     private init() {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            self.store.$entries
+            HudLogStore.shared.$entries
                 .receive(on: DispatchQueue.main)
                 .map { $0.map(Entry.init(hud:)) }
                 .sink { [weak self] mapped in
@@ -63,7 +62,7 @@ final class DiagnosticLog: ObservableObject {
     func error(_ msg: String)   { log(msg, level: .error) }
     func clear() {
         Task { @MainActor in
-            store.clear()
+            HudLogStore.shared.clear()
         }
     }
 

--- a/apps/mac/Tests/CompanionCockpitMappingTests.swift
+++ b/apps/mac/Tests/CompanionCockpitMappingTests.swift
@@ -1,0 +1,349 @@
+import XCTest
+import DeckKit
+@testable import Lattices
+
+final class CompanionCockpitMappingTests: XCTestCase {
+    func testSpaceTargetUsesSelectedDisplayAndZeroBasedIndex() throws {
+        let displays = [
+            DisplaySpaces(
+                displayIndex: 0,
+                displayId: "primary",
+                spaces: [
+                    SpaceInfo(id: 10, index: 1, display: 0, isCurrent: true),
+                ],
+                currentSpaceId: 10
+            ),
+            DisplaySpaces(
+                displayIndex: 1,
+                displayId: "secondary",
+                spaces: [
+                    SpaceInfo(id: 20, index: 1, display: 1, isCurrent: true),
+                    SpaceInfo(id: 21, index: 2, display: 1, isCurrent: false),
+                ],
+                currentSpaceId: 20
+            ),
+        ]
+
+        let target = try XCTUnwrap(
+            LatticesDeckHost.resolveSpaceTarget(
+                displays: displays,
+                displayIndex: 1,
+                index: 1
+            )
+        )
+        XCTAssertEqual(target.display.displayIndex, 1)
+        XCTAssertEqual(target.space.id, 21)
+        XCTAssertEqual(target.space.index, 2)
+        XCTAssertNil(
+            LatticesDeckHost.resolveSpaceTarget(
+                displays: displays,
+                displayIndex: 0,
+                index: 1
+            )
+        )
+    }
+
+    func testLegacyTrustedDeviceDoesNotGainScreenPreviewCapability() throws {
+        let json = """
+        {
+          "id": "legacy-ipad",
+          "name": "Legacy iPad",
+          "publicKey": "public-key",
+          "fingerprint": "ABCD-1234",
+          "platform": "iPadOS",
+          "pairedAt": 0,
+          "lastSeenAt": 0
+        }
+        """.data(using: .utf8)!
+
+        let record = try JSONDecoder().decode(LatticesCompanionTrustedDeviceRecord.self, from: json)
+        XCTAssertEqual(record.effectiveCapabilities, DeckBridgeCapability.legacyCompanionCapabilities)
+        XCTAssertFalse(record.effectiveCapabilities.contains(DeckBridgeCapability.screenPreview))
+    }
+
+    func testExistingExplicitPairingRequiresApprovalForScreenPreviewUpgrade() {
+        let existing = DeckBridgeCapability.legacyCompanionCapabilities
+        let requested = DeckBridgeCapability.defaultCompanionCapabilities
+        XCTAssertEqual(
+            LatticesCompanionSecurityCoordinator.additionalCapabilities(
+                existing: existing,
+                requested: requested
+            ),
+            [DeckBridgeCapability.screenPreview]
+        )
+        XCTAssertEqual(
+            LatticesCompanionSecurityCoordinator.capabilitiesAfterPairingRequest(
+                existing: existing,
+                requested: requested,
+                upgradeApproved: false
+            ),
+            existing.sorted()
+        )
+        XCTAssertTrue(
+            LatticesCompanionSecurityCoordinator.capabilitiesAfterPairingRequest(
+                existing: existing,
+                requested: requested,
+                upgradeApproved: true
+            ).contains(DeckBridgeCapability.screenPreview)
+        )
+    }
+
+    func testPairingDisclosureNamesScreenAndPointerAccess() {
+        XCTAssertEqual(
+            LatticesCompanionSecurityCoordinator.userFacingCapabilityName(
+                DeckBridgeCapability.screenPreview
+            ),
+            "View this Mac's screen"
+        )
+        XCTAssertEqual(
+            LatticesCompanionSecurityCoordinator.userFacingCapabilityName(
+                DeckBridgeCapability.inputTrackpad
+            ),
+            "Move, click, and scroll the pointer"
+        )
+
+        let legacyEmptyRequestDisclosure = LatticesCompanionSecurityCoordinator
+            .grantedCapabilities(for: [])
+            .map(LatticesCompanionSecurityCoordinator.userFacingCapabilityName)
+        XCTAssertTrue(legacyEmptyRequestDisclosure.contains("View this Mac's screen"))
+        XCTAssertTrue(legacyEmptyRequestDisclosure.contains("Move, click, and scroll the pointer"))
+    }
+
+    func testDesktopPreviewIsNativeCompanionNavigation() throws {
+        let state = LatticesCompanionCockpitCatalog.renderedState(
+            layout: LatticesCompanionCockpitCatalog.defaultLayout,
+            voice: nil,
+            desktop: nil,
+            layoutState: nil,
+            talkie: .unavailable
+        )
+
+        let page = try XCTUnwrap(state.pages.first(where: { $0.id == "remote" }))
+        let tile = try XCTUnwrap(page.tiles.first(where: { $0.shortcutID == "mac-windows" }))
+        let definition = try XCTUnwrap(LatticesCompanionCockpitCatalog.definition(for: "mac-windows"))
+
+        XCTAssertEqual(tile.title, "Desktop Preview")
+        XCTAssertEqual(tile.actionID, "desktop.preview.open")
+        XCTAssertTrue(tile.payload.isEmpty)
+        XCTAssertEqual(definition.category.id, "layout")
+        XCTAssertNil(TalkieDeckProvider.shortcut(for: "mac-windows"))
+    }
+
+    func testStarterDeckIsJobBasedAndHasNoRepeatedActions() throws {
+        let layout = LatticesCompanionCockpitCatalog.defaultLayout
+        XCTAssertEqual(layout.pages.map(\.id), ["remote", "move", "speak-run"])
+
+        let shortcutIDs = layout.pages.flatMap { page in
+            page.slots?.map(\.shortcutID) ?? page.slotIDs.filter { !$0.isEmpty }
+        }
+        XCTAssertEqual(shortcutIDs.count, 21)
+        XCTAssertEqual(Set(shortcutIDs).count, shortcutIDs.count)
+    }
+
+    func testStarterDeckPositionedControlsStayInsideTheirPagesWithoutOverlap() throws {
+        for page in LatticesCompanionCockpitCatalog.defaultLayout.pages {
+            let rows = try XCTUnwrap(page.rows)
+            let slots = try XCTUnwrap(page.slots)
+            var occupied = Set<String>()
+
+            for slot in slots {
+                XCTAssertGreaterThanOrEqual(slot.col, 0)
+                XCTAssertGreaterThanOrEqual(slot.row, 0)
+                XCTAssertLessThanOrEqual(slot.col + slot.colSpan, page.columns)
+                XCTAssertLessThanOrEqual(slot.row + slot.rowSpan, rows)
+
+                for row in slot.row..<(slot.row + slot.rowSpan) {
+                    for col in slot.col..<(slot.col + slot.colSpan) {
+                        XCTAssertTrue(
+                            occupied.insert("\(col),\(row)").inserted,
+                            "\(page.id) overlaps at column \(col), row \(row)"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    func testStarterDeckRemainsUsefulAndHonestWithoutTalkie() {
+        let state = LatticesCompanionCockpitCatalog.renderedState(
+            layout: LatticesCompanionCockpitCatalog.defaultLayout,
+            voice: nil,
+            desktop: nil,
+            layoutState: nil,
+            talkie: .unavailable
+        )
+
+        XCTAssertEqual(state.pages.map { $0.tiles.filter(\.isEnabled).count }, [4, 11, 2])
+        XCTAssertTrue(state.pages.flatMap(\.tiles).allSatisfy { $0.title != "Empty" })
+
+        let speakPage = state.pages.first(where: { $0.id == "speak-run" })
+        let providerTiles = speakPage?.tiles.filter { $0.shortcutID.hasPrefix("talkie-") || $0.shortcutID == "mac-sessions" }
+        XCTAssertEqual(providerTiles?.count, 4)
+        XCTAssertTrue(providerTiles?.allSatisfy { !$0.isEnabled && $0.actionID == nil } == true)
+    }
+
+    func testBuilderCatalogIncludesEveryAssignableShortcut() throws {
+        let json = try XCTUnwrap(CompanionDeckBuilderView.builderCatalogJSON())
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let groups = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [[String: Any]])
+        let actualIDs = Set(groups.flatMap { group in
+            (group["items"] as? [[String: Any]] ?? []).compactMap { $0["id"] as? String }
+        })
+        let expectedIDs = Set(
+            LatticesCompanionCockpitCatalog.shortcuts.map(\.id).filter { !$0.isEmpty }
+        )
+
+        XCTAssertEqual(actualIDs, expectedIDs)
+    }
+
+    func testBuilderRoundTripPreservesPageMetadataAndVisualOverrides() throws {
+        let layout = LatticesCompanionCockpitLayout(pages: [
+            .init(
+                id: "personal",
+                title: "My Page",
+                subtitle: "A carefully tuned remote",
+                columns: 3,
+                rows: 2,
+                slots: [
+                    .init(
+                        shortcutID: "key-copy",
+                        col: 0,
+                        row: 0,
+                        colSpan: 2,
+                        customLabel: "Copy the Good Part",
+                        customBuilderIcon: "Sparkles",
+                        customTint: "pink",
+                        customCategory: "personal"
+                    ),
+                    .init(shortcutID: "key-paste", col: 2, row: 0),
+                ]
+            )
+        ])
+
+        let json = try XCTUnwrap(CompanionDeckBuilderView.builderJSON(for: layout))
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let imported = try XCTUnwrap(CompanionDeckBuilderView.liveLayout(from: data))
+        let page = try XCTUnwrap(imported.pages.first)
+        let slots = try XCTUnwrap(page.slots)
+
+        XCTAssertEqual(page.subtitle, "A carefully tuned remote")
+        XCTAssertEqual(slots[0].customLabel, "Copy the Good Part")
+        XCTAssertEqual(slots[0].customBuilderIcon, "Sparkles")
+        XCTAssertEqual(slots[0].customTint, "pink")
+        XCTAssertEqual(slots[0].customCategory, "personal")
+        XCTAssertNil(slots[1].customLabel)
+        XCTAssertNil(slots[1].customBuilderIcon)
+        XCTAssertNil(slots[1].customTint)
+        XCTAssertNil(slots[1].customCategory)
+
+        let rendered = LatticesCompanionCockpitCatalog.renderedState(
+            layout: imported,
+            voice: nil,
+            desktop: nil,
+            layoutState: nil,
+            talkie: .unavailable
+        )
+        let tile = try XCTUnwrap(rendered.pages.first?.tiles.first)
+        XCTAssertEqual(tile.title, "Copy the Good Part")
+        XCTAssertEqual(tile.iconSystemName, "sparkles")
+        XCTAssertEqual(tile.categoryTint, "pink")
+    }
+
+    func testNormalizationPreservesAUserDefinedPageSetAndOrder() {
+        let custom = LatticesCompanionCockpitLayout(pages: [
+            .init(id: "favorites", title: "Favorites", columns: 3, slotIDs: ["key-copy"]),
+            .init(id: "remote", title: "My Remote", columns: 4, slotIDs: ["mac-windows"]),
+        ])
+
+        let normalized = LatticesCompanionCockpitCatalog.normalized(custom)
+        XCTAssertEqual(normalized.pages.map(\.id), ["favorites", "remote"])
+        XCTAssertEqual(normalized.pages.map(\.title), ["Favorites", "My Remote"])
+        XCTAssertEqual(normalized.pages[0].slotIDs.first, "key-copy")
+        XCTAssertEqual(normalized.pages[0].slotIDs.count, 16)
+    }
+
+    func testNormalizationRelocatesClampedSlotsWithoutOverlap() throws {
+        let custom = LatticesCompanionCockpitLayout(pages: [
+            .init(
+                id: "oversized",
+                title: "Oversized",
+                columns: 6,
+                rows: 6,
+                slots: (0..<16).map { index in
+                    .init(shortcutID: "key-\(index)", col: index % 6, row: index / 6)
+                }
+            ),
+        ])
+
+        let page = try XCTUnwrap(LatticesCompanionCockpitCatalog.normalized(custom).pages.first)
+        let slots = try XCTUnwrap(page.slots)
+        var occupied = Set<String>()
+        XCTAssertEqual(page.columns, 5)
+        XCTAssertEqual(page.rows, 4)
+        XCTAssertEqual(slots.count, 16)
+
+        for slot in slots {
+            for row in slot.row..<(slot.row + slot.rowSpan) {
+                for col in slot.col..<(slot.col + slot.colSpan) {
+                    XCTAssertTrue(occupied.insert("\(col),\(row)").inserted)
+                }
+            }
+        }
+    }
+
+    func testV4MigrationReplacesOnlyUntouchedStarters() {
+        XCTAssertEqual(
+            Preferences.migrateCompanionCockpitLayout(
+                LatticesCompanionCockpitCatalog.legacyDefaultLayoutV2,
+                fromVersion: 2
+            ),
+            LatticesCompanionCockpitCatalog.defaultLayout
+        )
+
+        XCTAssertEqual(
+            Preferences.migrateCompanionCockpitLayout(
+                LatticesCompanionCockpitCatalog.legacyDefaultLayoutV3,
+                fromVersion: 3
+            ),
+            LatticesCompanionCockpitCatalog.defaultLayout
+        )
+
+        var customized = LatticesCompanionCockpitCatalog.legacyDefaultLayoutV2
+        customized.pages[0].title = "My Commands"
+        XCTAssertEqual(
+            Preferences.migrateCompanionCockpitLayout(customized, fromVersion: 2),
+            customized
+        )
+
+        var customizedV3 = LatticesCompanionCockpitCatalog.legacyDefaultLayoutV3
+        customizedV3.pages[0].title = "My Remote"
+        XCTAssertEqual(
+            Preferences.migrateCompanionCockpitLayout(customizedV3, fromVersion: 3),
+            customizedV3
+        )
+    }
+
+    func testV4MigrationAdvancesTheUntouchedV1StarterThroughEveryVersion() throws {
+        var v1Starter = LatticesCompanionCockpitCatalog.legacyDefaultLayoutV2
+        let devIndex = try XCTUnwrap(v1Starter.pages.firstIndex(where: { $0.id == "dev" }))
+        v1Starter.pages[devIndex].slotIDs = [
+            "key-copy", "key-paste", "key-undo", "key-shift-tab",
+            "place-left", "place-right", "resize-wider", "resize-narrower",
+            "switch-window-prev", "switch-window-next", "switch-app-prev", "switch-app-next",
+            "layout-optimize", "mouse-find", "key-up", "key-down",
+        ]
+
+        XCTAssertEqual(
+            Preferences.migrateCompanionCockpitLayout(v1Starter, fromVersion: 1),
+            LatticesCompanionCockpitCatalog.defaultLayout
+        )
+
+        var renamed = v1Starter
+        renamed.pages[devIndex].title = "My Development Keys"
+        renamed.pages[devIndex].subtitle = "Keep this personal grouping"
+        XCTAssertEqual(
+            Preferences.migrateCompanionCockpitLayout(renamed, fromVersion: 1),
+            renamed
+        )
+    }
+}

--- a/swift/Sources/DeckKit/DeckBridgeSecurity.swift
+++ b/swift/Sources/DeckKit/DeckBridgeSecurity.swift
@@ -41,7 +41,7 @@ public struct DeckPairingRequest: Codable, Equatable, Sendable {
         platform = try container.decode(String.self, forKey: .platform)
         appVersion = try container.decodeIfPresent(String.self, forKey: .appVersion)
         requestedCapabilities = try container.decodeIfPresent([String].self, forKey: .requestedCapabilities)
-            ?? DeckBridgeCapability.defaultCompanionCapabilities
+            ?? DeckBridgeCapability.legacyCompanionCapabilities
     }
 }
 
@@ -95,7 +95,7 @@ public struct DeckPairingResponse: Codable, Equatable, Sendable {
         requestSigningRequired = try container.decode(Bool.self, forKey: .requestSigningRequired)
         payloadEncryptionRequired = try container.decode(Bool.self, forKey: .payloadEncryptionRequired)
         grantedCapabilities = try container.decodeIfPresent([String].self, forKey: .grantedCapabilities)
-            ?? DeckBridgeCapability.defaultCompanionCapabilities
+            ?? DeckBridgeCapability.legacyCompanionCapabilities
         detail = try container.decodeIfPresent(String.self, forKey: .detail)
     }
 }
@@ -143,10 +143,15 @@ public enum DeckBridgeCapability {
     public static let deckRead = "deck.read"
     public static let deckPerform = "deck.perform"
     public static let inputTrackpad = "input.trackpad"
+    public static let screenPreview = "screen.preview"
 
-    public static let defaultCompanionCapabilities = [
+    /// Capabilities granted before pairing records stored an explicit list.
+    /// This must remain frozen: expanding it would silently elevate old trust.
+    public static let legacyCompanionCapabilities = [
         deckRead,
         deckPerform,
         inputTrackpad,
     ]
+
+    public static let defaultCompanionCapabilities = legacyCompanionCapabilities + [screenPreview]
 }

--- a/swift/Sources/DeckKit/DeckDesktopPreview.swift
+++ b/swift/Sources/DeckKit/DeckDesktopPreview.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+public enum DeckDesktopPreviewScope: String, Codable, CaseIterable, Sendable {
+    case display
+    case frontmostWindow
+}
+
+/// A bounded request for one current desktop frame.
+///
+/// Desktop preview is intentionally pull-based: the iPad asks for the next
+/// frame only after it has decoded the previous one. That keeps a slow or
+/// backgrounded client from building an unbounded capture queue on the Mac.
+public struct DeckDesktopPreviewRequest: Codable, Equatable, Sendable {
+    public var displayIndex: Int?
+    public var maxPixelWidth: Int
+    public var scope: DeckDesktopPreviewScope
+
+    public init(
+        displayIndex: Int? = nil,
+        maxPixelWidth: Int = 1_440,
+        scope: DeckDesktopPreviewScope = .display
+    ) {
+        self.displayIndex = displayIndex
+        self.maxPixelWidth = maxPixelWidth
+        self.scope = scope
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case displayIndex
+        case maxPixelWidth
+        case scope
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        displayIndex = try container.decodeIfPresent(Int.self, forKey: .displayIndex)
+        maxPixelWidth = try container.decodeIfPresent(Int.self, forKey: .maxPixelWidth) ?? 1_440
+        scope = try container.decodeIfPresent(DeckDesktopPreviewScope.self, forKey: .scope) ?? .display
+    }
+}
+
+public struct DeckDesktopPreviewDisplay: Codable, Equatable, Identifiable, Sendable {
+    public var id: Int { displayIndex }
+    public var displayIndex: Int
+    public var name: String
+    public var pixelWidth: Int
+    public var pixelHeight: Int
+
+    public init(
+        displayIndex: Int,
+        name: String,
+        pixelWidth: Int,
+        pixelHeight: Int
+    ) {
+        self.displayIndex = displayIndex
+        self.name = name
+        self.pixelWidth = pixelWidth
+        self.pixelHeight = pixelHeight
+    }
+}
+
+/// One encrypted JPEG frame plus enough display metadata for the iPad to let
+/// the user move between monitors without a second discovery request.
+public struct DeckDesktopPreviewFrame: Codable, Equatable, Sendable {
+    public var capturedAt: Date
+    public var displayIndex: Int
+    public var displays: [DeckDesktopPreviewDisplay]
+    public var pixelWidth: Int
+    public var pixelHeight: Int
+    public var jpegBase64: String
+
+    public init(
+        capturedAt: Date = .now,
+        displayIndex: Int,
+        displays: [DeckDesktopPreviewDisplay],
+        pixelWidth: Int,
+        pixelHeight: Int,
+        jpegBase64: String
+    ) {
+        self.capturedAt = capturedAt
+        self.displayIndex = displayIndex
+        self.displays = displays
+        self.pixelWidth = pixelWidth
+        self.pixelHeight = pixelHeight
+        self.jpegBase64 = jpegBase64
+    }
+}

--- a/swift/Sources/DeckKit/DeckTrackpad.swift
+++ b/swift/Sources/DeckKit/DeckTrackpad.swift
@@ -8,6 +8,9 @@ public struct DeckTrackpadState: Codable, Equatable, Sendable {
     public var pointerScale: Double
     public var scrollScale: Double
     public var supportsDragLock: Bool
+    /// Current Mac pointer position normalized across the complete desktop.
+    public var pointerX: Double?
+    public var pointerY: Double?
 
     public init(
         isEnabled: Bool,
@@ -16,7 +19,9 @@ public struct DeckTrackpadState: Codable, Equatable, Sendable {
         statusDetail: String? = nil,
         pointerScale: Double = 1.6,
         scrollScale: Double = 1.0,
-        supportsDragLock: Bool = true
+        supportsDragLock: Bool = true,
+        pointerX: Double? = nil,
+        pointerY: Double? = nil
     ) {
         self.isEnabled = isEnabled
         self.isAvailable = isAvailable
@@ -25,6 +30,8 @@ public struct DeckTrackpadState: Codable, Equatable, Sendable {
         self.pointerScale = pointerScale
         self.scrollScale = scrollScale
         self.supportsDragLock = supportsDragLock
+        self.pointerX = pointerX
+        self.pointerY = pointerY
     }
 }
 
@@ -56,8 +63,12 @@ public enum DeckTrackpadEvent: String, Codable, CaseIterable, Sendable {
 
 public struct DeckTrackpadEventResult: Codable, Equatable, Sendable {
     public var ok: Bool
+    public var pointerX: Double?
+    public var pointerY: Double?
 
-    public init(ok: Bool) {
+    public init(ok: Bool, pointerX: Double? = nil, pointerY: Double? = nil) {
         self.ok = ok
+        self.pointerX = pointerX
+        self.pointerY = pointerY
     }
 }

--- a/swift/Tests/DeckKitTests/DeckKitTests.swift
+++ b/swift/Tests/DeckKitTests/DeckKitTests.swift
@@ -82,7 +82,8 @@ final class DeckKitTests: XCTestCase {
         """.data(using: .utf8)!
 
         let decodedResponse = try JSONDecoder().decode(DeckPairingResponse.self, from: responseJSON)
-        XCTAssertEqual(decodedResponse.grantedCapabilities, DeckBridgeCapability.defaultCompanionCapabilities)
+        XCTAssertEqual(decodedResponse.grantedCapabilities, DeckBridgeCapability.legacyCompanionCapabilities)
+        XCTAssertFalse(decodedResponse.grantedCapabilities.contains(DeckBridgeCapability.screenPreview))
 
         let requestJSON = """
         {
@@ -94,7 +95,60 @@ final class DeckKitTests: XCTestCase {
         """.data(using: .utf8)!
 
         let decodedRequest = try JSONDecoder().decode(DeckPairingRequest.self, from: requestJSON)
-        XCTAssertEqual(decodedRequest.requestedCapabilities, DeckBridgeCapability.defaultCompanionCapabilities)
+        XCTAssertEqual(decodedRequest.requestedCapabilities, DeckBridgeCapability.legacyCompanionCapabilities)
+        XCTAssertFalse(decodedRequest.requestedCapabilities.contains(DeckBridgeCapability.screenPreview))
+    }
+
+    func testDefaultCompanionCapabilitiesIncludeProtectedScreenPreview() {
+        XCTAssertTrue(
+            DeckBridgeCapability.defaultCompanionCapabilities.contains(DeckBridgeCapability.screenPreview)
+        )
+    }
+
+    func testDesktopPreviewFrameRoundTripPreservesDisplayMetadata() throws {
+        let frame = DeckDesktopPreviewFrame(
+            capturedAt: Date(timeIntervalSince1970: 1_713_700_000),
+            displayIndex: 1,
+            displays: [
+                DeckDesktopPreviewDisplay(
+                    displayIndex: 0,
+                    name: "Studio Display",
+                    pixelWidth: 5_120,
+                    pixelHeight: 2_880
+                ),
+                DeckDesktopPreviewDisplay(
+                    displayIndex: 1,
+                    name: "Built-in Display",
+                    pixelWidth: 3_456,
+                    pixelHeight: 2_234
+                ),
+            ],
+            pixelWidth: 1_440,
+            pixelHeight: 931,
+            jpegBase64: "aW1hZ2U="
+        )
+
+        let data = try JSONEncoder().encode(frame)
+        let decoded = try JSONDecoder().decode(DeckDesktopPreviewFrame.self, from: data)
+
+        XCTAssertEqual(decoded, frame)
+        XCTAssertEqual(decoded.displays.map(\.id), [0, 1])
+    }
+
+    func testDesktopPreviewRequestDecodesLegacyDisplayScope() throws {
+        let data = #"{"displayIndex":0,"maxPixelWidth":960}"#.data(using: .utf8)!
+        let request = try JSONDecoder().decode(DeckDesktopPreviewRequest.self, from: data)
+
+        XCTAssertEqual(request.scope, .display)
+        XCTAssertEqual(request.maxPixelWidth, 960)
+    }
+
+    func testTrackpadResultPreservesNormalizedPointerPosition() throws {
+        let result = DeckTrackpadEventResult(ok: true, pointerX: 0.42, pointerY: 0.73)
+        let data = try JSONEncoder().encode(result)
+        let decoded = try JSONDecoder().decode(DeckTrackpadEventResult.self, from: data)
+
+        XCTAssertEqual(decoded, result)
     }
 
     func testRuntimeSnapshotRoundTripPreservesSwitcherAndHistory() throws {


### PR DESCRIPTION
## Summary
- replace category-heavy starter pages with a job-based companion deck and migration path
- add native current-window desktop preview plus cursor/trackpad feedback and display-aware Space navigation
- harden pairing capability upgrades for screen preview and pointer control
- keep the native builder catalog and Talkie-backed commands aligned

## Verification
- `swift test --package-path swift` — 13 tests passed
- `LATTICES_HUDSON_SOURCE=git HUDSONKIT_WITH_VOICE=1 swift test --package-path apps/mac --filter CompanionCockpitMappingTests` — 14 tests passed
- iOS Simulator `xcodebuild` — build succeeded
- `git diff --check` — clean

## Stack
2 of 4. Depends on #81. The web Deck Builder bundle and app icon follow in separate PRs.