### PR TITLE
Harden assistant, voice, companion deck, and Space navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 - Window navigation falls through CG → AX → AppleScript depending on macOS permissions
 - Space switching uses private SkyLight framework APIs loaded via dlopen at runtime
 - The daemon runs on ws://127.0.0.1:9399 with 35+ RPC methods and real-time events (localhost only, no auth by design)
+- Voice runtime is hosted in-process by the menu bar app on ws://127.0.0.1:9398 (deterministic Lattices port family: 9399 agent API, 9398 voice; see `LatticesLocalEndpoints` / `docs/voice.md`)
 - Bare `lattices` (no args) shows a home/status screen — use `lattices start` (alias: `lattices tmux`) to create or attach a session
 - `lattices search <q> --deep` and `--all` both request all search sources (index + live terminal inspection)
 

--- a/apps/ios/Sources/FleetDeck/FleetDeckChannelStrip.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckChannelStrip.swift
@@ -2,40 +2,37 @@ import SwiftUI
 
 // MARK: - Channel strip
 //
-// `.fd-channels` — four columns in one recessed well. Tap a column to put that
-// Mac on deck. Blocked channels sort to the front; the status dot is the only
-// marker they carry.
+// Compact, horizontally scrollable host rail. Selecting a Mac also makes it the
+// route for commands and voice, so the deck does not need a second destination
+// picker.
 
 struct FleetChannelStrip: View {
     let channels: [FleetChannel]
     let order: [Int]
     let currentIndex: Int
-    /// `focus` collapses the strip to a 52pt switcher rail.
+    /// Retained for source compatibility; both layouts use the compact rail.
     let layout: FleetDeckLayout
     let onSelect: (Int) -> Void
 
     var body: some View {
-        FleetWell {
-            HStack(spacing: 0) {
+        ScrollView(.horizontal) {
+            LazyHStack(spacing: 6) {
                 ForEach(order, id: \.self) { index in
                     if channels.indices.contains(index) {
                         FleetChannelColumn(
                             channel: channels[index],
                             isActive: index == currentIndex,
-                            isRail: layout == .focus,
+                            isRail: true,
                             onSelect: { onSelect(index) }
                         )
-                        .frame(maxWidth: .infinity)
-                        .overlay(alignment: .leading) {
-                            if index != order.first {
-                                Rectangle().fill(FleetV6.brk2).frame(width: 1)
-                            }
-                        }
+                        .frame(width: 210)
                     }
                 }
             }
+            .padding(.horizontal, 4)
         }
-        .frame(height: layout == .focus ? FleetV6.M.channelsRailHeight : FleetV6.M.channelsHeight)
+        .scrollIndicators(.hidden)
+        .frame(height: 44)
     }
 }
 

--- a/apps/ios/Sources/FleetDeck/FleetDeckCommandBay.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckCommandBay.swift
@@ -15,8 +15,20 @@ struct FleetCommandBay: View {
         sets.indices.contains(setIndex) ? sets[setIndex].tiles : []
     }
 
-    private var columns: [GridItem] {
-        Array(repeating: GridItem(.flexible(), spacing: FleetV6.M.tileGap), count: 4)
+    private var activeSet: FleetCommandSet? {
+        sets.indices.contains(setIndex) ? sets[setIndex] : nil
+    }
+
+    private var columnCount: Int {
+        max(1, activeSet?.columns ?? 4)
+    }
+
+    private var rowCount: Int {
+        let flowRows = Int(ceil(Double(max(tiles.count, 1)) / Double(columnCount)))
+        let positionedRows = tiles.compactMap { tile in
+            tile.row.map { $0 + max(1, tile.rowSpan) }
+        }.max() ?? 0
+        return max(2, activeSet?.rows ?? 0, flowRows, positionedRows)
     }
 
     var body: some View {
@@ -24,6 +36,7 @@ struct FleetCommandBay: View {
             tabs
             grid
         }
+        .frame(maxHeight: .infinity)
         .background(FleetV6.tilesWrapBG)
         .overlay(alignment: .top) {
             ZStack(alignment: .top) {
@@ -36,49 +49,42 @@ struct FleetCommandBay: View {
     // `.set-tabs`
     private var tabs: some View {
         HStack(spacing: 8) {
-            FleetLabel(text: "COMMANDS")
-                .padding(.trailing, 4)
+            ScrollView(.horizontal) {
+                HStack(spacing: 8) {
+                    FleetLabel(text: "COMMANDS")
+                        .padding(.trailing, 4)
 
-            ForEach(Array(sets.enumerated()), id: \.element.id) { index, set in
-                Button { onSelectSet(index) } label: {
-                    HStack(spacing: 6) {
-                        Text("\(index + 1)")
-                            .foregroundStyle(FleetV6.fg4)
-                        Text(set.key)
-                            .foregroundStyle(index == setIndex ? FleetV6.fg : FleetV6.fg4)
-                    }
-                    .font(FleetV6.mono(10, .medium))
-                    .tracking(1.4)
-                    .padding(.horizontal, 14)
-                    .padding(.vertical, 6)
-                    .background {
-                        RoundedRectangle(cornerRadius: 6, style: .continuous)
-                            .fill(
-                                index == setIndex
-                                    ? AnyShapeStyle(Color.white.opacity(0.07))
-                                    : AnyShapeStyle(
-                                        LinearGradient(
-                                            colors: [FleetV6.rgb(0x101113), FleetV6.rgb(0x0B0C0D)],
-                                            startPoint: .top,
-                                            endPoint: .bottom
-                                        )
-                                    )
-                            )
-                            .overlay {
-                                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                    .strokeBorder(
-                                        index == setIndex ? Color.white.opacity(0.16) : FleetV6.brk2,
-                                        lineWidth: 1
-                                    )
+                    ForEach(Array(sets.enumerated()), id: \.element.id) { index, set in
+                        Button { onSelectSet(index) } label: {
+                            HStack(spacing: 6) {
+                                Text("\(index + 1)")
+                                    .foregroundStyle(FleetV6.fg4)
+                                Text(set.key)
+                                    .foregroundStyle(index == setIndex ? FleetV6.fg : FleetV6.fg4)
                             }
+                            .font(FleetV6.mono(10, .medium))
+                            .tracking(1.1)
+                            .padding(.horizontal, 14)
+                            .frame(minHeight: 44)
+                            .background {
+                                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                    .fill(index == setIndex ? Color.white.opacity(0.07) : .clear)
+                                    .overlay {
+                                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                            .strokeBorder(
+                                                index == setIndex ? Color.white.opacity(0.16) : FleetV6.brk2,
+                                                lineWidth: 1
+                                            )
+                                    }
+                            }
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityAddTraits(index == setIndex ? [.isSelected, .isButton] : .isButton)
                     }
-                    .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
-                .accessibilityAddTraits(index == setIndex ? [.isSelected, .isButton] : .isButton)
             }
-
-            Spacer(minLength: 8)
+            .scrollIndicators(.hidden)
 
             Text("SET \(setIndex + 1) / \(max(sets.count, 1))")
                 .font(FleetV6.mono(9.5, .medium))
@@ -87,20 +93,43 @@ struct FleetCommandBay: View {
                 .foregroundStyle(FleetV6.fg4)
         }
         .padding(.horizontal, 15)
-        .padding(.top, 10)
+        .padding(.vertical, 6)
     }
 
     // `.deck-tiles`
     private var grid: some View {
-        LazyVGrid(columns: columns, spacing: FleetV6.M.tileGap) {
-            ForEach(tiles) { tile in
-                FleetCommandTileView(tile: tile) { onTile(tile) }
+        GeometryReader { proxy in
+            let horizontalPadding: CGFloat = 15
+            let verticalPadding: CGFloat = 10
+            let gap = FleetV6.M.tileGap
+            let contentWidth = max(0, proxy.size.width - horizontalPadding * 2)
+            let contentHeight = max(0, proxy.size.height - verticalPadding * 2)
+            let cellWidth = max(0, (contentWidth - gap * CGFloat(columnCount - 1)) / CGFloat(columnCount))
+            let cellHeight = max(0, (contentHeight - gap * CGFloat(rowCount - 1)) / CGFloat(rowCount))
+
+            ZStack(alignment: .topLeading) {
+                ForEach(Array(tiles.enumerated()), id: \.element.id) { index, tile in
+                    let col = min(max(0, tile.col ?? index % columnCount), columnCount - 1)
+                    let row = min(max(0, tile.row ?? index / columnCount), rowCount - 1)
+                    let colSpan = min(max(1, tile.colSpan), columnCount - col)
+                    let rowSpan = min(max(1, tile.rowSpan), rowCount - row)
+
+                    FleetCommandTileView(tile: tile) { onTile(tile) }
+                        .frame(
+                            width: cellWidth * CGFloat(colSpan) + gap * CGFloat(colSpan - 1),
+                            height: cellHeight * CGFloat(rowSpan) + gap * CGFloat(rowSpan - 1)
+                        )
+                        .offset(
+                            x: CGFloat(col) * (cellWidth + gap),
+                            y: CGFloat(row) * (cellHeight + gap)
+                        )
+                }
             }
+            .frame(width: contentWidth, height: contentHeight, alignment: .topLeading)
+            .padding(.horizontal, horizontalPadding)
+            .padding(.vertical, verticalPadding)
         }
-        .padding(.horizontal, 15)
-        .padding(.top, 10)
-        .padding(.bottom, 12)
-        .frame(height: FleetV6.M.tilesHeight + 22)
+        .frame(minHeight: 180, maxHeight: .infinity)
     }
 }
 
@@ -164,6 +193,8 @@ struct FleetCommandTileView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(FleetPressStyle())
+        .disabled(!tile.isEnabled)
+        .opacity(tile.isEnabled ? 1 : 0.45)
         .accessibilityLabel(tile.title)
         .accessibilityHint(tile.meta)
     }
@@ -178,34 +209,31 @@ struct FleetKeyRow: View {
     let onKey: (String, [String]) -> Void
 
     var body: some View {
-        HStack(spacing: 14) {
+        ScrollView(.horizontal) {
             HStack(spacing: 7) {
                 key("esc") { onKey("escape", []) }
                 key("⌘C") { onKey("c", ["command"]) }
                 key("⌘V") { onKey("v", ["command"]) }
                 key("⌘Z") { onKey("z", ["command"]) }
                 key("space", wide: true) { onKey("space", []) }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
 
-            HStack(spacing: 7) {
+                keyDivider
                 symbolKey("arrow.left") { onKey("left", []) }
                 symbolKey("arrow.up") { onKey("up", []) }
                 symbolKey("arrow.down") { onKey("down", []) }
                 symbolKey("arrow.right") { onKey("right", []) }
-            }
 
-            HStack(spacing: 7) {
+                keyDivider
                 key("⌃") { onKey("control", []) }
                 key("⌥") { onKey("option", []) }
                 key("⇧") { onKey("shift", []) }
                 key("⌘") { onKey("command", []) }
                 key("↵ enter", wide: true) { onKey("return", []) }
             }
-            .frame(maxWidth: .infinity, alignment: .trailing)
+            .padding(.horizontal, 13)
         }
-        .padding(.horizontal, 13)
-        .padding(.vertical, 8)
+        .scrollIndicators(.hidden)
+        .frame(height: FleetV6.M.keyRowHeight)
         .background(FleetV6.bezel)
         .overlay(alignment: .top) {
             ZStack(alignment: .top) {
@@ -215,13 +243,20 @@ struct FleetKeyRow: View {
         }
     }
 
+    private var keyDivider: some View {
+        Rectangle()
+            .fill(FleetV6.brk2)
+            .frame(width: 1, height: 24)
+            .padding(.horizontal, 4)
+    }
+
     private func key(_ label: String, wide: Bool = false, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Text(label)
                 .font(FleetV6.mono(12))
                 .foregroundStyle(FleetV6.fg2)
                 .padding(.horizontal, 12)
-                .frame(minWidth: wide ? 84 : 42, minHeight: 30)
+                .frame(minWidth: wide ? 88 : 44, minHeight: 44)
                 .background { FleetKeycapBackground() }
                 .contentShape(Rectangle())
         }
@@ -234,7 +269,7 @@ struct FleetKeyRow: View {
             Image(systemName: symbol)
                 .font(.system(size: 12, weight: .medium))
                 .foregroundStyle(FleetV6.fg2)
-                .frame(minWidth: 42, minHeight: 30)
+                .frame(minWidth: 44, minHeight: 44)
                 .background { FleetKeycapBackground() }
                 .contentShape(Rectangle())
         }

--- a/apps/ios/Sources/FleetDeck/FleetDeckCommands.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckCommands.swift
@@ -3,8 +3,8 @@ import Foundation
 
 extension FleetCommandSet {
 
-    /// The design's four command sets, in its order — AGENT first, because this
-    /// deck steers agents, not cursors.
+    /// The four core remote-control contexts shown when a Mac has not advertised
+    /// a deck yet. Live tiles still come from the selected Mac.
     ///
     /// These are the *shape* of the bay, used when a Mac advertises no cockpit
     /// pages of its own (and by the design fixture). Tiles here carry no
@@ -12,60 +12,60 @@ extension FleetCommandSet {
     /// which come with the bridge's real action IDs attached.
     static let canonical: [FleetCommandSet] = [
         FleetCommandSet(
-            id: "agent",
-            key: "AGENT",
+            id: "command",
+            key: "COMMAND",
             tiles: tiles([
-                ("Run Agent", "spawn", "sparkles"),
-                ("Steer", "redirect", "slider.horizontal.3"),
-                ("Approve", "unblock", "checkmark.circle"),
-                ("Reject", "redo", "xmark.circle"),
-                ("Handoff", "pass work", "arrow.right.to.line"),
-                ("Delegate", "fan out", "point.3.connected.trianglepath.dotted"),
-                ("Summarize", "digest", "text.alignleft"),
-                ("Stop", "halt", "stop.circle")
-            ], prefix: "agent")
+                ("Desktop Preview", "see Mac", "display"),
+                ("Paste Device", "clipboard", "rectangle.portrait.and.arrow.forward"),
+                ("Previous App", "switch", "chevron.left.square"),
+                ("Next App", "switch", "chevron.right.square"),
+                ("Previous Window", "switch", "rectangle.on.rectangle"),
+                ("Next Window", "switch", "rectangle.on.rectangle"),
+                ("Find Mouse", "locate", "scope"),
+                ("Summon Mouse", "center", "dot.scope")
+            ], prefix: "command")
         ),
         FleetCommandSet(
-            id: "review",
-            key: "REVIEW",
+            id: "dev",
+            key: "DEV",
             tiles: tiles([
-                ("Open Diff", "inspect", "plusminus"),
-                ("Run Tests", "suite", "testtube.2"),
-                ("Browser Check", "see result", "globe"),
-                ("Screenshot", "capture", "camera"),
-                ("Logs", "stream", "list.bullet"),
-                ("Commit", "git", "smallcircle.filled.circle"),
-                ("Push", "ship", "arrow.up.to.line"),
-                ("Revert", "undo", "arrow.uturn.backward")
-            ], prefix: "review")
+                ("Copy", "command C", "doc.on.doc"),
+                ("Paste", "command V", "doc.on.clipboard"),
+                ("Undo", "command Z", "arrow.uturn.backward"),
+                ("Escape", "dismiss", "escape"),
+                ("Enter", "return", "return"),
+                ("Space", "input", "space"),
+                ("Up", "navigate", "arrow.up"),
+                ("Down", "navigate", "arrow.down")
+            ], prefix: "dev")
         ),
         FleetCommandSet(
-            id: "window",
-            key: "WINDOW",
+            id: "media",
+            key: "MEDIA",
             tiles: tiles([
-                ("Focus App", "front", "scope"),
-                ("Tile Left", "snap", "rectangle.lefthalf.inset.filled"),
-                ("Tile Right", "snap", "rectangle.righthalf.inset.filled"),
-                ("Fullscreen", "zoom", "arrow.up.left.and.arrow.down.right"),
-                ("Center", "place", "rectangle.center.inset.filled"),
-                ("Next Window", "cycle", "arrow.right.square"),
-                ("Paste", "clip", "doc.on.clipboard"),
-                ("Terminal", "shell", "terminal")
-            ], prefix: "window")
+                ("Play / Pause", "space", "playpause"),
+                ("Back", "seek", "gobackward"),
+                ("Forward", "seek", "goforward"),
+                ("Center", "place", "plus.rectangle.on.rectangle"),
+                ("Maximize", "fill screen", "macwindow"),
+                ("Grow", "resize", "plus.rectangle.fill.on.rectangle.fill"),
+                ("Shrink", "resize", "minus.rectangle"),
+                ("Escape", "dismiss", "escape")
+            ], prefix: "media")
         ),
         FleetCommandSet(
-            id: "system",
-            key: "SYSTEM",
+            id: "windows",
+            key: "WINDOWS",
             tiles: tiles([
-                ("Lock", "secure", "lock"),
-                ("Sleep", "idle", "moon"),
-                ("Restart", "reboot", "arrow.clockwise"),
-                ("Snapshot", "capture", "camera"),
-                ("Sync", "push", "arrow.triangle.2.circlepath"),
-                ("Mute", "silence", "speaker.slash"),
-                ("Journal", "history", "list.bullet"),
-                ("Clear", "reset", "xmark.circle")
-            ], prefix: "system")
+                ("Top Left", "quarter", "rectangle.inset.topleft.filled"),
+                ("Top Right", "quarter", "rectangle.inset.topright.filled"),
+                ("Bottom Left", "quarter", "rectangle.inset.bottomleft.filled"),
+                ("Bottom Right", "quarter", "rectangle.inset.bottomright.filled"),
+                ("Left", "half", "rectangle.leadinghalf.filled"),
+                ("Right", "half", "rectangle.trailinghalf.filled"),
+                ("Maximize", "fill screen", "macwindow"),
+                ("Optimize", "retile", "rectangle.3.group.fill")
+            ], prefix: "windows")
         )
     ]
 
@@ -88,6 +88,8 @@ extension FleetCommandSet {
         self.init(
             id: page.id,
             key: page.title.uppercased(),
+            columns: max(1, page.columns),
+            rows: page.rows,
             tiles: page.tiles.enumerated().map { index, tile in
                 let hint = tile.subtitle?.lowercased() ?? tile.shortcutID.lowercased()
                 return FleetCommandTile(
@@ -96,7 +98,12 @@ extension FleetCommandSet {
                     meta: "\(String(format: "%02d", index + 1)) · \(hint)",
                     symbol: tile.iconSystemName,
                     actionID: tile.actionID,
-                    payload: tile.payload
+                    payload: tile.payload,
+                    isEnabled: tile.isEnabled,
+                    col: tile.col,
+                    row: tile.row,
+                    colSpan: max(1, tile.colSpan ?? 1),
+                    rowSpan: max(1, tile.rowSpan ?? 1)
                 )
             }
         )

--- a/apps/ios/Sources/FleetDeck/FleetDeckConsole.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckConsole.swift
@@ -446,7 +446,7 @@ struct FleetConsoleButton: View {
             }
             .foregroundStyle(isEnabled ? tint : FleetV6.fg4)
             .frame(maxWidth: .infinity)
-            .frame(height: 32)
+            .frame(height: 44)
             .background { FleetKeycapBackground(radius: 7) }
             .opacity(isEnabled ? 1 : 0.55)
             .contentShape(Rectangle())

--- a/apps/ios/Sources/FleetDeck/FleetDeckModel.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckModel.swift
@@ -154,11 +154,18 @@ struct FleetCommandTile: Identifiable {
     var symbol: String
     var actionID: String?
     var payload: [String: DeckValue] = [:]
+    var isEnabled: Bool = true
+    var col: Int? = nil
+    var row: Int? = nil
+    var colSpan: Int = 1
+    var rowSpan: Int = 1
 }
 
 struct FleetCommandSet: Identifiable {
     let id: String
     var key: String
+    var columns: Int = 4
+    var rows: Int? = nil
     var tiles: [FleetCommandTile]
 }
 

--- a/apps/ios/Sources/FleetDeck/FleetDeckTheme.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckTheme.swift
@@ -93,11 +93,11 @@ enum FleetV6 {
         static let padH: CGFloat = 16
         static let padTop: CGFloat = 12
         static let padBottom: CGFloat = 9
-        static let stackGap: CGFloat = 9
+        static let stackGap: CGFloat = 8
 
         static let topBarHeight: CGFloat = 26
-        static let channelsHeight: CGFloat = 158
-        static let channelsRailHeight: CGFloat = 52     // .layout-focus
+        static let channelsHeight: CGFloat = 52
+        static let channelsRailHeight: CGFloat = 52
         static let voiceBarHeight: CGFloat = 58
         static let statusHeight: CGFloat = 26
 
@@ -108,13 +108,15 @@ enum FleetV6 {
         static let panelBodyPadH: CGFloat = 15
         static let panelBodyPadV: CGFloat = 12
         static let bodyGap: CGFloat = 14
-        static let consoleWidth: CGFloat = 390          // #bodyOps  390px 1fr
-        static let focusConsoleWidth: CGFloat = 340     // #bodyFocus 1fr 340px
+        static let consoleWidth: CGFloat = 340
+        static let focusConsoleWidth: CGFloat = 320
+        static let consoleBodyHeight: CGFloat = 280
+        static let decisionBodyHeight: CGFloat = 360
 
         static let tilesHeight: CGFloat = 128
         static let tileGap: CGFloat = 8
         static let trackpadHeight: CGFloat = 84
-        static let keyRowHeight: CGFloat = 46
+        static let keyRowHeight: CGFloat = 52
     }
 
     // MARK: Helper

--- a/apps/ios/Sources/FleetDeck/FleetDeckView.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckView.swift
@@ -33,28 +33,7 @@ struct FleetDeckView: View {
     var body: some View {
         VStack(spacing: FleetV6.M.stackGap) {
             topBar
-
-            FleetChannelStrip(
-                channels: model.channels,
-                order: model.channelOrder,
-                currentIndex: model.currentIndex,
-                layout: model.layout,
-                onSelect: { index in withAnimation(.easeOut(duration: 0.18)) { model.select(index) } }
-            )
-
-            FleetVoiceBar(
-                phase: voicePhase,
-                transcript: voiceTranscript,
-                channels: model.channels,
-                routeIndex: model.routeIndex,
-                isBusy: isBusy,
-                onPushToTalk: onPushToTalk,
-                onRoute: { model.routeIndex = $0 }
-            )
-
             deckPanel
-
-            statusBar
         }
         .padding(.horizontal, FleetV6.M.padH)
         .padding(.top, FleetV6.M.padTop)
@@ -70,83 +49,115 @@ struct FleetDeckView: View {
         .animation(.easeOut(duration: 0.25), value: model.layout)
     }
 
-    // MARK: Top bar — `.fd-top`
+    // MARK: Compact host and routing rail
 
     private var topBar: some View {
-        HStack(spacing: 14) {
-            HStack(alignment: .firstTextBaseline, spacing: 7) {
-                Text("LATS").font(FleetV6.mono(11, .bold)).foregroundStyle(FleetV6.fg)
-                Text("·").font(FleetV6.mono(11)).foregroundStyle(FleetV6.fg4)
-                Text("OPS").font(FleetV6.mono(11, .medium)).foregroundStyle(FleetV6.fg3)
-            }
-            .tracking(1.76)
-
-            HStack(spacing: 6) {
-                FleetDot(color: FleetV6.green, size: 4)
-                Text(model.layout.label)
-                    .font(FleetV6.mono(9, .medium))
-                    .tracking(1.26)
-                    .foregroundStyle(FleetV6.fg3)
-            }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 2)
-            .background {
-                RoundedRectangle(cornerRadius: 5, style: .continuous)
-                    .fill(Color.white.opacity(0.03))
-                    .overlay {
-                        RoundedRectangle(cornerRadius: 5, style: .continuous)
-                            .strokeBorder(FleetV6.brk, lineWidth: 1)
-                    }
-            }
-
-            Spacer(minLength: 8)
-
-            Text("\(model.channels.count) MACS · \(agentCount) AGENTS")
-                .font(FleetV6.mono(9, .medium))
-                .tracking(1.08)
-                .monospacedDigit()
-                .foregroundStyle(FleetV6.fg3)
-
-            if let onClose {
-                Button(action: onClose) {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(FleetV6.fg3)
-                        .frame(width: 18, height: 18)
-                        .contentShape(Rectangle())
+        FleetWell {
+            HStack(spacing: 8) {
+                HStack(spacing: 7) {
+                    FleetDot(color: isOnline ? FleetV6.green : FleetV6.fg4, size: 6, glow: isOnline)
+                    Text("LATS DECK")
+                        .font(FleetV6.mono(11, .bold))
+                        .tracking(1.2)
+                        .foregroundStyle(FleetV6.fg)
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Close deck")
+                .padding(.leading, 10)
+                .fixedSize()
+
+                Rectangle()
+                    .fill(FleetV6.brk2)
+                    .frame(width: 1, height: 28)
+
+                FleetChannelStrip(
+                    channels: model.channels,
+                    order: model.channelOrder,
+                    currentIndex: model.currentIndex,
+                    layout: model.layout,
+                    onSelect: { index in
+                        withAnimation(.easeOut(duration: 0.18)) { model.select(index) }
+                    }
+                )
+                .frame(maxWidth: .infinity)
+
+                if model.attentionIndices.count > 0 {
+                    Button {
+                        withAnimation(.easeOut(duration: 0.18)) { model.focusAttention() }
+                    } label: {
+                        Text("ATTN \(model.attentionIndices.count)")
+                            .font(FleetV6.mono(10, .semibold))
+                            .foregroundStyle(FleetV6.amber)
+                            .frame(minWidth: 62, minHeight: 44)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Focus next Mac that needs attention")
+                }
+
+                headerButton(
+                    symbol: voicePhase == .listening || voicePhase == .transcribing ? "mic.fill" : "mic",
+                    label: "Toggle voice on \(model.current?.deviceName ?? "selected Mac")",
+                    isActive: voicePhase == .listening || voicePhase == .transcribing,
+                    isEnabled: !isBusy,
+                    action: onPushToTalk
+                )
+
+                headerButton(
+                    symbol: model.layout == .ops ? "rectangle.split.2x1" : "rectangle.inset.filled",
+                    label: "Toggle deck view",
+                    action: {
+                        withAnimation(.easeOut(duration: 0.25)) {
+                            model.layout = model.layout == .ops ? .focus : .ops
+                        }
+                    }
+                )
+
+                if let onClose {
+                    headerButton(symbol: "xmark", label: "Close deck", action: onClose)
+                }
             }
+            .padding(.horizontal, 6)
         }
-        .padding(.horizontal, 6)
-        .padding(.bottom, 6)
-        .frame(height: FleetV6.M.topBarHeight)
-        .overlay(alignment: .bottom) {
-            Rectangle().fill(Color.white.opacity(0.07)).frame(height: 1)
-        }
+        .frame(height: FleetV6.M.channelsRailHeight)
     }
 
-    private var agentCount: Int {
-        model.channels.filter { $0.state != .idle }.count
+    private func headerButton(
+        symbol: String,
+        label: String,
+        isActive: Bool = false,
+        isEnabled: Bool = true,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: symbol)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(isActive ? FleetV6.fg : FleetV6.fg3)
+                .frame(width: 44, height: 44)
+                .background(isActive ? Color.white.opacity(0.08) : .clear)
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!isEnabled)
+        .opacity(isEnabled ? 1 : 0.45)
+        .accessibilityLabel(label)
     }
 
     // MARK: Deck panel — `.deck-panel`
 
     private var deckPanel: some View {
         VStack(spacing: 0) {
-            panelHead
-            panelBody
-            if showsTrackpadStrip {
-                FleetTrackpadStrip(onTrackpad: onTrackpad)
-                    .frame(height: FleetV6.M.trackpadHeight)
-            }
             FleetCommandBay(
                 sets: model.sets,
                 setIndex: model.setIndex,
                 onSelectSet: { model.setIndex = $0 },
                 onTile: onTile
             )
+            .layoutPriority(1)
+            panelBody
+            if showsTrackpadStrip {
+                FleetTrackpadStrip(onTrackpad: onTrackpad)
+                    .frame(height: FleetV6.M.trackpadHeight)
+            }
             FleetKeyRow(onKey: onKey)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -234,14 +245,14 @@ struct FleetDeckView: View {
         }
         .padding(.horizontal, FleetV6.M.panelBodyPadH)
         .padding(.vertical, FleetV6.M.panelBodyPadV)
-        .frame(maxHeight: .infinity)
+        .frame(height: model.current?.decision == nil ? FleetV6.M.consoleBodyHeight : FleetV6.M.decisionBodyHeight)
     }
 
     /// The design's fixed column widths, held as a share on narrower iPads so
     /// neither column collapses.
     private func consoleWidth(for available: CGFloat, target: CGFloat) -> CGFloat {
         guard available > 0 else { return target }
-        return min(target, max(260, available * 0.36))
+        return min(target, max(280, available * 0.30))
     }
 
     private func console(_ channel: FleetChannel, isRecent: Bool) -> some View {
@@ -271,27 +282,6 @@ struct FleetDeckView: View {
         )
     }
 
-    // MARK: Status bar
-
-    private var statusBar: some View {
-        FleetStatusBar(
-            deviceName: model.current?.deviceName ?? "—",
-            routeLabel: model.routeLabel,
-            attentionCount: model.attentionIndices.count,
-            machineCount: model.channels.count,
-            agentCount: agentCount,
-            layout: model.layout,
-            isOnline: isOnline,
-            onAttention: { withAnimation(.easeOut(duration: 0.18)) { model.focusAttention() } },
-            onToggleLayout: {
-                withAnimation(.easeOut(duration: 0.25)) {
-                    model.layout = model.layout == .ops ? .focus : .ops
-                }
-            }
-        )
-        .padding(.horizontal, -FleetV6.M.padH)
-        .padding(.bottom, -FleetV6.M.padBottom)
-    }
 }
 
 /// The three console buttons that are not a decision — they act on the agent

--- a/apps/ios/Sources/LatsDeckScreen.swift
+++ b/apps/ios/Sources/LatsDeckScreen.swift
@@ -2869,7 +2869,7 @@ struct FleetDeckScreen: View {
             // The Fleet Deck design is authored on a 1376×1032 iPad-landscape
             // canvas. Give it the screen whenever there is room for its fixed
             // rows; anything shorter (iPhone landscape) keeps the lane layout.
-            let fitsDeck = isLandscape && proxy.size.height >= 700 && !stores.isEmpty
+            let fitsDeck = isLandscape && proxy.size.height >= 820 && !stores.isEmpty
 
             if fitsDeck {
                 FleetDeckHost(
@@ -2877,7 +2877,6 @@ struct FleetDeckScreen: View {
                     initialMachineID: initialMachineID,
                     onClose: { dismiss() }
                 )
-                .ignoresSafeArea(.container, edges: .bottom)
             } else {
                 LatsBackground(grid: true) {
                     VStack(spacing: 0) {

--- a/apps/mac/Package.swift
+++ b/apps/mac/Package.swift
@@ -13,6 +13,14 @@ let hudsonDependency: Package.Dependency = hudsonSource == "git"
 
 let voiceEnabled = Context.environment["HUDSONKIT_WITH_VOICE"] == "1"
 
+// Vox is already a HudsonVoice transitive dep; Lattices also links VoxService
+// directly so it can host the live-session runtime in-process on boot.
+let voxSource = Context.environment["LATTICES_VOX_SOURCE"] ?? Context.environment["HUDSON_VOX_PATH"]
+let voxDependency: Package.Dependency? = voiceEnabled
+    ? (voxSource.map { .package(path: $0) }
+        ?? .package(url: "https://github.com/arach/vox.git", branch: "main"))
+    : nil
+
 var latticesDependencies: [Target.Dependency] = [
     .product(name: "DeckKit", package: "swift"),
     .product(name: "HudsonObservability", package: "hudson"),
@@ -22,15 +30,22 @@ var latticesDependencies: [Target.Dependency] = [
 ]
 if voiceEnabled {
     latticesDependencies.append(.product(name: "HudsonVoice", package: "hudson"))
+    // Package identity for https://github.com/arach/vox.git is "vox".
+    latticesDependencies.append(.product(name: "VoxService", package: "vox"))
+}
+
+var packageDependencies: [Package.Dependency] = [
+    .package(path: "../../swift"),
+    hudsonDependency,
+]
+if let voxDependency {
+    packageDependencies.append(voxDependency)
 }
 
 let package = Package(
     name: "Lattices",
     platforms: [.macOS(.v26)],
-    dependencies: [
-        .package(path: "../../swift"),
-        hudsonDependency,
-    ],
+    dependencies: packageDependencies,
     targets: [
         .executableTarget(
             name: "Lattices",

--- a/apps/mac/Sources/AppShell/FrontWindowPlacement.swift
+++ b/apps/mac/Sources/AppShell/FrontWindowPlacement.swift
@@ -107,10 +107,19 @@ enum FrontWindowPlacer {
     }
 }
 
-/// Compact 3×3 grid — tap a cell to snap the frontmost window there.
+/// Quick Action: one-line **Move** row that expands to a placement grid.
+///
+/// Collapsed by default so the menu-bar popover stays compact. Tap the row to
+/// unfold slots for the frontmost window; pick a cell to snap and (optionally)
+/// dismiss the host surface.
 struct FrontWindowPlacementGrid: View {
     var onPlaced: (() -> Void)? = nil
-    @State private var refreshToken = UUID()
+    /// Host can listen for expand/collapse to resize a fixed-size popover.
+    var onExpandedChange: ((Bool) -> Void)? = nil
+
+    @State private var expanded = false
+    @State private var targetLabel: String?
+    @State private var isHovered = false
 
     private let cells: [[TilePosition?]] = [
         [.topLeft, .top, .topRight],
@@ -118,29 +127,89 @@ struct FrontWindowPlacementGrid: View {
         [.bottomLeft, .bottom, .bottomRight],
     ]
 
+    private var targetSubtitle: String {
+        if let targetLabel, !targetLabel.isEmpty {
+            return targetLabel
+        }
+        return "Focus another app, then pick a slot"
+    }
+
     var body: some View {
+        VStack(spacing: 0) {
+            headerRow
+
+            if expanded {
+                placementPanel
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 10)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .onAppear { refreshTarget() }
+        .onReceive(NotificationCenter.default.publisher(for: .latticesPopoverWillShow)) { _ in
+            // Each open starts collapsed so the popover stays a short action list.
+            if expanded {
+                withAnimation(.easeOut(duration: 0.12)) {
+                    expanded = false
+                }
+            }
+            refreshTarget()
+        }
+        .onChange(of: expanded) { _, isOpen in
+            onExpandedChange?(isOpen)
+        }
+    }
+
+    private var headerRow: some View {
+        Button {
+            withAnimation(.easeOut(duration: 0.15)) {
+                expanded.toggle()
+            }
+        } label: {
+            HStack(spacing: 10) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 5)
+                        .fill(Palette.running.opacity(isHovered || expanded ? 0.18 : 0.12))
+                    Image(systemName: "arrow.up.left.and.arrow.down.right")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(isHovered || expanded ? Palette.text : Palette.running)
+                }
+                .frame(width: 22, height: 22)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Move")
+                        .font(Typo.body(12))
+                        .foregroundColor(isHovered || expanded ? Palette.text : Palette.textDim)
+                        .lineLimit(1)
+
+                    Text(targetSubtitle)
+                        .font(Typo.mono(9))
+                        .foregroundColor(Palette.textMuted)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 8)
+
+                Image(systemName: expanded ? "chevron.up" : "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(Palette.textMuted)
+                    .frame(width: 16, height: 16)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(isHovered || expanded ? Palette.surfaceHov : Color.clear)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+        .help(expanded ? "Hide placement grid" : "Position the frontmost window")
+    }
+
+    private var placementPanel: some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 6) {
-                Image(systemName: "macwindow")
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundColor(Palette.running)
-                Text("Move front window")
-                    .font(Typo.monoBold(10))
-                    .foregroundColor(Palette.textMuted)
-                Spacer()
-            }
-
-            if let label = FrontWindowPlacer.targetLabel() {
-                Text(label)
-                    .font(Typo.mono(9))
-                    .foregroundColor(Palette.textDim)
-                    .lineLimit(1)
-            } else {
-                Text("Focus another app, then pick a slot")
-                    .font(Typo.mono(9))
-                    .foregroundColor(Palette.textMuted)
-            }
-
             VStack(spacing: 4) {
                 ForEach(0..<cells.count, id: \.self) { row in
                     HStack(spacing: 4) {
@@ -160,13 +229,19 @@ struct FrontWindowPlacementGrid: View {
                 placementPill(.rightThird, label: "⅓ R")
             }
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .id(refreshToken)
-        .onAppear { refreshToken = UUID() }
-        .onReceive(NotificationCenter.default.publisher(for: .latticesPopoverWillShow)) { _ in
-            refreshToken = UUID()
-        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Palette.surface.opacity(0.55))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .strokeBorder(Palette.border, lineWidth: 0.5)
+                )
+        )
+    }
+
+    private func refreshTarget() {
+        targetLabel = FrontWindowPlacer.targetLabel()
     }
 
     private func placementCell(_ position: TilePosition) -> some View {

--- a/apps/mac/Sources/AppShell/MainView.swift
+++ b/apps/mac/Sources/AppShell/MainView.swift
@@ -155,14 +155,6 @@ struct MainView: View {
                     .fill(Palette.border)
                     .frame(height: 0.5)
 
-                FrontWindowPlacementGrid {
-                    MenuBarController.shared.dismissPopover()
-                }
-
-                Rectangle()
-                    .fill(Palette.border)
-                    .frame(height: 0.5)
-
                 actionsSection
 
                 Rectangle()
@@ -353,6 +345,21 @@ struct MainView: View {
             .padding(.horizontal, 14)
             .padding(.top, 10)
             .padding(.bottom, 6)
+
+            // Move is a one-line action that unfolds the placement grid —
+            // keeps the popover compact until you need window spots.
+            FrontWindowPlacementGrid(
+                onPlaced: {
+                    MenuBarController.shared.dismissPopover()
+                },
+                onExpandedChange: { expanded in
+                    MenuBarController.shared.setPopoverContentHeight(
+                        expanded
+                            ? MenuBarController.popoverHeightExpanded
+                            : MenuBarController.popoverHeightCollapsed
+                    )
+                }
+            )
 
             ActionRow(
                 label: "Assistant",

--- a/apps/mac/Sources/AppShell/MenuBarController.swift
+++ b/apps/mac/Sources/AppShell/MenuBarController.swift
@@ -4,6 +4,12 @@ import SwiftUI
 final class MenuBarController: NSObject, NSPopoverDelegate {
     static let shared = MenuBarController()
 
+    /// Collapsed quick-actions layout (Move row closed).
+    static let popoverHeightCollapsed: CGFloat = 360
+    /// Move grid unfolded — room for 3×3 slots + thirds row.
+    static let popoverHeightExpanded: CGFloat = 540
+    static let popoverWidth: CGFloat = 380
+
     private var statusItem: NSStatusItem?
     private var popover: NSPopover?
     private var contextMenu: NSMenu?
@@ -39,9 +45,22 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
         popover?.performClose(nil)
     }
 
+    /// Resize the menu-bar popover when inline sections expand (e.g. Move grid).
+    func setPopoverContentHeight(_ height: CGFloat) {
+        guard let popover else { return }
+        let size = NSSize(width: Self.popoverWidth, height: height)
+        guard popover.contentSize != size else { return }
+        popover.contentSize = size
+    }
+
     private func showProjectsPopover() {
         guard let button = statusItem?.button else { return }
         let popover = makePopover()
+        // Always open collapsed; Move expands on demand.
+        popover.contentSize = NSSize(
+            width: Self.popoverWidth,
+            height: Self.popoverHeightCollapsed
+        )
         popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
         popover.contentViewController?.view.window?.sharingType = .readOnly
         popover.contentViewController?.view.window?.makeKey()
@@ -66,7 +85,14 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
         let popover = NSPopover()
         popover.contentViewController = NSHostingController(rootView: MainView(scanner: ProjectScanner.shared))
         popover.behavior = .transient
-        popover.contentSize = NSSize(width: 380, height: 430)
+        // Keep resize of contentSize (Move expand/collapse) non-animated —
+        // animating NSPopover + SwiftUI layout has crashed with nested material
+        // resolve (EXC_BAD_ACCESS / stack guard) on recent macOS builds.
+        popover.animates = false
+        popover.contentSize = NSSize(
+            width: Self.popoverWidth,
+            height: Self.popoverHeightCollapsed
+        )
         popover.appearance = NSAppearance(named: .darkAqua)
         popover.delegate = self
         self.popover = popover

--- a/apps/mac/Sources/AppShell/Preferences.swift
+++ b/apps/mac/Sources/AppShell/Preferences.swift
@@ -32,7 +32,7 @@ class Preferences: ObservableObject {
         static let cockpitLayoutVersion = "companion.cockpit.layoutVersion"
     }
 
-    private static let currentCockpitLayoutVersion = 4
+    private static let currentCockpitLayoutVersion = 5
 
     private static let dismissedCapabilitiesKey = "permissions.dismissed"
 
@@ -372,6 +372,10 @@ class Preferences: ObservableObject {
         }
         if fromVersion < 4,
            migrated == LatticesCompanionCockpitCatalog.legacyDefaultLayoutV3 {
+            migrated = LatticesCompanionCockpitCatalog.legacyDefaultLayoutV4
+        }
+        if fromVersion < 5,
+           migrated == LatticesCompanionCockpitCatalog.legacyDefaultLayoutV4 {
             migrated = LatticesCompanionCockpitCatalog.defaultLayout
         }
         return migrated

--- a/apps/mac/Sources/AppShell/SettingsView.swift
+++ b/apps/mac/Sources/AppShell/SettingsView.swift
@@ -2424,15 +2424,29 @@ struct SettingsContentView: View {
                                 Text("HudsonVoice runtime")
                                     .font(Typo.mono(12))
                                     .foregroundColor(Palette.text)
-                                Text("Voice mode is compiled in. The Workspace Assistant mic uses HudsonVoice's Vox local WebSocket session.")
+                                Text("Lattices hosts the voice engine in-process on a fixed loopback port. The Workspace Assistant mic, Hands-Off, and voice commands all use that session.")
                                     .font(Typo.caption(9.5))
                                     .foregroundColor(Palette.textMuted)
                                     .fixedSize(horizontal: false, vertical: true)
                             }
                         }
 
+                        Text("Well-known endpoint: \(LatticesLocalEndpoints.voiceRuntimeWebSocketURL)")
+                            .font(Typo.mono(10))
+                            .foregroundColor(Palette.textDim)
+
+                        if LatticesVoiceRuntime.isRunning {
+                            Text("Host: running")
+                                .font(Typo.mono(10))
+                                .foregroundColor(Palette.running)
+                        } else {
+                            Text("Host: not running — restart Lattices if dictation fails")
+                                .font(Typo.mono(10))
+                                .foregroundColor(Palette.kill)
+                        }
+
                         if let runtime = HudsonVoiceRuntimeResolver.resolve(clientId: "lattices") {
-                            Text("Endpoint: \(runtime.endpoint.url.absoluteString)")
+                            Text("Resolved: \(runtime.endpoint.url.absoluteString) (\(runtime.source))")
                                 .font(Typo.mono(10))
                                 .foregroundColor(Palette.textDim)
                         }
@@ -2833,11 +2847,11 @@ struct SettingsContentView: View {
             VStack(alignment: .leading, spacing: 12) {
                 HStack(alignment: .center, spacing: 10) {
                     RoundedRectangle(cornerRadius: 6)
-                        .fill(scoutTint.opacity(0.13))
+                        .fill(chatTransportTint.opacity(0.13))
                         .overlay(
-                            Image(systemName: "point.3.connected.trianglepath.dotted")
+                            Image(systemName: "bubble.left.and.bubble.right")
                                 .font(.system(size: 12, weight: .semibold))
-                                .foregroundColor(scoutTint)
+                                .foregroundColor(chatTransportTint)
                         )
                         .frame(width: 30, height: 30)
 
@@ -2853,10 +2867,10 @@ struct SettingsContentView: View {
 
                     Spacer()
 
-                    aiStatusPill(scoutStatusLabel, tint: scoutTint)
+                    aiStatusPill(chatTransportStatusLabel, tint: chatTransportTint)
                 }
 
-                Text("In-app chat uses your existing local Scout broker and Scout session. Lattices does not ask for or store a separate model credential for chat.")
+                Text("Chat prefers a local agent runtime (Claude Code, Codex, Pi, OpenCode — ACP when the harness uses it). Falls back to a saved API key (HudsonAI), then Scout.")
                     .font(Typo.caption(10))
                     .foregroundColor(Palette.textMuted)
                     .fixedSize(horizontal: false, vertical: true)
@@ -2864,12 +2878,36 @@ struct SettingsContentView: View {
                 cardDivider
 
                 VStack(alignment: .leading, spacing: 8) {
-                    voiceFactRow("Transport", value: "Scout local broker", detail: "Scout owns model routing, authorization, and the concrete harness session.")
-                    voiceFactRow("Conversation", value: "Persistent ref", detail: "Follow-up turns reuse the same Scout session until you clear the chat.")
-                    voiceFactRow("Chat credential", value: "None in Lattices", detail: "Any provider authentication remains owned by Scout.")
+                    voiceFactRow(
+                        "Transport",
+                        value: assistantSession.chatTransportSummary,
+                        detail: "Order: agent-runtime → API key → Scout."
+                    )
+                    voiceFactRow(
+                        "Preferred harness",
+                        value: assistantSession.preferredAgentHarness ?? "auto",
+                        detail: "Auto picks pi, then claude-code, codex, opencode."
+                    )
+                    voiceFactRow("API fallback", value: assistantSession.currentProvider.name, detail: "Used when no local harness is available and a key is saved.")
+                    voiceFactRow("API credential", value: assistantSession.selectedCredentialSummary, detail: "Optional for chat; used for HudsonAI API fallback and voice interpretation.")
                 }
                 .padding(10)
                 .background(shortcutsInsetPanel)
+
+                HStack(spacing: 8) {
+                    ForEach(["auto", "claude-code", "codex", "pi", "opencode"], id: \.self) { harness in
+                        aiActionButton(
+                            harness,
+                            tint: (assistantSession.preferredAgentHarness ?? "auto") == harness
+                                || (harness == "auto" && assistantSession.preferredAgentHarness == nil)
+                                ? Palette.running
+                                : Palette.textMuted
+                        ) {
+                            assistantSession.preferredAgentHarness = harness == "auto" ? nil : harness
+                        }
+                    }
+                    Spacer()
+                }
 
                 HStack {
                     aiActionButton("Refresh Scout", tint: Palette.running) {
@@ -2977,6 +3015,22 @@ struct SettingsContentView: View {
         case true: return "SCOUT READY"
         case false: return "SCOUT OFFLINE"
         case nil: return "CHECKING"
+        }
+    }
+
+    private var chatTransportTint: Color {
+        Palette.running
+    }
+
+    private var chatTransportStatusLabel: String {
+        if let harness = assistantSession.agentRuntimeHarnessLabel {
+            return harness.uppercased()
+        }
+        if assistantSession.hasSelectedCredential { return "API READY" }
+        switch assistantSession.isScoutAvailable {
+        case true: return "SCOUT FALLBACK"
+        case false: return "SCOUT OFFLINE"
+        case nil: return "RUNTIME"
         }
     }
 

--- a/apps/mac/Sources/Core/Assistant/AgentRuntimeTransport.swift
+++ b/apps/mac/Sources/Core/Assistant/AgentRuntimeTransport.swift
@@ -1,0 +1,764 @@
+import Foundation
+
+/// One completed agent-runtime turn.
+struct AgentRuntimeReply {
+    let text: String
+    let harness: String
+    let sessionId: String
+}
+
+enum AgentRuntimeTransportError: LocalizedError {
+    case bunMissing
+    case runnerMissing
+    case notAvailable(String)
+    case startFailed(String)
+    case turnFailed(String)
+    case emptyReply
+    case timeout
+    case requestTimeout
+
+    var errorDescription: String? {
+        switch self {
+        case .bunMissing:
+            return "Bun is required for the local agent runtime."
+        case .runnerMissing:
+            return "Agent runner script not found. Rebuild Lattices from the repo."
+        case .notAvailable(let detail):
+            return detail
+        case .startFailed(let detail):
+            return "Could not start agent runtime: \(detail)"
+        case .turnFailed(let detail):
+            return detail
+        case .emptyReply:
+            return "The agent finished without a text reply."
+        case .timeout:
+            return "The agent turn timed out."
+        case .requestTimeout:
+            return "The agent runtime did not respond in time."
+        }
+    }
+}
+
+/// Catalog entry from `{"op":"catalog"}`.
+struct AgentRuntimeHarness: Equatable {
+    let id: String
+    let name: String
+    let available: Bool
+    let binary: String?
+}
+
+/// Long-lived Bun stdio host for `packages/npm/agent-runner`.
+///
+/// Speaks agent-sessions under the covers (including ACP adapters when the
+/// chosen harness uses them). Native chat drives: start → prompt → events → interrupt.
+final class AgentRuntimeTransport {
+    static let shared = AgentRuntimeTransport()
+
+    /// Preferred harness order when the user has not picked one.
+    /// Pi first: it has been the most reliable local one-shot for assistant chat
+    /// on this stack; claude-code often exits 1 with an empty turn when not fully
+    /// wired for non-interactive use.
+    static let defaultHarnessPreference = ["pi", "claude-code", "codex", "opencode"]
+
+    /// Wall-clock for catalog/start/prompt-ack RPC (not the model turn itself).
+    private static let requestTimeoutSeconds: TimeInterval = 12
+    /// Default model-turn budget per harness for chat (cascade stays responsive).
+    static let defaultTurnTimeoutSeconds: TimeInterval = 60
+
+    private let lock = NSLock()
+    private var process: Process?
+    private var stdinHandle: FileHandle?
+    private var stdoutSource: DispatchSourceRead?
+    private var lineBuffer = Data()
+    private var pendingRequests: [Int: CheckedContinuation<[String: Any], Error>] = [:]
+    private var pendingRequestTimeouts: [Int: DispatchWorkItem] = [:]
+    private var nextRequestID = 1
+
+    private var activeSessionID: String?
+    private var activeHarness: String?
+    private var textBlockIDs = Set<String>()
+    private var accumulatedText = ""
+    /// Last adapter/process error seen on stderr or session:update status=error.
+    private var lastAdapterError: String?
+    private var turnContinuation: CheckedContinuation<AgentRuntimeReply, Error>?
+    private var turnTimeoutWork: DispatchWorkItem?
+    private var onTextDelta: ((String) -> Void)?
+    private var onTool: ((String) -> Void)?
+
+    private init() {}
+
+    // MARK: - Public
+
+    /// Whether Bun + runner script exist and at least one non-echo harness (or echo) is available.
+    func isAvailable() async -> Bool {
+        guard bunURL != nil, runnerScriptURL != nil else { return false }
+        do {
+            let harnesses = try await catalog()
+            return harnesses.contains(where: \.available)
+        } catch {
+            return false
+        }
+    }
+
+    func catalog() async throws -> [AgentRuntimeHarness] {
+        try await ensureProcess()
+        let response = try await request(["op": "catalog"])
+        guard let list = response["harnesses"] as? [[String: Any]] else { return [] }
+        return list.compactMap { row in
+            guard let id = row["id"] as? String else { return nil }
+            return AgentRuntimeHarness(
+                id: id,
+                name: (row["name"] as? String) ?? id,
+                available: row["available"] as? Bool ?? false,
+                binary: row["binary"] as? String
+            )
+        }
+    }
+
+    /// Pick the best available harness (user preference, then defaults, then any).
+    func resolveHarness(preferred: String? = nil) async throws -> AgentRuntimeHarness {
+        let harnesses = try await catalog()
+        let available = harnesses.filter(\.available)
+        guard !available.isEmpty else {
+            throw AgentRuntimeTransportError.notAvailable(
+                "No local agent runtime is installed (claude, codex, pi, or opencode)."
+            )
+        }
+        if let preferred,
+           let match = available.first(where: { $0.id == preferred }) {
+            return match
+        }
+        for id in Self.defaultHarnessPreference {
+            if let match = available.first(where: { $0.id == id }) {
+                return match
+            }
+        }
+        // Last resort: echo (dev) if somehow only that is available.
+        if let echo = available.first(where: { $0.id == "echo" }) {
+            return echo
+        }
+        return available[0]
+    }
+
+    /// Run one chat turn. Streams text deltas via `onDelta`.
+    /// Tries preferred harness, then the rest of the preference list on empty/crash.
+    func ask(
+        text: String,
+        systemPrompt: String,
+        cwd: String,
+        preferredHarness: String? = nil,
+        onDelta: @escaping (String) -> Void,
+        onTool: ((String) -> Void)? = nil,
+        timeoutSeconds: TimeInterval = AgentRuntimeTransport.defaultTurnTimeoutSeconds
+    ) async throws -> AgentRuntimeReply {
+        let candidates = try await orderedAvailableHarnesses(preferred: preferredHarness)
+        guard !candidates.isEmpty else {
+            throw AgentRuntimeTransportError.notAvailable(
+                "No local agent runtime is installed (pi, claude, codex, or opencode)."
+            )
+        }
+
+        var lastError: Error = AgentRuntimeTransportError.emptyReply
+        for (index, harness) in candidates.enumerated() {
+            do {
+                DiagnosticLog.shared.info(
+                    "AgentRuntime · trying harness \(harness.id)\(index == 0 ? "" : " (fallback)")"
+                )
+                return try await askOnce(
+                    text: text,
+                    systemPrompt: systemPrompt,
+                    cwd: cwd,
+                    harness: harness.id,
+                    onDelta: onDelta,
+                    onTool: onTool,
+                    timeoutSeconds: timeoutSeconds
+                )
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                lastError = error
+                DiagnosticLog.shared.warn(
+                    "AgentRuntime · harness \(harness.id) failed: \(error.localizedDescription)"
+                )
+                // Force a fresh session for the next harness; restart process if
+                // the stdio host itself hung or died.
+                lock.lock()
+                activeSessionID = nil
+                activeHarness = nil
+                lock.unlock()
+                if error is AgentRuntimeTransportError {
+                    let kind = error as? AgentRuntimeTransportError
+                    switch kind {
+                    case .timeout?, .requestTimeout?, .startFailed?:
+                        restartProcess()
+                    default:
+                        break
+                    }
+                }
+                continue
+            }
+        }
+        throw lastError
+    }
+
+    private func orderedAvailableHarnesses(preferred: String?) async throws -> [AgentRuntimeHarness] {
+        let available = try await catalog().filter(\.available)
+        var ordered: [AgentRuntimeHarness] = []
+        var seen = Set<String>()
+        func append(_ id: String) {
+            guard !seen.contains(id),
+                  let match = available.first(where: { $0.id == id }) else { return }
+            seen.insert(id)
+            ordered.append(match)
+        }
+        if let preferred { append(preferred) }
+        for id in Self.defaultHarnessPreference { append(id) }
+        for h in available where h.id != "echo" { append(h.id) }
+        return ordered
+    }
+
+    private func askOnce(
+        text: String,
+        systemPrompt: String,
+        cwd: String,
+        harness: String,
+        onDelta: @escaping (String) -> Void,
+        onTool: ((String) -> Void)?,
+        timeoutSeconds: TimeInterval
+    ) async throws -> AgentRuntimeReply {
+        try await ensureSession(harness: harness, systemPrompt: systemPrompt, cwd: cwd)
+
+        return try await withCheckedThrowingContinuation { (cont: CheckedContinuation<AgentRuntimeReply, Error>) in
+            lock.lock()
+            if turnContinuation != nil {
+                lock.unlock()
+                cont.resume(throwing: AgentRuntimeTransportError.turnFailed("A turn is already in flight."))
+                return
+            }
+            turnContinuation = cont
+            accumulatedText = ""
+            textBlockIDs.removeAll()
+            lastAdapterError = nil
+            self.onTextDelta = onDelta
+            self.onTool = onTool
+            lock.unlock()
+
+            let timeout = DispatchWorkItem { [weak self] in
+                self?.failTurn(AgentRuntimeTransportError.timeout)
+            }
+            lock.lock()
+            turnTimeoutWork = timeout
+            lock.unlock()
+            DispatchQueue.global().asyncAfter(deadline: .now() + timeoutSeconds, execute: timeout)
+
+            Task {
+                do {
+                    _ = try await self.request([
+                        "op": "prompt",
+                        "sessionId": self.activeSessionID ?? "lattices-assistant",
+                        "text": text,
+                    ])
+                } catch {
+                    self.failTurn(error)
+                }
+            }
+        }
+    }
+
+    func interrupt() {
+        guard let sessionID = activeSessionID else { return }
+        Task {
+            _ = try? await request(["op": "interrupt", "sessionId": sessionID])
+        }
+        failTurn(CancellationError())
+    }
+
+    func shutdown() {
+        lock.lock()
+        let cont = turnContinuation
+        turnContinuation = nil
+        turnTimeoutWork?.cancel()
+        turnTimeoutWork = nil
+        lock.unlock()
+        cont?.resume(throwing: CancellationError())
+
+        if let handle = stdinHandle {
+            let line = (try? JSONSerialization.data(withJSONObject: ["op": "shutdown", "id": 0]))
+                .flatMap { String(data: $0, encoding: .utf8) }
+            if let line {
+                handle.write(Data((line + "\n").utf8))
+            }
+        }
+        process?.terminate()
+        teardownProcess()
+    }
+
+    // MARK: - Session lifecycle
+
+    private func ensureSession(harness: String, systemPrompt: String, cwd: String) async throws {
+        try await ensureProcess()
+        lock.lock()
+        let same = activeSessionID != nil && activeHarness == harness
+        lock.unlock()
+        if same { return }
+
+        // Drop prior session id; start fresh for harness / prompt changes.
+        lock.lock()
+        activeSessionID = nil
+        activeHarness = nil
+        lock.unlock()
+
+        let sessionID = "lattices-assistant-\(UUID().uuidString.prefix(8).lowercased())"
+        let response = try await request([
+            "op": "start",
+            "sessionId": sessionID,
+            "harness": harness,
+            "name": "Lattices Assistant",
+            "cwd": cwd,
+            "systemPrompt": systemPrompt,
+        ])
+        guard response["ok"] as? Bool == true else {
+            let err = response["error"] as? String ?? "start failed"
+            throw AgentRuntimeTransportError.startFailed(err)
+        }
+        let resolvedID = (response["sessionId"] as? String) ?? sessionID
+        lock.lock()
+        activeSessionID = resolvedID
+        activeHarness = harness
+        lock.unlock()
+    }
+
+    // MARK: - Process
+
+    private var bunURL: URL? {
+        LatticesRuntime.bunPath.map { URL(fileURLWithPath: $0) }
+    }
+
+    private var runnerScriptURL: URL? {
+        let candidates: [String] = {
+            var list: [String] = []
+            if let root = LatticesRuntime.cliRoot {
+                list.append(root + "/packages/npm/agent-runner/bin/agent-runner.mjs")
+            }
+            list.append(NSHomeDirectory() + "/dev/lattices/packages/npm/agent-runner/bin/agent-runner.mjs")
+            return list
+        }()
+        return candidates
+            .first(where: { FileManager.default.isReadableFile(atPath: $0) })
+            .map { URL(fileURLWithPath: $0) }
+    }
+
+    private func ensureProcess() async throws {
+        lock.lock()
+        let running = process?.isRunning == true
+        lock.unlock()
+        if running { return }
+
+        guard let bunURL else { throw AgentRuntimeTransportError.bunMissing }
+        guard let runnerScriptURL else { throw AgentRuntimeTransportError.runnerMissing }
+
+        let proc = Process()
+        proc.executableURL = bunURL
+        proc.arguments = [runnerScriptURL.path]
+        proc.currentDirectoryURL = runnerScriptURL
+            .deletingLastPathComponent() // bin/
+            .deletingLastPathComponent() // agent-runner/
+
+        var env = ProcessInfo.processInfo.environment
+        env["PATH"] = Self.enrichedPath
+        proc.environment = env
+
+        let stdin = Pipe()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        proc.standardInput = stdin
+        proc.standardOutput = stdout
+        proc.standardError = stderr
+
+        proc.terminationHandler = { [weak self] _ in
+            self?.teardownProcess()
+        }
+
+        try proc.run()
+
+        lock.lock()
+        process = proc
+        stdinHandle = stdin.fileHandleForWriting
+        lock.unlock()
+
+        let readHandle = stdout.fileHandleForReading
+        let source = DispatchSource.makeReadSource(fileDescriptor: readHandle.fileDescriptor, queue: .global(qos: .userInitiated))
+        source.setEventHandler { [weak self] in
+            let data = readHandle.availableData
+            if data.isEmpty {
+                self?.teardownProcess()
+                return
+            }
+            self?.consumeStdout(data)
+        }
+        source.setCancelHandler {
+            try? readHandle.close()
+        }
+        source.resume()
+
+        // Surface `[session-registry] adapter error (…): …` from agent-runner.
+        stderr.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty, let text = String(data: data, encoding: .utf8) else { return }
+            self?.consumeStderr(text)
+        }
+
+        lock.lock()
+        stdoutSource = source
+        lock.unlock()
+
+        // Warm ping
+        _ = try await request(["op": "ping"])
+    }
+
+    private func consumeStderr(_ text: String) {
+        for rawLine in text.split(whereSeparator: \.isNewline) {
+            let line = String(rawLine)
+            // Example: [session-registry] adapter error (t1): claude exited with code 1
+            if let range = line.range(of: "adapter error") {
+                let message = line[range.upperBound...]
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .trimmingCharacters(in: CharacterSet(charactersIn: ": "))
+                lock.lock()
+                lastAdapterError = message.isEmpty ? line : message
+                let hasTurn = turnContinuation != nil
+                lock.unlock()
+                DiagnosticLog.shared.warn("AgentRuntime · \(line)")
+                // If a turn is live and the harness is already dead, fail promptly
+                // rather than waiting for an empty turn:end.
+                if hasTurn, message.localizedCaseInsensitiveContains("exited")
+                    || message.localizedCaseInsensitiveContains("not running")
+                    || message.localizedCaseInsensitiveContains("ENOENT") {
+                    failTurn(AgentRuntimeTransportError.turnFailed(
+                        message.isEmpty ? "Agent runtime crashed." : message
+                    ))
+                }
+            } else if line.contains("error") || line.contains("Error") {
+                DiagnosticLog.shared.info("AgentRuntime · stderr: \(line)")
+            }
+        }
+    }
+
+    private func teardownProcess() {
+        lock.lock()
+        stdoutSource?.cancel()
+        stdoutSource = nil
+        try? stdinHandle?.close()
+        stdinHandle = nil
+        process = nil
+        activeSessionID = nil
+        activeHarness = nil
+        let pending = pendingRequests
+        pendingRequests.removeAll()
+        for work in pendingRequestTimeouts.values { work.cancel() }
+        pendingRequestTimeouts.removeAll()
+        let turn = turnContinuation
+        turnContinuation = nil
+        turnTimeoutWork?.cancel()
+        turnTimeoutWork = nil
+        lock.unlock()
+
+        for (_, cont) in pending {
+            cont.resume(throwing: AgentRuntimeTransportError.turnFailed("Agent runtime process exited."))
+        }
+        turn?.resume(throwing: AgentRuntimeTransportError.turnFailed("Agent runtime process exited."))
+    }
+
+    private static var enrichedPath: String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let prefixes = [
+            "\(home)/.bun/bin",
+            "\(home)/.local/bin",
+            "\(home)/.claude/local",
+            "\(home)/.opencode/bin",
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+        ]
+        let existing = (ProcessInfo.processInfo.environment["PATH"] ?? "")
+            .split(separator: ":")
+            .map(String.init)
+        var seen = Set<String>()
+        var parts: [String] = []
+        for part in prefixes + existing where !part.isEmpty && seen.insert(part).inserted {
+            parts.append(part)
+        }
+        return parts.joined(separator: ":")
+    }
+
+    // MARK: - Request / response
+
+    private func request(_ fields: [String: Any]) async throws -> [String: Any] {
+        try await ensureProcessRunningOnly()
+        lock.lock()
+        let id = nextRequestID
+        nextRequestID += 1
+        lock.unlock()
+        var payload = fields
+        payload["id"] = id
+
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        guard var line = String(data: data, encoding: .utf8) else {
+            throw AgentRuntimeTransportError.turnFailed("Could not encode request.")
+        }
+        line += "\n"
+
+        return try await withCheckedThrowingContinuation { cont in
+            lock.lock()
+            pendingRequests[id] = cont
+            let handle = stdinHandle
+            let timeout = DispatchWorkItem { [weak self] in
+                self?.failPendingRequest(
+                    id: id,
+                    error: AgentRuntimeTransportError.requestTimeout
+                )
+            }
+            pendingRequestTimeouts[id] = timeout
+            lock.unlock()
+            DispatchQueue.global().asyncAfter(
+                deadline: .now() + Self.requestTimeoutSeconds,
+                execute: timeout
+            )
+            guard let handle else {
+                failPendingRequest(
+                    id: id,
+                    error: AgentRuntimeTransportError.turnFailed("Agent runtime stdin is closed.")
+                )
+                return
+            }
+            handle.write(Data(line.utf8))
+        }
+    }
+
+    private func failPendingRequest(id: Int, error: Error) {
+        lock.lock()
+        let cont = pendingRequests.removeValue(forKey: id)
+        pendingRequestTimeouts.removeValue(forKey: id)?.cancel()
+        lock.unlock()
+        cont?.resume(throwing: error)
+    }
+
+    /// Kill and clear the Bun host so the next ensureProcess starts fresh.
+    private func restartProcess() {
+        DiagnosticLog.shared.warn("AgentRuntime · restarting stdio host after hard failure")
+        shutdown()
+    }
+
+    private func ensureProcessRunningOnly() async throws {
+        lock.lock()
+        let running = process?.isRunning == true
+        lock.unlock()
+        if !running {
+            try await ensureProcess()
+        }
+    }
+
+    private func consumeStdout(_ data: Data) {
+        lock.lock()
+        lineBuffer.append(data)
+        var chunks: [Data] = []
+        while let range = lineBuffer.range(of: Data([0x0A])) {
+            chunks.append(lineBuffer.subdata(in: lineBuffer.startIndex..<range.lowerBound))
+            lineBuffer.removeSubrange(lineBuffer.startIndex...range.lowerBound)
+        }
+        lock.unlock()
+
+        for chunk in chunks {
+            guard !chunk.isEmpty,
+                  let obj = try? JSONSerialization.jsonObject(with: chunk) as? [String: Any],
+                  let type = obj["type"] as? String else { continue }
+            if type == "response" {
+                handleResponse(obj)
+            } else if type == "event", let event = obj["event"] as? [String: Any] {
+                handleEvent(event)
+            }
+        }
+    }
+
+    private func handleResponse(_ obj: [String: Any]) {
+        let id = obj["id"] as? Int
+        lock.lock()
+        let cont: CheckedContinuation<[String: Any], Error>? = {
+            guard let id else { return nil }
+            pendingRequestTimeouts.removeValue(forKey: id)?.cancel()
+            return pendingRequests.removeValue(forKey: id)
+        }()
+        lock.unlock()
+        guard let cont else { return }
+        if obj["ok"] as? Bool == false {
+            let err = obj["error"] as? String ?? "request failed"
+            cont.resume(throwing: AgentRuntimeTransportError.turnFailed(err))
+        } else {
+            cont.resume(returning: obj)
+        }
+    }
+
+    private func handleEvent(_ event: [String: Any]) {
+        let name = event["event"] as? String ?? ""
+
+        switch name {
+        case "block:start":
+            if let block = event["block"] as? [String: Any],
+               let type = block["type"] as? String,
+               type == "text",
+               let blockId = block["id"] as? String {
+                lock.lock()
+                textBlockIDs.insert(blockId)
+                lock.unlock()
+            }
+            if let block = event["block"] as? [String: Any],
+               let type = block["type"] as? String,
+               type == "action",
+               let action = block["action"] as? [String: Any],
+               let toolName = action["toolName"] as? String {
+                lock.lock()
+                let cb = onTool
+                lock.unlock()
+                cb?(toolName)
+            }
+
+        case "block:delta":
+            guard let text = event["text"] as? String, !text.isEmpty else { return }
+            let blockId = event["blockId"] as? String
+            lock.lock()
+            let isTextBlock = blockId.map { textBlockIDs.contains($0) } ?? true
+            // Prefer text blocks; if none were typed yet, still accumulate deltas.
+            let accept = textBlockIDs.isEmpty || isTextBlock
+            if accept {
+                accumulatedText += text
+            }
+            let snapshot = accumulatedText
+            let cb = onTextDelta
+            lock.unlock()
+            if accept {
+                cb?(snapshot)
+            }
+
+        case "block:end":
+            // Some adapters only put full text on block:end.
+            if let blockId = event["blockId"] as? String {
+                lock.lock()
+                let isText = textBlockIDs.contains(blockId) || textBlockIDs.isEmpty
+                lock.unlock()
+                if isText, let text = event["text"] as? String, !text.isEmpty {
+                    lock.lock()
+                    if accumulatedText.isEmpty {
+                        accumulatedText = text
+                    } else if !accumulatedText.contains(text) {
+                        accumulatedText += text
+                    }
+                    let snapshot = accumulatedText
+                    let cb = onTextDelta
+                    lock.unlock()
+                    cb?(snapshot)
+                }
+            }
+            if let block = event["block"] as? [String: Any],
+               (block["type"] as? String) == "text",
+               let text = block["text"] as? String,
+               !text.isEmpty {
+                lock.lock()
+                if accumulatedText.isEmpty || text.count > accumulatedText.count {
+                    accumulatedText = text
+                }
+                let snapshot = accumulatedText
+                let cb = onTextDelta
+                lock.unlock()
+                cb?(snapshot)
+            }
+
+        case "block:action:status":
+            break
+
+        case "turn:end":
+            finishTurn(status: event["status"] as? String)
+
+        case "turn:error":
+            let message = event["message"] as? String ?? "Agent turn error"
+            failTurn(AgentRuntimeTransportError.turnFailed(message))
+
+        case "session:update":
+            if let session = event["session"] as? [String: Any],
+               let status = session["status"] as? String,
+               status == "error" {
+                lock.lock()
+                if lastAdapterError == nil {
+                    lastAdapterError = "Agent session entered error state."
+                }
+                let hasTurn = turnContinuation != nil
+                let err = lastAdapterError
+                lock.unlock()
+                if hasTurn, let err {
+                    // Don't fail immediately on every error update — claude often
+                    // errors after an empty turn:end. Keep for finishTurn.
+                    DiagnosticLog.shared.warn("AgentRuntime · session error: \(err)")
+                }
+            }
+
+        case "session:closed":
+            lock.lock()
+            activeSessionID = nil
+            activeHarness = nil
+            let hasTurn = turnContinuation != nil
+            let err = lastAdapterError
+            lock.unlock()
+            // Harness died mid-turn without a clean turn:end.
+            if hasTurn {
+                failTurn(AgentRuntimeTransportError.turnFailed(
+                    err ?? "Agent session closed before a reply."
+                ))
+            }
+
+        default:
+            break
+        }
+    }
+
+    private func finishTurn(status: String?) {
+        lock.lock()
+        let cont = turnContinuation
+        turnContinuation = nil
+        turnTimeoutWork?.cancel()
+        turnTimeoutWork = nil
+        let text = accumulatedText
+        let harness = activeHarness ?? "unknown"
+        let sessionId = activeSessionID ?? ""
+        let adapterError = lastAdapterError
+        onTextDelta = nil
+        onTool = nil
+        lock.unlock()
+
+        guard let cont else { return }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            let reason: String
+            if let adapterError, !adapterError.isEmpty {
+                reason = adapterError
+            } else if let status, status != "completed" {
+                reason = "Agent turn ended (\(status)) without a text reply."
+            } else {
+                reason = "The agent finished without a text reply (harness may have exited early — check \(harness) is logged in)."
+            }
+            cont.resume(throwing: AgentRuntimeTransportError.turnFailed(reason))
+        } else {
+            cont.resume(returning: AgentRuntimeReply(text: trimmed, harness: harness, sessionId: sessionId))
+        }
+    }
+
+    private func failTurn(_ error: Error) {
+        lock.lock()
+        let cont = turnContinuation
+        turnContinuation = nil
+        turnTimeoutWork?.cancel()
+        turnTimeoutWork = nil
+        onTextDelta = nil
+        onTool = nil
+        lock.unlock()
+        cont?.resume(throwing: error)
+    }
+}
+

--- a/apps/mac/Sources/Core/Assistant/ScoutAssistantTransport.swift
+++ b/apps/mac/Sources/Core/Assistant/ScoutAssistantTransport.swift
@@ -11,6 +11,8 @@ enum ScoutAssistantTransportError: LocalizedError {
     case invalidResponse(String)
     case commandFailed(String)
     case emptyReply
+    /// Flight parked for an offline/offline-queued target — not worth a 10‑minute wait.
+    case targetOffline(summary: String, targetLabel: String?)
 
     var errorDescription: String? {
         switch self {
@@ -22,7 +24,20 @@ enum ScoutAssistantTransportError: LocalizedError {
             return detail.isEmpty ? "Scout could not complete this turn." : detail
         case .emptyReply:
             return "Scout completed the turn without returning a reply."
+        case .targetOffline(let summary, let targetLabel):
+            let target = (targetLabel?.trimmingCharacters(in: .whitespacesAndNewlines)).flatMap { $0.isEmpty ? nil : $0 }
+            // Keep user-facing copy product-level; avoid "Waiting for …" style transport copy.
+            if let target {
+                return "The assistant session is offline (\(target)). \(summary) The binding was cleared — try again."
+            }
+            return "The assistant session is offline. \(summary) The binding was cleared — try again."
         }
+    }
+
+    /// True when the binding should be dropped so the next ask re-resolves a live target.
+    var shouldClearBinding: Bool {
+        if case .targetOffline = self { return true }
+        return false
     }
 }
 
@@ -75,24 +90,50 @@ final class ScoutAssistantTransport {
             ?? bindingRef
         let targetLabel = Self.string(in: ids, key: "targetAgentId")
 
-        if let immediate = Self.replyText(fromFlight: receipt["flight"] as? [String: Any]) {
+        let receiptFlight = receipt["flight"] as? [String: Any]
+        if let immediate = Self.replyText(fromFlight: receiptFlight) {
             return ScoutAssistantReply(text: immediate, bindingRef: nextRef, targetLabel: targetLabel)
+        }
+
+        // Offline targets return state=queued with "when online" and never complete
+        // until the session wakes — do not hang the composer for the full wait window.
+        if let offline = Self.offlineQueueError(fromFlight: receiptFlight, targetLabel: targetLabel) {
+            throw offline
         }
 
         guard let invocationID, !invocationID.isEmpty else {
             throw ScoutAssistantTransportError.invalidResponse("The ask receipt did not include an invocation id.")
         }
 
+        // Cap wait well under Scout's multi-minute parking window so a stuck
+        // flight surfaces as an error instead of a permanent LIVE / Composing card.
         let waitData = try await run(
-            arguments: ["--json", "wait", invocationID, "--timeout", "600"],
+            arguments: ["--json", "wait", invocationID, "--timeout", "90"],
             currentDirectory: projectPath
         )
         let wait = try Self.jsonObject(from: waitData)
         if let error = Self.string(in: wait, key: "error"), !error.isEmpty {
             throw ScoutAssistantTransportError.commandFailed(error)
         }
+
+        let waitFlight = wait["flight"] as? [String: Any] ?? receiptFlight
+        if wait["timedOut"] as? Bool == true {
+            if let offline = Self.offlineQueueError(fromFlight: waitFlight, targetLabel: targetLabel) {
+                throw offline
+            }
+            let summary = Self.string(in: waitFlight, key: "summary")
+                ?? Self.string(in: wait, key: "summary")
+                ?? "No reply yet."
+            throw ScoutAssistantTransportError.commandFailed(
+                "Scout timed out waiting for a reply. \(summary)"
+            )
+        }
+
         guard let output = Self.string(in: wait, key: "output")?.trimmingCharacters(in: .whitespacesAndNewlines),
               !output.isEmpty else {
+            if let offline = Self.offlineQueueError(fromFlight: waitFlight, targetLabel: targetLabel) {
+                throw offline
+            }
             if let summary = Self.string(in: wait, key: "summary")?.trimmingCharacters(in: .whitespacesAndNewlines),
                !summary.isEmpty {
                 return ScoutAssistantReply(text: summary, bindingRef: nextRef, targetLabel: targetLabel)
@@ -110,8 +151,7 @@ final class ScoutAssistantTransport {
     }
 
     private var executableURL: URL? {
-        let environment = ProcessInfo.processInfo.environment
-        let pathCandidates = (environment["PATH"] ?? "")
+        let pathCandidates = Self.enrichedPath
             .split(separator: ":")
             .map { String($0) + "/scout" }
         let home = FileManager.default.homeDirectoryForCurrentUser.path
@@ -123,6 +163,33 @@ final class ScoutAssistantTransport {
         ]
         return candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) })
             .map(URL.init(fileURLWithPath:))
+    }
+
+    /// PATH with common user install prefixes prepended so GUI-spawned Scout
+    /// can resolve `bun` / `node` (macOS LaunchServices PATH is often bare).
+    private static var enrichedPath: String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let prefixes = [
+            "\(home)/.bun/bin",
+            "\(home)/.local/bin",
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+        ]
+        let existing = (ProcessInfo.processInfo.environment["PATH"] ?? "")
+            .split(separator: ":")
+            .map(String.init)
+        var seen = Set<String>()
+        var parts: [String] = []
+        for part in prefixes + existing where !part.isEmpty && seen.insert(part).inserted {
+            parts.append(part)
+        }
+        return parts.joined(separator: ":")
+    }
+
+    private static func processEnvironment() -> [String: String] {
+        var env = ProcessInfo.processInfo.environment
+        env["PATH"] = enrichedPath
+        return env
     }
 
     private func run(
@@ -155,6 +222,9 @@ final class ScoutAssistantTransport {
             let process = Process()
             process.executableURL = executableURL
             process.arguments = arguments
+            // GUI apps inherit a minimal PATH from LaunchServices, so scout's
+            // shell wrapper cannot find bun/node unless we restore user bins.
+            process.environment = Self.processEnvironment()
             if let currentDirectory, FileManager.default.fileExists(atPath: currentDirectory) {
                 process.currentDirectoryURL = URL(fileURLWithPath: currentDirectory, isDirectory: true)
             }
@@ -167,7 +237,29 @@ final class ScoutAssistantTransport {
             }
 
             try process.run()
-            process.waitUntilExit()
+            // Wall-clock cap so a hung scout binary cannot leave the composer on
+            // "Composing…" forever (wait --timeout alone is not enough if the
+            // process never returns).
+            let wallSeconds = Self.wallClockSeconds(for: arguments)
+            let deadline = Date().addingTimeInterval(wallSeconds)
+            while process.isRunning, Date() < deadline {
+                Thread.sleep(forTimeInterval: 0.05)
+                try Task.checkCancellation()
+            }
+            if process.isRunning {
+                process.terminate()
+                // Brief grace, then hard kill if still alive.
+                let killDeadline = Date().addingTimeInterval(1.0)
+                while process.isRunning, Date() < killDeadline {
+                    Thread.sleep(forTimeInterval: 0.05)
+                }
+                if process.isRunning {
+                    process.interrupt()
+                }
+                throw ScoutAssistantTransportError.commandFailed(
+                    "Scout timed out after \(Int(wallSeconds))s (\(arguments.dropFirst().prefix(3).joined(separator: " ")))."
+                )
+            }
             try stdout.synchronize()
             try stderr.synchronize()
             try Task.checkCancellation()
@@ -186,6 +278,14 @@ final class ScoutAssistantTransport {
         }.value
     }
 
+    /// Max seconds a Scout subprocess may live before Lattices kills it.
+    static func wallClockSeconds(for arguments: [String]) -> TimeInterval {
+        if arguments.contains("wait") { return 105 }
+        if arguments.contains("whoami") { return 8 }
+        if arguments.contains("ask") { return 45 }
+        return 30
+    }
+
     private static func jsonObject(from data: Data) throws -> [String: Any] {
         guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             let text = String(data: data, encoding: .utf8) ?? ""
@@ -201,6 +301,28 @@ final class ScoutAssistantTransport {
     private static func replyText(fromFlight flight: [String: Any]?) -> String? {
         guard flight?["state"] as? String == "completed" else { return nil }
         return (flight?["output"] as? String) ?? (flight?["summary"] as? String)
+    }
+
+    /// Detect Scout parking a flight for a session that is not currently online.
+    static func offlineQueueError(
+        fromFlight flight: [String: Any]?,
+        targetLabel: String?
+    ) -> ScoutAssistantTransportError? {
+        guard let flight else { return nil }
+        let state = (flight["state"] as? String)?.lowercased() ?? ""
+        let summary = string(in: flight, key: "summary")?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let looksOffline =
+            summary.localizedCaseInsensitiveContains("when online")
+            || summary.localizedCaseInsensitiveContains("will deliver when")
+            || summary.localizedCaseInsensitiveContains("offline")
+        let parked = state == "queued" || state == "pending" || state == "deferred"
+        // Definitive signal: parked + offline wording (e.g. "Will deliver when online").
+        guard parked && looksOffline else { return nil }
+        return .targetOffline(
+            summary: summary.isEmpty ? "Will deliver when the target is online." : summary,
+            targetLabel: targetLabel ?? string(in: flight, key: "targetAgentId")
+        )
     }
 
     private static func normalizedRef(_ value: String) -> String {

--- a/apps/mac/Sources/Core/Assistant/WorkspaceAssistantSession.swift
+++ b/apps/mac/Sources/Core/Assistant/WorkspaceAssistantSession.swift
@@ -166,7 +166,11 @@ final class WorkspaceAssistantSession: ObservableObject {
     private let scoutTransport = ScoutAssistantTransport()
     private var scoutBindingRef: String? {
         didSet {
-            UserDefaults.standard.set(scoutBindingRef, forKey: Self.scoutBindingRefDefaultsKey)
+            if let scoutBindingRef, !scoutBindingRef.isEmpty {
+                UserDefaults.standard.set(scoutBindingRef, forKey: Self.scoutBindingRefDefaultsKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: Self.scoutBindingRefDefaultsKey)
+            }
         }
     }
     private var streamingMessageID: UUID?
@@ -191,6 +195,10 @@ final class WorkspaceAssistantSession: ObservableObject {
 
     private static let selectedProviderDefaultsKey = "HudsonAISelectedProvider"
     private static let scoutBindingRefDefaultsKey = "ScoutWorkspaceAssistantBindingRef"
+    private static let preferredHarnessDefaultsKey = "LatticesAssistantPreferredHarness"
+
+    /// Last successful agent-runtime harness id (for status chrome).
+    @Published private(set) var agentRuntimeHarnessLabel: String?
     private static let voiceInferenceTimeout: TimeInterval = 45
     private static let voiceAppendSystemPrompt = """
         You are the Workspace Assistant for Lattices voice surfaces.
@@ -276,8 +284,7 @@ final class WorkspaceAssistantSession: ObservableObject {
         !hasSelectedCredential
     }
 
-    /// Chat never needs a Lattices-owned model credential. Scout owns routing,
-    /// authorization, and the concrete harness session.
+    /// Chat always has a path: HudsonAI when a key is saved, otherwise Scout.
     var needsChatSetup: Bool { false }
 
     var scoutStatusSummary: String {
@@ -291,6 +298,28 @@ final class WorkspaceAssistantSession: ObservableObject {
             return "Scout unavailable"
         case nil:
             return "Checking Scout…"
+        }
+    }
+
+    var chatTransportSummary: String {
+        if let harness = agentRuntimeHarnessLabel, !harness.isEmpty {
+            return "Agent runtime · \(harness)"
+        }
+        if hasSelectedCredential {
+            return "\(currentProvider.name) · API"
+        }
+        return "Scout · project session"
+    }
+
+    var preferredAgentHarness: String? {
+        get { UserDefaults.standard.string(forKey: Self.preferredHarnessDefaultsKey) }
+        set {
+            if let newValue, !newValue.isEmpty {
+                UserDefaults.standard.set(newValue, forKey: Self.preferredHarnessDefaultsKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: Self.preferredHarnessDefaultsKey)
+            }
+            objectWillChange.send()
         }
     }
 
@@ -318,7 +347,7 @@ final class WorkspaceAssistantSession: ObservableObject {
     }
 
     var setupStatusSummary: String {
-        scoutStatusSummary
+        chatTransportSummary
     }
 
     /// Active tool name when the runtime is mid-tool-call, else nil. Drives
@@ -423,14 +452,13 @@ final class WorkspaceAssistantSession: ObservableObject {
         }
 
         isSending = true
-        statusText = "asking scout..."
+        statusText = "thinking..."
         settleActiveStreamingMessage(interrupted: false)   // snap any prior reveal to full before a new turn
         turnGeneration &+= 1
         let turnGen = turnGeneration
-        let prompt = scoutPrompt(for: trimmed, attachments: attachments)
-        let projectPath = scoutProjectPath()
-        let inferenceTimer = DiagnosticLog.shared.startTimed("Chat inference via Scout")
         let messageID = UUID()
+        // Empty body while the turn is in flight — HudAgentTurn already shows LIVE /
+        // Composing. Do not leak transport brand names into the message stream.
         messages.append(WorkspaceAssistantMessage(
             id: messageID,
             role: .assistant,
@@ -441,17 +469,165 @@ final class WorkspaceAssistantSession: ObservableObject {
         streamingMessageID = messageID
         resetStreamingDrain()
 
-        sendViaScout(
-            prompt: prompt,
-            projectPath: projectPath,
-            messageID: messageID,
-            generation: turnGen,
-            inferenceTimer: inferenceTimer
-        )
+        // Transport preference:
+        // 1) local agent-runtime / ACP harness (no Lattices API key)
+        // 2) HudsonAI direct when a key is saved
+        // 3) Scout project session fallback
+        let system = chatSystemPrompt(attachments: attachments)
+        let projectPath = scoutProjectPath()
+        let preferredHarness = UserDefaults.standard.string(forKey: Self.preferredHarnessDefaultsKey)
+        let canUseAPI = hasSelectedCredential
+        let providerName = currentProvider.name
+        streamingTask = Task { [weak self] in
+            guard let self else { return }
+            let runtime = AgentRuntimeTransport.shared
+            if await runtime.isAvailable() {
+                let timer = DiagnosticLog.shared.startTimed("Chat inference via agent-runtime")
+                await self.sendViaAgentRuntime(
+                    userText: trimmed,
+                    systemPrompt: system,
+                    cwd: projectPath,
+                    preferredHarness: preferredHarness,
+                    messageID: messageID,
+                    generation: turnGen,
+                    inferenceTimer: timer,
+                    canUseAPI: canUseAPI,
+                    providerName: providerName,
+                    attachments: attachments
+                )
+                return
+            }
+            if canUseAPI {
+                let timer = DiagnosticLog.shared.startTimed(
+                    "Chat inference via HudsonAI · \(providerName)"
+                )
+                await MainActor.run {
+                    self.sendViaDirectProvider(
+                        userText: trimmed,
+                        attachments: attachments,
+                        messageID: messageID,
+                        generation: turnGen,
+                        inferenceTimer: timer
+                    )
+                }
+                return
+            }
+            let prompt = await MainActor.run {
+                self.scoutPrompt(for: trimmed, attachments: attachments)
+            }
+            let timer = DiagnosticLog.shared.startTimed("Chat inference via Scout")
+            await MainActor.run {
+                self.sendViaScout(
+                    prompt: prompt,
+                    projectPath: projectPath,
+                    messageID: messageID,
+                    generation: turnGen,
+                    inferenceTimer: timer
+                )
+            }
+        }
     }
 
-    /// Ask through the user's existing Scout broker and retain the returned ref
-    /// so every follow-up stays attached to the same concrete Scout session.
+    /// Local harness path (claude / codex / pi / opencode / ACP adapters via agent-runner).
+    private func sendViaAgentRuntime(
+        userText: String,
+        systemPrompt: String,
+        cwd: String,
+        preferredHarness: String?,
+        messageID: UUID,
+        generation: Int,
+        inferenceTimer: DiagnosticLog.TimedAction,
+        canUseAPI: Bool,
+        providerName: String,
+        attachments: [WorkspaceAssistantAttachment]
+    ) async {
+        do {
+            let reply = try await AgentRuntimeTransport.shared.ask(
+                text: userText,
+                systemPrompt: systemPrompt,
+                cwd: cwd,
+                preferredHarness: preferredHarness,
+                onDelta: { [weak self] snapshot in
+                    Task { @MainActor in
+                        guard let self, self.turnGeneration == generation else { return }
+                        self.statusText = "streaming..."
+                        self.commitStreamingText(snapshot)
+                    }
+                },
+                onTool: { [weak self] name in
+                    Task { @MainActor in
+                        guard let self, self.turnGeneration == generation else { return }
+                        self.statusText = "tool: \(name)"
+                    }
+                }
+            )
+            await MainActor.run { [weak self] in
+                guard let self, self.turnGeneration == generation else { return }
+                self.streamingTask = nil
+                self.isSending = false
+                self.statusText = "idle"
+                self.agentRuntimeHarnessLabel = reply.harness
+                DiagnosticLog.shared.finish(inferenceTimer)
+                DiagnosticLog.shared.info("Assistant · agent-runtime \(reply.harness) completed")
+                self.commitStreamingText(reply.text)
+                self.finalizeStreaming(finalText: reply.text)
+                self.drainQueuedPrompt()
+            }
+        } catch is CancellationError {
+            DiagnosticLog.shared.info("Assistant · agent-runtime cancelled")
+            await MainActor.run { [weak self] in
+                guard let self, self.turnGeneration == generation else { return }
+                self.streamingTask = nil
+                if self.isSending {
+                    self.isSending = false
+                    self.statusText = "idle"
+                    self.settleActiveStreamingMessage(interrupted: true)
+                }
+            }
+        } catch {
+            let detail = error.localizedDescription
+            DiagnosticLog.shared.fail(inferenceTimer, message: detail)
+            DiagnosticLog.shared.info("Assistant · agent-runtime failed (\(detail)) — falling back")
+            await MainActor.run { [weak self] in
+                guard let self, self.turnGeneration == generation else { return }
+                self.statusText = canUseAPI
+                    ? "agent runtime failed · trying API…"
+                    : "agent runtime failed · trying Scout…"
+            }
+            if canUseAPI {
+                let timer = DiagnosticLog.shared.startTimed(
+                    "Chat inference via HudsonAI · \(providerName)"
+                )
+                await MainActor.run {
+                    self.streamingTask = nil
+                    self.sendViaDirectProvider(
+                        userText: userText,
+                        attachments: attachments,
+                        messageID: messageID,
+                        generation: generation,
+                        inferenceTimer: timer
+                    )
+                }
+            } else {
+                let prompt = await MainActor.run {
+                    self.scoutPrompt(for: userText, attachments: attachments)
+                }
+                let timer = DiagnosticLog.shared.startTimed("Chat inference via Scout")
+                await MainActor.run {
+                    self.streamingTask = nil
+                    self.sendViaScout(
+                        prompt: prompt,
+                        projectPath: cwd,
+                        messageID: messageID,
+                        generation: generation,
+                        inferenceTimer: timer
+                    )
+                }
+            }
+        }
+    }
+
+    /// Scout path kept as fallback when no in-app provider key is saved.
     private func sendViaScout(
         prompt: String,
         projectPath: String,
@@ -463,7 +639,7 @@ final class WorkspaceAssistantSession: ObservableObject {
         streamingTask = Task { [weak self] in
             guard let self else { return }
             do {
-                let reply = try await self.scoutTransport.ask(
+                let reply = try await self.askWithOfflineRetry(
                     prompt: prompt,
                     projectPath: projectPath,
                     bindingRef: continuingRef
@@ -477,8 +653,13 @@ final class WorkspaceAssistantSession: ObservableObject {
                     self.scoutBindingRef = reply.bindingRef
                     self.scoutTargetLabel = reply.targetLabel
                     DiagnosticLog.shared.finish(inferenceTimer)
-                    self.commitStreamingText(reply.text)
-                    self.finalizeStreaming(finalText: reply.text)
+                    let text = reply.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if text.isEmpty {
+                        self.failAssistantMessage(id: messageID, detail: "Empty reply.")
+                    } else {
+                        self.commitStreamingText(text)
+                        self.finalizeStreaming(finalText: text)
+                    }
                     self.drainQueuedPrompt()
                 }
             } catch {
@@ -489,12 +670,223 @@ final class WorkspaceAssistantSession: ObservableObject {
                     let detail = error.localizedDescription
                     DiagnosticLog.shared.fail(inferenceTimer, message: detail)
                     self.failAssistantMessage(id: messageID, detail: detail)
-                    self.statusText = "scout offline"
-                    self.isScoutAvailable = false
+                    if Self.isOfflineTargetError(error) {
+                        self.scoutBindingRef = nil
+                        self.scoutTargetLabel = nil
+                        self.statusText = "idle"
+                        self.isScoutAvailable = true
+                    } else {
+                        self.statusText = "scout offline"
+                        self.isScoutAvailable = false
+                    }
                     self.drainQueuedPrompt()
                 }
             }
         }
+    }
+
+    private func askWithOfflineRetry(
+        prompt: String,
+        projectPath: String,
+        bindingRef: String?
+    ) async throws -> ScoutAssistantReply {
+        do {
+            return try await scoutTransport.ask(
+                prompt: prompt,
+                projectPath: projectPath,
+                bindingRef: bindingRef
+            )
+        } catch {
+            guard Self.isOfflineTargetError(error),
+                  let bindingRef,
+                  !bindingRef.isEmpty else { throw error }
+
+            await MainActor.run {
+                self.scoutBindingRef = nil
+                self.scoutTargetLabel = nil
+                DiagnosticLog.shared.info(
+                    "Assistant · bound session offline — retrying project route \(projectPath)"
+                )
+            }
+            return try await scoutTransport.ask(
+                prompt: prompt,
+                projectPath: projectPath,
+                bindingRef: nil
+            )
+        }
+    }
+
+    private static func isOfflineTargetError(_ error: Error) -> Bool {
+        if let scoutError = error as? ScoutAssistantTransportError {
+            return scoutError.shouldClearBinding
+        }
+        let text = error.localizedDescription
+        return text.localizedCaseInsensitiveContains("offline session")
+            || text.localizedCaseInsensitiveContains("when online")
+    }
+
+    /// Direct chat path: HudsonAI provider stream (same credential vault as voice).
+    /// Skips Scout broker / offline session parking for ordinary assistant turns.
+    private func sendViaDirectProvider(
+        userText: String,
+        attachments: [WorkspaceAssistantAttachment],
+        messageID: UUID,
+        generation: Int,
+        inferenceTimer: DiagnosticLog.TimedAction
+    ) {
+        let provider = currentProvider
+        let system = chatSystemPrompt(attachments: attachments)
+        let history = chatHistoryMessages(excludingAssistantID: messageID)
+        let request = HudAIRequest(
+            model: provider.modelID,
+            messages: history + [.user(userText)],
+            system: system
+        )
+        let client = HudAIClient(
+            provider: provider.makeAdapter(),
+            model: provider.modelID,
+            hudVault: voiceVault,
+            defaults: HudAIDefaults(maxOutputTokens: 4_096, timeout: 120),
+            routeDefault: .local
+        )
+
+        streamingTask = Task { [weak self] in
+            guard let self else { return }
+            var accumulated = ""
+            do {
+                for try await event in client.stream(request) {
+                    try Task.checkCancellation()
+                    switch event {
+                    case .textDelta(_, let text):
+                        accumulated += text
+                        let snapshot = accumulated
+                        await MainActor.run { [weak self] in
+                            guard let self, self.turnGeneration == generation else { return }
+                            self.statusText = "streaming..."
+                            self.commitStreamingText(snapshot)
+                        }
+                    case .toolCallStarted(_, let name):
+                        await MainActor.run { [weak self] in
+                            guard let self, self.turnGeneration == generation else { return }
+                            self.statusText = "tool: \(name)"
+                        }
+                    case .completed(let response):
+                        if accumulated.isEmpty {
+                            accumulated = response.text
+                        }
+                    case .failed(let error):
+                        throw error
+                    case .cancelled:
+                        throw CancellationError()
+                    case .started, .reasoningDelta, .toolCallInputDelta, .toolCallReady,
+                         .toolResultAccepted, .usage:
+                        break
+                    }
+                }
+
+                let finalText = accumulated.trimmingCharacters(in: .whitespacesAndNewlines)
+                await MainActor.run { [weak self] in
+                    guard let self, self.turnGeneration == generation else { return }
+                    self.streamingTask = nil
+                    self.isSending = false
+                    self.statusText = "idle"
+                    DiagnosticLog.shared.finish(inferenceTimer)
+                    if finalText.isEmpty {
+                        self.failAssistantMessage(
+                            id: messageID,
+                            detail: "The model returned an empty reply."
+                        )
+                    } else {
+                        self.commitStreamingText(finalText)
+                        self.finalizeStreaming(finalText: finalText)
+                    }
+                    self.drainQueuedPrompt()
+                }
+            } catch is CancellationError {
+                await MainActor.run { [weak self] in
+                    guard let self, self.turnGeneration == generation else { return }
+                    self.streamingTask = nil
+                    // stop() already settled the UI; only clean up if still marked sending.
+                    if self.isSending {
+                        self.isSending = false
+                        self.statusText = "idle"
+                        self.settleActiveStreamingMessage(interrupted: true)
+                    }
+                }
+            } catch {
+                await MainActor.run { [weak self] in
+                    guard let self, self.turnGeneration == generation else { return }
+                    self.streamingTask = nil
+                    self.isSending = false
+                    let detail = error.localizedDescription
+                    DiagnosticLog.shared.fail(inferenceTimer, message: detail)
+                    self.failAssistantMessage(id: messageID, detail: detail)
+                    if Self.isAuthFailure(detail) {
+                        self.statusText = "setup ai"
+                        self.authErrorText = detail
+                        self.isAuthPanelVisible = true
+                    } else {
+                        self.statusText = "idle"
+                    }
+                    self.drainQueuedPrompt()
+                }
+            }
+        }
+    }
+
+    /// Prior turns for multi-turn chat (excludes the empty streaming placeholder).
+    private func chatHistoryMessages(excludingAssistantID: UUID) -> [HudAIMessage] {
+        messages.compactMap { message -> HudAIMessage? in
+            if message.id == excludingAssistantID { return nil }
+            let text = message.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { return nil }
+            switch message.role {
+            case .user:
+                return .user(text)
+            case .assistant:
+                // Skip prior error cards — they pollute the model context.
+                if text.hasPrefix("**Assistant error**") { return nil }
+                return .assistant(text)
+            case .system:
+                return nil
+            }
+        }
+    }
+
+    private func chatSystemPrompt(attachments: [WorkspaceAssistantAttachment] = []) -> String {
+        let knowledge = Self.capabilitiesGuide
+        let knowledgeBlock = knowledge.isEmpty ? "" : """
+
+            Lattices product knowledge (how the app works; cite the linked docs when a question goes deeper):
+            \(knowledge)
+            """
+        let attachmentBlock = attachments.isEmpty ? "" : """
+
+            Attached files:
+            \(assistantAttachmentBlock(attachments))
+            """
+        return """
+        You are the Workspace Assistant, the in-app assistant for Lattices.
+
+        Use the structured context as ground truth for this user's current configuration, and the product knowledge to explain how Lattices works and point to the right feature or doc. Answer naturally and concretely. For informational questions, explain what is currently configured and what the available choices mean.
+
+        For setting changes, say what should change and the exact next step if you cannot apply it yourself. Never claim a setting or file changed unless you know it did.
+        \(knowledgeBlock)
+        \(attachmentBlock)
+
+        Structured context:
+        \(assistantKnowledgeBrief())
+        """
+    }
+
+    private static func isAuthFailure(_ detail: String) -> Bool {
+        let lower = detail.lowercased()
+        return lower.contains("unauthorized")
+            || lower.contains("invalid api key")
+            || lower.contains("authentication")
+            || lower.contains("401")
+            || lower.contains("missing api key")
+            || lower.contains("no credential")
     }
 
     func askVoiceAdvisor(transcript: String, matched: String, callback: @escaping (AgentResponse?) -> Void) {
@@ -747,10 +1139,10 @@ final class WorkspaceAssistantSession: ObservableObject {
     /// `interrupted`, tag the partial so it reads as deliberately cut off.
     private func settleActiveStreamingMessage(interrupted: Bool) {
         guard let id = streamingMessageID else { return }
-        let full = streamingTargetText
+        let full = streamingTargetText.trimmingCharacters(in: .whitespacesAndNewlines)
         resetStreamingDrain()
         streamingMessageID = nil
-        if full.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        if full.isEmpty {
             removeMessageIfEmpty(id: id)
         } else if interrupted {
             updateAssistantMessage(id: id, text: full + "\n\n— stopped —")
@@ -773,6 +1165,7 @@ final class WorkspaceAssistantSession: ObservableObject {
     private func stop(drainQueue: Bool) {
         turnGeneration &+= 1
         scoutTransport.cancelCurrentTurn()
+        AgentRuntimeTransport.shared.interrupt()
         streamingTask?.cancel()
         streamingTask = nil
         isSending = false
@@ -906,6 +1299,7 @@ final class WorkspaceAssistantSession: ObservableObject {
 
     private func invalidateChatRuntime() {
         scoutTransport.cancelCurrentTurn()
+        AgentRuntimeTransport.shared.interrupt()
         streamingTask?.cancel()
         streamingTask = nil
     }
@@ -958,7 +1352,7 @@ final class WorkspaceAssistantSession: ObservableObject {
         return """
         Welcome to the Workspace Assistant.
 
-        Chat is routed through your existing Scout broker and stays attached to one Scout session until you clear it. No separate model authorization is required in Lattices.
+        Chat prefers a local agent runtime (Claude Code, Codex, Pi, OpenCode — ACP under the covers when the harness uses it). Falls back to a saved API key or Scout if no local runtime is ready.
         """
     }
 
@@ -1394,10 +1788,11 @@ final class WorkspaceAssistantSession: ObservableObject {
             "assistant": [
                 "name": "Workspace Assistant",
                 "chatRuntime": [
-                    "transport": "Scout local broker",
-                    "authorization": "Inherited from Scout",
-                    "bindingRef": scoutBindingRef ?? "new session",
-                    "target": scoutTargetLabel ?? "Scout project route",
+                    "transportPreference": ["agent-runtime", "hudson-ai-api", "scout"],
+                    "agentRuntimeHarness": agentRuntimeHarnessLabel ?? preferredAgentHarness ?? "auto",
+                    "apiProvider": currentProvider.name,
+                    "apiModel": currentProvider.modelID,
+                    "apiCredential": selectedCredentialSummary,
                 ],
                 "voiceProvider": [
                     "id": authProviderID,

--- a/apps/mac/Sources/Core/Assistant/WorkspaceAssistantUI.swift
+++ b/apps/mac/Sources/Core/Assistant/WorkspaceAssistantUI.swift
@@ -149,8 +149,8 @@ struct WorkspaceAssistantTranscript: View {
     }
 
     private var showsEmptyState: Bool {
-        // Scout chat has no provider-auth setup wall, so the rich empty state
-        // is always the first conversation surface.
+        // Show starters until the first real turn; credential setup is handled
+        // when the user tries to send without a key.
         !session.hasConversationHistory
     }
 
@@ -493,10 +493,16 @@ struct WorkspaceAssistantComposer: View {
     #endif
 
     var body: some View {
-        VStack(spacing: 7) {
+        VStack(spacing: 0) {
             #if LATTICES_VOICE && canImport(HudsonVoice)
+            // Keep the idle composer footprint identical to pre-voice chrome.
+            // Grow only while recording/transcribing, or for a brief outcome note.
             if voice.state.isCaptureActive || voice.state.isProcessing {
                 dictationStrip
+            } else if voice.lastOutcome != nil {
+                if let outcome = voice.lastOutcome {
+                    voiceOutcomeStrip(outcome)
+                }
             }
             #endif
 
@@ -600,20 +606,56 @@ struct WorkspaceAssistantComposer: View {
         }
     }
 
-    /// Live dictation strip above the field: a 5-bar waveform with the running
-    /// partial transcript beside it. Shown only while the mic is hot.
+    /// Compact live strip while the mic is hot. Sits inside the same chrome as
+    /// HudComposer — no extra horizontal pad (parent already applies it).
     private var dictationStrip: some View {
-        HStack(spacing: 9) {
+        HStack(spacing: 8) {
             WorkspaceAssistantWaveform(tint: micAccent)
-            if !voice.partial.isEmpty {
-                Text(voice.partial)
-                    .font(Typo.body(style.composerSize))
-                    .foregroundColor(Palette.textDim)
-                    .lineLimit(2)
+            Group {
+                if voice.state.isProcessing {
+                    Text("Transcribing…")
+                        .foregroundColor(Palette.detach)
+                } else if !voice.partial.isEmpty {
+                    Text(voice.partial)
+                        .foregroundColor(Palette.textDim)
+                        .lineLimit(1)
+                } else {
+                    Text(voice.state == .starting ? "Starting…" : "Listening…")
+                        .foregroundColor(Palette.textMuted)
+                }
             }
+            .font(Typo.caption(11))
             Spacer(minLength: 0)
         }
-        .padding(.horizontal, 14)
+        .padding(.bottom, 6)
+        .transition(.opacity)
+    }
+
+    /// Soft note for empty/fail only — keeps the idle input box uncluttered.
+    private func voiceOutcomeStrip(_ outcome: WorkspaceVoiceOutcome) -> some View {
+        let tint: Color = outcome.kind == .failed ? Palette.kill : Palette.detach
+        return HStack(spacing: 6) {
+            Image(systemName: outcome.kind == .failed ? "exclamationmark.circle" : "waveform")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(tint.opacity(0.9))
+            Text(outcome.message)
+                .font(Typo.caption(10.5))
+                .foregroundColor(Palette.textMuted)
+                .lineLimit(1)
+            Spacer(minLength: 0)
+            Button {
+                voice.dismissOutcome()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundColor(Palette.textMuted.opacity(0.7))
+                    .frame(width: 16, height: 16)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help("Dismiss")
+        }
+        .padding(.bottom, 6)
         .transition(.opacity)
     }
 

--- a/apps/mac/Sources/Core/Assistant/WorkspaceAssistantView.swift
+++ b/apps/mac/Sources/Core/Assistant/WorkspaceAssistantView.swift
@@ -69,7 +69,7 @@ struct WorkspaceAssistantView: View {
     }
 
     private var headerSubtitle: String {
-        "Scout-backed chat for settings, layout help, planning, and debugging."
+        "Local agent runtime chat for settings, layout help, planning, and debugging."
     }
 
     private var statusPill: some View {

--- a/apps/mac/Sources/Core/Assistant/WorkspaceVoiceInput.swift
+++ b/apps/mac/Sources/Core/Assistant/WorkspaceVoiceInput.swift
@@ -30,6 +30,44 @@ enum WorkspaceVoiceState: Equatable {
     }
 }
 
+/// One-line outcome shown under the composer after a dictation turn.
+struct WorkspaceVoiceOutcome: Equatable {
+    enum Kind: Equatable {
+        case heard
+        case empty
+        case failed
+    }
+
+    let kind: Kind
+    let message: String
+    let transcript: String?
+    let at: Date
+
+    static func heard(_ text: String) -> WorkspaceVoiceOutcome {
+        WorkspaceVoiceOutcome(
+            kind: .heard,
+            message: "Heard: \(Self.preview(text))",
+            transcript: text,
+            at: Date()
+        )
+    }
+
+    static func empty(detail: String) -> WorkspaceVoiceOutcome {
+        WorkspaceVoiceOutcome(kind: .empty, message: detail, transcript: nil, at: Date())
+    }
+
+    static func failed(_ reason: String) -> WorkspaceVoiceOutcome {
+        WorkspaceVoiceOutcome(kind: .failed, message: reason, transcript: nil, at: Date())
+    }
+
+    private static func preview(_ text: String, limit: Int = 80) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count > limit else { return "“\(trimmed)”" }
+        let end = trimmed.index(trimmed.startIndex, offsetBy: limit)
+        return "“\(trimmed[..<end])…”"
+    }
+}
+
 /// Splice a dictated phrase into an existing buffer: empty → set; non-empty →
 /// append with a single separating space. Mirrors OpenScout's ScoutDictationBuffer.
 enum WorkspaceDictationBuffer {
@@ -57,13 +95,23 @@ final class WorkspaceVoiceInput: ObservableObject {
     /// Most recent final transcript. The chat session observes this and splices
     /// it into the draft, then calls `consumeFinalText()` so it fires once.
     @Published private(set) var lastFinalText: String = ""
+    /// Human-readable result of the last completed turn (success, empty, fail).
+    @Published private(set) var lastOutcome: WorkspaceVoiceOutcome?
 
     private var session: HudVoxLiveSession?
     private var pumpTask: Task<Void, Never>?
     private var stopTimeoutTask: Task<Void, Never>?
+    private var outcomeClearTask: Task<Void, Never>?
     private var activeCaptureID: String?
+    private var turnStartedAt: Date?
+    /// When the runtime first reported `.recording` (mic actually hot).
+    private var recordingStartedAt: Date?
     private var finalDelivered = false
     private static let stopTimeoutNanoseconds: UInt64 = 10_000_000_000
+    private static let outcomeVisibleNanoseconds: UInt64 = 8_000_000_000
+    /// AVCapture often needs a short settle after start; stopping too early yields
+    /// a near-empty WAV and a useless empty transcript.
+    private static let minimumRecordingNanoseconds: UInt64 = 700_000_000
 
     private init() {}
 
@@ -81,25 +129,38 @@ final class WorkspaceVoiceInput: ObservableObject {
     }
 
     @MainActor
+    func dismissOutcome() {
+        lastOutcome = nil
+        outcomeClearTask?.cancel()
+        outcomeClearTask = nil
+    }
+
+    @MainActor
     func start() {
         guard session == nil else {
-            DiagnosticLog.shared.warn("WorkspaceVoiceInput: start ignored; existing capture \(activeCaptureID ?? "unknown") is still \(stateLabel)")
+            voiceLog("already listening — ignored", level: .info)
             return
         }
         partial = ""
         finalDelivered = false
+        lastOutcome = nil
+        recordingStartedAt = nil
+        outcomeClearTask?.cancel()
         let captureID = UUID().uuidString.prefix(8).lowercased()
         activeCaptureID = String(captureID)
+        turnStartedAt = Date()
         state = .starting
 
         guard let runtime = HudsonVoiceRuntimeResolver.resolve(clientId: "lattices") else {
-            DiagnosticLog.shared.warn("WorkspaceVoiceInput[\(captureID)]: HudsonVoice runtime unavailable")
-            activeCaptureID = nil
-            state = .unavailable(reason: "Hudson Voice runtime is unavailable.")
+            finishTurn(
+                .failed("Voice runtime is not running. Restart Lattices."),
+                captureID: String(captureID),
+                asUnavailable: true
+            )
             return
         }
         let endpoint = runtime.endpoint
-        DiagnosticLog.shared.info("WorkspaceVoiceInput[\(captureID)]: starting voice session at \(endpoint.url.absoluteString)")
+        voiceLog("listening on \(endpoint.url.absoluteString)", level: .info, id: String(captureID))
         let session = HudVoxLiveSession(
             endpoint: endpoint,
             options: runtime.options
@@ -122,20 +183,35 @@ final class WorkspaceVoiceInput: ObservableObject {
     @MainActor
     func stop() {
         guard state.isCaptureActive else {
-            DiagnosticLog.shared.warn("WorkspaceVoiceInput: stop ignored while \(stateLabel)")
+            voiceLog("stop ignored (not recording)", level: .info)
+            return
+        }
+        // Wait until the runtime is actually recording — stop during `.starting`
+        // is a common source of empty WAVs.
+        guard state == .recording, recordingStartedAt != nil else {
+            voiceLog("still starting mic — hold a moment, then tap again", level: .info)
+            lastOutcome = .empty(detail: "Mic is still starting — hold a beat, then tap to finish.")
+            scheduleOutcomeClear()
             return
         }
         let captureID = activeCaptureID ?? "unknown"
-        DiagnosticLog.shared.info("WorkspaceVoiceInput[\(captureID)]: stopping voice session")
+        voiceLog("transcribing…", level: .info, id: captureID)
         state = .processing
         let session = self.session
+        let recordedFor = recordingStartedAt.map { Date().timeIntervalSince($0) } ?? 0
         stopTimeoutTask?.cancel()
         stopTimeoutTask = Task { [weak self, captureID] in
             try? await Task.sleep(nanoseconds: Self.stopTimeoutNanoseconds)
             guard !Task.isCancelled else { return }
             await MainActor.run { self?.stopTimedOut(captureID: captureID) }
         }
-        Task { [weak self, captureID] in
+        Task { [weak self, captureID, recordedFor] in
+            // Give AVCapture a minimum window so the file isn't just a header.
+            let minSeconds = Double(Self.minimumRecordingNanoseconds) / 1_000_000_000
+            if recordedFor < minSeconds {
+                let remaining = minSeconds - recordedFor
+                try? await Task.sleep(nanoseconds: UInt64(remaining * 1_000_000_000))
+            }
             do {
                 try await session?.stop()
             } catch {
@@ -147,7 +223,7 @@ final class WorkspaceVoiceInput: ObservableObject {
     @MainActor
     func cancel() {
         let captureID = activeCaptureID ?? "unknown"
-        DiagnosticLog.shared.info("WorkspaceVoiceInput[\(captureID)]: cancelling voice session")
+        voiceLog("cancelled", level: .info, id: captureID)
         let session = self.session
         finalDelivered = true   // suppress any trailing final
         partial = ""
@@ -169,15 +245,22 @@ final class WorkspaceVoiceInput: ObservableObject {
         guard isCurrentCapture(captureID) else { return }
         switch event {
         case .state(let s):
-            DiagnosticLog.shared.info("WorkspaceVoiceInput[\(captureID)]: session -> \(s.state)")
+            // Only surface user-meaningful states — skip noisy starting/done chatter.
             switch s.state {
             case .recording:
+                if state != .recording {
+                    voiceLog("recording", level: .info, id: captureID)
+                    recordingStartedAt = Date()
+                }
                 state = .recording
             case .processing:
                 state = .processing
             case .error:
-                DiagnosticLog.shared.warn("WorkspaceVoiceInput[\(captureID)]: voice runtime reported a session error state")
-                state = .unavailable(reason: "Voice runtime reported a session error.")
+                finishTurn(
+                    .failed("Voice engine reported an error. Try again."),
+                    captureID: captureID,
+                    asUnavailable: true
+                )
                 clearCapture(closeSession: true)
             case .cancelled:
                 if !state.isUnavailable { state = .idle }
@@ -186,8 +269,12 @@ final class WorkspaceVoiceInput: ObservableObject {
                 if state != .recording { state = .starting }
             case .done:
                 if !finalDelivered {
-                    DiagnosticLog.shared.warn("WorkspaceVoiceInput[\(captureID)]: session ended without a final transcript")
-                    state = .unavailable(reason: "No speech detected. Try again.")
+                    finishTurn(
+                        .empty(detail: "No speech detected."),
+                        captureID: captureID,
+                        asUnavailable: false
+                    )
+                    state = .idle
                 }
                 clearCapture(closeSession: true)
             }
@@ -207,12 +294,27 @@ final class WorkspaceVoiceInput: ObservableObject {
         finalDelivered = true
         partial = ""
         let trimmed = final.text.trimmingCharacters(in: .whitespacesAndNewlines)
-        DiagnosticLog.shared.info("WorkspaceVoiceInput[\(captureID)]: final transcript length=\(trimmed.count) elapsed=\(final.elapsedMs)ms")
+        let elapsed = final.elapsedMs
         if trimmed.isEmpty {
-            DiagnosticLog.shared.warn("WorkspaceVoiceInput[\(captureID)]: empty transcript from voice runtime")
-            state = .unavailable(reason: "No speech detected. Try again.")
+            // Empty is usually a truncated/empty capture (mic wrote almost no samples),
+            // not a hard system failure — keep out of red status-bar sticky.
+            finishTurn(
+                .empty(detail: "No audio captured — check the mic and speak for a second or two."),
+                captureID: captureID,
+                asUnavailable: false
+            )
+            state = .idle
         } else {
             lastFinalText = trimmed
+            // Success lands in the draft; still surface a brief confirmation so it
+            // doesn't feel like the mic did nothing.
+            finishTurn(
+                .heard(trimmed),
+                captureID: captureID,
+                asUnavailable: false,
+                elapsedMs: elapsed,
+                surfaceOutcome: true
+            )
             state = .idle
         }
         clearCapture(closeSession: true)
@@ -222,10 +324,9 @@ final class WorkspaceVoiceInput: ObservableObject {
     private func streamEnded(error: Error?, captureID: String) {
         guard isCurrentCapture(captureID) else { return }
         if let error, !finalDelivered {
-            DiagnosticLog.shared.warn("WorkspaceVoiceInput[\(captureID)]: session stream ended with error — \(error.localizedDescription)")
-            state = .unavailable(reason: error.localizedDescription)
+            let detail = Self.friendlyConnectionError(error)
+            finishTurn(.failed(detail), captureID: captureID, asUnavailable: true)
         } else if !finalDelivered, !state.isUnavailable {
-            DiagnosticLog.shared.warn("WorkspaceVoiceInput[\(captureID)]: stream ended without final transcript")
             state = .idle
         }
         clearCapture(closeSession: false)
@@ -234,8 +335,11 @@ final class WorkspaceVoiceInput: ObservableObject {
     @MainActor
     private func stopTimedOut(captureID: String) {
         guard isCurrentCapture(captureID), state.isProcessing else { return }
-        DiagnosticLog.shared.warn("WorkspaceVoiceInput[\(captureID)]: stop timed out waiting for final transcript")
-        state = .unavailable(reason: "Transcription timed out. Try again.")
+        finishTurn(
+            .failed("Transcription timed out. Try again."),
+            captureID: captureID,
+            asUnavailable: true
+        )
         let session = self.session
         clearCapture(closeSession: false)
         Task { try? await session?.cancel() }
@@ -244,9 +348,69 @@ final class WorkspaceVoiceInput: ObservableObject {
     @MainActor
     private func stopFailed(_ error: Error, captureID: String) {
         guard isCurrentCapture(captureID) else { return }
-        DiagnosticLog.shared.warn("WorkspaceVoiceInput[\(captureID)]: stop failed — \(error.localizedDescription)")
-        state = .unavailable(reason: error.localizedDescription)
+        finishTurn(
+            .failed(Self.friendlyConnectionError(error)),
+            captureID: captureID,
+            asUnavailable: true
+        )
         clearCapture(closeSession: true)
+    }
+
+    @MainActor
+    private func finishTurn(
+        _ outcome: WorkspaceVoiceOutcome,
+        captureID: String,
+        asUnavailable: Bool,
+        elapsedMs: Int? = nil,
+        surfaceOutcome: Bool = true
+    ) {
+        if surfaceOutcome {
+            lastOutcome = outcome
+            scheduleOutcomeClear()
+        } else {
+            lastOutcome = nil
+            outcomeClearTask?.cancel()
+            outcomeClearTask = nil
+        }
+        if asUnavailable {
+            state = .unavailable(reason: outcome.message)
+        }
+
+        let holdMs: String = {
+            if let elapsedMs { return "\(elapsedMs)ms" }
+            if let started = turnStartedAt {
+                return "\(Int(Date().timeIntervalSince(started) * 1000))ms"
+            }
+            return "?"
+        }()
+
+        switch outcome.kind {
+        case .heard:
+            let text = outcome.transcript ?? ""
+            DiagnosticLog.shared.success("Voice · heard (\(holdMs)): \(text)")
+        case .empty:
+            // Soft outcome — not a system fault; keep out of red status-bar sticky.
+            DiagnosticLog.shared.info("Voice · \(outcome.message)")
+        case .failed:
+            DiagnosticLog.shared.warn("Voice · \(outcome.message)")
+        }
+
+        _ = captureID
+    }
+
+    @MainActor
+    private func scheduleOutcomeClear() {
+        outcomeClearTask?.cancel()
+        outcomeClearTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: Self.outcomeVisibleNanoseconds)
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                self?.lastOutcome = nil
+                if case .unavailable = self?.state {
+                    self?.state = .idle
+                }
+            }
+        }
     }
 
     @MainActor
@@ -258,6 +422,8 @@ final class WorkspaceVoiceInput: ObservableObject {
         pumpTask?.cancel()
         pumpTask = nil
         activeCaptureID = nil
+        turnStartedAt = nil
+        recordingStartedAt = nil
         if closeSession {
             currentSession?.close()
         }
@@ -267,19 +433,25 @@ final class WorkspaceVoiceInput: ObservableObject {
         activeCaptureID == captureID
     }
 
-    private var stateLabel: String {
-        switch state {
-        case .idle:
-            return "idle"
-        case .starting:
-            return "starting"
-        case .recording:
-            return "recording"
-        case .processing:
-            return "processing"
-        case .unavailable(let reason):
-            return "unavailable(\(reason))"
+    private func voiceLog(_ message: String, level: DiagnosticLog.Entry.Level, id: String? = nil) {
+        let prefix = id.map { "Voice[\($0)] · " } ?? "Voice · "
+        switch level {
+        case .info: DiagnosticLog.shared.info(prefix + message)
+        case .success: DiagnosticLog.shared.success(prefix + message)
+        case .warning: DiagnosticLog.shared.warn(prefix + message)
+        case .error: DiagnosticLog.shared.error(prefix + message)
         }
+    }
+
+    private static func friendlyConnectionError(_ error: Error) -> String {
+        let raw = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+        if raw.localizedCaseInsensitiveContains("could not connect")
+            || raw.localizedCaseInsensitiveContains("connection refused")
+            || raw.localizedCaseInsensitiveContains("network connection was lost") {
+            return "Could not reach the voice runtime on \(LatticesLocalEndpoints.voiceRuntimeWebSocketURL). Restart Lattices."
+        }
+        if raw.isEmpty { return "Voice session failed." }
+        return raw
     }
 }
 

--- a/apps/mac/Sources/Core/Companion/LatticesCompanionBridgeServer.swift
+++ b/apps/mac/Sources/Core/Companion/LatticesCompanionBridgeServer.swift
@@ -467,10 +467,7 @@ private extension LatticesCompanionBridgeServer {
     func sendDeckBuilderAsset(path: String, to fd: Int32) -> Bool {
         guard !path.contains(".."), !path.hasPrefix("/") else { return false }
 
-        let roots = [
-            Bundle.main.resourceURL?.appendingPathComponent("DeckBuilder", isDirectory: true),
-            Bundle.module.resourceURL?.appendingPathComponent("DeckBuilder", isDirectory: true),
-        ].compactMap { $0 }
+        let roots = Self.deckBuilderResourceRoots()
 
         for root in roots {
             let url = root.appendingPathComponent(path)
@@ -564,5 +561,35 @@ private extension LatticesCompanionBridgeServer {
         } catch { }
 
         return Host.current().localizedName ?? "localhost"
+    }
+}
+
+extension LatticesCompanionBridgeServer {
+    /// Resolve both the hand-built app bundle and SwiftPM's nested resource
+    /// bundles without touching `Bundle.module`, whose generated accessor traps
+    /// when a manually packaged app does not contain the expected bundle.
+    static func deckBuilderResourceRoots(
+        applicationResourceURL: URL? = Bundle.main.resourceURL,
+        loadedBundles: [Bundle] = Bundle.allBundles + Bundle.allFrameworks,
+        fileManager: FileManager = .default
+    ) -> [URL] {
+        var resourceURLs = [applicationResourceURL].compactMap { $0 }
+        resourceURLs.append(contentsOf: loadedBundles.compactMap(\.resourceURL))
+
+        if let applicationResourceURL,
+           let children = try? fileManager.contentsOfDirectory(
+               at: applicationResourceURL,
+               includingPropertiesForKeys: nil
+           ) {
+            resourceURLs.append(contentsOf: children.compactMap { child in
+                guard child.pathExtension == "bundle" else { return nil }
+                return Bundle(url: child)?.resourceURL
+            })
+        }
+
+        var seen = Set<String>()
+        return resourceURLs
+            .map { $0.appendingPathComponent("DeckBuilder", isDirectory: true) }
+            .filter { seen.insert($0.standardizedFileURL.path).inserted }
     }
 }

--- a/apps/mac/Sources/Core/Companion/LatticesCompanionCockpit.swift
+++ b/apps/mac/Sources/Core/Companion/LatticesCompanionCockpit.swift
@@ -296,11 +296,9 @@ enum LatticesCompanionCockpitCatalog {
         ]
     )
 
-    /// The companion is a remote for the Mac in front of the user, not a
-    /// catalog of the subsystems that happen to implement its commands. Keep
-    /// the starter deliberately small and job-based; the complete catalog
-    /// remains available in the Mac deck builder.
-    static let defaultLayout = LatticesCompanionCockpitLayout(
+    /// The first compact job-based starter shipped as v4. Retain it so an exact,
+    /// untouched copy can move forward without changing personalized decks.
+    static let legacyDefaultLayoutV4 = LatticesCompanionCockpitLayout(
         pages: [
             .init(
                 id: "remote",
@@ -348,6 +346,89 @@ enum LatticesCompanionCockpitCatalog {
                     .init(shortcutID: "talkie-record", col: 2, row: 1, colSpan: 2),
                     .init(shortcutID: "talkie-settings", col: 0, row: 2, colSpan: 2),
                     .init(shortcutID: "mac-sessions", col: 2, row: 2, colSpan: 2),
+                ]
+            ),
+        ]
+    )
+
+    /// Keep the default deck focused on the four contexts that are useful from
+    /// the couch even when Talkie and voice are unavailable. The Mac deck
+    /// builder still exposes the complete action catalog for personalization.
+    static let defaultLayout = LatticesCompanionCockpitLayout(
+        pages: [
+            .init(
+                id: "command",
+                title: "Command",
+                subtitle: "See the Mac, move between apps, and recover the pointer",
+                columns: 4,
+                rows: 3,
+                slots: [
+                    .init(shortcutID: "mac-windows", col: 0, row: 0, colSpan: 2),
+                    .init(shortcutID: "paste-device", col: 2, row: 0, colSpan: 2),
+                    .init(shortcutID: "switch-app-prev", col: 0, row: 1, colSpan: 2),
+                    .init(shortcutID: "switch-app-next", col: 2, row: 1, colSpan: 2),
+                    .init(shortcutID: "switch-window-prev", col: 0, row: 2),
+                    .init(shortcutID: "switch-window-next", col: 1, row: 2),
+                    .init(shortcutID: "mouse-find", col: 2, row: 2),
+                    .init(shortcutID: "mouse-summon", col: 3, row: 2),
+                ]
+            ),
+            .init(
+                id: "dev",
+                title: "Dev",
+                subtitle: "Clipboard, editing, and terminal-friendly navigation",
+                columns: 4,
+                rows: 3,
+                slots: [
+                    .init(shortcutID: "key-copy", col: 0, row: 0),
+                    .init(shortcutID: "key-paste", col: 1, row: 0),
+                    .init(shortcutID: "key-undo", col: 2, row: 0),
+                    .init(shortcutID: "key-escape", col: 3, row: 0),
+                    .init(shortcutID: "key-enter", col: 0, row: 1),
+                    .init(shortcutID: "key-space", col: 1, row: 1),
+                    .init(shortcutID: "key-up", col: 2, row: 1),
+                    .init(shortcutID: "key-down", col: 3, row: 1),
+                    .init(shortcutID: "key-left", col: 0, row: 2),
+                    .init(shortcutID: "key-right", col: 1, row: 2),
+                    .init(shortcutID: "switch-window-prev", col: 2, row: 2),
+                    .init(shortcutID: "switch-window-next", col: 3, row: 2),
+                ]
+            ),
+            .init(
+                id: "media",
+                title: "Media",
+                subtitle: "Playback and presentation controls",
+                columns: 4,
+                rows: 2,
+                slots: [
+                    .init(shortcutID: "key-space", col: 0, row: 0, colSpan: 2),
+                    .init(shortcutID: "key-left", col: 2, row: 0),
+                    .init(shortcutID: "key-right", col: 3, row: 0),
+                    .init(shortcutID: "place-center", col: 0, row: 1),
+                    .init(shortcutID: "place-maximize", col: 1, row: 1),
+                    .init(shortcutID: "resize-grow", col: 2, row: 1),
+                    .init(shortcutID: "resize-shrink", col: 3, row: 1),
+                ]
+            ),
+            .init(
+                id: "windows",
+                title: "Windows",
+                subtitle: "Place and resize the frontmost window",
+                columns: 4,
+                rows: 3,
+                slots: [
+                    .init(shortcutID: "place-top-left", col: 0, row: 0),
+                    .init(shortcutID: "place-top-right", col: 1, row: 0),
+                    .init(shortcutID: "place-bottom-left", col: 2, row: 0),
+                    .init(shortcutID: "place-bottom-right", col: 3, row: 0),
+                    .init(shortcutID: "place-left-third", col: 0, row: 1),
+                    .init(shortcutID: "place-center-third", col: 1, row: 1),
+                    .init(shortcutID: "place-right-third", col: 2, row: 1),
+                    .init(shortcutID: "place-center", col: 3, row: 1),
+                    .init(shortcutID: "place-left", col: 0, row: 2),
+                    .init(shortcutID: "place-right", col: 1, row: 2),
+                    .init(shortcutID: "place-maximize", col: 2, row: 2),
+                    .init(shortcutID: "layout-optimize", col: 3, row: 2),
                 ]
             ),
         ]

--- a/apps/mac/Sources/Core/Companion/LatticesDeckHost.swift
+++ b/apps/mac/Sources/Core/Companion/LatticesDeckHost.swift
@@ -191,6 +191,29 @@ extension LatticesDeckHost {
         }
         return (display, display.spaces[index])
     }
+
+    /// Pure relative target resolution for previous/next space (no SkyLight call).
+    /// `direction` is typically −1 (previous) or +1 (next). Does not wrap.
+    static func relativeSpaceTarget(in display: DisplaySpaces, direction: Int) -> SpaceInfo? {
+        guard let currentIdx = display.spaces.firstIndex(where: { $0.isCurrent }) else { return nil }
+        let targetIdx = currentIdx + direction
+        guard display.spaces.indices.contains(targetIdx) else { return nil }
+        return display.spaces[targetIdx]
+    }
+
+    /// Map Control+Left/Right (and variants) to a previous/next space direction.
+    func spaceSwitchDirection(key: String, modifiers: [String]) -> Int? {
+        let normalized = key.lowercased()
+            .replacingOccurrences(of: "←", with: "left")
+            .replacingOccurrences(of: "→", with: "right")
+        guard normalized == "left" || normalized == "right" else { return nil }
+        let hasControl = modifiers.contains { mod in
+            let m = mod.lowercased()
+            return m == "control" || m == "ctrl" || m == "⌃"
+        }
+        guard hasControl else { return nil }
+        return normalized == "right" ? 1 : -1
+    }
 }
 
 private extension LatticesDeckHost {
@@ -1113,19 +1136,6 @@ private extension LatticesDeckHost {
             }
     }
 
-    func spaceSwitchDirection(key: String, modifiers: [String]) -> Int? {
-        let normalized = key.lowercased()
-            .replacingOccurrences(of: "←", with: "left")
-            .replacingOccurrences(of: "→", with: "right")
-        guard normalized == "left" || normalized == "right" else { return nil }
-        let hasControl = modifiers.contains { mod in
-            let m = mod.lowercased()
-            return m == "control" || m == "ctrl" || m == "⌃"
-        }
-        guard hasControl else { return nil }
-        return normalized == "right" ? 1 : -1
-    }
-
     @MainActor
     func switchActiveSpace(direction: Int, displayIndex: Int? = nil) -> ActionOutcome {
         let displays = WindowTiler.getDisplaySpaces()
@@ -1147,7 +1157,7 @@ private extension LatticesDeckHost {
             ?? 0
         let display = displays.first(where: { $0.displayIndex == preferredDisplayIndex }) ?? displays[0]
 
-        guard let currentIdx = display.spaces.firstIndex(where: { $0.isCurrent }) else {
+        guard display.spaces.contains(where: { $0.isCurrent }) else {
             return ActionOutcome(
                 summary: "No current space",
                 detail: "Could not determine the active space on display \(display.displayIndex + 1).",
@@ -1155,8 +1165,7 @@ private extension LatticesDeckHost {
             )
         }
 
-        let targetIdx = currentIdx + direction
-        guard targetIdx >= 0, targetIdx < display.spaces.count else {
+        guard let target = Self.relativeSpaceTarget(in: display, direction: direction) else {
             return ActionOutcome(
                 summary: direction > 0 ? "Already on last space" : "Already on first space",
                 detail: nil,
@@ -1164,7 +1173,6 @@ private extension LatticesDeckHost {
             )
         }
 
-        let target = display.spaces[targetIdx]
         WindowTiler.switchToSpace(spaceId: target.id)
         return ActionOutcome(
             summary: direction > 0 ? "Next space" : "Previous space",

--- a/apps/mac/Sources/Core/Daemon/DaemonServer.swift
+++ b/apps/mac/Sources/Core/Daemon/DaemonServer.swift
@@ -3,7 +3,8 @@ import CommonCrypto
 
 // MARK: - POSIX WebSocket Server
 // NWListener is broken on macOS 26 (Tahoe) — EINVAL on any listener creation.
-// This is a minimal POSIX-socket WebSocket server on 127.0.0.1:9399.
+// Minimal POSIX-socket WebSocket server on LatticesLocalEndpoints.agentAPIPort
+// (ws://127.0.0.1:9399).
 
 final class DaemonServer: ObservableObject {
     static let shared = DaemonServer()
@@ -38,11 +39,11 @@ final class DaemonServer: ObservableObject {
         var yes: Int32 = 1
         setsockopt(serverFd, SOL_SOCKET, SO_REUSEADDR, &yes, socklen_t(MemoryLayout<Int32>.size))
 
-        // 2. Bind to 127.0.0.1:9399
+        // 2. Bind to Lattices agent API port (well-known: 9399)
         var addr = sockaddr_in()
         addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
         addr.sin_family = sa_family_t(AF_INET)
-        addr.sin_port = UInt16(9399).bigEndian
+        addr.sin_port = LatticesLocalEndpoints.agentAPIPort.bigEndian
         addr.sin_addr.s_addr = UInt32(0x7f000001).bigEndian // 127.0.0.1
 
         let bindResult = withUnsafePointer(to: &addr) {
@@ -80,7 +81,7 @@ final class DaemonServer: ObservableObject {
         acceptSource = source
 
         DispatchQueue.main.async { self.isListening = true }
-        diag.success("DaemonServer: listening on ws://127.0.0.1:9399")
+        diag.success("DaemonServer: listening on \(LatticesLocalEndpoints.agentAPIWebSocketURL)")
 
         // Subscribe to EventBus for broadcasting
         EventBus.shared.subscribe { [weak self] event in

--- a/apps/mac/Sources/Core/Desktop/DesktopModel.swift
+++ b/apps/mac/Sources/Core/Desktop/DesktopModel.swift
@@ -83,8 +83,30 @@ final class DesktopModel: ObservableObject {
         Array(windows.values).sorted { $0.zIndex < $1.zIndex }
     }
 
+    /// The frontmost window a user would call "the current window".
+    ///
+    /// Raw z-order is not enough: apps keep untitled helper surfaces (Chrome's
+    /// 64×64 status/drag windows, tooltip and panel shims) in the window list,
+    /// and those routinely sort above the real window. They are also absent from
+    /// the app's `AXWindows`, so tiling one resolves 0 moves and then reports
+    /// "drifted" forever. Filter to windows that can actually be placed, and
+    /// prefer the AX-focused window when it survives the same filter.
     func frontmostWindow() -> WindowEntry? {
-        windows.values.min { $0.zIndex < $1.zIndex }
+        let placeable = windows.values.filter(Self.isPlaceableTarget)
+        if let focused = focusedWindowID.flatMap({ windows[$0] }),
+           Self.isPlaceableTarget(focused) {
+            return focused
+        }
+        return placeable.min { $0.zIndex < $1.zIndex }
+    }
+
+    /// Minimum size for a window to count as a real, user-facing target.
+    private static let minTargetSide: Double = 120
+
+    static func isPlaceableTarget(_ entry: WindowEntry) -> Bool {
+        guard entry.isOnScreen, !entry.title.isEmpty else { return false }
+        guard entry.frame.w >= minTargetSide, entry.frame.h >= minTargetSide else { return false }
+        return entry.pid != getpid()   // never target Lattices' own panels
     }
 
     func focusedWindow() -> WindowEntry? {

--- a/apps/mac/Sources/Core/Desktop/WindowTiler.swift
+++ b/apps/mac/Sources/Core/Desktop/WindowTiler.swift
@@ -457,7 +457,7 @@ enum TilePosition: String, CaseIterable, Identifiable {
         switch self {
         // 1x1
         case .maximize:    return (0,     0,   1.0,   1.0)
-        case .center:      return (0.15,  0.1, 0.7,   0.8)
+        case .center:      return (0.1,   0.1, 0.8,   0.8)
         // 2x1
         case .left:        return tileGrid(cols: 2, rows: 1, col: 0, row: 0)
         case .right:       return tileGrid(cols: 2, rows: 1, col: 1, row: 0)

--- a/apps/mac/Sources/Core/System/LatticesLocalEndpoints.swift
+++ b/apps/mac/Sources/Core/System/LatticesLocalEndpoints.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Loopback endpoints owned by the Lattices menu bar process.
+///
+/// These ports are **deterministic and Lattices-owned**. They are not discovered
+/// at random and should not depend on an external daemon for normal operation.
+///
+/// | Service            | Port | WebSocket                         | Lifecycle                         |
+/// |--------------------|------|-----------------------------------|-----------------------------------|
+/// | Agent API / daemon | 9399 | `ws://127.0.0.1:9399`             | `DaemonServer` at app boot        |
+/// | Voice runtime      | 9398 | `ws://127.0.0.1:9398`             | `LatticesVoiceRuntime` at app boot|
+///
+/// Documented for agents and humans in `docs/voice.md`, `docs/app.md`, and
+/// `docs/api.md`. Prefer these constants over magic numbers elsewhere in the app.
+enum LatticesLocalEndpoints {
+    /// Loopback bind host for all Lattices-local services.
+    static let loopbackHost = "127.0.0.1"
+
+    /// Agent API / daemon WebSocket (`DaemonServer`).
+    static let agentAPIPort: UInt16 = 9399
+
+    /// Lattices-hosted Hudson Voice / Vox live-session WebSocket.
+    ///
+    /// Adjacent to the agent API (9399) so the Lattices local port family is
+    /// self-describing: `939x` = Lattices process-owned loopback services.
+    ///
+    /// Override only for tests/dev with `LATTICES_VOICE_PORT` (preferred) or
+    /// the legacy `HUDSON_VOICE_VOX_PORT` env var.
+    static let voiceRuntimePort: UInt16 = 9398
+
+    static var agentAPIWebSocketURL: String {
+        "ws://\(loopbackHost):\(agentAPIPort)"
+    }
+
+    static var voiceRuntimeWebSocketURL: String {
+        "ws://\(loopbackHost):\(resolvedVoiceRuntimePort)"
+    }
+
+    /// Effective voice port after env override (still always loopback).
+    static var resolvedVoiceRuntimePort: UInt16 {
+        let env = ProcessInfo.processInfo.environment
+        if let raw = env["LATTICES_VOICE_PORT"] ?? env["HUDSON_VOICE_VOX_PORT"],
+           let value = UInt16(raw), value > 0 {
+            return value
+        }
+        return voiceRuntimePort
+    }
+}

--- a/apps/mac/Sources/Core/Voice/AudioProvider.swift
+++ b/apps/mac/Sources/Core/Voice/AudioProvider.swift
@@ -541,17 +541,26 @@ final class AudioLayer: ObservableObject {
 final class HudVoxAudioProvider: AudioProvider {
     private var session: HudVoxLiveSession?
     private var pumpTask: Task<Void, Never>?
+    private var stopTimeoutTask: Task<Void, Never>?
     private var onTranscript: ((Transcription) -> Void)?
     private var stopCompletion: ((Transcription?) -> Void)?
     private var _isListening = false
     private var finalDelivered = false
     private var lastProviderError: String?
+    private var listeningStartedAt: Date?
+    /// Match WorkspaceVoiceInput: short taps produce empty WAVs; stop needs a deadline.
+    private static let minimumRecordingNanoseconds: UInt64 = 700_000_000
+    private static let stopTimeoutNanoseconds: UInt64 = 10_000_000_000
 
-    var isAvailable: Bool { HudsonVoiceRuntimeResolver.resolve(clientId: "lattices") != nil }
+    var isAvailable: Bool {
+        LatticesVoiceRuntime.ensureRunning()
+        return HudsonVoiceRuntimeResolver.resolve(clientId: "lattices") != nil
+    }
     var isListening: Bool { _isListening }
     var lastErrorMessage: String? { lastProviderError }
 
     func checkHealth(completion: @escaping (Bool) -> Void) {
+        _ = LatticesVoiceRuntime.ensureRunning()
         guard let runtime = HudsonVoiceRuntimeResolver.resolve(clientId: "lattices") else {
             lastProviderError = "Voice runtime unavailable"
             completion(false)
@@ -561,7 +570,8 @@ final class HudVoxAudioProvider: AudioProvider {
             do {
                 _ = try await HudVoxProbe.health(
                     endpoint: runtime.endpoint,
-                    clientId: runtime.options.clientId
+                    clientId: runtime.options.clientId,
+                    authToken: runtime.options.authToken ?? runtime.authToken
                 )
                 await MainActor.run {
                     self.lastProviderError = nil
@@ -583,10 +593,13 @@ final class HudVoxAudioProvider: AudioProvider {
         self.onTranscript = onTranscript
         _isListening = true
         finalDelivered = false
+        listeningStartedAt = Date()
 
+        _ = LatticesVoiceRuntime.ensureRunning()
         guard let runtime = HudsonVoiceRuntimeResolver.resolve(clientId: "lattices") else {
             DiagnosticLog.shared.warn("HudVoxAudioProvider: cannot start because HudsonVoice runtime is unavailable")
             _isListening = false
+            listeningStartedAt = nil
             self.onTranscript = nil
             lastProviderError = "Voice runtime unavailable"
             AudioLayer.shared.setFinalResult("Voice runtime unavailable", warning: true)
@@ -621,7 +634,33 @@ final class HudVoxAudioProvider: AudioProvider {
         }
         DiagnosticLog.shared.info("HudVoxAudioProvider: stopping session")
         self.stopCompletion = completion
-        Task { try? await session.stop() }
+
+        // Pad short captures so the mic buffer is not empty; then hard-stop
+        // if the runtime never delivers a final transcript.
+        let started = listeningStartedAt ?? Date()
+        let elapsedNs = UInt64(max(0, Date().timeIntervalSince(started)) * 1_000_000_000)
+        let padNs = elapsedNs < Self.minimumRecordingNanoseconds
+            ? Self.minimumRecordingNanoseconds - elapsedNs
+            : 0
+
+        stopTimeoutTask?.cancel()
+        stopTimeoutTask = Task { [weak self] in
+            if padNs > 0 {
+                try? await Task.sleep(nanoseconds: padNs)
+            }
+            guard !Task.isCancelled else { return }
+            try? await session.stop()
+
+            try? await Task.sleep(nanoseconds: Self.stopTimeoutNanoseconds)
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                guard let self, !self.finalDelivered else { return }
+                DiagnosticLog.shared.warn("HudVoxAudioProvider: stop timed out waiting for final transcript")
+                self.lastProviderError = "Transcription timed out"
+                AudioLayer.shared.setFinalResult("Transcription timed out", error: "Transcription timed out", warning: true)
+                self.streamEnded(error: nil)
+            }
+        }
     }
 
     // MARK: - Event handling (main actor)
@@ -646,6 +685,9 @@ final class HudVoxAudioProvider: AudioProvider {
         guard !finalDelivered else { return }
         finalDelivered = true
         _isListening = false
+        listeningStartedAt = nil
+        stopTimeoutTask?.cancel()
+        stopTimeoutTask = nil
         let t = Transcription(text: text, confidence: 0.95, source: "hudson-voice", isPartial: false, durationMs: elapsedMs)
         DiagnosticLog.shared.info("HudVoxAudioProvider: transcribed → '\(text)' (\(elapsedMs)ms)")
         // onTranscript drives the streaming-execute path; stopCompletion the stop path.
@@ -664,6 +706,9 @@ final class HudVoxAudioProvider: AudioProvider {
     @MainActor
     private func streamEnded(error: Error?) {
         _isListening = false
+        listeningStartedAt = nil
+        stopTimeoutTask?.cancel()
+        stopTimeoutTask = nil
         if !finalDelivered {
             if let error {
                 let message = Self.voiceRuntimeMessage(for: error)
@@ -676,6 +721,8 @@ final class HudVoxAudioProvider: AudioProvider {
             stopCompletion = nil
             finalDelivered = true
         }
+        pumpTask?.cancel()
+        session?.close()
         session = nil
         pumpTask = nil
     }

--- a/apps/mac/Sources/Core/Voice/LatticesVoiceRuntime.swift
+++ b/apps/mac/Sources/Core/Voice/LatticesVoiceRuntime.swift
@@ -1,21 +1,259 @@
 import Foundation
+import Security
 
 #if LATTICES_VOICE && canImport(HudsonVoice)
 import HudsonVoice
+import VoxService
 #endif
 
+/// Boot/shutdown owner for Lattices' embedded voice runtime.
+///
+/// Lattices is the permission and lifecycle owner: the menu bar process starts
+/// an in-process Vox live-session server on a **deterministic** loopback port
+/// (`LatticesLocalEndpoints.voiceRuntimePort`, default **9398**), writes a
+/// private Hudson capability file, and tears it down on quit.
+///
+/// Clients (Workspace Assistant mic, Hands-Off, voice commands) resolve through
+/// `HudsonVoiceRuntimeResolver` → that capability file — they do not depend on
+/// an external `voxd` being up.
 enum LatticesVoiceRuntime {
     static func start() {
         #if LATTICES_VOICE && canImport(HudsonVoice)
-        DiagnosticLog.shared.info("HudsonVoice: live session client compiled in")
+        do {
+            try Host.shared.start()
+            let endpoint = Host.shared.endpointURL
+            DiagnosticLog.shared.success(
+                "HudsonVoice: embedded runtime started at \(endpoint) (capability \(Host.shared.capabilityURL.path))"
+            )
+        } catch {
+            DiagnosticLog.shared.warn(
+                "HudsonVoice: embedded runtime failed to start — \(error.localizedDescription)"
+            )
+        }
         #else
-        DiagnosticLog.shared.info("HudsonVoice: runtime host skipped because HudsonVoice is not compiled into this build")
+        DiagnosticLog.shared.info(
+            "HudsonVoice: runtime host skipped because HudsonVoice is not compiled into this build"
+        )
+        #endif
+    }
+
+    /// Start if needed (e.g. boot failed earlier, or first capture after idle).
+    /// Safe to call repeatedly; no-ops when already hosting.
+    @discardableResult
+    static func ensureRunning() -> Bool {
+        #if LATTICES_VOICE && canImport(HudsonVoice)
+        if Host.shared.isRunning { return true }
+        start()
+        return Host.shared.isRunning
+        #else
+        return false
         #endif
     }
 
     static func stop() {
         #if LATTICES_VOICE && canImport(HudsonVoice)
-        DiagnosticLog.shared.info("HudsonVoice: live session client stopped")
+        Host.shared.stop()
+        DiagnosticLog.shared.info("HudsonVoice: embedded runtime stopped")
         #endif
     }
+
+    #if LATTICES_VOICE && canImport(HudsonVoice)
+    /// True when this process is currently hosting the voice WebSocket.
+    static var isRunning: Bool { Host.shared.isRunning }
+
+    static var endpointDescription: String? {
+        guard Host.shared.isRunning else { return nil }
+        return Host.shared.endpointURL
+    }
+    #else
+    static var isRunning: Bool { false }
+    #endif
 }
+
+#if LATTICES_VOICE && canImport(HudsonVoice)
+
+// MARK: - In-process host
+
+/// Lattices-owned Vox host. Modeled on the former HudsonKit
+/// `HudsonVoiceRuntimeHost`, but with a fixed Lattices port family instead of
+/// a random ephemeral port.
+private final class Host: @unchecked Sendable {
+    static let shared = Host()
+
+    private let lock = NSRecursiveLock()
+    private let bindAddress = LatticesLocalEndpoints.loopbackHost
+    private let port: UInt16
+    private let runtimeHomeURL: URL
+    private let runtimeCapabilityURL: URL
+    private let voxRuntimeURL: URL
+    private var runtimeService: VoxRuntimeService?
+
+    private(set) var isRunning = false
+
+    var capabilityURL: URL { runtimeCapabilityURL }
+
+    var endpointURL: String {
+        "ws://\(bindAddress):\(port)"
+    }
+
+    private init() {
+        let home = Self.defaultRuntimeHomeURL()
+        runtimeHomeURL = home
+        runtimeCapabilityURL = home.appendingPathComponent("hudson-voice-runtime.json")
+        voxRuntimeURL = home.appendingPathComponent("vox-runtime.json")
+        port = LatticesLocalEndpoints.resolvedVoiceRuntimePort
+    }
+
+    func start() throws {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if runtimeService != nil, isRunning, HudsonVoiceRuntime.isAvailable() {
+            return
+        }
+
+        // Tear down a half-started previous attempt before retrying.
+        runtimeService?.stop()
+        runtimeService = nil
+        removeRuntimeCapability()
+
+        let authToken = try Self.generateCapabilityToken()
+        try configureEnvironment(authToken: authToken)
+        try persistPreferences()
+
+        let service = VoxRuntimeService(
+            port: port,
+            bindAddress: bindAddress,
+            authToken: authToken
+        )
+        do {
+            try service.start()
+            try writeRuntimeCapability(authToken: authToken, startedAt: Date())
+            runtimeService = service
+            isRunning = true
+        } catch {
+            service.stop()
+            removeRuntimeCapability()
+            isRunning = false
+            throw error
+        }
+    }
+
+    func stop() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        runtimeService?.stop()
+        runtimeService = nil
+        removeRuntimeCapability()
+        isRunning = false
+    }
+
+    private func configureEnvironment(authToken: String) throws {
+        try FileManager.default.createDirectory(at: runtimeHomeURL, withIntermediateDirectories: true)
+        try? FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: runtimeHomeURL.path
+        )
+        setenv("VOX_HOME", runtimeHomeURL.path, 1)
+        setenv("VOX_RUNTIME_PATH", voxRuntimeURL.path, 1)
+        setenv("VOX_HOST", bindAddress, 1)
+        setenv("VOX_PORT", String(port), 1)
+        setenv("VOX_AUTH_TOKEN", authToken, 1)
+        // Point HudsonVoice's capability reader at Lattices' file (not Hudson Menu's).
+        setenv(HudsonVoiceRuntime.runtimePathEnvironmentKey, runtimeCapabilityURL.path, 1)
+        setenv("LATTICES_VOICE_PORT", String(port), 1)
+    }
+
+    private func persistPreferences() throws {
+        let preferences = (try? HudsonVoicePreferences.load()) ?? HudsonVoicePreferences()
+        try preferences.normalized().save()
+    }
+
+    private func writeRuntimeCapability(authToken: String, startedAt: Date) throws {
+        let document = RuntimeCapabilityDocument(
+            host: bindAddress,
+            port: port,
+            authToken: authToken,
+            pid: getpid(),
+            startedAt: ISO8601DateFormatter().string(from: startedAt),
+            voxRuntimePath: voxRuntimeURL.path
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(document)
+        try data.write(to: runtimeCapabilityURL, options: .atomic)
+        try? FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: runtimeCapabilityURL.path
+        )
+    }
+
+    private func removeRuntimeCapability() {
+        if FileManager.default.fileExists(atPath: runtimeCapabilityURL.path) {
+            try? FileManager.default.removeItem(at: runtimeCapabilityURL)
+        }
+    }
+
+    private static func defaultRuntimeHomeURL() -> URL {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+        // Lattices-owned home — separate from Hudson Menu's Application Support/Hudson/Vox.
+        return base
+            .appendingPathComponent("Lattices", isDirectory: true)
+            .appendingPathComponent("Voice", isDirectory: true)
+    }
+
+    private static func generateCapabilityToken() throws -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        let byteCount = bytes.count
+        let status = bytes.withUnsafeMutableBytes { buffer in
+            SecRandomCopyBytes(kSecRandomDefault, byteCount, buffer.baseAddress!)
+        }
+        guard status == errSecSuccess else {
+            throw NSError(
+                domain: "LatticesVoiceRuntime",
+                code: Int(status),
+                userInfo: [NSLocalizedDescriptionKey: "Could not generate voice capability token."]
+            )
+        }
+        return Data(bytes)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+/// Wire format expected by `HudsonVoiceRuntime` (schemaVersion 1, service hudson-voice).
+private struct RuntimeCapabilityDocument: Encodable {
+    let schemaVersion = 1
+    let service = "hudson-voice"
+    let transport = "ws+json-rpc"
+    let host: String
+    let port: UInt16
+    let webSocketUrl: String
+    let authToken: String
+    let pid: Int32
+    let startedAt: String
+    let voxRuntimePath: String
+
+    init(
+        host: String,
+        port: UInt16,
+        authToken: String,
+        pid: Int32,
+        startedAt: String,
+        voxRuntimePath: String
+    ) {
+        self.host = host
+        self.port = port
+        self.webSocketUrl = "ws://\(host):\(port)"
+        self.authToken = authToken
+        self.pid = pid
+        self.startedAt = startedAt
+        self.voxRuntimePath = voxRuntimePath
+    }
+}
+
+#endif

--- a/apps/mac/Sources/Core/Voice/VoxEndpointResolver.swift
+++ b/apps/mac/Sources/Core/Voice/VoxEndpointResolver.swift
@@ -5,9 +5,13 @@ import HudsonVoice
 
 /// Resolves the voice runtime Lattices should use.
 ///
-/// HudsonVoice speaks Vox's local WebSocket JSON-RPC contract directly. Prefer
-/// the runtime file written by Vox so dev builds can move ports without making
-/// Lattices point at a stale default.
+/// Preferred path: the Lattices-hosted capability file written at boot by
+/// `LatticesVoiceRuntime` (`HUDSON_VOICE_RUNTIME_PATH` → Application Support/
+/// Lattices/Voice/hudson-voice-runtime.json) on the deterministic port
+/// `LatticesLocalEndpoints.voiceRuntimePort` (**9398**).
+///
+/// Fallbacks exist for dev (external voxd / env overrides) but normal product
+/// operation does not require an external daemon.
 enum HudsonVoiceRuntimeResolver {
     private struct RuntimeFile: Decodable {
         let host: String?
@@ -24,15 +28,34 @@ enum HudsonVoiceRuntimeResolver {
         clientId: String = "lattices",
         mode: HudVoiceMode? = nil
     ) -> (endpoint: HudVoxEndpoint, options: HudVoxLiveSessionOptions, source: String, pid: Int?, authToken: String?, capabilityPath: String?)? {
-        let runtime = resolvedRuntime()
-        let endpoint = HudVoxEndpoint(host: runtime.host, port: runtime.port)
-        let options = HudVoxLiveSessionOptions(
+        // 1. Canonical Hudson capability (Lattices-hosted, auth token included).
+        if let connection = try? HudsonVoiceRuntime.resolveConnection(
+            clientId: clientId,
+            mode: mode,
+            metadata: ["hostApp": "lattices"]
+        ) {
+            return (
+                endpoint: connection.endpoint,
+                options: connection.options,
+                source: "lattices-host",
+                pid: connection.capability.pid.map(Int.init),
+                authToken: connection.capability.authToken,
+                capabilityPath: HudsonVoiceRuntime.runtimeURL().path
+            )
+        }
+
+        // 2. File / env discovery (legacy external voxd, tests).
+        guard let runtime = resolvedRuntimeFallback() else { return nil }
+        var options = HudVoxLiveSessionOptions(
             clientId: clientId,
             mode: mode ?? .pushToTalk,
-            metadata: ["hostApp": "lattices"]
+            metadata: ["hostApp": "lattices"],
+            authToken: runtime.authToken
         )
+        // Keep options.authToken populated even if init signature drifts.
+        options.authToken = runtime.authToken
         return (
-            endpoint: endpoint,
+            endpoint: HudVoxEndpoint(host: runtime.host, port: runtime.port),
             options: options,
             source: runtime.source,
             pid: runtime.pid,
@@ -41,19 +64,20 @@ enum HudsonVoiceRuntimeResolver {
         )
     }
 
-    private static func resolvedRuntime() -> (host: String, port: UInt16, source: String, pid: Int?, authToken: String?, path: String?) {
+    /// Fallbacks when the Lattices capability file is missing (host failed, or
+    /// a non-voice build tool is probing). Prefer Lattices' deterministic port
+    /// over the old external voxd default so we do not silently talk to a
+    /// dead/unrelated process.
+    private static func resolvedRuntimeFallback() -> (host: String, port: UInt16, source: String, pid: Int?, authToken: String?, path: String?)? {
         for candidate in runtimeFileCandidates() {
             guard let runtime = readRuntimeFile(candidate.url),
                   let port = runtime.port,
                   port > 0,
                   runtime.pid.map(processIsAlive) ?? true else { continue }
-            // HudVoxLiveSession does not currently expose an auth-token field,
-            // so authenticated Hudson capability files cannot be used safely yet.
-            guard nonEmpty(runtime.authToken) == nil else { continue }
 
             let host = runtime.host
                 ?? hostFromWebSocketURL(runtime.webSocketUrl)
-                ?? "127.0.0.1"
+                ?? LatticesLocalEndpoints.loopbackHost
             guard isLoopback(host) else { continue }
 
             return (
@@ -67,10 +91,10 @@ enum HudsonVoiceRuntimeResolver {
         }
 
         let env = ProcessInfo.processInfo.environment
-        if let rawPort = env["VOX_PORT"] ?? env["HUDSON_VOICE_VOX_PORT"],
-           let port = UInt16(rawPort) {
+        if let rawPort = env["LATTICES_VOICE_PORT"] ?? env["VOX_PORT"] ?? env["HUDSON_VOICE_VOX_PORT"],
+           let port = UInt16(rawPort), port > 0 {
             return (
-                host: nonEmpty(env["VOX_HOST"]) ?? "127.0.0.1",
+                host: nonEmpty(env["VOX_HOST"]) ?? LatticesLocalEndpoints.loopbackHost,
                 port: port,
                 source: "env",
                 pid: nil,
@@ -79,23 +103,51 @@ enum HudsonVoiceRuntimeResolver {
             )
         }
 
-        // Vox's current daemon default is 42137. HudsonVoice's older 42138
-        // default is intentionally avoided here because it makes Lattices miss
-        // a running Vox dev daemon and surface a fake transcription failure.
-        return (
-            host: "127.0.0.1",
-            port: 42137,
-            source: "vox-default",
-            pid: nil,
-            authToken: nil,
-            path: nil
-        )
+        // Only advertise the well-known port when this process is actually
+        // hosting the voice runtime (auth + listener ready). Avoids clients
+        // connecting to a dead 9398 and hanging on "Transcribing…".
+        if LatticesVoiceRuntime.isRunning {
+            return (
+                host: LatticesLocalEndpoints.loopbackHost,
+                port: LatticesLocalEndpoints.resolvedVoiceRuntimePort,
+                source: "lattices-default",
+                pid: nil,
+                authToken: nil,
+                path: nil
+            )
+        }
+
+        return nil
     }
 
     private static func runtimeFileCandidates() -> [(url: URL, source: String)] {
         var candidates: [(URL, String)] = []
         let env = ProcessInfo.processInfo.environment
+        let support = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
 
+        // Lattices-hosted capability first (set at boot via setenv).
+        if let path = nonEmpty(env[HudsonVoiceRuntime.runtimePathEnvironmentKey]) {
+            candidates.append((URL(fileURLWithPath: path), "lattices-host"))
+        }
+        candidates.append((
+            support
+                .appendingPathComponent("Lattices", isDirectory: true)
+                .appendingPathComponent("Voice", isDirectory: true)
+                .appendingPathComponent("hudson-voice-runtime.json"),
+            "lattices-host"
+        ))
+
+        // Hudson Menu / shared Hudson capability (if user runs Hudson Voice separately).
+        candidates.append((
+            support
+                .appendingPathComponent("Hudson", isDirectory: true)
+                .appendingPathComponent("Vox", isDirectory: true)
+                .appendingPathComponent("hudson-voice-runtime.json"),
+            "hudson-voice"
+        ))
+
+        // Standalone voxd runtime registry.
         if let path = nonEmpty(env["VOX_RUNTIME_PATH"]) {
             candidates.append((URL(fileURLWithPath: path), "vox"))
         }
@@ -104,19 +156,6 @@ enum HudsonVoiceRuntimeResolver {
                 .appendingPathComponent(".vox", isDirectory: true)
                 .appendingPathComponent("runtime.json"),
             "vox"
-        ))
-
-        let support = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-            ?? FileManager.default.temporaryDirectory
-        if let path = nonEmpty(env["HUDSON_VOICE_RUNTIME_PATH"]) {
-            candidates.append((URL(fileURLWithPath: path), "hudson-voice"))
-        }
-        candidates.append((
-            support
-                .appendingPathComponent("Hudson", isDirectory: true)
-                .appendingPathComponent("Vox", isDirectory: true)
-                .appendingPathComponent("hudson-voice-runtime.json"),
-            "hudson-voice"
         ))
 
         var seen = Set<String>()

--- a/apps/mac/Tests/AdjacentSpaceTests.swift
+++ b/apps/mac/Tests/AdjacentSpaceTests.swift
@@ -1,0 +1,155 @@
+import XCTest
+@testable import Lattices
+
+/// Pure unit tests for Lattices previous/next Space navigation.
+///
+/// Product path under test: resolve an adjacent Space ID, then switch via
+/// SkyLight (`switchToSpace`) — mouse gestures (`space.previous` /
+/// `space.next`), companion deck relative focus, etc.
+///
+/// These tests do **not** exercise macOS Mission Control Control+Left/Right
+/// system shortcuts. Live SkyLight switches are intentionally out of scope
+/// (would move the real desktop).
+final class AdjacentSpaceTests: XCTestCase {
+
+    // MARK: - Gesture / tiler adjacent target (space.previous / space.next)
+
+    /// Same resolution used by mouse-gesture `space.previous` (−1) / `space.next` (+1).
+    func testAdjacentSpaceMovesNextAndPrevious() {
+        let spaces = [
+            SpaceInfo(id: 10, index: 1, display: 0, isCurrent: true),
+            SpaceInfo(id: 11, index: 2, display: 0, isCurrent: false),
+            SpaceInfo(id: 12, index: 3, display: 0, isCurrent: false),
+        ]
+
+        XCTAssertEqual(
+            WindowTiler.adjacentSpace(in: spaces, currentSpaceId: 11, offset: -1)?.id,
+            10,
+            "space.previous should target the prior Space id"
+        )
+        XCTAssertEqual(
+            WindowTiler.adjacentSpace(in: spaces, currentSpaceId: 11, offset: 1)?.id,
+            12,
+            "space.next should target the following Space id"
+        )
+        XCTAssertEqual(
+            WindowTiler.adjacentSpace(in: spaces, currentSpaceId: 10, offset: 1)?.id,
+            11
+        )
+    }
+
+    func testAdjacentSpaceBoundsReturnNil() {
+        let spaces = [
+            SpaceInfo(id: 10, index: 1, display: 0, isCurrent: true),
+            SpaceInfo(id: 11, index: 2, display: 0, isCurrent: false),
+        ]
+
+        XCTAssertNil(
+            WindowTiler.adjacentSpace(in: spaces, currentSpaceId: 10, offset: -1),
+            "no previous Space on the first slot"
+        )
+        XCTAssertNil(
+            WindowTiler.adjacentSpace(in: spaces, currentSpaceId: 11, offset: 1),
+            "no next Space on the last slot"
+        )
+        XCTAssertNil(WindowTiler.adjacentSpace(in: spaces, currentSpaceId: 99, offset: 1))
+        XCTAssertNil(WindowTiler.adjacentSpace(in: [], currentSpaceId: 10, offset: 1))
+    }
+
+    func testAdjacentSpaceOffsetZeroReturnsCurrent() {
+        let spaces = [
+            SpaceInfo(id: 10, index: 1, display: 0, isCurrent: false),
+            SpaceInfo(id: 11, index: 2, display: 0, isCurrent: true),
+        ]
+        XCTAssertEqual(
+            WindowTiler.adjacentSpace(in: spaces, currentSpaceId: 11, offset: 0)?.id,
+            11
+        )
+    }
+
+    // MARK: - Companion deck relative focus (spaces.focusRelative)
+
+    func testRelativeSpaceTargetDirection() {
+        let display = DisplaySpaces(
+            displayIndex: 0,
+            displayId: "main",
+            spaces: [
+                SpaceInfo(id: 10, index: 1, display: 0, isCurrent: false),
+                SpaceInfo(id: 11, index: 2, display: 0, isCurrent: true),
+                SpaceInfo(id: 12, index: 3, display: 0, isCurrent: false),
+            ],
+            currentSpaceId: 11
+        )
+
+        XCTAssertEqual(LatticesDeckHost.relativeSpaceTarget(in: display, direction: -1)?.id, 10)
+        XCTAssertEqual(LatticesDeckHost.relativeSpaceTarget(in: display, direction: 1)?.id, 12)
+        XCTAssertNil(LatticesDeckHost.relativeSpaceTarget(in: display, direction: 2))
+    }
+
+    func testRelativeSpaceTargetAtEnds() {
+        let firstCurrent = DisplaySpaces(
+            displayIndex: 0,
+            displayId: "main",
+            spaces: [
+                SpaceInfo(id: 10, index: 1, display: 0, isCurrent: true),
+                SpaceInfo(id: 11, index: 2, display: 0, isCurrent: false),
+            ],
+            currentSpaceId: 10
+        )
+        XCTAssertNil(LatticesDeckHost.relativeSpaceTarget(in: firstCurrent, direction: -1))
+        XCTAssertEqual(LatticesDeckHost.relativeSpaceTarget(in: firstCurrent, direction: 1)?.id, 11)
+
+        let lastCurrent = DisplaySpaces(
+            displayIndex: 0,
+            displayId: "main",
+            spaces: [
+                SpaceInfo(id: 10, index: 1, display: 0, isCurrent: false),
+                SpaceInfo(id: 11, index: 2, display: 0, isCurrent: true),
+            ],
+            currentSpaceId: 11
+        )
+        XCTAssertNil(LatticesDeckHost.relativeSpaceTarget(in: lastCurrent, direction: 1))
+        XCTAssertEqual(LatticesDeckHost.relativeSpaceTarget(in: lastCurrent, direction: -1)?.id, 10)
+    }
+
+    /// Deck may receive Control+arrow key events from the phone, but Lattices
+    /// must map them to relative Space targets (SkyLight), not synthesize the
+    /// system Mission Control shortcut.
+    func testCompanionKeyChordMapsToRelativeDirectionNotSystemShortcut() {
+        let host = LatticesDeckHost.shared
+
+        XCTAssertEqual(host.spaceSwitchDirection(key: "left", modifiers: ["control"]), -1)
+        XCTAssertEqual(host.spaceSwitchDirection(key: "right", modifiers: ["ctrl"]), 1)
+        XCTAssertEqual(host.spaceSwitchDirection(key: "←", modifiers: ["⌃"]), -1)
+        XCTAssertEqual(host.spaceSwitchDirection(key: "→", modifiers: ["Control"]), 1)
+
+        // Without Control, leave the chord alone (not a space switch).
+        XCTAssertNil(host.spaceSwitchDirection(key: "left", modifiers: ["command"]))
+        XCTAssertNil(host.spaceSwitchDirection(key: "up", modifiers: ["control"]))
+        XCTAssertNil(host.spaceSwitchDirection(key: "right", modifiers: []))
+    }
+
+    // MARK: - Mouse gesture defaults → Lattices actions
+
+    func testDefaultMouseShortcutsWireSpacePreviousAndNextActions() {
+        let rules = MouseShortcutConfig.defaults.rules
+        let previous = rules.first { $0.id == "space-previous" }
+        let next = rules.first { $0.id == "space-next" }
+
+        XCTAssertNotNil(previous)
+        XCTAssertNotNil(next)
+        XCTAssertEqual(previous?.enabled, true)
+        XCTAssertEqual(next?.enabled, true)
+        // Action types drive WindowTiler.switchToAdjacentSpace — not OS shortcuts.
+        XCTAssertEqual(previous?.action.type, .spacePrevious)
+        XCTAssertEqual(next?.action.type, .spaceNext)
+        XCTAssertEqual(MouseShortcutActionType.spacePrevious.rawValue, "space.previous")
+        XCTAssertEqual(MouseShortcutActionType.spaceNext.rawValue, "space.next")
+        XCTAssertEqual(previous?.trigger.button, .middle)
+        XCTAssertEqual(next?.trigger.button, .middle)
+        XCTAssertEqual(previous?.trigger.kind, .drag)
+        XCTAssertEqual(next?.trigger.kind, .drag)
+        XCTAssertEqual(previous?.trigger.direction, .left)
+        XCTAssertEqual(next?.trigger.direction, .right)
+    }
+}

--- a/apps/mac/Tests/AssistantReliabilityTests.swift
+++ b/apps/mac/Tests/AssistantReliabilityTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import Lattices
+
+/// Pure unit tests for assistant / dictation helpers (no Bun, Scout, or mic).
+final class AssistantReliabilityTests: XCTestCase {
+
+    // MARK: - Dictation buffer
+
+    func testDictationBufferEmptyDraftTakesPhrase() {
+        XCTAssertEqual(WorkspaceDictationBuffer.appending("hello", to: ""), "hello")
+        XCTAssertEqual(WorkspaceDictationBuffer.appending("  hi  ", to: "   "), "hi")
+    }
+
+    func testDictationBufferAppendsWithSingleSpace() {
+        XCTAssertEqual(
+            WorkspaceDictationBuffer.appending("world", to: "hello"),
+            "hello world"
+        )
+        XCTAssertEqual(
+            WorkspaceDictationBuffer.appending("world", to: "hello "),
+            "hello world"
+        )
+    }
+
+    func testDictationBufferIgnoresEmptyPhrase() {
+        XCTAssertEqual(WorkspaceDictationBuffer.appending("   ", to: "keep"), "keep")
+        XCTAssertEqual(WorkspaceDictationBuffer.appending("", to: "keep"), "keep")
+    }
+
+    // MARK: - Scout offline detection
+
+    func testScoutOfflineQueueWhenParkedForOnline() {
+        let flight: [String: Any] = [
+            "state": "queued",
+            "summary": "Will deliver when online",
+            "targetAgentId": "session-abc",
+        ]
+        let error = ScoutAssistantTransport.offlineQueueError(
+            fromFlight: flight,
+            targetLabel: nil
+        )
+        guard case .targetOffline(let summary, let label)? = error else {
+            return XCTFail("expected targetOffline, got \(String(describing: error))")
+        }
+        XCTAssertTrue(summary.localizedCaseInsensitiveContains("online"))
+        XCTAssertEqual(label, "session-abc")
+        XCTAssertTrue(error?.shouldClearBinding == true)
+    }
+
+    func testScoutOfflineNotRaisedForActiveFlight() {
+        let flight: [String: Any] = [
+            "state": "running",
+            "summary": "Working…",
+        ]
+        XCTAssertNil(
+            ScoutAssistantTransport.offlineQueueError(fromFlight: flight, targetLabel: "x")
+        )
+    }
+
+    func testScoutOfflineRequiresOfflineWording() {
+        let flight: [String: Any] = [
+            "state": "queued",
+            "summary": "Waiting in broker queue",
+        ]
+        XCTAssertNil(
+            ScoutAssistantTransport.offlineQueueError(fromFlight: flight, targetLabel: nil)
+        )
+    }
+
+    // MARK: - Agent-runtime error copy
+
+    func testAgentRuntimeEmptyReplyMessage() {
+        let error = AgentRuntimeTransportError.emptyReply
+        XCTAssertEqual(error.errorDescription, "The agent finished without a text reply.")
+    }
+
+    func testAgentRuntimeTimeoutMessage() {
+        let error = AgentRuntimeTransportError.timeout
+        XCTAssertEqual(error.errorDescription, "The agent turn timed out.")
+    }
+
+    func testDefaultHarnessPreferencePutsPiFirst() {
+        XCTAssertEqual(AgentRuntimeTransport.defaultHarnessPreference.first, "pi")
+        XCTAssertTrue(AgentRuntimeTransport.defaultHarnessPreference.contains("claude-code"))
+    }
+}

--- a/apps/mac/Tests/CompanionCockpitMappingTests.swift
+++ b/apps/mac/Tests/CompanionCockpitMappingTests.swift
@@ -118,7 +118,7 @@ final class CompanionCockpitMappingTests: XCTestCase {
             talkie: .unavailable
         )
 
-        let page = try XCTUnwrap(state.pages.first(where: { $0.id == "remote" }))
+        let page = try XCTUnwrap(state.pages.first(where: { $0.id == "command" }))
         let tile = try XCTUnwrap(page.tiles.first(where: { $0.shortcutID == "mac-windows" }))
         let definition = try XCTUnwrap(LatticesCompanionCockpitCatalog.definition(for: "mac-windows"))
 
@@ -129,15 +129,16 @@ final class CompanionCockpitMappingTests: XCTestCase {
         XCTAssertNil(TalkieDeckProvider.shortcut(for: "mac-windows"))
     }
 
-    func testStarterDeckIsJobBasedAndHasNoRepeatedActions() throws {
+    func testStarterDeckFocusesOnFourCoreContexts() throws {
         let layout = LatticesCompanionCockpitCatalog.defaultLayout
-        XCTAssertEqual(layout.pages.map(\.id), ["remote", "move", "speak-run"])
+        XCTAssertEqual(layout.pages.map(\.id), ["command", "dev", "media", "windows"])
 
         let shortcutIDs = layout.pages.flatMap { page in
             page.slots?.map(\.shortcutID) ?? page.slotIDs.filter { !$0.isEmpty }
         }
-        XCTAssertEqual(shortcutIDs.count, 21)
-        XCTAssertEqual(Set(shortcutIDs).count, shortcutIDs.count)
+        XCTAssertEqual(shortcutIDs.count, 39)
+        XCTAssertFalse(shortcutIDs.contains(where: { $0.hasPrefix("talkie-") }))
+        XCTAssertFalse(shortcutIDs.contains(where: { $0.hasPrefix("voice-") }))
     }
 
     func testStarterDeckPositionedControlsStayInsideTheirPagesWithoutOverlap() throws {
@@ -164,7 +165,7 @@ final class CompanionCockpitMappingTests: XCTestCase {
         }
     }
 
-    func testStarterDeckRemainsUsefulAndHonestWithoutTalkie() {
+    func testStarterDeckRemainsFullyUsefulWithoutTalkieOrVoice() {
         let state = LatticesCompanionCockpitCatalog.renderedState(
             layout: LatticesCompanionCockpitCatalog.defaultLayout,
             voice: nil,
@@ -173,13 +174,19 @@ final class CompanionCockpitMappingTests: XCTestCase {
             talkie: .unavailable
         )
 
-        XCTAssertEqual(state.pages.map { $0.tiles.filter(\.isEnabled).count }, [4, 11, 2])
+        XCTAssertEqual(state.pages.map { $0.tiles.filter(\.isEnabled).count }, [8, 12, 7, 12])
         XCTAssertTrue(state.pages.flatMap(\.tiles).allSatisfy { $0.title != "Empty" })
+        XCTAssertTrue(state.pages.flatMap(\.tiles).allSatisfy(\.isEnabled))
+    }
 
-        let speakPage = state.pages.first(where: { $0.id == "speak-run" })
-        let providerTiles = speakPage?.tiles.filter { $0.shortcutID.hasPrefix("talkie-") || $0.shortcutID == "mac-sessions" }
-        XCTAssertEqual(providerTiles?.count, 4)
-        XCTAssertTrue(providerTiles?.allSatisfy { !$0.isEnabled && $0.actionID == nil } == true)
+    func testDeckBuilderLookupStartsWithPackagedAppResources() {
+        let resources = URL(fileURLWithPath: "/Applications/Lattices.app/Contents/Resources")
+        let roots = LatticesCompanionBridgeServer.deckBuilderResourceRoots(
+            applicationResourceURL: resources,
+            loadedBundles: []
+        )
+
+        XCTAssertEqual(roots.first, resources.appendingPathComponent("DeckBuilder", isDirectory: true))
     }
 
     func testBuilderCatalogIncludesEveryAssignableShortcut() throws {
@@ -291,7 +298,7 @@ final class CompanionCockpitMappingTests: XCTestCase {
         }
     }
 
-    func testV4MigrationReplacesOnlyUntouchedStarters() {
+    func testV5MigrationReplacesOnlyUntouchedStarters() {
         XCTAssertEqual(
             Preferences.migrateCompanionCockpitLayout(
                 LatticesCompanionCockpitCatalog.legacyDefaultLayoutV2,
@@ -304,6 +311,14 @@ final class CompanionCockpitMappingTests: XCTestCase {
             Preferences.migrateCompanionCockpitLayout(
                 LatticesCompanionCockpitCatalog.legacyDefaultLayoutV3,
                 fromVersion: 3
+            ),
+            LatticesCompanionCockpitCatalog.defaultLayout
+        )
+
+        XCTAssertEqual(
+            Preferences.migrateCompanionCockpitLayout(
+                LatticesCompanionCockpitCatalog.legacyDefaultLayoutV4,
+                fromVersion: 4
             ),
             LatticesCompanionCockpitCatalog.defaultLayout
         )
@@ -321,9 +336,16 @@ final class CompanionCockpitMappingTests: XCTestCase {
             Preferences.migrateCompanionCockpitLayout(customizedV3, fromVersion: 3),
             customizedV3
         )
+
+        var customizedV4 = LatticesCompanionCockpitCatalog.legacyDefaultLayoutV4
+        customizedV4.pages[0].title = "My Remote"
+        XCTAssertEqual(
+            Preferences.migrateCompanionCockpitLayout(customizedV4, fromVersion: 4),
+            customizedV4
+        )
     }
 
-    func testV4MigrationAdvancesTheUntouchedV1StarterThroughEveryVersion() throws {
+    func testV5MigrationAdvancesTheUntouchedV1StarterThroughEveryVersion() throws {
         var v1Starter = LatticesCompanionCockpitCatalog.legacyDefaultLayoutV2
         let devIndex = try XCTUnwrap(v1Starter.pages.firstIndex(where: { $0.id == "dev" }))
         v1Starter.pages[devIndex].slotIDs = [

--- a/bin/lattices-app.ts
+++ b/bin/lattices-app.ts
@@ -569,7 +569,9 @@ function buildFromSource(): boolean {
 
   mkdirSync(binaryDir, { recursive: true });
   execSync(`cp '${builtPath}' '${binaryPath}'`);
-  writeInfoPlist();
+  // Source builds are local/dev — stamp channel so Settings shows DEV, not the
+  // release fallback when LatticesBuildChannel is missing from Info.plist.
+  writeInfoPlist({ channel: "dev" });
   syncBundleResources();
 
   // Re-sign the bundle so macOS TCC recognizes a stable identity across rebuilds.

--- a/bin/lattices.ts
+++ b/bin/lattices.ts
@@ -2689,7 +2689,7 @@ const tilePresets: Record<string, (s: ScreenBounds) => number[]> = {
   "maximize":     (s) => [s.x, s.y, s.x + s.w, s.y + s.h],
   "max":          (s) => [s.x, s.y, s.x + s.w, s.y + s.h],
   "center":       (s) => {
-    const mw = Math.round(s.w * 0.7);
+    const mw = Math.round(s.w * 0.8);
     const mh = Math.round(s.h * 0.8);
     const mx = s.x + Math.round((s.w - mw) / 2);
     const my = s.y + Math.round((s.h - mh) / 2);

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,7 +4,9 @@ description: WebSocket API reference for programmatic control of lattices
 order: 5
 ---
 
-The lattices menu bar app runs a WebSocket server on `ws://127.0.0.1:9399`.
+The lattices menu bar app runs a WebSocket server on `ws://127.0.0.1:9399`
+(agent API). The same process also hosts the voice live-session runtime on
+`ws://127.0.0.1:9398` (see [Voice](/docs/voice) — deterministic Lattices ports).
 35+ RPC methods and 5 real-time events.
 
 ## Quick start

--- a/docs/app.md
+++ b/docs/app.md
@@ -151,7 +151,7 @@ frontmost window.
 | Left Third   | Left third                      |
 | Center Third | Center third                    |
 | Right Third  | Right third                     |
-| Center       | 70% width, 80% height, centered |
+| Center       | 80% width, 80% height, centered (20% margin all sides) |
 
 ## Space navigation
 
@@ -343,6 +343,18 @@ More in the [Agent API reference](/docs/api#ocrsnapshot).
 
 - **Screen Recording** permission — required to capture window images
 - Granted via System Settings > Privacy & Security > Screen Recording
+
+## Local loopback services
+
+The menu bar process owns fixed loopback ports (see `LatticesLocalEndpoints`):
+
+| Service | Port | Endpoint |
+|---------|------|----------|
+| Agent API / daemon | **9399** | `ws://127.0.0.1:9399` |
+| Voice runtime (Hudson Voice / Vox) | **9398** | `ws://127.0.0.1:9398` |
+
+Both start automatically when the app launches and stop when the app quits.
+Voice does not require an external `voxd` for normal operation.
 
 ## Agent API server
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -280,7 +280,7 @@ screen position. Available positions:
 | `left-third`   | Left third                  |
 | `center-third` | Center third                |
 | `right-third`  | Right third                 |
-| `center`       | 70% width, 80% height, centered |
+| `center`       | 80% width, 80% height, centered (20% margin all sides) |
 
 Aliases: `left-half`/`left`, `right-half`/`right`, `top-half`/`top`,
 `bottom-half`/`bottom`, `max`/`maximize`.

--- a/docs/tiling-reference.md
+++ b/docs/tiling-reference.md
@@ -13,7 +13,7 @@ All valid position strings that `TilePosition` accepts:
 | Position string | Grid | Cell (col, row) | Description |
 |---|---|---|---|
 | `maximize` | 1×1 | full | Full screen (100% × 100%) |
-| `center` | — | — | Centered floating (70% × 80%, offset 15%/10%) |
+| `center` | — | — | Centered floating (80% × 80%, offset 10%/10%) |
 | **Halves (2×1, full height)** | | | |
 | `left` | 2×1 | 0,0 | Left 50% |
 | `right` | 2×1 | 1,0 | Right 50% |

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -6,12 +6,36 @@ order: 7
 
 Voice commands let you control Lattices by speaking. Press **Hyper+D**
 to open the voice command window, hold **Option** to speak, release to
-stop. Lattices transcribes your speech via Vox,
-matches it to an intent, and executes it.
+stop. Lattices transcribes your speech via its **embedded Hudson Voice /
+Vox runtime**, matches it to an intent, and executes it.
+
+## Embedded voice runtime
+
+Lattices **hosts** the voice engine inside the menu bar process. You do not
+need a separate `voxd` for normal use. On app boot, Lattices starts an
+in-process live-session server and tears it down on quit.
+
+| Service | Port | Endpoint | Owner |
+|---------|------|----------|--------|
+| Agent API / daemon | **9399** | `ws://127.0.0.1:9399` | `DaemonServer` |
+| Voice runtime | **9398** | `ws://127.0.0.1:9398` | `LatticesVoiceRuntime` |
+
+These ports are **deterministic** and Lattices-owned (`LatticesLocalEndpoints`
+in the app). The `939x` loopback family is the self-describing local contract:
+
+- **9399** — agent RPC (existing)
+- **9398** — voice live session (transcription)
+
+Capability file (auth token + pid + port) lives at:
+
+`~/Library/Application Support/Lattices/Voice/hudson-voice-runtime.json`
+
+Override the voice port only for tests/dev with `LATTICES_VOICE_PORT`
+(or legacy `HUDSON_VOICE_VOX_PORT`).
 
 ## Quick start
 
-1. Install Vox (provides mic + transcription)
+1. Grant microphone access when prompted (Settings → Voice if you skipped it)
 2. Optionally connect a voice provider in **Settings > Voice** for provider-backed interpretation and speech services
 3. Press **Hyper+D** to open the voice command window
 4. Hold **Option** and speak a command

--- a/packages/npm/agent-runner/bin/agent-runner.mjs
+++ b/packages/npm/agent-runner/bin/agent-runner.mjs
@@ -27,6 +27,26 @@ runner.onEvent((sequenced) => {
   write({ type: "event", event: sequenced.event ?? sequenced });
 });
 
+// Also mirror registry adapter errors as structured events so native hosts
+// do not have to scrape stderr for "claude exited with code 1".
+const originalError = console.error.bind(console);
+console.error = (...args) => {
+  originalError(...args);
+  const joined = args.map((a) => (typeof a === "string" ? a : a?.message ?? String(a))).join(" ");
+  if (joined.includes("adapter error")) {
+    const message = joined.replace(/^.*adapter error\s*\([^)]*\):\s*/i, "").trim() || joined;
+    write({
+      type: "event",
+      event: {
+        event: "turn:error",
+        sessionId: "unknown",
+        turnId: "unknown",
+        message,
+      },
+    });
+  }
+};
+
 function write(obj) {
   process.stdout.write(JSON.stringify(obj) + "\n");
 }

--- a/tests/e2e-daemon.test.mjs
+++ b/tests/e2e-daemon.test.mjs
@@ -108,6 +108,47 @@ test("tmux.inventory returns array buckets", async () => {
   assert.ok(Array.isArray(inventory.orphans));
 });
 
+test("spaces.list returns displays with ordered spaces and a current space", async () => {
+  const payload = await daemonCall("spaces.list");
+  // Daemon may return an array of displays or { displays: [...] }.
+  const displays = Array.isArray(payload)
+    ? payload
+    : Array.isArray(payload?.displays)
+      ? payload.displays
+      : null;
+  assert.ok(Array.isArray(displays), "spaces.list should return displays");
+  assert.ok(displays.length > 0, "expected at least one display");
+
+  for (const display of displays) {
+    assert.equal(typeof display.displayIndex, "number");
+    assert.ok(Array.isArray(display.spaces), "display.spaces must be an array");
+    assert.ok(display.spaces.length > 0, "display should list at least one space");
+    assert.equal(typeof display.currentSpaceId, "number");
+
+    let currentCount = 0;
+    for (const space of display.spaces) {
+      assert.equal(typeof space.id, "number");
+      if (typeof space.index === "number") {
+        assert.ok(space.index >= 1, "space.index is 1-based when present");
+      }
+      if (space.isCurrent === true || space.id === display.currentSpaceId) {
+        currentCount += 1;
+      }
+    }
+    assert.ok(
+      currentCount >= 1,
+      `display ${display.displayId ?? display.displayIndex} should mark a current space`
+    );
+  }
+
+  // Contract for previous/next math: spaces are ordered; first has no prev, last no next.
+  const primary = displays[0];
+  if (primary.spaces.length >= 2) {
+    const ids = primary.spaces.map((s) => s.id);
+    assert.equal(new Set(ids).size, ids.length, "space ids unique per display");
+  }
+});
+
 test("voice.simulate parses a search command without executing", async () => {
   const result = await daemonCall("voice.simulate", {
     text: "find lattices",


### PR DESCRIPTION
## Summary

- **Assistant:** local agent-runtime first (pi → claude-code → …) with 12s RPC timeouts, 60s turn budget, harness cascade, Scout wall-clock kill, offline fail-fast, and clearer fallback status
- **Voice / dictation:** deterministic embedded host on **9398**, `ensureRunning`, no dead-port advertise, min capture + stop timeout on voice-command path (parity with assistant mic)
- **Menu bar Move:** collapsed quick action that expands the placement grid
- **Previous / next Space:** pure unit tests for Lattices adjacency (mouse `space.previous` / `space.next`, deck relative focus, SkyLight target math)—not Mission Control Control+Left/Right. E2E `spaces.list` shape coverage when the daemon is up
- **Companion:** deck reliability fixes already on this branch, plus relative Space target helper for testable navigation
- **Build:** source builds stamp `LatticesBuildChannel=dev`

## Test plan

- [x] `swift test --package-path apps/mac --filter 'AdjacentSpaceTests|AssistantReliabilityTests'` (17 tests)
- [x] `node --experimental-strip-types --test tests/e2e-daemon.test.mjs` with app/daemon running (includes `spaces.list`)
- [ ] Manual: assistant chat via agent-runtime (pi), empty-harness fallback
- [ ] Manual: menu bar Move expand/place
- [ ] Manual: middle-drag left/right space previous/next (does not depend on OS Ctrl+arrows)