### PR TITLE
Add workspace map and window movement CLI/API

### DIFF
--- a/apps/mac/Sources/Core/Actions/Execution/ActionRuntime.swift
+++ b/apps/mac/Sources/Core/Actions/Execution/ActionRuntime.swift
@@ -48,8 +48,16 @@ final class ActionRuntime {
         var events: [JSON] = []
 
         let resolved = try resolveWindowTarget(params: normalizedParams, trace: &trace, events: &events)
-        let screen = onMain {
-            Self.resolveTargetScreen(for: resolved.entry, displayIndex: displayIndex)
+        let screen: NSScreen
+        if let displayIndex {
+            guard let requestedScreen = onMain({ DisplayGeometryMapper.screen(forDisplayIndex: displayIndex) }) else {
+                throw RouterError.notFound("display \(displayIndex)")
+            }
+            screen = requestedScreen
+        } else {
+            screen = onMain {
+                Self.resolveTargetScreen(for: resolved.entry, displayIndex: nil)
+            }
         }
 
         var result: [String: JSON] = [
@@ -86,16 +94,209 @@ final class ActionRuntime {
         return .object(result)
     }
 
-    func executeWindowPlace(params: JSON?, source: String = "daemon", requestId: String? = nil) throws -> JSON {
+    func executeWindowPlace(
+        params: JSON?,
+        source: String = "daemon",
+        requestId: String? = nil,
+        compatibilityMethod: String? = nil
+    ) throws -> JSON {
         let context = ActionInvocationContext(
             requestId: requestId ?? Self.makeId(prefix: "req"),
             actionId: Self.makeId(prefix: "act"),
             source: source,
-            compatibilityMethod: nil
+            compatibilityMethod: compatibilityMethod
         )
         let receipt = try executeWindowPlace(params: params, context: context)
         history.record(receipt)
         return receipt
+    }
+
+    /// Geometry moves for `window.move`: a display target with an optional
+    /// placement slot. Space moves stay in the `window.move` endpoint handler.
+    ///
+    /// With a placement the move routes through the canonical `window.place`
+    /// execution path. Without one, the window's normalized x/y/w/h within its
+    /// source display's visible frame is preserved onto the target display's
+    /// visible frame and clamped to fit.
+    func executeWindowMove(params: JSON?, source: String = "daemon") throws -> JSON {
+        let displayIndex = params?["display"]?.intValue
+        let placementJSON = params?["placement"] ?? params?["position"]
+
+        if let placementJSON {
+            guard PlacementSpec(json: placementJSON) != nil else {
+                throw RouterError.custom("Unknown placement: \(placementJSON.stringValue ?? "<object>")")
+            }
+            return try executeWindowPlace(params: params, source: source, compatibilityMethod: "window.move")
+        }
+
+        guard let displayIndex else {
+            throw RouterError.missingParam("display, placement, or spaceId")
+        }
+
+        let dryRun = params?["dryRun"]?.boolValue == true
+        var trace: [String] = []
+        var events: [JSON] = []
+
+        let resolved = try resolveMoveTarget(params: params, trace: &trace, events: &events)
+        guard let entry = resolved.entry, let wid = resolved.wid, let pid = resolved.pid else {
+            throw RouterError.custom("window.move requires a resolvable on-screen window; no window found for the target")
+        }
+
+        guard let targetScreen = onMain({ DisplayGeometryMapper.screen(forDisplayIndex: displayIndex) }) else {
+            throw RouterError.notFound("display \(displayIndex)")
+        }
+
+        let beforeFrame = Self.cgWindowFrameTopLeft(wid: wid) ?? CGRect(
+            x: CGFloat(entry.frame.x),
+            y: CGFloat(entry.frame.y),
+            width: CGFloat(entry.frame.w),
+            height: CGFloat(entry.frame.h)
+        )
+
+        let geometry = onMain { () -> (source: NSScreen, fractions: (x: CGFloat, y: CGFloat, w: CGFloat, h: CGFloat)?, targetFrame: CGRect?) in
+            let sourceScreen = WindowTiler.screenForWindowFrame(entry.frame)
+            let primaryHeight = NSScreen.screens.first?.frame.height ?? 0
+            let sourceVisible = DisplayGeometryMapper.topLeftFrame(sourceScreen.visibleFrame, primaryHeight: primaryHeight)
+            guard let fractions = DisplayGeometryMapper.normalizedFractions(of: beforeFrame, in: sourceVisible) else {
+                return (sourceScreen, nil, nil)
+            }
+            return (sourceScreen, fractions, WindowTiler.tileFrame(fractions: fractions, on: targetScreen))
+        }
+        guard let fractions = geometry.fractions, let targetFrame = geometry.targetFrame else {
+            throw RouterError.custom("window.move could not derive source geometry for wid \(wid)")
+        }
+        let sourceScreen = geometry.source
+        let verificationTolerance = Self.verificationTolerance(forApp: resolved.app)
+
+        trace.append("normalized frame x=\(fractions.x) y=\(fractions.y) w=\(fractions.w) h=\(fractions.h)")
+        events.append(event("plan.computeFrame", "remapped source frame onto \(targetScreen.localizedName)"))
+
+        var blockedReason: String?
+        var requiredPermissions: [String] = []
+
+        if dryRun {
+            trace.append("dry run; skipped execution")
+            events.append(event("execute.skipped", "dry run requested; no window mutation performed"))
+        } else if !AXIsProcessTrusted() {
+            blockedReason = "accessibility-not-trusted"
+            requiredPermissions.append("accessibility")
+            trace.append("blocked: Accessibility permission required for deterministic window movement")
+            events.append(event("execute.blocked", "Accessibility permission required to move wid \(wid)"))
+        } else {
+            onMain {
+                WindowTiler.tileWindowById(wid: wid, pid: pid, fractions: fractions, on: targetScreen)
+            }
+            DesktopModel.shared.markInteraction(wid: wid)
+            trace.append("executed window move to display \(displayIndex)")
+            events.append(event("execute.moveWindow", "moved wid \(wid) to display \(displayIndex)"))
+        }
+
+        let afterFrame = dryRun ? nil : Self.waitForWindowFrame(
+            wid: wid,
+            targetFrame: targetFrame,
+            tolerance: verificationTolerance
+        )
+        let verified = dryRun ? false : (afterFrame.map { Self.framesClose($0, targetFrame, tolerance: verificationTolerance) } ?? false)
+        if dryRun {
+            trace.append("verification skipped for dry run")
+            events.append(event("verify.skipped", "dry run requested; no final frame verification performed"))
+        } else if verified {
+            trace.append("verified target frame")
+            events.append(event("verify.frame", "verified final frame"))
+        } else if blockedReason == nil {
+            trace.append("verification could not confirm exact target frame")
+            events.append(event("verify.frame", "final frame did not match target within tolerance"))
+        }
+
+        let status: String
+        if dryRun {
+            status = "planned"
+        } else if blockedReason != nil {
+            status = "blocked"
+        } else if verified {
+            status = "ok"
+        } else {
+            status = "failed"
+        }
+        let ok = status == "ok" || status == "planned"
+
+        var mutation: [String: JSON] = [
+            "kind": .string("moveWindowToDisplay"),
+            "wid": .int(Int(wid)),
+            "pid": .int(Int(pid)),
+            "from": Self.frameJSON(beforeFrame),
+            "to": Self.frameJSON(targetFrame),
+        ]
+        if let afterFrame { mutation["after"] = Self.frameJSON(afterFrame) }
+
+        let receiptId = Self.makeId(prefix: "exec")
+        var receipt: [String: JSON] = [
+            "ok": .bool(ok),
+            "status": .string(status),
+            "receiptId": .string(receiptId),
+            "requestId": .string(Self.makeId(prefix: "req")),
+            "source": .string(source),
+            "action": .object([
+                "id": .string(Self.makeId(prefix: "act")),
+                "type": .string("window.move"),
+            ]),
+            "target": resolved.json,
+            "targetKind": .string(resolved.kind),
+            "targetResolution": .string(resolved.resolution),
+            "dryRun": .bool(dryRun),
+            "sourceDisplay": onMain { displayJSON(sourceScreen, requestedIndex: nil) },
+            "display": onMain { displayJSON(targetScreen, requestedIndex: displayIndex) },
+            "fractions": .object([
+                "x": .double(Double(fractions.x)),
+                "y": .double(Double(fractions.y)),
+                "w": .double(Double(fractions.w)),
+                "h": .double(Double(fractions.h)),
+            ]),
+            "verificationTolerance": .double(Double(verificationTolerance)),
+            "plan": .object([
+                "actionType": .string("window.move"),
+                "target": resolved.json,
+                "steps": .array([
+                    .string("resolve target"),
+                    .string("resolve displays"),
+                    .string("remap normalized frame"),
+                    .string("move window"),
+                    .string("verify frame"),
+                ]),
+                "mutations": .array([.object(mutation)]),
+            ]),
+            "mutations": .array([.object(mutation)]),
+            "verified": .bool(verified),
+            "trace": .array(trace.map { .string($0) }),
+            "events": .array(events),
+            "timestamp": .double(Date().timeIntervalSince1970),
+        ]
+
+        receipt["wid"] = .int(Int(wid))
+        receipt["pid"] = .int(Int(pid))
+        if let app = resolved.app { receipt["app"] = .string(app) }
+        if let title = resolved.title { receipt["title"] = .string(title) }
+        if let session = resolved.session { receipt["session"] = .string(session) }
+        if let blockedReason {
+            receipt["blockedReason"] = .string(blockedReason)
+        }
+        if !requiredPermissions.isEmpty {
+            receipt["requiredPermissions"] = .array(requiredPermissions.map { .string($0) })
+        }
+
+        let undoable = status == "ok" && !dryRun && afterFrame != nil
+        receipt["undoable"] = .bool(undoable)
+        if undoable {
+            receipt["undo"] = .object([
+                "strategy": .string("restore-frame"),
+                "requiresCurrentFrameMatch": .bool(true),
+                "frameSource": .string("mutations.from"),
+            ])
+        }
+
+        let result = JSON.object(receipt)
+        history.record(result)
+        return result
     }
 
     private func executeBatch(root: [String: JSON], actions: [JSON]) throws -> JSON {
@@ -166,8 +367,16 @@ final class ActionRuntime {
         var events: [JSON] = []
 
         let resolved = try resolveWindowTarget(params: params, trace: &trace, events: &events)
-        let screen = onMain {
-            Self.resolveTargetScreen(for: resolved.entry, displayIndex: displayIndex)
+        let screen: NSScreen
+        if let displayIndex {
+            guard let requestedScreen = onMain({ DisplayGeometryMapper.screen(forDisplayIndex: displayIndex) }) else {
+                throw RouterError.notFound("display \(displayIndex)")
+            }
+            screen = requestedScreen
+        } else {
+            screen = onMain {
+                Self.resolveTargetScreen(for: resolved.entry, displayIndex: nil)
+            }
         }
         let targetFrame = onMain {
             WindowTiler.tileFrame(for: placement, on: screen)
@@ -593,6 +802,36 @@ final class ActionRuntime {
         throw RouterError.custom("Could not resolve a window target for placement")
     }
 
+    /// Strict target resolution for `window.move`: an explicit wid or session
+    /// only. Never falls back to the frontmost window — a malformed or missing
+    /// target must fail loudly rather than move whatever happens to be focused.
+    private func resolveMoveTarget(params: JSON?, trace: inout [String], events: inout [JSON]) throws -> ResolvedWindowTarget {
+        if let wid = params?["wid"]?.uint32Value {
+            guard let entry = DesktopModel.shared.windows[wid] else {
+                throw RouterError.notFound("window \(wid)")
+            }
+            trace.append("resolved target by wid")
+            events.append(event("plan.resolveTarget", "resolved wid \(wid)"))
+            return ResolvedWindowTarget(kind: "wid", resolution: "wid", confidence: 1.0, entry: entry)
+        }
+
+        if let session = params?["session"]?.stringValue {
+            if let entry = DesktopModel.shared.windowForSession(session) {
+                trace.append("resolved target by session")
+                events.append(event("plan.resolveTarget", "resolved session \(session) to wid \(entry.wid)"))
+                return ResolvedWindowTarget(kind: "session", resolution: "session", confidence: 1.0, entry: entry, session: session)
+            }
+            if let entry = Self.windowForSessionViaTerminalSynthesis(session) {
+                trace.append("resolved target by terminal synthesis")
+                events.append(event("plan.resolveTarget", "resolved session \(session) through terminal synthesis to wid \(entry.wid)"))
+                return ResolvedWindowTarget(kind: "session", resolution: "terminal-synthesis", confidence: 0.9, entry: entry, session: session)
+            }
+            throw RouterError.notFound("window for session \(session)")
+        }
+
+        throw RouterError.missingParam("wid or session")
+    }
+
     private static func windowPlaceParams(action: JSON?, root: JSON?) throws -> JSON {
         var dict: [String: JSON] = [:]
 
@@ -736,10 +975,11 @@ final class ActionRuntime {
     }
 
     private func isUndoableReceipt(_ receipt: JSON, undoneReceiptIds: Set<String>) -> Bool {
+        let actionType = receipt["action"]?["type"]?.stringValue
         guard let receiptId = receipt["receiptId"]?.stringValue,
               !undoneReceiptIds.contains(receiptId),
               receipt["status"]?.stringValue == "ok",
-              receipt["action"]?["type"]?.stringValue == "window.place" else {
+              actionType == "window.place" || actionType == "window.move" else {
             return false
         }
         if receipt["undoable"]?.boolValue == false {
@@ -789,6 +1029,25 @@ final class ActionRuntime {
         if let requestedIndex {
             obj["requestedIndex"] = .int(requestedIndex)
         }
+        return .object(obj)
+    }
+
+    /// screenJSON plus the SkyLight display index and visible frame in API
+    /// (top-left) coordinates. Call on the main thread.
+    private func displayJSON(_ screen: NSScreen, requestedIndex: Int?) -> JSON {
+        guard case .object(var obj) = screenJSON(screen, requestedIndex: requestedIndex) else {
+            return screenJSON(screen, requestedIndex: requestedIndex)
+        }
+        let screens = NSScreen.screens
+        if let display = WindowTiler.getDisplaySpaces().first(where: {
+            DisplayGeometryMapper.screen(for: $0, in: screens) === screen
+        }) {
+            obj["displayIndex"] = .int(display.displayIndex)
+        }
+        let primaryHeight = screens.first?.frame.height ?? 0
+        obj["visibleFrame"] = Self.frameJSON(
+            DisplayGeometryMapper.topLeftFrame(screen.visibleFrame, primaryHeight: primaryHeight)
+        )
         return .object(obj)
     }
 
@@ -881,8 +1140,8 @@ final class ActionRuntime {
     }
 
     private static func resolveTargetScreen(for entry: WindowEntry?, displayIndex: Int?) -> NSScreen {
-        if let displayIndex, displayIndex >= 0, displayIndex < NSScreen.screens.count {
-            return NSScreen.screens[displayIndex]
+        if let displayIndex, let screen = DisplayGeometryMapper.screen(forDisplayIndex: displayIndex) {
+            return screen
         }
         if let entry {
             return WindowTiler.screenForWindowFrame(entry.frame)

--- a/apps/mac/Sources/Core/Daemon/LatticesApi.swift
+++ b/apps/mac/Sources/Core/Daemon/LatticesApi.swift
@@ -47,6 +47,51 @@ struct ApiModel {
     let fields: [Field]
 }
 
+// MARK: - Display Geometry
+
+enum DisplayGeometryMapper {
+    /// Convert AppKit's bottom-left global coordinates to the top-left global
+    /// coordinates used by CG window bounds and the Lattices API.
+    static func topLeftFrame(_ frame: CGRect, primaryHeight: CGFloat) -> CGRect {
+        CGRect(
+            x: frame.origin.x,
+            y: primaryHeight - frame.maxY,
+            width: frame.width,
+            height: frame.height
+        )
+    }
+
+    /// SkyLight and AppKit do not document matching array order. Prefer the
+    /// stable display UUID and retain the historical index fallback.
+    static func screen(for display: DisplaySpaces, in screens: [NSScreen]) -> NSScreen? {
+        let wanted = normalizeIdentifier(display.displayId)
+        if !wanted.isEmpty,
+           let matched = screens.first(where: { screen in
+               guard let identifier = identifier(for: screen) else { return false }
+               return normalizeIdentifier(identifier) == wanted
+           }) {
+            return matched
+        }
+        return screens.indices.contains(display.displayIndex) ? screens[display.displayIndex] : nil
+    }
+
+    private static func identifier(for screen: NSScreen) -> String? {
+        let key = NSDeviceDescriptionKey("NSScreenNumber")
+        guard let number = screen.deviceDescription[key] as? NSNumber,
+              let uuid = CGDisplayCreateUUIDFromDisplayID(CGDirectDisplayID(number.uint32Value))?.takeRetainedValue()
+        else {
+            return nil
+        }
+        return CFUUIDCreateString(nil, uuid) as String
+    }
+
+    private static func normalizeIdentifier(_ value: String) -> String {
+        value
+            .trimmingCharacters(in: CharacterSet(charactersIn: "{}"))
+            .lowercased()
+    }
+}
+
 // MARK: - Central Registry
 
 final class LatticesApi {
@@ -212,6 +257,9 @@ final class LatticesApi {
         api.model(ApiModel(name: "Display", fields: [
             Field(name: "displayIndex", type: "int", required: true, description: "Display index"),
             Field(name: "displayId", type: "string", required: true, description: "Display identifier"),
+            Field(name: "name", type: "string", required: true, description: "Human-readable display name"),
+            Field(name: "frame", type: "Frame", required: true, description: "Full display frame in top-left screen coordinates"),
+            Field(name: "visibleFrame", type: "Frame", required: true, description: "Usable display frame in top-left screen coordinates"),
             Field(name: "currentSpaceId", type: "int", required: true, description: "Currently active space ID"),
             Field(name: "spaces", type: "[Space]", required: true, description: "Spaces on this display"),
         ]))
@@ -889,10 +937,33 @@ final class LatticesApi {
             returns: .array(model: "Display"),
             handler: { _ in
                 let displays = WindowTiler.getDisplaySpaces()
+                let screens: [NSScreen]
+                if Thread.isMainThread {
+                    screens = NSScreen.screens
+                } else {
+                    screens = DispatchQueue.main.sync { NSScreen.screens }
+                }
+                let primaryHeight = screens.first?.frame.height ?? 0
                 return .array(displays.map { display in
-                    .object([
+                    let screen = DisplayGeometryMapper.screen(for: display, in: screens)
+                    func topLeftFrame(_ frame: CGRect?) -> JSON {
+                        guard let frame else {
+                            return .object(["x": .double(0), "y": .double(0), "w": .double(0), "h": .double(0)])
+                        }
+                        let converted = DisplayGeometryMapper.topLeftFrame(frame, primaryHeight: primaryHeight)
+                        return .object([
+                            "x": .double(converted.origin.x),
+                            "y": .double(converted.origin.y),
+                            "w": .double(converted.width),
+                            "h": .double(converted.height),
+                        ])
+                    }
+                    return .object([
                         "displayIndex": .int(display.displayIndex),
                         "displayId": .string(display.displayId),
+                        "name": .string(screen?.localizedName ?? display.displayId),
+                        "frame": topLeftFrame(screen?.frame),
+                        "visibleFrame": topLeftFrame(screen?.visibleFrame),
                         "currentSpaceId": .int(display.currentSpaceId),
                         "spaces": .array(display.spaces.map { space in
                             .object([

--- a/apps/mac/Sources/Core/Daemon/LatticesApi.swift
+++ b/apps/mac/Sources/Core/Daemon/LatticesApi.swift
@@ -64,15 +64,61 @@ enum DisplayGeometryMapper {
     /// SkyLight and AppKit do not document matching array order. Prefer the
     /// stable display UUID and retain the historical index fallback.
     static func screen(for display: DisplaySpaces, in screens: [NSScreen]) -> NSScreen? {
-        let wanted = normalizeIdentifier(display.displayId)
-        if !wanted.isEmpty,
-           let matched = screens.first(where: { screen in
-               guard let identifier = identifier(for: screen) else { return false }
-               return normalizeIdentifier(identifier) == wanted
-           }) {
-            return matched
+        let identifiers = screens.map { identifier(for: $0) }
+        guard let index = matchIndex(
+            displayId: display.displayId,
+            displayIndex: display.displayIndex,
+            identifiers: identifiers
+        ) else {
+            return nil
         }
-        return screens.indices.contains(display.displayIndex) ? screens[display.displayIndex] : nil
+        return screens[index]
+    }
+
+    /// Pure matching core: given the SkyLight display identifier and index plus
+    /// the per-screen UUID strings (nil when a screen has no resolvable UUID),
+    /// pick the screen index. UUID equality wins; the array index is only a
+    /// fallback for identifier-less environments.
+    static func matchIndex(displayId: String, displayIndex: Int, identifiers: [String?]) -> Int? {
+        let wanted = normalizeIdentifier(displayId)
+        if !wanted.isEmpty {
+            for (index, identifier) in identifiers.enumerated() {
+                guard let identifier else { continue }
+                if normalizeIdentifier(identifier) == wanted {
+                    return index
+                }
+            }
+        }
+        return identifiers.indices.contains(displayIndex) ? displayIndex : nil
+    }
+
+    /// Resolve an API display index to an NSScreen through the SkyLight display
+    /// list and UUID matching — never by assuming NSScreen.screens shares the
+    /// SkyLight array order. Call on the main thread.
+    static func screen(forDisplayIndex index: Int) -> NSScreen? {
+        let screens = NSScreen.screens
+        if let display = WindowTiler.getDisplaySpaces().first(where: { $0.displayIndex == index }) {
+            return screen(for: display, in: screens)
+        }
+        return screens.indices.contains(index) ? screens[index] : nil
+    }
+
+    /// Normalized x/y/w/h of `frame` within `container`, clamped so the result
+    /// always describes a rect that fits inside the unit square. Both rects must
+    /// share one coordinate space. Returns nil when either has no area.
+    static func normalizedFractions(
+        of frame: CGRect,
+        in container: CGRect
+    ) -> (x: CGFloat, y: CGFloat, w: CGFloat, h: CGFloat)? {
+        guard container.width > 0, container.height > 0,
+              frame.width > 0, frame.height > 0 else {
+            return nil
+        }
+        let w = min(frame.width / container.width, 1)
+        let h = min(frame.height / container.height, 1)
+        let x = min(max((frame.minX - container.minX) / container.width, 0), 1 - w)
+        let y = min(max((frame.minY - container.minY) / container.height, 0), 1 - h)
+        return (x, y, w, h)
     }
 
     private static func identifier(for screen: NSScreen) -> String? {
@@ -2638,25 +2684,99 @@ final class LatticesApi {
 
         api.register(Endpoint(
             method: "window.move",
-            description: "Move a session's window to a different space",
+            description: "Move a window to another display, placement slot, or Space",
             access: .mutate,
             params: [
-                Param(name: "session", type: "string", required: true, description: "Tmux session name"),
-                Param(name: "spaceId", type: "int", required: true, description: "Target space ID"),
+                Param(name: "wid", type: "uint32", required: false, description: "Window ID (preferred target)"),
+                Param(name: "session", type: "string", required: false, description: "Tmux session name (legacy target)"),
+                Param(name: "display", type: "int", required: false, description: "Target display index (spaces.list displayIndex)"),
+                Param(name: "placement", type: "string|object", required: false, description: "Placement slot on the target display; omit to preserve the window's normalized frame"),
+                Param(name: "position", type: "string", required: false, description: "Alias for placement"),
+                Param(name: "spaceId", type: "int", required: false, description: "Target Space ID (exclusive with display/placement)"),
+                Param(name: "dryRun", type: "bool", required: false, description: "Plan and verify inputs without moving the window"),
             ],
-            returns: .ok,
+            returns: .custom("Execution receipt with before/target/after geometry, source/target display, and verification"),
             handler: { params in
-                guard let session = params?["session"]?.stringValue else {
-                    throw RouterError.missingParam("session")
+                let wid = params?["wid"]?.uint32Value
+                let session = params?["session"]?.stringValue
+                let spaceId = params?["spaceId"]?.intValue
+                let hasDisplay = params?["display"]?.intValue != nil
+                let hasPlacement = (params?["placement"] ?? params?["position"]) != nil
+
+                guard wid != nil || session != nil else {
+                    throw RouterError.missingParam("wid or session")
                 }
-                guard let spaceId = params?["spaceId"]?.intValue else {
-                    throw RouterError.missingParam("spaceId")
+                if let spaceId {
+                    guard !hasDisplay, !hasPlacement else {
+                        throw RouterError.custom("spaceId cannot be combined with display or placement; move Spaces and geometry in separate calls")
+                    }
+                    if let wid {
+                        // wid → Space rides the same CGS primitive present()
+                        // and the legacy session path already use. When CGS is
+                        // unavailable we report that instead of pretending.
+                        guard DesktopModel.shared.windows[wid] != nil else {
+                            throw RouterError.notFound("window \(wid)")
+                        }
+                        let knownSpaces = WindowTiler.getDisplaySpaces().flatMap { $0.spaces.map(\.id) }
+                        guard knownSpaces.isEmpty || knownSpaces.contains(spaceId) else {
+                            throw RouterError.notFound("space \(spaceId)")
+                        }
+                        let dryRun = params?["dryRun"]?.boolValue == true
+                        let fromSpaces = WindowTiler.getSpacesForWindow(wid)
+                        if fromSpaces.contains(spaceId) {
+                            return .object([
+                                "ok": .bool(true),
+                                "wid": .int(Int(wid)),
+                                "spaceId": .int(spaceId),
+                                "moved": .bool(false),
+                                "method": .string("already-on-space"),
+                                "dryRun": .bool(dryRun),
+                                "targetResolution": .string("wid"),
+                            ])
+                        }
+                        if dryRun {
+                            return .object([
+                                "ok": .bool(true),
+                                "status": .string("planned"),
+                                "wid": .int(Int(wid)),
+                                "spaceId": .int(spaceId),
+                                "moved": .bool(false),
+                                "dryRun": .bool(true),
+                                "fromSpaceIds": .array(fromSpaces.map { .int($0) }),
+                                "targetResolution": .string("wid"),
+                            ])
+                        }
+                        let result = Self.syncOnMain {
+                            WindowTiler.moveViaCGS(wid: wid, fromSpaces: fromSpaces, toSpace: spaceId)
+                        }
+                        guard let result, case .success(let method) = result else {
+                            throw RouterError.custom("Space moves are unavailable: CGS APIs could not be loaded")
+                        }
+                        return .object([
+                            "ok": .bool(true),
+                            "wid": .int(Int(wid)),
+                            "spaceId": .int(spaceId),
+                            "moved": .bool(method == "CGS"),
+                            "method": .string(method),
+                            "fromSpaceIds": .array(fromSpaces.map { .int($0) }),
+                            "targetResolution": .string("wid"),
+                        ])
+                    }
+                    // Legacy contract: session + spaceId, fire-and-forget.
+                    if params?["dryRun"]?.boolValue == true {
+                        return .object(["ok": .bool(true), "status": .string("planned"), "dryRun": .bool(true)])
+                    }
+                    let terminal = Preferences.shared.terminal
+                    DispatchQueue.main.async {
+                        _ = WindowTiler.moveWindowToSpace(session: session!, terminal: terminal, spaceId: spaceId)
+                    }
+                    return .object(["ok": .bool(true)])
                 }
-                let terminal = Preferences.shared.terminal
-                DispatchQueue.main.async {
-                    _ = WindowTiler.moveWindowToSpace(session: session, terminal: terminal, spaceId: spaceId)
+
+                guard hasDisplay || hasPlacement else {
+                    throw RouterError.missingParam("display, placement, or spaceId")
                 }
-                return .object(["ok": .bool(true)])
+                return try ActionRuntime.shared.executeWindowMove(params: params)
             }
         ))
 
@@ -4353,8 +4473,8 @@ private extension LatticesApi {
     }
 
     static func resolveTargetScreen(for entry: WindowEntry?, displayIndex: Int?) -> NSScreen {
-        if let displayIndex, displayIndex >= 0, displayIndex < NSScreen.screens.count {
-            return NSScreen.screens[displayIndex]
+        if let displayIndex, let screen = DisplayGeometryMapper.screen(forDisplayIndex: displayIndex) {
+            return screen
         }
         if let entry {
             return WindowTiler.screenForWindowFrame(entry.frame)

--- a/apps/mac/Tests/WindowMoveGeometryTests.swift
+++ b/apps/mac/Tests/WindowMoveGeometryTests.swift
@@ -1,0 +1,120 @@
+import CoreGraphics
+import XCTest
+@testable import Lattices
+
+final class WindowMoveGeometryTests: XCTestCase {
+    // MARK: - Display index → screen resolution (UUID matching)
+
+    private let uuidA = "37D8832A-2D66-02CA-B9F7-8F30A301B230"
+    private let uuidB = "A46D2F5E-11B8-4A1C-9F0D-63C1F1249B77"
+
+    func testMatchIndexPrefersUUIDOverArrayOrder() {
+        // SkyLight says display 0 is uuidB, but NSScreen.screens lists uuidB
+        // second. UUID matching must win over the index.
+        let index = DisplayGeometryMapper.matchIndex(
+            displayId: uuidB,
+            displayIndex: 0,
+            identifiers: [uuidA, uuidB]
+        )
+        XCTAssertEqual(index, 1)
+    }
+
+    func testMatchIndexNormalizesBracesAndCase() {
+        let index = DisplayGeometryMapper.matchIndex(
+            displayId: "{\(uuidB.lowercased())}",
+            displayIndex: 0,
+            identifiers: [uuidA, uuidB]
+        )
+        XCTAssertEqual(index, 1)
+    }
+
+    func testMatchIndexFallsBackToArrayIndexWithoutIdentifier() {
+        let index = DisplayGeometryMapper.matchIndex(
+            displayId: "",
+            displayIndex: 1,
+            identifiers: [nil, nil]
+        )
+        XCTAssertEqual(index, 1)
+    }
+
+    func testMatchIndexFallsBackToArrayIndexWhenUUIDUnknown() {
+        // The wanted UUID matches no screen; the historical index fallback
+        // still resolves rather than dropping the request.
+        let index = DisplayGeometryMapper.matchIndex(
+            displayId: "0000AAAA-0000-0000-0000-000000000000",
+            displayIndex: 0,
+            identifiers: [uuidA, uuidB]
+        )
+        XCTAssertEqual(index, 0)
+    }
+
+    func testMatchIndexReturnsNilWhenNothingResolves() {
+        let index = DisplayGeometryMapper.matchIndex(
+            displayId: "0000AAAA-0000-0000-0000-000000000000",
+            displayIndex: 5,
+            identifiers: [uuidA, uuidB]
+        )
+        XCTAssertNil(index)
+    }
+
+    // MARK: - Normalized frame remap for display-only window.move
+
+    func testNormalizedFractionsOfInteriorWindow() {
+        let container = CGRect(x: 0, y: 30, width: 1_000, height: 970)
+        let frame = CGRect(x: 250, y: 272.5, width: 500, height: 485)
+        let fractions = DisplayGeometryMapper.normalizedFractions(of: frame, in: container)
+        XCTAssertNotNil(fractions)
+        XCTAssertEqual(fractions!.x, 0.25, accuracy: 0.0001)
+        XCTAssertEqual(fractions!.y, 0.25, accuracy: 0.0001)
+        XCTAssertEqual(fractions!.w, 0.5, accuracy: 0.0001)
+        XCTAssertEqual(fractions!.h, 0.5, accuracy: 0.0001)
+    }
+
+    func testNormalizedFractionsClampsOversizedWindow() {
+        // A window larger than the target's visible frame must shrink to fit
+        // rather than overflow the display.
+        let container = CGRect(x: 0, y: 0, width: 800, height: 600)
+        let frame = CGRect(x: -100, y: -50, width: 1_600, height: 1_200)
+        let fractions = DisplayGeometryMapper.normalizedFractions(of: frame, in: container)
+        XCTAssertNotNil(fractions)
+        XCTAssertEqual(fractions!.x, 0, accuracy: 0.0001)
+        XCTAssertEqual(fractions!.y, 0, accuracy: 0.0001)
+        XCTAssertEqual(fractions!.w, 1, accuracy: 0.0001)
+        XCTAssertEqual(fractions!.h, 1, accuracy: 0.0001)
+    }
+
+    func testNormalizedFractionsClampsWindowHangingOffTheEdge() {
+        // Half off the right edge: size is preserved, origin clamps so the
+        // remapped window still fits inside the unit square.
+        let container = CGRect(x: 100, y: 0, width: 1_000, height: 1_000)
+        let frame = CGRect(x: 900, y: 0, width: 400, height: 400)
+        let fractions = DisplayGeometryMapper.normalizedFractions(of: frame, in: container)
+        XCTAssertNotNil(fractions)
+        XCTAssertEqual(fractions!.w, 0.4, accuracy: 0.0001)
+        XCTAssertEqual(fractions!.x, 0.6, accuracy: 0.0001)
+        XCTAssertEqual(fractions!.x + fractions!.w, 1, accuracy: 0.0001)
+    }
+
+    func testNormalizedFractionsPreservesGlobalOffsets() {
+        // A secondary display to the right of the primary: fractions are
+        // relative to that display's own visible frame, not global zero.
+        let container = CGRect(x: 3_440, y: 265, width: 3_840, height: 2_130)
+        let frame = CGRect(x: 5_360, y: 265, width: 1_920, height: 1_065)
+        let fractions = DisplayGeometryMapper.normalizedFractions(of: frame, in: container)
+        XCTAssertNotNil(fractions)
+        XCTAssertEqual(fractions!.x, 0.5, accuracy: 0.0001)
+        XCTAssertEqual(fractions!.y, 0, accuracy: 0.0001)
+        XCTAssertEqual(fractions!.w, 0.5, accuracy: 0.0001)
+        XCTAssertEqual(fractions!.h, 0.5, accuracy: 0.0001)
+    }
+
+    func testNormalizedFractionsRejectsDegenerateGeometry() {
+        let container = CGRect(x: 0, y: 0, width: 0, height: 600)
+        let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
+        XCTAssertNil(DisplayGeometryMapper.normalizedFractions(of: frame, in: container))
+        XCTAssertNil(DisplayGeometryMapper.normalizedFractions(
+            of: CGRect(x: 0, y: 0, width: 0, height: 0),
+            in: CGRect(x: 0, y: 0, width: 800, height: 600)
+        ))
+    }
+}

--- a/apps/mac/Tests/WorkspaceMapGeometryTests.swift
+++ b/apps/mac/Tests/WorkspaceMapGeometryTests.swift
@@ -1,0 +1,43 @@
+import CoreGraphics
+import XCTest
+@testable import Lattices
+
+final class WorkspaceMapGeometryTests: XCTestCase {
+    private let primaryHeight: CGFloat = 1_117
+
+    func testPrimaryDisplayStartsAtTopLeftOrigin() {
+        let converted = DisplayGeometryMapper.topLeftFrame(
+            CGRect(x: 0, y: 0, width: 1_728, height: primaryHeight),
+            primaryHeight: primaryHeight
+        )
+        XCTAssertEqual(converted, CGRect(x: 0, y: 0, width: 1_728, height: primaryHeight))
+    }
+
+    func testDisplaysAboveAndBelowPrimaryKeepSignedGlobalOffsets() {
+        let above = DisplayGeometryMapper.topLeftFrame(
+            CGRect(x: 200, y: primaryHeight, width: 1_200, height: 900),
+            primaryHeight: primaryHeight
+        )
+        XCTAssertEqual(above, CGRect(x: 200, y: -900, width: 1_200, height: 900))
+
+        let below = DisplayGeometryMapper.topLeftFrame(
+            CGRect(x: 200, y: -700, width: 1_200, height: 700),
+            primaryHeight: primaryHeight
+        )
+        XCTAssertEqual(below, CGRect(x: 200, y: primaryHeight, width: 1_200, height: 700))
+    }
+
+    func testDisplaysLeftAndRightPreserveHorizontalOffsets() {
+        let left = DisplayGeometryMapper.topLeftFrame(
+            CGRect(x: -1_920, y: 37, width: 1_920, height: 1_080),
+            primaryHeight: primaryHeight
+        )
+        XCTAssertEqual(left, CGRect(x: -1_920, y: 0, width: 1_920, height: 1_080))
+
+        let right = DisplayGeometryMapper.topLeftFrame(
+            CGRect(x: 1_728, y: 37, width: 2_560, height: 1_080),
+            primaryHeight: primaryHeight
+        )
+        XCTAssertEqual(right, CGRect(x: 1_728, y: 0, width: 2_560, height: 1_080))
+    }
+}

--- a/bin/cli/map-reference.ts
+++ b/bin/cli/map-reference.ts
@@ -1,0 +1,94 @@
+export type MapFrame = { x: number; y: number; w: number; h: number };
+
+export type MapCanvasRect = {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+};
+
+export type DesktopMapReference = {
+  viewport: MapFrame;
+  columns: number;
+  rows: number;
+  cellsPerPoint: number;
+  cellAspectRatio: number;
+};
+
+export const DEFAULT_TERMINAL_CELL_ASPECT_RATIO = 2;
+
+export function unionMapFrames(frames: MapFrame[]): MapFrame | undefined {
+  const valid = frames.filter((frame) =>
+    Number.isFinite(frame.x) &&
+    Number.isFinite(frame.y) &&
+    Number.isFinite(frame.w) &&
+    Number.isFinite(frame.h) &&
+    frame.w > 0 &&
+    frame.h > 0
+  );
+  if (!valid.length) return undefined;
+
+  const left = Math.min(...valid.map((frame) => frame.x));
+  const top = Math.min(...valid.map((frame) => frame.y));
+  const right = Math.max(...valid.map((frame) => frame.x + frame.w));
+  const bottom = Math.max(...valid.map((frame) => frame.y + frame.h));
+  return { x: left, y: top, w: right - left, h: bottom - top };
+}
+
+export function intersectMapFrames(a: MapFrame, b: MapFrame): MapFrame | undefined {
+  const left = Math.max(a.x, b.x);
+  const top = Math.max(a.y, b.y);
+  const right = Math.min(a.x + a.w, b.x + b.w);
+  const bottom = Math.min(a.y + a.h, b.y + b.h);
+  if (right <= left || bottom <= top) return undefined;
+  return { x: left, y: top, w: right - left, h: bottom - top };
+}
+
+export function createDesktopMapReference(
+  frames: MapFrame[],
+  options: {
+    maxColumns: number;
+    maxRows: number;
+    cellAspectRatio?: number;
+  },
+): DesktopMapReference | undefined {
+  const viewport = unionMapFrames(frames);
+  if (!viewport) return undefined;
+
+  const maxColumns = Math.max(2, Math.floor(options.maxColumns));
+  const maxRows = Math.max(2, Math.floor(options.maxRows));
+  const cellAspectRatio = options.cellAspectRatio ?? DEFAULT_TERMINAL_CELL_ASPECT_RATIO;
+  if (!Number.isFinite(cellAspectRatio) || cellAspectRatio <= 0) {
+    throw new Error("cellAspectRatio must be a positive number");
+  }
+
+  // A terminal row is taller than a terminal column is wide. Use one uniform
+  // physical scale, then divide vertical coordinates by the cell aspect ratio.
+  const horizontalScale = (maxColumns - 1) / viewport.w;
+  const verticalScale = ((maxRows - 1) * cellAspectRatio) / viewport.h;
+  const cellsPerPoint = Math.min(horizontalScale, verticalScale);
+  const columns = Math.max(2, Math.round(viewport.w * cellsPerPoint) + 1);
+  const rows = Math.max(2, Math.round((viewport.h * cellsPerPoint) / cellAspectRatio) + 1);
+
+  return {
+    viewport,
+    columns,
+    rows,
+    cellsPerPoint,
+    cellAspectRatio,
+  };
+}
+
+export function projectMapFrame(reference: DesktopMapReference, frame: MapFrame): MapCanvasRect {
+  const horizontal = (value: number): number =>
+    Math.round((value - reference.viewport.x) * reference.cellsPerPoint);
+  const vertical = (value: number): number =>
+    Math.round(((value - reference.viewport.y) * reference.cellsPerPoint) / reference.cellAspectRatio);
+
+  return {
+    left: horizontal(frame.x),
+    top: vertical(frame.y),
+    right: horizontal(frame.x + frame.w),
+    bottom: vertical(frame.y + frame.h),
+  };
+}

--- a/bin/cli/map.ts
+++ b/bin/cli/map.ts
@@ -1,4 +1,11 @@
-type Frame = { x: number; y: number; w: number; h: number };
+import {
+  createDesktopMapReference,
+  intersectMapFrames,
+  projectMapFrame,
+} from "./map-reference.ts";
+import type { DesktopMapReference, MapCanvasRect, MapFrame } from "./map-reference.ts";
+
+type Frame = MapFrame;
 
 export type MapSpace = {
   id: number;
@@ -58,6 +65,9 @@ const MIN_WIDTH = 32;
 const MAX_WIDTH = 120;
 const MIN_HEIGHT = 8;
 const MAX_HEIGHT = 40;
+const FALLBACK_WIDTH = 72;
+const FALLBACK_HEIGHT = 24;
+const MAX_LEGEND_LABEL = 46;
 
 function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
@@ -72,77 +82,385 @@ function cleanLabel(value: string): string {
     .trim();
 }
 
-// Canvas cells must stay exactly one terminal column wide. Keep full Unicode
-// in the legend, but use a printable ASCII projection inside the fixed grid.
+// The canvas is a fixed grid, so every glyph inside it must occupy exactly one
+// terminal column: printable ASCII, the box-drawing block, and the middle dot.
+// Anything else — emoji, CJK, combining marks — is projected to "?".
 function canvasLabel(value: string): string {
-  return cleanLabel(value).replace(/[^\x20-\x7e]/gu, "?");
+  return cleanLabel(value).replace(/[^\x20-\x7e·]/gu, "?");
 }
 
-function windowLabel(window: MapWindow, index: number, width: number): string {
+function fit(text: string, width: number): string {
+  if (width <= 0) return "";
+  if (text.length <= width) return text;
+  if (width === 1) return text.slice(0, 1);
+  return `${text.slice(0, width - 1)}~`;
+}
+
+function fitLegend(text: string, width: number): string {
+  if (text.length <= width) return text;
+  return `${text.slice(0, Math.max(1, width - 1))}…`;
+}
+
+function formatFrame(frame: Frame): string {
+  return `${Math.round(frame.w)}×${Math.round(frame.h)} @ ${Math.round(frame.x)},${Math.round(frame.y)}`;
+}
+
+// ── canvas primitives ────────────────────────────────────────────────
+//
+// Displays are double-line outer frames; every on-screen window is a
+// single-line rectangle whose title bar carries its legend number, so a
+// monitor outline never reads as a window.
+//
+// The map is an x-ray floor plan. A window never fills or erases its interior,
+// so a window that is completely covered on the real desktop still reads as its
+// own numbered rectangle here. Where two outlines meet, their single-line edges
+// merge into the correct box-drawing junction instead of one erasing the other.
+// The legend — not the drawing — is the authoritative front-to-back order.
+
+// bit order: 1 = up, 2 = right, 4 = down, 8 = left
+const UP = 1;
+const RIGHT = 2;
+const DOWN = 4;
+const LEFT = 8;
+
+const DISPLAY_EDGE_BITS: Record<string, number> = {
+  "═": 10,
+  "║": 5,
+  "╔": 6,
+  "╗": 12,
+  "╚": 3,
+  "╝": 9,
+  "╠": 7,
+  "╣": 13,
+  "╦": 14,
+  "╩": 11,
+  "╬": 15,
+};
+
+const WINDOW_EDGE_BITS: Record<string, number> = {
+  "─": 10,
+  "│": 5,
+  "┌": 6,
+  "┐": 12,
+  "└": 3,
+  "┘": 9,
+  "├": 7,
+  "┤": 13,
+  "┬": 14,
+  "┴": 11,
+  "┼": 15,
+};
+
+function glyphsByBits(bits: Record<string, number>): Map<number, string> {
+  return new Map(Object.entries(bits).map(([glyph, value]) => [value, glyph]));
+}
+
+const DISPLAY_EDGE_GLYPHS = glyphsByBits(DISPLAY_EDGE_BITS);
+const WINDOW_EDGE_GLYPHS = glyphsByBits(WINDOW_EDGE_BITS);
+
+function setCell(canvas: string[][], y: number, x: number, glyph: string): void {
+  const row = canvas[y];
+  if (!row || x < 0 || x >= row.length) return;
+  row[x] = glyph;
+}
+
+// Merge new edge bits into whatever edge already occupies the cell, within one
+// line weight. A crossing becomes ┼/╬ rather than the newer line winning.
+function mergeEdge(
+  canvas: string[][],
+  y: number,
+  x: number,
+  bits: number,
+  table: Record<string, number>,
+  glyphs: Map<number, string>,
+): boolean {
+  const row = canvas[y];
+  if (!row || x < 0 || x >= row.length) return false;
+  const existing = table[row[x]!];
+  const merged = existing === undefined ? bits : existing | bits;
+  row[x] = glyphs.get(merged) ?? glyphs.get(bits) ?? row[x]!;
+  return true;
+}
+
+function setDisplayEdge(canvas: string[][], y: number, x: number, bits: number): void {
+  mergeEdge(canvas, y, x, bits, DISPLAY_EDGE_BITS, DISPLAY_EDGE_GLYPHS);
+}
+
+function isDisplayEdge(canvas: string[][], y: number, x: number): boolean {
+  const glyph = canvas[y]?.[x];
+  return glyph !== undefined && DISPLAY_EDGE_BITS[glyph] !== undefined;
+}
+
+// Windows may never write over a display border. Insetting the window bounds
+// by one cell already keeps them inside, but that is arithmetic; this is the
+// invariant. It makes a damaged double-line frame unreachable however the
+// window drawing language evolves.
+function mergeWindowEdge(canvas: string[][], y: number, x: number, bits: number): boolean {
+  if (isDisplayEdge(canvas, y, x)) return false;
+  return mergeEdge(canvas, y, x, bits, WINDOW_EDGE_BITS, WINDOW_EDGE_GLYPHS);
+}
+
+function setWindowCell(canvas: string[][], y: number, x: number, glyph: string): void {
+  if (isDisplayEdge(canvas, y, x)) return;
+  setCell(canvas, y, x, glyph);
+}
+
+function writeText(canvas: string[][], y: number, x: number, text: string): void {
+  for (let index = 0; index < text.length; index++) setCell(canvas, y, x + index, text[index]!);
+}
+
+// Keep a projected rectangle inside the canvas and at least one cell wide/tall
+// so a small display or window still has a drawable footprint.
+function normalizeRect(rect: MapCanvasRect, columns: number, rows: number): MapCanvasRect {
+  let left = clamp(rect.left, 0, columns - 1);
+  let right = clamp(rect.right, 0, columns - 1);
+  let top = clamp(rect.top, 0, rows - 1);
+  let bottom = clamp(rect.bottom, 0, rows - 1);
+  if (right - left < 1) {
+    if (right + 1 <= columns - 1) right = left + 1;
+    else left = right - 1;
+  }
+  if (bottom - top < 1) {
+    if (bottom + 1 <= rows - 1) bottom = top + 1;
+    else top = bottom - 1;
+  }
+  return { left, top, right, bottom };
+}
+
+function displayHeader(display: MapDisplay, room: number): string {
+  const tag = `D${display.displayIndex}`;
+  const name = display.name ? canvasLabel(display.name) : "";
+  const space = `Space ${display.currentSpaceId}`;
+  const candidates = [
+    name ? `${tag} · ${name} · ${space}` : `${tag} · ${space}`,
+    `${tag} · ${space}`,
+    name ? `${tag} · ${name}` : tag,
+    tag,
+  ];
+  for (const candidate of candidates) {
+    if (candidate.length <= room) return candidate;
+  }
+  return fit(tag, room);
+}
+
+function drawDisplay(canvas: string[][], rect: MapCanvasRect, display: MapDisplay): void {
+  const { left, top, right, bottom } = rect;
+
+  for (let y = top + 1; y < bottom; y++) {
+    for (let x = left + 1; x < right; x++) setCell(canvas, y, x, " ");
+  }
+  for (let x = left + 1; x < right; x++) {
+    setDisplayEdge(canvas, top, x, LEFT | RIGHT);
+    setDisplayEdge(canvas, bottom, x, LEFT | RIGHT);
+  }
+  for (let y = top + 1; y < bottom; y++) {
+    setDisplayEdge(canvas, y, left, UP | DOWN);
+    setDisplayEdge(canvas, y, right, UP | DOWN);
+  }
+  setDisplayEdge(canvas, top, left, RIGHT | DOWN);
+  setDisplayEdge(canvas, top, right, LEFT | DOWN);
+  setDisplayEdge(canvas, bottom, left, UP | RIGHT);
+  setDisplayEdge(canvas, bottom, right, UP | LEFT);
+
+  // Identity rides in the top border: ╔═ D0 · Name · Space 1 ═══╗
+  const room = right - left - 4;
+  if (room >= 2) writeText(canvas, top, left + 1, `═ ${displayHeader(display, room)} `);
+}
+
+// ── window outlines and markers ──────────────────────────────────────
+
+type EdgeMark = { y: number; x: number; bits: number };
+
+type WindowShape = {
+  marks: EdgeMark[];
+  box: boolean;
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+};
+
+// The drawable area for windows: the display rect inset by two cells, so a
+// blank gutter always separates the double-line bezel from any window border.
+// Without it a maximized window renders "║┌" and the two read as one thick
+// frame. On a display too small to afford the gutter the inset falls back to
+// one cell — windows still never reach the bezel, which is the hard guarantee.
+function windowBounds(rect: MapCanvasRect): MapCanvasRect | undefined {
+  const gutter: MapCanvasRect = {
+    left: rect.left + 2,
+    top: rect.top + 2,
+    right: rect.right - 2,
+    bottom: rect.bottom - 2,
+  };
+  if (gutter.right >= gutter.left && gutter.bottom >= gutter.top) return gutter;
+
+  const tight: MapCanvasRect = {
+    left: rect.left + 1,
+    top: rect.top + 1,
+    right: rect.right - 1,
+    bottom: rect.bottom - 1,
+  };
+  return tight.right >= tight.left && tight.bottom >= tight.top ? tight : undefined;
+}
+
+// The outline of one window, as edge bits rather than glyphs, so intersecting
+// windows can merge into junctions instead of overwriting each other. Windows
+// thinner than two cells in a dimension collapse to a rule; they still carry an
+// outline and still get a marker below.
+function windowShape(bounds: MapCanvasRect, rect: MapCanvasRect): WindowShape | undefined {
+  const left = clamp(rect.left, bounds.left, bounds.right);
+  const right = clamp(rect.right, bounds.left, bounds.right);
+  const top = clamp(rect.top, bounds.top, bounds.bottom);
+  const bottom = clamp(rect.bottom, bounds.top, bounds.bottom);
+  if (right < left || bottom < top) return undefined;
+
+  const marks: EdgeMark[] = [];
+  const wide = right - left >= 1;
+  const tall = bottom - top >= 1;
+
+  if (!wide || !tall) {
+    const bits = wide ? LEFT | RIGHT : UP | DOWN;
+    for (let y = top; y <= bottom; y++) {
+      for (let x = left; x <= right; x++) marks.push({ y, x, bits });
+    }
+    return { marks, box: false, left, top, right, bottom };
+  }
+
+  for (let x = left + 1; x < right; x++) {
+    marks.push({ y: top, x, bits: LEFT | RIGHT });
+    marks.push({ y: bottom, x, bits: LEFT | RIGHT });
+  }
+  for (let y = top + 1; y < bottom; y++) {
+    marks.push({ y, x: left, bits: UP | DOWN });
+    marks.push({ y, x: right, bits: UP | DOWN });
+  }
+  marks.push({ y: top, x: left, bits: RIGHT | DOWN });
+  marks.push({ y: top, x: right, bits: LEFT | DOWN });
+  marks.push({ y: bottom, x: left, bits: UP | RIGHT });
+  marks.push({ y: bottom, x: right, bits: UP | LEFT });
+  return { marks, box: true, left, top, right, bottom };
+}
+
+type MarkerTier = "full" | "bare";
+
+type MarkerPlacement = { y: number; x: number; text: string; tier: MarkerTier };
+
+// A run is available when no nearer window has claimed it for text and it does
+// not sit on a display border.
+function runIsFree(
+  canvas: string[][],
+  claimed: number[][],
+  y: number,
+  x: number,
+  length: number,
+): boolean {
+  const row = claimed[y];
+  if (!row) return false;
+  for (let step = 0; step < length; step++) {
+    const cx = x + step;
+    if (cx < 0 || cx >= row.length || row[cx] !== 0) return false;
+    if (isDisplayEdge(canvas, y, cx)) return false;
+  }
+  return true;
+}
+
+function isDigit(canvas: string[][], y: number, x: number): boolean {
+  const glyph = canvas[y]?.[x];
+  return glyph !== undefined && glyph >= "0" && glyph <= "9";
+}
+
+// Find somewhere inside this window's own footprint for its marker that no
+// nearer window has already claimed. Markers are placed front to back, so the
+// search only ever has to avoid text that is closer to the front.
+//
+// The marker hugs the window's own left edge and walks down its rows before it
+// slides right: a number sitting under its own top-left corner is unambiguous,
+// while one pushed along a shared title-bar row reads as the neighbour's.
+function findMarkerSlot(
+  canvas: string[][],
+  claimed: number[][],
+  shape: WindowShape,
+  text: string,
+  tier: MarkerTier,
+): MarkerPlacement | undefined {
+  const length = text.length;
+  // "[12]" delimits itself, but a bare "12" butted against the next window's
+  // bare "13" reads as "1213". A bare marker therefore also needs a non-digit
+  // cell on each side; those flanks are reserved when it lands.
+  const fits = (y: number, x: number): boolean =>
+    runIsFree(canvas, claimed, y, x, length) &&
+    (tier === "full" || (!isDigit(canvas, y, x - 1) && !isDigit(canvas, y, x + length)));
+
+  const anchors: number[] = [];
+  if (shape.left + length <= shape.right) anchors.push(shape.left + 1);
+  if (shape.left + length - 1 <= shape.right) anchors.push(shape.left);
+
+  for (const x of anchors) {
+    for (let y = shape.top; y <= shape.bottom; y++) {
+      if (fits(y, x)) return { y, x, text, tier };
+    }
+  }
+  for (let y = shape.top; y <= shape.bottom; y++) {
+    for (let x = shape.left + 1; x + length - 1 <= shape.right; x++) {
+      if (fits(y, x)) return { y, x, text, tier };
+    }
+  }
+  return undefined;
+}
+
+// A window one cell wide and two cells tall has no room for "[12]" anywhere, so
+// fall back to the bare number — but only ever in full. A truncated numeral is
+// worse than an absent one, because "12" clipped to "1" is silently another
+// window's marker. The legend states which tier a window got.
+function markerForms(index: number): { text: string; tier: MarkerTier }[] {
+  return [
+    { text: `[${index}]`, tier: "full" },
+    { text: String(index), tier: "bare" },
+  ];
+}
+
+function windowDescription(window: MapWindow, room: number): string {
+  if (room < 3) return "";
   const app = canvasLabel(window.app);
   const title = canvasLabel(window.title);
-  const full = `${index} ${app}${title ? ` - ${title}` : ""}`;
-  return full.length <= width ? full : `${full.slice(0, Math.max(1, width - 1))}…`;
+  const full = ` ${app}${title ? ` - ${title}` : ""}`;
+  if (full.length <= room) return full;
+  const short = ` ${app}`;
+  if (short.length <= room) return short;
+  return fit(short, room);
+}
+
+// ── data selection ───────────────────────────────────────────────────
+
+function usableFrame(display: MapDisplay): Frame | undefined {
+  return display.visibleFrame ?? display.frame;
+}
+
+// The full frame owns the display outline and the global viewport; the visible
+// frame is only the usable area windows live in.
+function boundaryFrame(display: MapDisplay): Frame | undefined {
+  return display.frame ?? display.visibleFrame;
+}
+
+function hasArea(frame: Frame | undefined): frame is Frame {
+  return !!frame && frame.w > 0 && frame.h > 0;
 }
 
 function intersects(a: Frame, b: Frame): boolean {
   return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
 }
 
-function drawWindow(canvas: string[][], display: Frame, window: MapWindow, index: number): void {
-  const rows = canvas.length;
-  const columns = canvas[0]?.length ?? 0;
-  if (rows < 3 || columns < 3) return;
-
-  const clipped = {
-    x: Math.max(display.x, window.frame.x),
-    y: Math.max(display.y, window.frame.y),
-    w: Math.min(display.x + display.w, window.frame.x + window.frame.w) - Math.max(display.x, window.frame.x),
-    h: Math.min(display.y + display.h, window.frame.y + window.frame.h) - Math.max(display.y, window.frame.y),
-  };
-  if (clipped.w <= 0 || clipped.h <= 0) return;
-
-  const x1 = clamp(Math.round(((clipped.x - display.x) / display.w) * (columns - 1)), 0, columns - 2);
-  const y1 = clamp(Math.round(((clipped.y - display.y) / display.h) * (rows - 1)), 0, rows - 2);
-  const x2 = clamp(Math.round(((clipped.x + clipped.w - display.x) / display.w) * (columns - 1)), x1 + 1, columns - 1);
-  const y2 = clamp(Math.round(((clipped.y + clipped.h - display.y) / display.h) * (rows - 1)), y1 + 1, rows - 1);
-
-  for (let y = y1 + 1; y < y2; y++) {
-    for (let x = x1 + 1; x < x2; x++) canvas[y]![x] = " ";
-  }
-  for (let x = x1 + 1; x < x2; x++) {
-    canvas[y1]![x] = "─";
-    canvas[y2]![x] = "─";
-  }
-  for (let y = y1 + 1; y < y2; y++) {
-    canvas[y]![x1] = "│";
-    canvas[y]![x2] = "│";
-  }
-  canvas[y1]![x1] = "┌";
-  canvas[y1]![x2] = "┐";
-  canvas[y2]![x1] = "└";
-  canvas[y2]![x2] = "┘";
-
-  const available = x2 - x1 - 1;
-  if (available > 2) {
-    const label = windowLabel(window, index, available);
-    for (let i = 0; i < label.length && i < available; i++) canvas[y1]![x1 + 1 + i] = label[i]!;
-  }
-}
-
-function displayFrame(display: MapDisplay): Frame | undefined {
-  return display.visibleFrame ?? display.frame;
-}
-
 function windowsForDisplay(display: MapDisplay, windows: MapWindow[]): MapWindow[] {
-  const frame = displayFrame(display);
-  if (!frame || frame.w <= 0 || frame.h <= 0) return [];
+  const frame = usableFrame(display);
+  if (!hasArea(frame)) return [];
   return windows.filter((window) =>
     window.isOnScreen &&
     window.spaceIds.includes(display.currentSpaceId) &&
     intersects(window.frame, frame)
   );
 }
+
+// ── JSON snapshot (unchanged contract) ───────────────────────────────
 
 function snapshotFrame(frame: Frame): Frame {
   return { x: frame.x, y: frame.y, w: frame.w, h: frame.h };
@@ -187,6 +505,22 @@ function snapshotDisplay(display: MapDisplay, windows: MapWindow[]): WorkspaceMa
   };
 }
 
+/**
+ * Displays whose daemon payload carries no usable geometry (a pre-frame
+ * `spaces.list`, i.e. an app build that predates the workspace map). Windows
+ * cannot be assigned to such a display, so a snapshot containing it would
+ * silently report an occupied desktop as empty.
+ */
+export function displaysMissingGeometry(
+  displays: MapDisplay[],
+  options: Pick<MapOptions, "display"> = {},
+): MapDisplay[] {
+  return displays.filter((display) =>
+    (options.display === undefined || display.displayIndex === options.display) &&
+    !hasArea(usableFrame(display))
+  );
+}
+
 export function createWorkspaceMapSnapshot(
   displays: MapDisplay[],
   windows: MapWindow[],
@@ -206,6 +540,92 @@ export function createWorkspaceMapSnapshot(
   };
 }
 
+// ── terminal map ─────────────────────────────────────────────────────
+
+type PlacedWindow = { window: MapWindow; index: number };
+
+type DisplayPlacement = {
+  display: MapDisplay;
+  boundary: Frame;
+  usable: Frame;
+  windows: PlacedWindow[];
+};
+
+function summaryLine(reference: DesktopMapReference, placements: DisplayPlacement[]): string {
+  const windowCount = placements.reduce((total, placement) => total + placement.windows.length, 0);
+  const pointsPerColumn = Math.round(1 / reference.cellsPerPoint);
+  const pointsPerRow = Math.round(reference.cellAspectRatio / reference.cellsPerPoint);
+  return [
+    `Desktop ${formatFrame(reference.viewport)}`,
+    `${placements.length} display${placements.length === 1 ? "" : "s"}`,
+    `${windowCount} window${windowCount === 1 ? "" : "s"}`,
+    `1 cell ≈ ${pointsPerColumn}×${pointsPerRow} pt`,
+  ].join(" · ");
+}
+
+function displayLegendLines(placements: DisplayPlacement[]): string[] {
+  const rows = placements.map((placement) => {
+    const { display, boundary, usable } = placement;
+    const name = display.name ? cleanLabel(display.name) : "";
+    return {
+      tag: `D${display.displayIndex}`,
+      identity: `Display ${display.displayIndex}${name ? ` · ${name}` : ""} · Space ${display.currentSpaceId}`,
+      frame: `frame ${formatFrame(boundary)}`,
+      usable: usable.x === boundary.x && usable.y === boundary.y &&
+          usable.w === boundary.w && usable.h === boundary.h
+        ? ""
+        : `usable ${formatFrame(usable)}`,
+    };
+  });
+  const tagWidth = Math.max(...rows.map((row) => row.tag.length));
+  const identityWidth = Math.max(...rows.map((row) => row.identity.length));
+  const frameWidth = Math.max(...rows.map((row) => row.frame.length));
+  return rows.map((row) =>
+    `  ${row.tag.padEnd(tagWidth)}  ${row.identity.padEnd(identityWidth)}  ${row.usable ? row.frame.padEnd(frameWidth) : row.frame}${row.usable ? `  ${row.usable}` : ""}`
+  );
+}
+
+// Every legend row resolves to exactly one of four states, and the note says
+// which: `[n]` on the canvas (no note), a bare number (small), an outline with
+// no room for any numeral (too small to label), or nothing drawn at all
+// (off-canvas). There is no unannotated absence. The x-ray model has no
+// `(occluded)` state — a covered window still draws its whole rectangle.
+type Coverage = { outlined: Set<number>; markers: Map<number, MarkerTier> };
+
+function legendNote(index: number, coverage: Coverage): string {
+  if (!coverage.outlined.has(index)) return "(off-canvas)";
+  const tier = coverage.markers.get(index);
+  if (tier === "full") return "";
+  return tier === "bare" ? "(small)" : "(too small to label)";
+}
+
+function windowLegendLines(placements: DisplayPlacement[], coverage: Coverage): string[] {
+  const rows = placements.flatMap((placement) =>
+    placement.windows.map(({ window, index }) => ({
+      index: String(index),
+      tag: `D${placement.display.displayIndex}`,
+      label: fitLegend(
+        `${cleanLabel(window.app)}${cleanLabel(window.title) ? ` · ${cleanLabel(window.title)}` : ""}`,
+        MAX_LEGEND_LABEL,
+      ),
+      wid: `wid:${window.wid}`,
+      geometry: formatFrame(window.frame),
+      note: legendNote(index, coverage),
+    }))
+  );
+  if (!rows.length) return ["  No on-screen windows on the current Spaces."];
+
+  const indexWidth = Math.max(...rows.map((row) => row.index.length));
+  const tagWidth = Math.max(...rows.map((row) => row.tag.length));
+  const labelWidth = Math.max(...rows.map((row) => row.label.length));
+  const widWidth = Math.max(...rows.map((row) => row.wid.length));
+  const geometryWidth = Math.max(...rows.map((row) => row.geometry.length));
+  return rows.map((row) => {
+    const line = `  ${row.index.padStart(indexWidth)}  ${row.tag.padEnd(tagWidth)}  ${row.label.padEnd(labelWidth)}  ${row.wid.padEnd(widWidth)}  ${row.geometry}`;
+    return row.note ? `${line.padEnd(line.length + geometryWidth - row.geometry.length)}  ${row.note}` : line;
+  });
+}
+
 export function renderWorkspaceMap(
   displays: MapDisplay[],
   windows: MapWindow[],
@@ -214,54 +634,169 @@ export function renderWorkspaceMap(
   const selected = displays.filter((display) => options.display === undefined || display.displayIndex === options.display);
   if (!selected.length) return options.display === undefined ? "No displays found." : `Display ${options.display} not found.`;
 
-  const width = clamp(Math.round(options.width ?? 72), MIN_WIDTH, MAX_WIDTH);
-  const requestedHeight = options.height === undefined ? undefined : clamp(Math.round(options.height), MIN_HEIGHT, MAX_HEIGHT);
-  const sections: string[] = [];
+  const maxColumns = clamp(Math.round(options.width ?? FALLBACK_WIDTH), MIN_WIDTH, MAX_WIDTH);
+  const maxRows = clamp(Math.round(options.height ?? FALLBACK_HEIGHT), MIN_HEIGHT, MAX_HEIGHT);
 
+  const placements: DisplayPlacement[] = [];
+  const unavailable: MapDisplay[] = [];
+  let counter = 0;
   for (const display of selected) {
-    const frame = displayFrame(display);
-    if (!frame || frame.w <= 0 || frame.h <= 0) {
-      sections.push(`Display ${display.displayIndex}${display.name ? ` · ${display.name}` : ""}\n  Geometry unavailable. Update the Lattices app.`);
+    const boundary = boundaryFrame(display);
+    const usable = usableFrame(display);
+    if (!hasArea(boundary) || !hasArea(usable)) {
+      unavailable.push(display);
       continue;
     }
-
-    const innerWidth = width - 2;
-    const proportionalHeight = Math.round((innerWidth * frame.h) / frame.w / 2);
-    const innerHeight = requestedHeight ? requestedHeight - 2 : clamp(proportionalHeight, MIN_HEIGHT - 2, MAX_HEIGHT - 2);
-    const canvas = Array.from({ length: innerHeight }, () => Array.from({ length: innerWidth }, () => " "));
-    const visible = windowsForDisplay(display, windows);
-
-    // windows.list is front-to-back. Paint back-to-front so visible windows win.
-    for (let i = visible.length - 1; i >= 0; i--) drawWindow(canvas, frame, visible[i]!, i + 1);
-
-    const displayName = display.name ? ` · ${canvasLabel(display.name)}` : "";
-    const fullTitle = ` Display ${display.displayIndex}${displayName} · Space ${display.currentSpaceId} `;
-    const title = fullTitle.length <= innerWidth ? fullTitle : `${fullTitle.slice(0, Math.max(1, innerWidth - 1))}…`;
-    const top = `┌${title}${"─".repeat(Math.max(0, innerWidth - title.length))}┐`;
-    const body = canvas.map((row) => `│${row.join("")}│`);
-    const bottom = `└${"─".repeat(innerWidth)}┘`;
-    const legend = visible.map((window, index) => {
-      const titleText = cleanLabel(window.title);
-      const geometry = `${Math.round(window.frame.w)}×${Math.round(window.frame.h)} @ ${Math.round(window.frame.x)},${Math.round(window.frame.y)}`;
-      const app = cleanLabel(window.app);
-      return `  ${index + 1}  ${app}${titleText ? ` · ${titleText}` : ""}  wid:${window.wid}  ${geometry}`;
-    });
-
-    sections.push([top, ...body, bottom, ...(legend.length ? ["", ...legend] : ["", "  No visible windows on this Space."])].join("\n"));
+    // windows.list is front-to-back; index 1 is the frontmost window of the
+    // first selected display, so legend numbers are stable across renders.
+    const windowsHere = windowsForDisplay(display, windows).map((window) => ({ window, index: ++counter }));
+    placements.push({ display, boundary, usable, windows: windowsHere });
   }
 
-  return sections.join("\n\n");
+  const unavailableLines = unavailable.map((display) =>
+    `  D${display.displayIndex}  Display ${display.displayIndex}${display.name ? ` · ${cleanLabel(display.name)}` : ""}  geometry unavailable — update the Lattices app.`
+  );
+
+  const reference = createDesktopMapReference(placements.map((placement) => placement.boundary), {
+    maxColumns,
+    maxRows,
+  });
+  if (!reference) {
+    return ["No display geometry available.", ...unavailableLines].join("\n");
+  }
+
+  const canvas = Array.from({ length: reference.rows }, () =>
+    Array.from({ length: reference.columns }, () => " ")
+  );
+  // Which window owns each cell's marker text. Outlines merge and never claim a
+  // cell, so this is only about keeping two numbers from landing on top of each
+  // other — the front-most window claims first.
+  const claimed = Array.from({ length: reference.rows }, () =>
+    Array.from({ length: reference.columns }, () => 0)
+  );
+
+  // One uniform projection for the whole desktop. Displays are painted first;
+  // their interior fill is the only thing that clears cells.
+  const rects = new Map<DisplayPlacement, MapCanvasRect>();
+  for (const placement of placements) {
+    const rect = normalizeRect(
+      projectMapFrame(reference, placement.boundary),
+      reference.columns,
+      reference.rows,
+    );
+    rects.set(placement, rect);
+    drawDisplay(canvas, rect, placement.display);
+  }
+
+  // Pass one: every window outline, merged. Order does not matter because
+  // nothing is erased — a covered window keeps its full rectangle.
+  const shapes: { window: MapWindow; index: number; shape: WindowShape; primary: boolean }[] = [];
+  const outlined = new Set<number>();
+  for (const placement of placements) {
+    // Windows stay inside the monitor outline, separated from it by a gutter,
+    // so the bezel always reads as its own thing. The legend keeps the exact
+    // global geometry.
+    const bounds = windowBounds(rects.get(placement)!);
+    if (!bounds) continue;
+    let primaryClaimed = false;
+    for (const { window, index } of placement.windows) {
+      const clipped = intersectMapFrames(window.frame, placement.usable);
+      if (!clipped) continue;
+      const shape = windowShape(bounds, projectMapFrame(reference, clipped));
+      if (!shape) continue;
+      outlined.add(index);
+      // Exactly one window per display carries an app/title label: the
+      // frontmost one that is actually drawable.
+      shapes.push({ window, index, shape, primary: !primaryClaimed });
+      primaryClaimed = true;
+      for (const mark of shape.marks) mergeWindowEdge(canvas, mark.y, mark.x, mark.bits);
+    }
+  }
+
+  // Pass two: closure. A window's bottom-right endpoint is restamped as its own
+  // corner so it terminates visibly instead of dissolving into a shared rail.
+  // Where two windows want the same cell the glyph is identical, so the result
+  // is order-independent; where a corner lands mid-edge, closure deliberately
+  // wins over line continuity.
+  for (const { shape } of shapes) {
+    if (shape.box) setWindowCell(canvas, shape.bottom, shape.right, "┘");
+  }
+
+  // Pass three: markers, front to back, so the primary window gets the title
+  // bar and windows behind it slide to the next free run inside their own
+  // footprint. A marker may overwrite an outline; that is the point — every
+  // window must stay identifiable.
+  const markers = new Map<number, MarkerTier>();
+  for (const { window, index, shape, primary } of shapes.sort((a, b) => a.index - b.index)) {
+    let placement: MarkerPlacement | undefined;
+    for (const { text, tier } of markerForms(index)) {
+      placement = findMarkerSlot(canvas, claimed, shape, text, tier);
+      if (placement) break;
+    }
+    if (!placement) continue;
+    markers.set(index, placement.tier);
+    const { y, x, text, tier } = placement;
+    for (let step = 0; step < text.length; step++) {
+      setWindowCell(canvas, y, x + step, text[step]!);
+      claimed[y]![x + step] = index;
+    }
+    // Reserve the flanking cells of a bare number without drawing in them, so
+    // a window further back cannot butt its own number up against this one.
+    if (tier === "bare") {
+      for (const cx of [x - 1, x + text.length]) {
+        if (claimed[y]?.[cx] === 0) claimed[y]![cx] = index;
+      }
+    }
+
+    // Only the primary window spells out its app and title on the canvas.
+    // Labelling every overlapping window is what turned the map into noise;
+    // secondary windows keep their full geometry and their number, and the
+    // legend carries their identity.
+    if (!primary) continue;
+
+    // The app/title only fills unclaimed cells to the right of the marker and
+    // stops before the window's own right edge, so it never buries a number.
+    let room = 0;
+    for (let cx = x + text.length; cx < shape.right; cx++) {
+      if (!runIsFree(canvas, claimed, y, cx, 1)) break;
+      room++;
+    }
+    const description = windowDescription(window, room);
+    for (let step = 0; step < description.length; step++) {
+      const cx = x + text.length + step;
+      setWindowCell(canvas, y, cx, description[step]!);
+      claimed[y]![cx] = index;
+    }
+  }
+
+  const map = canvas.map((row) => row.join("").replace(/\s+$/u, ""));
+  const sections: string[] = [
+    summaryLine(reference, placements),
+    "",
+    ...map,
+    "",
+    "Key · ╔═ display ═╗   ┌[1] frontmost window ─┐   ┌[n]──┘ others, numbered only",
+    "       lower n = nearer the front of its own display; n does not order across displays",
+    "",
+    "Displays",
+    ...displayLegendLines(placements),
+    ...unavailableLines,
+    "",
+    "Windows · front to back within each display",
+    ...windowLegendLines(placements, { outlined, markers }),
+  ];
+  return sections.join("\n");
 }
 
 export function mapUsage(): string {
   return `Usage: lattices map [options]
 
-Render the current Space on each display as a terminal map.
+Render the current Space of every display as one scaled map of the desktop.
 
 Options:
   --display <n>  Render one display index
-  --width <n>    Map width (32–120; defaults to terminal width)
-  --height <n>   Map height (8–40; defaults to display aspect ratio)
+  --width <n>    Maximum map width (32–120; defaults to terminal width)
+  --height <n>   Maximum map height (8–40; defaults to 24)
   --json         Return a versioned current-Space snapshot for agents
   -h, --help     Show this help`;
 }
@@ -317,6 +852,16 @@ export async function mapCommand(
   const windows = (Array.isArray(windowsPayload) ? windowsPayload : []) as MapWindow[];
 
   if (json) {
+    // A display without geometry would yield a valid-looking snapshot whose
+    // windows array is empty — false state, worse than no state. Refuse it.
+    const missing = displaysMissingGeometry(displays, { display });
+    if (missing.length) {
+      const tags = missing.map((entry) => `Display ${entry.displayIndex}`).join(", ");
+      throw new Error(
+        `${tags} reported no frame geometry; the running Lattices app predates the workspace map snapshot. ` +
+        `Update and restart the app (lattices app update), then retry.`
+      );
+    }
     console.log(JSON.stringify(createWorkspaceMapSnapshot(displays, windows, { display }), null, 2));
     return;
   }

--- a/bin/cli/map.ts
+++ b/bin/cli/map.ts
@@ -1,0 +1,324 @@
+type Frame = { x: number; y: number; w: number; h: number };
+
+export type MapSpace = {
+  id: number;
+  index: number;
+  name?: string;
+  display: number;
+  isCurrent: boolean;
+};
+
+export type MapDisplay = {
+  displayIndex: number;
+  displayId?: string;
+  name?: string;
+  currentSpaceId: number;
+  spaces?: MapSpace[];
+  frame?: Frame;
+  visibleFrame?: Frame;
+};
+
+export type MapWindow = {
+  wid: number;
+  app: string;
+  pid?: number;
+  title: string;
+  frame: Frame;
+  spaceIds: number[];
+  isOnScreen: boolean;
+  axVerified?: boolean;
+  latticesSession?: string;
+  layerTag?: string;
+};
+
+type MapOptions = {
+  width?: number;
+  height?: number;
+  display?: number;
+};
+
+export type WorkspaceMapSnapshotWindow = MapWindow & { zIndex: number };
+
+export type WorkspaceMapSnapshotDisplay = MapDisplay & {
+  spaces: MapSpace[];
+  windows: WorkspaceMapSnapshotWindow[];
+};
+
+export type WorkspaceMapSnapshot = {
+  version: 1;
+  coordinateSystem: {
+    origin: "top-left";
+    units: "points";
+    reference: "global-desktop";
+  };
+  displays: WorkspaceMapSnapshotDisplay[];
+};
+
+const MIN_WIDTH = 32;
+const MAX_WIDTH = 120;
+const MIN_HEIGHT = 8;
+const MAX_HEIGHT = 40;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function cleanLabel(value: string): string {
+  return value
+    .replace(/\u001B\][^\u0007]*(?:\u0007|\u001B\\)/gu, "")
+    .replace(/\u001B\[[0-?]*[ -/]*[@-~]/gu, "")
+    .replace(/[\p{Cc}\p{Cf}]/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+// Canvas cells must stay exactly one terminal column wide. Keep full Unicode
+// in the legend, but use a printable ASCII projection inside the fixed grid.
+function canvasLabel(value: string): string {
+  return cleanLabel(value).replace(/[^\x20-\x7e]/gu, "?");
+}
+
+function windowLabel(window: MapWindow, index: number, width: number): string {
+  const app = canvasLabel(window.app);
+  const title = canvasLabel(window.title);
+  const full = `${index} ${app}${title ? ` - ${title}` : ""}`;
+  return full.length <= width ? full : `${full.slice(0, Math.max(1, width - 1))}…`;
+}
+
+function intersects(a: Frame, b: Frame): boolean {
+  return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
+}
+
+function drawWindow(canvas: string[][], display: Frame, window: MapWindow, index: number): void {
+  const rows = canvas.length;
+  const columns = canvas[0]?.length ?? 0;
+  if (rows < 3 || columns < 3) return;
+
+  const clipped = {
+    x: Math.max(display.x, window.frame.x),
+    y: Math.max(display.y, window.frame.y),
+    w: Math.min(display.x + display.w, window.frame.x + window.frame.w) - Math.max(display.x, window.frame.x),
+    h: Math.min(display.y + display.h, window.frame.y + window.frame.h) - Math.max(display.y, window.frame.y),
+  };
+  if (clipped.w <= 0 || clipped.h <= 0) return;
+
+  const x1 = clamp(Math.round(((clipped.x - display.x) / display.w) * (columns - 1)), 0, columns - 2);
+  const y1 = clamp(Math.round(((clipped.y - display.y) / display.h) * (rows - 1)), 0, rows - 2);
+  const x2 = clamp(Math.round(((clipped.x + clipped.w - display.x) / display.w) * (columns - 1)), x1 + 1, columns - 1);
+  const y2 = clamp(Math.round(((clipped.y + clipped.h - display.y) / display.h) * (rows - 1)), y1 + 1, rows - 1);
+
+  for (let y = y1 + 1; y < y2; y++) {
+    for (let x = x1 + 1; x < x2; x++) canvas[y]![x] = " ";
+  }
+  for (let x = x1 + 1; x < x2; x++) {
+    canvas[y1]![x] = "─";
+    canvas[y2]![x] = "─";
+  }
+  for (let y = y1 + 1; y < y2; y++) {
+    canvas[y]![x1] = "│";
+    canvas[y]![x2] = "│";
+  }
+  canvas[y1]![x1] = "┌";
+  canvas[y1]![x2] = "┐";
+  canvas[y2]![x1] = "└";
+  canvas[y2]![x2] = "┘";
+
+  const available = x2 - x1 - 1;
+  if (available > 2) {
+    const label = windowLabel(window, index, available);
+    for (let i = 0; i < label.length && i < available; i++) canvas[y1]![x1 + 1 + i] = label[i]!;
+  }
+}
+
+function displayFrame(display: MapDisplay): Frame | undefined {
+  return display.visibleFrame ?? display.frame;
+}
+
+function windowsForDisplay(display: MapDisplay, windows: MapWindow[]): MapWindow[] {
+  const frame = displayFrame(display);
+  if (!frame || frame.w <= 0 || frame.h <= 0) return [];
+  return windows.filter((window) =>
+    window.isOnScreen &&
+    window.spaceIds.includes(display.currentSpaceId) &&
+    intersects(window.frame, frame)
+  );
+}
+
+function snapshotFrame(frame: Frame): Frame {
+  return { x: frame.x, y: frame.y, w: frame.w, h: frame.h };
+}
+
+function snapshotSpace(space: MapSpace): MapSpace {
+  return {
+    id: space.id,
+    index: space.index,
+    ...(space.name === undefined ? {} : { name: space.name }),
+    display: space.display,
+    isCurrent: space.isCurrent,
+  };
+}
+
+function snapshotWindow(window: MapWindow, zIndex: number): WorkspaceMapSnapshotWindow {
+  return {
+    wid: window.wid,
+    app: window.app,
+    ...(window.pid === undefined ? {} : { pid: window.pid }),
+    title: window.title,
+    frame: snapshotFrame(window.frame),
+    spaceIds: [...window.spaceIds],
+    isOnScreen: window.isOnScreen,
+    ...(window.axVerified === undefined ? {} : { axVerified: window.axVerified }),
+    ...(window.latticesSession === undefined ? {} : { latticesSession: window.latticesSession }),
+    ...(window.layerTag === undefined ? {} : { layerTag: window.layerTag }),
+    zIndex,
+  };
+}
+
+function snapshotDisplay(display: MapDisplay, windows: MapWindow[]): WorkspaceMapSnapshotDisplay {
+  return {
+    displayIndex: display.displayIndex,
+    ...(display.displayId === undefined ? {} : { displayId: display.displayId }),
+    ...(display.name === undefined ? {} : { name: display.name }),
+    currentSpaceId: display.currentSpaceId,
+    spaces: (display.spaces ?? []).map(snapshotSpace),
+    ...(display.frame === undefined ? {} : { frame: snapshotFrame(display.frame) }),
+    ...(display.visibleFrame === undefined ? {} : { visibleFrame: snapshotFrame(display.visibleFrame) }),
+    windows: windowsForDisplay(display, windows).map(snapshotWindow),
+  };
+}
+
+export function createWorkspaceMapSnapshot(
+  displays: MapDisplay[],
+  windows: MapWindow[],
+  options: Pick<MapOptions, "display"> = {},
+): WorkspaceMapSnapshot {
+  const selected = displays.filter((display) =>
+    options.display === undefined || display.displayIndex === options.display
+  );
+  return {
+    version: 1,
+    coordinateSystem: {
+      origin: "top-left",
+      units: "points",
+      reference: "global-desktop",
+    },
+    displays: selected.map((display) => snapshotDisplay(display, windows)),
+  };
+}
+
+export function renderWorkspaceMap(
+  displays: MapDisplay[],
+  windows: MapWindow[],
+  options: MapOptions = {},
+): string {
+  const selected = displays.filter((display) => options.display === undefined || display.displayIndex === options.display);
+  if (!selected.length) return options.display === undefined ? "No displays found." : `Display ${options.display} not found.`;
+
+  const width = clamp(Math.round(options.width ?? 72), MIN_WIDTH, MAX_WIDTH);
+  const requestedHeight = options.height === undefined ? undefined : clamp(Math.round(options.height), MIN_HEIGHT, MAX_HEIGHT);
+  const sections: string[] = [];
+
+  for (const display of selected) {
+    const frame = displayFrame(display);
+    if (!frame || frame.w <= 0 || frame.h <= 0) {
+      sections.push(`Display ${display.displayIndex}${display.name ? ` · ${display.name}` : ""}\n  Geometry unavailable. Update the Lattices app.`);
+      continue;
+    }
+
+    const innerWidth = width - 2;
+    const proportionalHeight = Math.round((innerWidth * frame.h) / frame.w / 2);
+    const innerHeight = requestedHeight ? requestedHeight - 2 : clamp(proportionalHeight, MIN_HEIGHT - 2, MAX_HEIGHT - 2);
+    const canvas = Array.from({ length: innerHeight }, () => Array.from({ length: innerWidth }, () => " "));
+    const visible = windowsForDisplay(display, windows);
+
+    // windows.list is front-to-back. Paint back-to-front so visible windows win.
+    for (let i = visible.length - 1; i >= 0; i--) drawWindow(canvas, frame, visible[i]!, i + 1);
+
+    const displayName = display.name ? ` · ${canvasLabel(display.name)}` : "";
+    const fullTitle = ` Display ${display.displayIndex}${displayName} · Space ${display.currentSpaceId} `;
+    const title = fullTitle.length <= innerWidth ? fullTitle : `${fullTitle.slice(0, Math.max(1, innerWidth - 1))}…`;
+    const top = `┌${title}${"─".repeat(Math.max(0, innerWidth - title.length))}┐`;
+    const body = canvas.map((row) => `│${row.join("")}│`);
+    const bottom = `└${"─".repeat(innerWidth)}┘`;
+    const legend = visible.map((window, index) => {
+      const titleText = cleanLabel(window.title);
+      const geometry = `${Math.round(window.frame.w)}×${Math.round(window.frame.h)} @ ${Math.round(window.frame.x)},${Math.round(window.frame.y)}`;
+      const app = cleanLabel(window.app);
+      return `  ${index + 1}  ${app}${titleText ? ` · ${titleText}` : ""}  wid:${window.wid}  ${geometry}`;
+    });
+
+    sections.push([top, ...body, bottom, ...(legend.length ? ["", ...legend] : ["", "  No visible windows on this Space."])].join("\n"));
+  }
+
+  return sections.join("\n\n");
+}
+
+export function mapUsage(): string {
+  return `Usage: lattices map [options]
+
+Render the current Space on each display as a terminal map.
+
+Options:
+  --display <n>  Render one display index
+  --width <n>    Map width (32–120; defaults to terminal width)
+  --height <n>   Map height (8–40; defaults to display aspect ratio)
+  --json         Return a versioned current-Space snapshot for agents
+  -h, --help     Show this help`;
+}
+
+export function parseMapOptions(args: string[]): MapOptions & { json: boolean } {
+  const options: MapOptions & { json: boolean } = { json: false };
+  const numericOptions = new Set(["display", "width", "height"]);
+
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index]!;
+    if (argument === "--json") {
+      options.json = true;
+      continue;
+    }
+
+    const match = argument.match(/^--([^=]+)(?:=(.*))?$/u);
+    if (!match || !numericOptions.has(match[1]!)) {
+      throw new Error(`Unknown option: ${argument}`);
+    }
+
+    const name = match[1]! as "display" | "width" | "height";
+    const inlineValue = match[2];
+    const raw = inlineValue === undefined ? args[++index] : inlineValue;
+    if (raw === undefined || raw === "" || raw.startsWith("--")) {
+      throw new Error(`--${name} expects a non-negative integer`);
+    }
+
+    const parsed = Number(raw);
+    if (!Number.isInteger(parsed) || parsed < 0) {
+      throw new Error(`--${name} expects a non-negative integer`);
+    }
+    options[name] = parsed;
+  }
+
+  return options;
+}
+
+export async function mapCommand(
+  args: string[],
+  daemonCall: (method: string, params?: Record<string, unknown> | null) => Promise<unknown>,
+): Promise<void> {
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log(mapUsage());
+    return;
+  }
+  const { json, display, height, width: requestedWidth } = parseMapOptions(args);
+  const width = requestedWidth ?? process.stdout.columns;
+  const [spacesPayload, windowsPayload] = await Promise.all([
+    daemonCall("spaces.list"),
+    daemonCall("windows.list"),
+  ]);
+  const displays = (Array.isArray(spacesPayload) ? spacesPayload : (spacesPayload as { displays?: MapDisplay[] })?.displays ?? []) as MapDisplay[];
+  const windows = (Array.isArray(windowsPayload) ? windowsPayload : []) as MapWindow[];
+
+  if (json) {
+    console.log(JSON.stringify(createWorkspaceMapSnapshot(displays, windows, { display }), null, 2));
+    return;
+  }
+  console.log(renderWorkspaceMap(displays, windows, { display, width, height }));
+}

--- a/bin/cli/usage.ts
+++ b/bin/cli/usage.ts
@@ -79,6 +79,11 @@ Usage:
   lattices computer demo-terminal  Record/focus/type a safe terminal demo
   lattices tile <position>    Tile the frontmost window (left, right, top, etc.)
   lattices tile family [app] [region]  Smart-grid the frontmost app family, or a named app
+  lattices window move <wid> --display <n> [--placement <slot>]
+                         Move a window to another display, keeping its
+                         normalized frame or snapping to a slot (daemon required)
+  lattices window place <wid> <slot> [--display <n>]
+                         Snap a window into a named or grid placement slot
   lattices distribute [app] [region]   Smart-grid visible windows or just one app (daemon required)
   lattices layer [name|index]  List layers or switch by name/index (daemon required)
   lattices layer create <name> [wid:N ...] [--json '<specs>']  Create a session layer

--- a/bin/cli/usage.ts
+++ b/bin/cli/usage.ts
@@ -56,6 +56,8 @@ Usage:
   lattices place <query> [pos]  Deep search + focus + tile (default: bottom-right)
   lattices focus <session>    Raise a session's window
   lattices windows [--json]   List all desktop windows (daemon required)
+  lattices map [--display n]  Render displays and visible windows as an ASCII map
+  lattices map --json         Return the structured display/window map for agents
   lattices sessions [--json]  List active sessions via daemon
   lattices terminals [--json] [--refresh]
                          List synthesized terminal instances

--- a/bin/cli/window.ts
+++ b/bin/cli/window.ts
@@ -1,0 +1,247 @@
+// `lattices window move` / `lattices window place` — CLI front-ends for the
+// daemon's canonical window movement APIs (window.move / window.place).
+//
+// The CLI exposes slots: named positions and grid placements. Fractional typed
+// placements stay available through the raw API (`lattices call window.place`).
+
+/** Named placement slots, mirroring the daemon's TilePosition catalog. */
+export const NAMED_PLACEMENTS = [
+  "maximize", "center",
+  "left", "right", "top", "bottom",
+  "top-left", "top-right", "bottom-left", "bottom-right",
+  "left-third", "center-third", "right-third",
+  "top-third", "middle-third", "bottom-third",
+  "top-left-third", "top-center-third", "top-right-third",
+  "bottom-left-third", "bottom-center-third", "bottom-right-third",
+  "first-fourth", "second-fourth", "third-fourth", "last-fourth",
+  "top-first-fourth", "top-second-fourth", "top-third-fourth", "top-last-fourth",
+  "bottom-first-fourth", "bottom-second-fourth", "bottom-third-fourth", "bottom-last-fourth",
+  "left-quarter", "right-quarter", "top-quarter", "bottom-quarter",
+] as const;
+
+const PLACEMENT_ALIASES: Record<string, string> = {
+  "max": "maximize",
+  "left-half": "left",
+  "right-half": "right",
+  "top-half": "top",
+  "bottom-half": "bottom",
+  "upper-third": "top-third",
+  "lower-third": "bottom-third",
+};
+
+const GRID_WIRE = /^grid:\d+x\d+:\d+,\d+(?:-\d+,\d+)?$/u;   // 0-based API form
+const GRID_COMPACT = /^\d+x\d+:\d+,\d+(?:-\d+,\d+)?$/u;      // 1-based human form
+const GRID_SHORTHAND = /^grid:\d+\.\d+$/u;                    // grid:N.K row-major
+
+/**
+ * Canonicalize a CLI placement token to what the daemon accepts, or return
+ * undefined when the token is not a known slot.
+ */
+export function normalizePlacement(input: string): string | undefined {
+  const token = input.trim().toLowerCase().replace(/[_\s]+/gu, "-");
+  if ((NAMED_PLACEMENTS as readonly string[]).includes(token)) return token;
+  const alias = PLACEMENT_ALIASES[token];
+  if (alias) return alias;
+  if (GRID_WIRE.test(token) || GRID_COMPACT.test(token) || GRID_SHORTHAND.test(token)) return token;
+  return undefined;
+}
+
+export function placementSlotsHelp(): string {
+  return `Slots:
+  Named   ${NAMED_PLACEMENTS.slice(0, 10).join(", ")},
+          ${NAMED_PLACEMENTS.slice(10, 22).join(", ")},
+          ${NAMED_PLACEMENTS.slice(22, 30).join(", ")},
+          ${NAMED_PLACEMENTS.slice(30).join(", ")}
+  Grid    grid:CxR:c,r (0-based)   CxR:c,r (1-based)   grid:CxR:c0,r0-c1,r1 (span)   grid:N.K (N×N cell K)
+  Fractional placements stay available via: lattices call window.place '{"wid":123,"placement":{"kind":"fractions","x":0.5,"y":0,"w":0.5,"h":1}}'`;
+}
+
+export type WindowMoveArgs = {
+  wid: number;
+  display?: number;
+  placement?: string;
+  json: boolean;
+  dryRun: boolean;
+};
+
+/** Parse `--flag value` and `--flag=value` forms. Throws on malformed input. */
+function parseFlags(args: string[]): { flags: Map<string, string | true>; positional: string[] } {
+  const flags = new Map<string, string | true>();
+  const positional: string[] = [];
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index]!;
+    if (!argument.startsWith("--")) {
+      positional.push(argument);
+      continue;
+    }
+    const match = argument.match(/^--([^=]+)(?:=(.*))?$/u);
+    if (!match) throw new Error(`Unknown option: ${argument}`);
+    const name = match[1]!;
+    if (match[2] !== undefined) {
+      flags.set(name, match[2]);
+      continue;
+    }
+    if (name === "json" || name === "dry-run") {
+      flags.set(name, true);
+      continue;
+    }
+    const next = args[index + 1];
+    if (next === undefined || next.startsWith("--")) {
+      throw new Error(`--${name} expects a value`);
+    }
+    flags.set(name, next);
+    index++;
+  }
+  return { flags, positional };
+}
+
+/**
+ * A window id must be an explicit positive integer. A malformed wid is an
+ * error — it must never fall back to the frontmost window.
+ */
+function parseWid(raw: string | undefined): number {
+  if (raw === undefined) throw new Error("A window id is required. Find one with: lattices map");
+  if (!/^\d+$/u.test(raw)) throw new Error(`Invalid window id: ${raw} (expected a positive integer wid)`);
+  const wid = Number(raw);
+  if (wid <= 0 || !Number.isSafeInteger(wid)) {
+    throw new Error(`Invalid window id: ${raw} (expected a positive integer wid)`);
+  }
+  return wid;
+}
+
+function parseDisplay(value: string | true | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  if (value === true || !/^\d+$/u.test(value)) {
+    throw new Error(`--display expects a non-negative display index`);
+  }
+  return Number(value);
+}
+
+function parsePlacementFlag(value: string | true | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  if (value === true) throw new Error("--placement expects a slot name");
+  const normalized = normalizePlacement(value);
+  if (!normalized) {
+    throw new Error(`Unknown placement slot: ${value}\n${placementSlotsHelp()}`);
+  }
+  return normalized;
+}
+
+export function parseWindowMoveArgs(args: string[]): WindowMoveArgs {
+  const { flags, positional } = parseFlags(args);
+  for (const name of flags.keys()) {
+    if (!["display", "placement", "json", "dry-run"].includes(name)) {
+      throw new Error(`Unknown option: --${name}`);
+    }
+  }
+  if (positional.length > 1) throw new Error(`Unexpected argument: ${positional[1]}`);
+  const wid = parseWid(positional[0]);
+  const display = parseDisplay(flags.get("display"));
+  const placement = parsePlacementFlag(flags.get("placement"));
+  if (display === undefined && placement === undefined) {
+    throw new Error("window move requires --display <n> and/or --placement <slot>");
+  }
+  return {
+    wid,
+    display,
+    placement,
+    json: flags.get("json") === true,
+    dryRun: flags.get("dry-run") === true,
+  };
+}
+
+export function parseWindowPlaceArgs(args: string[]): WindowMoveArgs {
+  const { flags, positional } = parseFlags(args);
+  for (const name of flags.keys()) {
+    if (!["display", "json", "dry-run"].includes(name)) {
+      throw new Error(`Unknown option: --${name}`);
+    }
+  }
+  if (positional.length > 2) throw new Error(`Unexpected argument: ${positional[2]}`);
+  const wid = parseWid(positional[0]);
+  const rawSlot = positional[1];
+  if (rawSlot === undefined) {
+    throw new Error(`window place requires a slot.\n${placementSlotsHelp()}`);
+  }
+  const placement = normalizePlacement(rawSlot);
+  if (!placement) {
+    throw new Error(`Unknown placement slot: ${rawSlot}\n${placementSlotsHelp()}`);
+  }
+  return {
+    wid,
+    display: parseDisplay(flags.get("display")),
+    placement,
+    json: flags.get("json") === true,
+    dryRun: flags.get("dry-run") === true,
+  };
+}
+
+export function windowMoveUsage(): string {
+  return `Usage:
+  lattices window move <wid> --display <n> [--placement <slot>] [--dry-run] [--json]
+  lattices window place <wid> <slot> [--display <n>] [--dry-run] [--json]
+
+Move a specific window (CGWindowID) to another display and/or placement slot.
+--display alone preserves the window's normalized size/position on the target
+display. Adding a placement snaps it into that slot instead.
+
+${placementSlotsHelp()}
+
+Find wids with: lattices map  ·  lattices windows --json  ·  lattices search <q> --wid`;
+}
+
+type FrameJSON = { x?: number; y?: number; w?: number; h?: number };
+
+function formatFrame(frame: FrameJSON | undefined): string {
+  if (!frame) return "?";
+  const round = (value: number | undefined) => (value === undefined ? "?" : Math.round(value));
+  return `${round(frame.w)}×${round(frame.h)} @ ${round(frame.x)},${round(frame.y)}`;
+}
+
+/** Render an execution receipt from window.move / window.place for humans. */
+export function describeMoveReceipt(receipt: any): string {
+  const lines: string[] = [];
+  const status = receipt?.status ?? (receipt?.ok ? "ok" : "failed");
+  const app = receipt?.app ? ` ${receipt.app}` : "";
+  const wid = receipt?.wid !== undefined ? ` (wid:${receipt.wid})` : "";
+  const displayName = receipt?.display?.name ? ` on ${receipt.display.name}` : "";
+  const mutation = receipt?.mutations?.[0];
+  const before = mutation?.from as FrameJSON | undefined;
+  const target = mutation?.to as FrameJSON | undefined;
+  const after = mutation?.after as FrameJSON | undefined;
+
+  if (status === "planned") {
+    lines.push(`Planned${app}${wid}${displayName}: ${formatFrame(before)} → ${formatFrame(target)} (dry run, not executed)`);
+  } else if (status === "ok") {
+    lines.push(`Moved${app}${wid}${displayName}: ${formatFrame(before)} → ${formatFrame(after ?? target)}${receipt?.verified ? " · verified" : ""}`);
+  } else if (status === "blocked") {
+    lines.push(`Blocked${app}${wid}: ${receipt?.blockedReason ?? "unknown reason"}`);
+    if (Array.isArray(receipt?.requiredPermissions) && receipt.requiredPermissions.length) {
+      lines.push(`  Grant: ${receipt.requiredPermissions.join(", ")} (System Settings → Privacy & Security)`);
+    }
+  } else {
+    lines.push(`Move did not verify${app}${wid}${displayName}: wanted ${formatFrame(target)}, saw ${formatFrame(after)}`);
+  }
+  if (receipt?.receiptId) lines.push(`  receipt ${receipt.receiptId} · undo with: lattices call action.undo '{}'`);
+  return lines.join("\n");
+}
+
+type DaemonCallFn = (method: string, params?: Record<string, unknown> | null) => Promise<unknown>;
+
+/** Execute already-parsed move/place args against the daemon. */
+export async function runWindowMovement(
+  method: "move" | "place",
+  parsed: WindowMoveArgs,
+  daemonCall: DaemonCallFn,
+): Promise<void> {
+  const params: Record<string, unknown> = { wid: parsed.wid };
+  if (parsed.placement !== undefined) params.placement = parsed.placement;
+  if (parsed.display !== undefined) params.display = parsed.display;
+  if (parsed.dryRun) params.dryRun = true;
+  const receipt = await daemonCall(method === "move" ? "window.move" : "window.place", params);
+  if (parsed.json) {
+    console.log(JSON.stringify(receipt, null, 2));
+    return;
+  }
+  console.log(describeMoveReceipt(receipt));
+}

--- a/bin/lattices.ts
+++ b/bin/lattices.ts
@@ -4,7 +4,7 @@ import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { basename, dirname, isAbsolute, resolve } from "node:path";
 import { homedir } from "node:os";
-import { tryDaemon, withDaemon } from "./cli/daemon.ts";
+import { loadDaemonClient, tryDaemon, withDaemon } from "./cli/daemon.ts";
 import { printHome, printUsage } from "./cli/usage.ts";
 import {
   hasFlag,
@@ -2801,6 +2801,36 @@ function gridTileBounds(position: string, screen: ScreenBounds): number[] | null
   ];
 }
 
+/**
+ * Legacy `lattices tile <position>`: prefer the canonical daemon placement
+ * (window.place, frontmost target). Only when the daemon is down fall back to
+ * the AppleScript path — and say so, since that path is frontmost-app,
+ * primary-display only.
+ */
+async function tileFrontmostCommand(position: string): Promise<void> {
+  const { normalizePlacement, describeMoveReceipt } = await import("./cli/window.ts");
+  const placement = normalizePlacement(position);
+  if (!placement) {
+    tileWindow(position); // prints the unknown-position help
+    return;
+  }
+
+  const client = await loadDaemonClient();
+  if (await client.isDaemonRunning()) {
+    try {
+      const receipt = await client.daemonCall("window.place", { placement });
+      console.log(describeMoveReceipt(receipt));
+    } catch (e: unknown) {
+      console.error(`Daemon placement failed: ${(e as Error).message}`);
+      process.exit(1);
+    }
+    return;
+  }
+
+  console.log("Daemon not running — AppleScript fallback (frontmost app, primary display).");
+  tileWindow(position);
+}
+
 function tileWindow(position: string): void {
   const normalized = position.toLowerCase();
   const screen = getScreenBounds();
@@ -3016,7 +3046,7 @@ switch (command) {
     } else if (args[1] === "all") {
       await distributeCommand(args.slice(2));
     } else if (args[1]) {
-      tileWindow(args[1]);
+      await tileFrontmostCommand(args[1]);
     } else {
       console.log("Usage:");
       console.log("  lattices tile <position>");
@@ -3048,10 +3078,34 @@ switch (command) {
       await windowAssignCommand(args[2], args[3]);
     } else if (args[1] === "map") {
       await windowLayerMapCommand(args[2] === "--json");
+    } else if (args[1] === "move" || args[1] === "place") {
+      const method = args[1];
+      const { parseWindowMoveArgs, parseWindowPlaceArgs, runWindowMovement, windowMoveUsage } =
+        await import("./cli/window.ts");
+      const rest = args.slice(2);
+      if (rest.includes("--help") || rest.includes("-h")) {
+        console.log(windowMoveUsage());
+        break;
+      }
+      // Parse before touching the daemon: malformed input (a bad wid above
+      // all) must fail here and never fall back to another window.
+      let parsed;
+      try {
+        parsed = method === "move" ? parseWindowMoveArgs(rest) : parseWindowPlaceArgs(rest);
+      } catch (e: unknown) {
+        console.error((e as Error).message);
+        process.exit(1);
+      }
+      await withDaemon(async ({ daemonCall }) => runWindowMovement(method, parsed, daemonCall));
     } else {
+      const { windowMoveUsage } = await import("./cli/window.ts");
       console.log("Usage:");
+      console.log("  lattices window move <wid> --display <n> [--placement <slot>] [--dry-run] [--json]");
+      console.log("  lattices window place <wid> <slot> [--display <n>] [--dry-run] [--json]");
       console.log("  lattices window assign <wid> <layer-id>   Tag a window to a layer");
       console.log("  lattices window map [--json]               Show all layer tags");
+      console.log("");
+      console.log(windowMoveUsage());
     }
     break;
   case "search":

--- a/bin/lattices.ts
+++ b/bin/lattices.ts
@@ -19,6 +19,7 @@ import { searchCommand, placeCommand } from "./cli/search.ts";
 import { captureCommand } from "./cli/capture.ts";
 import { layerCommand } from "./cli/layer.ts";
 import { runsCommand } from "./cli/runs.ts";
+import { mapCommand, mapUsage } from "./cli/map.ts";
 import {
   esc,
   sessionExists,
@@ -3034,6 +3035,13 @@ switch (command) {
     break;
   case "windows":
     await windowsCommand(args[1] === "--json");
+    break;
+  case "map":
+    if (args.includes("--help") || args.includes("-h")) {
+      console.log(mapUsage());
+    } else {
+      await withDaemon(async ({ daemonCall }) => mapCommand(args.slice(1), daemonCall));
+    }
     break;
   case "window":
     if (args[1] === "assign") {

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -40,10 +40,11 @@ Compatibility wrappers still exist:
 Agents should use these paths in order:
 
 1. **API schema**: `lattices call api.schema`
-2. **Daemon reference**: [/docs/api](/docs/api)
-3. **Agent guide**: [/docs/agents](/docs/agents)
-4. **Voice model**: [/docs/voice](/docs/voice)
-5. **Concepts / config**: [/docs/concepts](/docs/concepts), [/docs/config](/docs/config)
+2. **Read-only workspace map and UI hygiene**: [/docs/workspace-map](/docs/workspace-map)
+3. **Daemon reference**: [/docs/api](/docs/api)
+4. **Agent guide**: [/docs/agents](/docs/agents)
+5. **Voice model**: [/docs/voice](/docs/voice)
+6. **Concepts / config**: [/docs/concepts](/docs/concepts), [/docs/config](/docs/config)
 
 Useful CLI discovery commands:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1569,6 +1569,11 @@ The response includes `cached` and `loading`. A ready preview also includes
 
 List macOS display spaces (virtual desktops).
 
+Display `frame` and `visibleFrame` use the same top-left global coordinate
+system as window frames returned by `windows.list`.
+See [Workspace Map](/docs/workspace-map) for the complete coordinate contract,
+terminal/JSON projection, and visible-surface lifecycle guidance.
+
 **Params**: none
 
 **Returns**: array of display objects:
@@ -1578,10 +1583,13 @@ List macOS display spaces (virtual desktops).
   {
     "displayIndex": 0,
     "displayId": "main",
+    "name": "Built-in Liquid Retina XDR Display",
+    "frame": { "x": 0, "y": 0, "w": 1728, "h": 1117 },
+    "visibleFrame": { "x": 0, "y": 38, "w": 1728, "h": 1079 },
     "currentSpaceId": 1,
     "spaces": [
-      { "id": 1, "index": 0, "display": 0, "isCurrent": true },
-      { "id": 2, "index": 1, "display": 0, "isCurrent": false }
+      { "id": 1, "index": 1, "display": 0, "isCurrent": true },
+      { "id": 2, "index": 2, "display": 0, "isCurrent": false }
     ]
   }
 ]

--- a/docs/api.md
+++ b/docs/api.md
@@ -1452,7 +1452,7 @@ Supported action types:
 | `window.place` | write | Place a window or session using a typed placement spec |
 | `window.tile` | write | Compatibility wrapper for session tiling |
 | `window.focus` | write | Focus a window / switch Spaces |
-| `window.move` | write | Move a window to another Space |
+| `window.move` | write | Move a window to another display, placement slot, or Space |
 | `window.assignLayer` | write | Tag a window to a layer |
 | `window.removeLayer` | write | Remove a window's layer tag |
 | `window.layerMap` | read | All window→layer assignments |
@@ -1610,6 +1610,7 @@ single, typed placement contract across voice, CLI, and daemon clients.
 | `title`     | string          | no       | Optional title substring for app matching |
 | `display`   | number          | no       | Target display index                      |
 | `placement` | string \| object | yes     | Placement shorthand or typed object       |
+| `dryRun`    | bool            | no       | Plan and verify inputs without moving     |
 
 Target resolution priority is `wid` → `session` → `app/title` → frontmost window.
 
@@ -1679,14 +1680,65 @@ Provide either `wid` or `session`. If `wid` is given, it takes priority.
 
 #### `window.move`
 
-Move a session's window to a different macOS Space.
+Move a specific window to another display, into a placement slot, or to a
+different macOS Space. `window.place` stays the canonical placement mutation;
+`window.move` adds the display-to-display move that preserves the window's
+normalized geometry.
 
 **Params**:
 
-| Field     | Type   | Required | Description                |
-|-----------|--------|----------|----------------------------|
-| `session` | string | yes      | Session name               |
-| `spaceId` | number | yes      | Target Space ID (from `spaces.list`) |
+| Field       | Type             | Required | Description                                        |
+|-------------|------------------|----------|----------------------------------------------------|
+| `wid`       | number           | no       | Target CGWindowID (preferred)                      |
+| `session`   | string           | no       | Session name (legacy target)                       |
+| `display`   | number           | no       | Target display index (`spaces.list` `displayIndex`) |
+| `placement` | string \| object | no       | Placement slot on the target display               |
+| `position`  | string           | no       | Alias for `placement`                              |
+| `spaceId`   | number           | no       | Target Space ID (from `spaces.list`)               |
+| `dryRun`    | bool             | no       | Plan and validate without moving the window        |
+
+Provide `wid` or `session` — there is no frontmost fallback — plus at least one
+of `display`, `placement`, or `spaceId`. Invalid combinations are rejected
+synchronously:
+
+- `spaceId` cannot be combined with `display` or `placement`; move Spaces and
+  geometry in separate calls.
+- An unknown `placement` string or unresolvable `display` index is an error,
+  not a silent default.
+
+**Semantics**:
+
+- `display` **without** `placement` — the window's normalized `x/y/w/h` within
+  its source display's visible frame is preserved onto the target display's
+  visible frame and clamped to fit. Display indexes resolve to screens through
+  stable display UUIDs, not array order.
+- `display` **with** `placement` (or `placement` alone) — routes through the
+  canonical `window.place` execution path; the receipt carries
+  `compatibilityMethod: "window.move"`.
+- `session` + `spaceId` — legacy Space move, fire-and-forget `{ ok: true }`.
+- `wid` + `spaceId` — synchronous Space move through the CGS primitive. Returns
+  `{ ok, moved, method, fromSpaceIds }`; `method` is `"CGS"` when the window
+  actually moved or `"switch-view"` when macOS denied the move and only the
+  view switched. An unknown `spaceId` is rejected with `Not found`, and CGS
+  being unavailable is an error. `dryRun: true` validates the target and
+  returns `status: "planned"` without touching the window or the view.
+
+**Returns** (geometry moves): an execution receipt with `status`
+(`ok`/`planned`/`blocked`/`failed`), before/target/after frames in `mutations`,
+`sourceDisplay` and `display` (name, index, visible frame), `targetResolution`,
+`verified`, `trace`, and undo metadata. Successful moves are undoable via
+`action.undo`.
+
+```js
+// Move window 4182 to display 1, keeping its relative size and position
+await daemonCall('window.move', { wid: 4182, display: 1 })
+
+// Move it to display 1 and snap it into the right half
+await daemonCall('window.move', { wid: 4182, display: 1, placement: 'right' })
+
+// Plan only — validate the move and preview frames without executing
+await daemonCall('window.move', { wid: 4182, display: 1, dryRun: true })
+```
 
 #### `window.assignLayer`
 

--- a/docs/app.md
+++ b/docs/app.md
@@ -272,6 +272,13 @@ from Settings > Shortcuts.
 | Ctrl+B  Z         | Zoom pane (toggle)   |
 | Ctrl+B  [         | Scroll mode          |
 
+Hyper+L opens Studio; close it with Escape or `q` when the map owns keyboard
+focus, or use the window close button. Hyper+3 opens or dismisses the HUD and
+its miniature workspace map. The Scattered and Full HUD presets intentionally
+retain a faint, non-interactive ambient surface after dismissal. Neither UI is
+the read-only terminal [`lattices map`](/docs/workspace-map) command; see that
+page for exact side effects, full-teardown steps, and tab-stack cleanup.
+
 ### Docs
 
 Embedded quick reference with glossary, "how it works" steps, and

--- a/docs/config.md
+++ b/docs/config.md
@@ -134,6 +134,8 @@ Run `lattices init` in your project directory to generate a starter
 | `lattices restart [pane]`    | Restart a pane's process (by name or index)       |
 | `lattices tile <position>`   | Tile the frontmost window to a screen position    |
 | `lattices tile family [app] [region]` | Smart-grid the frontmost app family, or a named app |
+| `lattices window move <wid> --display <n> [--placement <slot>]` | Move a window to another display |
+| `lattices window place <wid> <slot> [--display <n>]` | Snap a window into a placement slot |
 | `lattices distribute [app] [region]` | Smart-grid visible windows or just one app      |
 | `lattices group [id]`        | List tab groups or launch/attach a group          |
 | `lattices groups`            | List all tab groups with status                   |
@@ -293,6 +295,27 @@ area, not the full screen.
 For arbitrary cells, use compact `CxR:c,r` with 1-indexed coordinates
 from the top-left, or canonical `grid:CxR:c,r` with 0-indexed coordinates.
 Example: `lattices tile 4x4:1,2`.
+
+When the menu bar app is running, `lattices tile` routes through the daemon's
+canonical `window.place` and reports a verified receipt. Without the daemon it
+falls back to AppleScript (frontmost app, primary display) and says so.
+
+### Moving a specific window
+
+`lattices tile` always targets the frontmost window. To move a *specific*
+window — by the CGWindowID shown in `lattices map` or `lattices windows` —
+use `lattices window move` / `lattices window place` (daemon required):
+
+```bash
+lattices window move 4182 --display 1              # keep relative size/position
+lattices window move 4182 --display 1 --placement right
+lattices window place 4182 top-left                # slot on its current display
+lattices window move 4182 --display 0 --dry-run --json   # plan without moving
+```
+
+A malformed wid is an error; these commands never fall back to the frontmost
+window. Slots are the named positions above plus grid placements; fractional
+typed placements remain available via `lattices call window.place`.
 
 ### Smart app tiling
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -147,6 +147,7 @@ Run `lattices init` in your project directory to generate a starter
 | `lattices app restart`       | Rebuild and relaunch the menu bar app             |
 | `lattices layer [name\|index]` | Switch to a workspace layer by name or index      |
 | `lattices windows [--json]`  | List all visible windows                          |
+| [`lattices map [--json]`](/docs/workspace-map) | Read-only current-Space terminal/JSON map |
 | `lattices window assign <wid> <layer>` | Tag a window to a layer                |
 | `lattices window map [--json]` | Show all window→layer assignments                |
 | `lattices actor toggle`      | Hide/show persistent overlay actors               |
@@ -201,15 +202,16 @@ Keyboard remaps. Hold Caps Lock to send Hyper (`Control` + `Option` +
 
 ### `--json` flag
 
-The `lattices windows` command supports a `--json` flag for structured
-output:
+`lattices windows --json` returns the raw window array.
+[`lattices map --json`](/docs/workspace-map) returns a versioned, per-display
+current-Space snapshot with coordinate metadata:
 
 ```bash
 lattices windows --json
+lattices map --json
 ```
 
-Returns a JSON array of window objects to stdout, useful for piping
-into `jq` or consuming from scripts.
+Both are useful for piping into `jq` or consuming from scripts.
 
 ### Daemon responses
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -97,4 +97,5 @@ await daemonCall('window.place', {
 - [Concepts](/docs/concepts): architecture, glossary, and how it all works
 - [Agent Guide](/docs/agents): canonical action contracts for voice, CLI, and daemon clients
 - [Agent API](/docs/api): RPC method reference for agents and scripts
+- [Workspace Map](/docs/workspace-map): read-only terminal/JSON desktop snapshots and visible-surface hygiene
 - [Embedded SDK](/docs/embedded-sdk): host-owned helper model for Scout, HudsonKit, and other embeddings

--- a/docs/workspace-map.md
+++ b/docs/workspace-map.md
@@ -1,0 +1,198 @@
+---
+title: Workspace Map
+description: Read-only terminal and JSON views of the current macOS workspace
+order: 5.5
+---
+
+`lattices map` is a read-only view of the current desktop. It joins
+`spaces.list` and `windows.list` from the localhost daemon, then either draws a
+proportional terminal diagram or returns a versioned JSON snapshot for an
+agent.
+
+It does **not** open, focus, move, resize, or capture a macOS window. Its box
+drawing exists only in the invoking terminal. This is separate from the
+interactive **Studio / Screen Map** window and the **Hyper+3 HUD**.
+
+## Terminal map
+
+```bash
+lattices map
+```
+
+Example:
+
+```text
+┌ Display 0 · Built-in Display · Space 83 ───────────────────────┐
+│┌1 Ghostty - lattices──────────────────┐ ┌2 Safari - API docs─┐│
+││                                      │ │                    ││
+││                                      │ │                    ││
+│└──────────────────────────────────────┘ └────────────────────┘│
+└────────────────────────────────────────────────────────────────┘
+
+  1  Ghostty · lattices  wid:4182  960×1038 @ 0,38
+  2  Safari · API docs   wid:4210  768×1038 @ 960,38
+```
+
+The diagram represents each display's usable `visibleFrame`, not a pixel
+capture. Window rectangles are clipped to that frame. Only on-screen windows
+on the display's current Space appear. `windows.list` is ordered front to back;
+the renderer paints back to front so a foreground window occludes the windows
+behind it.
+
+Terminal cells are not square, so the automatic height compensates for a
+roughly 2:1 character aspect ratio. Geometry and overlap are proportional but
+approximate. Labels inside the fixed-width canvas use a one-cell-safe ASCII
+projection; the legend preserves cleaned Unicode app names and titles.
+
+## Options
+
+| Option | Effect |
+|--------|--------|
+| `--display <n>` | Include only the zero-based display index `n` |
+| `--width <n>` | Set terminal width; clamped to 32–120 columns |
+| `--height <n>` | Set terminal height; clamped to 8–40 rows |
+| `--json` | Emit the versioned current-Space snapshot instead of a diagram |
+| `-h`, `--help` | Print command help without contacting the daemon |
+
+Without `--width`, the command uses the terminal width when available and 72
+columns otherwise. Without `--height`, it derives the height from each
+display's aspect ratio. Numeric options must be non-negative integers.
+
+## JSON for agents
+
+```bash
+lattices map --json
+lattices map --display 1 --json
+```
+
+The JSON form is a canonical projection of the same current-Space view; it is
+not the unfiltered response from `windows.list`:
+
+```json
+{
+  "version": 1,
+  "coordinateSystem": {
+    "origin": "top-left",
+    "units": "points",
+    "reference": "global-desktop"
+  },
+  "displays": [
+    {
+      "displayIndex": 0,
+      "displayId": "37d8832a-2d66-02ca-b9f7-8f30a301b230",
+      "name": "Built-in Liquid Retina XDR Display",
+      "frame": { "x": 0, "y": 0, "w": 1728, "h": 1117 },
+      "visibleFrame": { "x": 0, "y": 38, "w": 1728, "h": 1079 },
+      "currentSpaceId": 83,
+      "spaces": [
+        { "id": 83, "index": 1, "display": 0, "isCurrent": true }
+      ],
+      "windows": [
+        {
+          "wid": 4182,
+          "app": "Ghostty",
+          "pid": 916,
+          "title": "lattices",
+          "frame": { "x": 0, "y": 38, "w": 960, "h": 1038 },
+          "spaceIds": [83],
+          "isOnScreen": true,
+          "axVerified": true,
+          "zIndex": 0
+        }
+      ]
+    }
+  ]
+}
+```
+
+Each display nests only windows that are on-screen, belong to its current
+Space, and intersect its usable frame. `zIndex: 0` is frontmost within that
+display snapshot. `--display` filters both terminal and JSON output. For every
+known window, including hidden and off-Space windows, call `windows.list`
+directly instead. The versioned projection copies the documented display,
+Space, and window fields explicitly rather than passing through arbitrary
+future daemon fields; optional `latticesSession` and `layerTag` values remain
+available when `windows.list` supplies them.
+
+The two daemon reads happen close together but are not an atomic WindowServer
+transaction. A window or Space change during the calls can produce a briefly
+mixed snapshot; retry before a consequential mutation if the desktop is moving.
+
+## Daemon fields and coordinates
+
+`spaces.list` adds these fields to each display:
+
+| Field | Meaning |
+|-------|---------|
+| `name` | Human-readable `NSScreen.localizedName` |
+| `frame` | Full display bounds in global top-left coordinates |
+| `visibleFrame` | Usable bounds after the menu bar, Dock, and system reservations |
+
+The display geometry uses the same coordinate system as `windows.list` window
+frames:
+
+- origin: top-left of the primary display;
+- units: macOS logical points, not capture pixels;
+- positive `x`: right;
+- positive `y`: down;
+- displays left of the primary display have negative `x`;
+- displays above the primary display have negative `y`;
+- displays below or to the right have offsets beyond the primary bounds.
+
+AppKit reports global screen rectangles from a bottom-left origin. Lattices
+converts them with:
+
+```text
+apiY = primaryDisplayHeight - (appKitY + height)
+```
+
+For a 1117-point-high primary display, a 900-point display immediately above
+it starts at `y: -900`; a 700-point display immediately below it starts at
+`y: 1117`. Horizontal offsets are unchanged. Lattices matches SkyLight display
+records to `NSScreen` by display UUID, with the existing index as a fallback.
+
+## Surface and side-effect matrix
+
+A miniature workspace diagram on the desktop—often near the lower-left—is a
+HUD minimap, not terminal `lattices map` output.
+
+| Primitive | CLI / daemon method | Read or mutate | Moves or focuses windows? | Visible desktop surface? | Lifetime and exact cleanup | Structured verification? |
+|-----------|---------------------|----------------|---------------------------|--------------------------|----------------------------|--------------------------|
+| Terminal workspace map | `lattices map`; `spaces.list` + `windows.list` | Read-only | No | No; terminal output only | Ends with the command; no desktop cleanup | **Yes, preferred**; use `--json` |
+| Raw inventory | `lattices windows --json`; `windows.list` | Read-only | No | No | One-shot | **Yes, preferred** |
+| Resolve or plan a target | `lattices call window.resolve ...`; `window.resolve` | Read-only | No | No | One-shot | **Yes, preferred** before mutations |
+| Studio / interactive Screen Map | No CLI/RPC open method; **Hyper+L** opens Studio | Opening is UI-only; Apply and explicit actions can mutate | Not merely by opening; Apply/focus/tile actions can | **Yes**, a normal Lattices window; preview mode can add an overlay | Hyper+L is an opener, not a close toggle. With map keyboard focus use **Escape** or **q**; the window close button also closes it and ends preview | No structured surface lifecycle API; do not open for verification |
+| HUD and HUD minimap | No CLI/RPC open method; **Hyper+3** toggles HUD | Opening is UI-only; chosen HUD actions can mutate | Selected actions can focus/tile | **Yes**, including the miniature map panels | Press **Hyper+3** while the HUD is active, or Escape from the base HUD. Tile/search submodes consume the first Escape, so another may be required. `M` cycles minimap hidden/docked/expanded. The Scattered and Full presets intentionally fade to ambient opacity instead of fully disappearing; while the HUD is active, use `X` (or `Option+X` from any HUD context) to select Classic, Glass, or Alive before dismissing when full teardown is required | No; agents should not open it for verification |
+| Live tab-stack chrome | `tabStacks.list`; `tabStacks.create` / `layout` / `select` / `delete` | List is read-only; the others mutate stack or window state | Create/layout can move windows; select focuses one | **Yes**, an enclosure and reserved rail independent of the HUD | Persists after Hyper+3 dismissal. Call `tabStacks.delete` with its `id` to remove the stack without closing member windows | `tabStacks.list` is structured; never create a stack only to verify state |
+| Screenshot artifact | `lattices capture window [wid]`; `capture.screenshotWindow` | Writes a run and PNG | No | No Lattices picker or overlay; macOS can show a permission prompt on first use | One-shot; the artifact persists in the run store, but no Lattices UI remains | Yes when pixels are actually required; otherwise prefer state APIs |
+| Recording artifact | `lattices capture record ...`; `capture.recordWindow` / `capture.recordRegion` | Writes a run and MOV | No | No visible Lattices capture UI; an offscreen probe runs in the background | Until `--duration-ms` expires or `lattices capture stop <run-id>` completes | Use only when temporal pixels are required |
+| Place a window | `lattices place ...`; `window.place` / `actions.execute` | Mutating | **Yes** | No Lattices overview surface | One-shot; use the returned undo receipt / `actions.undo` when applicable | Verify afterward with `lattices map --json` or raw reads |
+
+The Scattered and Full HUD presets intentionally leave a faint, non-interactive
+ambient visual after dismissal. That is why Hyper+3 can appear to dismiss a
+miniature map without removing every pixel. Live tab-stack chrome is a separate
+persistent surface and must be removed with `tabStacks.delete`, not Hyper+3.
+The current API cannot enumerate or force-dismiss Lattices-owned transient
+HUD/Studio panels, so there is no honest structured proof that every such panel
+has torn down. That lifecycle API is a follow-up, not something agents should
+approximate with screenshots.
+
+## Agent workflow and cleanup guarantees
+
+1. Read `spaces.list`, `windows.list`, or `lattices map --json`.
+2. Use `window.resolve` or an `actions.execute` dry run when target identity or
+   placement matters.
+3. Mutate only through the explicit daemon action.
+4. Read structured state again and compare window ID, Space IDs, and frame.
+5. Capture pixels only when the result is inherently visual.
+
+Agents must not open Studio, the HUD/minimap, a capture/review UI, or another
+visible Lattices surface when structured state is sufficient. `lattices map`
+itself is always safe for this workflow because it cannot create macOS UI.
+
+If an agent intentionally opens a visible Lattices surface, it must close that
+same surface before finishing and verify the desktop through structured state
+where possible. `windows.list` can prove that target windows did not move, but
+it cannot currently prove HUD/Studio teardown. Report that gap instead of
+leaving a surface open or using a screenshot as a substitute for lifecycle
+state.

--- a/docs/workspace-map.md
+++ b/docs/workspace-map.md
@@ -19,44 +19,125 @@ interactive **Studio / Screen Map** window and the **Hyper+3 HUD**.
 lattices map
 ```
 
-Example:
+Example with two differently sized, vertically offset displays
+(`lattices map --width 110 --height 14`):
 
 ```text
-┌ Display 0 · Built-in Display · Space 83 ───────────────────────┐
-│┌1 Ghostty - lattices──────────────────┐ ┌2 Safari - API docs─┐│
-││                                      │ │                    ││
-││                                      │ │                    ││
-│└──────────────────────────────────────┘ └────────────────────┘│
-└────────────────────────────────────────────────────────────────┘
+Desktop 7280×2395 @ 0,0 · 2 displays · 4 windows · 1 cell ≈ 92×184 pt
 
-  1  Ghostty · lattices  wid:4182  960×1038 @ 0,38
-  2  Safari · API docs   wid:4210  768×1038 @ 960,38
+╔═ D0 · AW3425DWM · Space 1 ═════════╗
+║                                    ╠═ D1 · U32J59x · Space 7 ════════════════╗
+║ ┌[2]┬[1] ChatGPT - ChatGPT───────┐ ║                                         ║
+║ │   │      │                     │ ║ ┌[3] Chrome────────┐                    ║
+║ │   │      │                     │ ║ │                  │                    ║
+║ │   │      │                     │ ║ │                  │    ┌[4]─┐          ║
+║ └───┴──────┘─────────────────────┘ ║ │                  │    │    │          ║
+║                                    ║ │                  │    │    │          ║
+╚════════════════════════════════════╣ │                  │    │    │          ║
+                                     ║ │                  │    │    │          ║
+                                     ║ │                  │    └────┘          ║
+                                     ║ └──────────────────┘                    ║
+                                     ║                                         ║
+                                     ╚═════════════════════════════════════════╝
+
+Key · ╔═ display ═╗   ┌[1] frontmost window ─┐   ┌[n]──┘ others, numbered only
+       lower n = nearer the front of its own display; n does not order across displays
+
+Displays
+  D0  Display 0 · AW3425DWM · Space 1  frame 3440×1440 @ 0,0       usable 3440×1410 @ 0,30
+  D1  Display 1 · U32J59x · Space 7    frame 3840×2160 @ 3440,235  usable 3840×2130 @ 3440,265
+
+Windows · front to back within each display
+  1  D0  ChatGPT · ChatGPT      wid:114   2847×1410 @ 593,30
+  2  D0  iTerm · lattices       wid:208   1235×1255 @ 0,30
+  3  D1  Chrome · API docs      wid:3874  1920×2130 @ 3440,265
+  4  D1  Simulator · iPhone 16  wid:146   447×950 @ 5783,913
 ```
 
-The diagram represents each display's usable `visibleFrame`, not a pixel
-capture. Window rectangles are clipped to that frame. Only on-screen windows
-on the display's current Space appear. `windows.list` is ordered front to back;
-the renderer paints back to front so a foreground window occludes the windows
-behind it.
+The diagram uses each full display `frame` to build one global desktop viewport,
+so displays above, below, left, right, or offset from the primary display retain
+their real topology and relative dimensions. One uniform point-to-cell scale is
+chosen for the entire canvas; displays are never independently normalized.
+Windows use the display's usable `visibleFrame`, are clipped to that frame, and
+remain positioned in the same global coordinate system. Only on-screen windows
+on each display's current Space appear. `windows.list` is ordered front to back,
+and the legend preserves that order: `[1]` is the frontmost window of its
+display. Numbering runs continuously across displays, so `[4]` on D0 and `[5]`
+on D1 have no z-relationship — depth is only meaningful within one display.
 
-Terminal cells are not square, so the automatic height compensates for a
-roughly 2:1 character aspect ratio. Geometry and overlap are proportional but
-approximate. Labels inside the fixed-width canvas use a one-cell-safe ASCII
-projection; the legend preserves cleaned Unicode app names and titles.
+Terminal cells are not square, so the projection compensates for a roughly 2:1
+character aspect ratio. The map summary reports the approximate point size of
+one terminal cell. Geometry and overlap are proportional but approximate.
+
+### The x-ray floor plan
+
+The drawing has a deliberate reading order: **monitor bezel → labelled primary
+window → numbered secondary shapes → legend.**
+
+**The bezel** is a double-line outer frame with a blank gutter inside it, so a
+window border is never adjacent to the monitor frame — `║ ┌` rather than `║┌`,
+which reads as one thick border. Window painting also refuses outright any cell
+already holding a double-line glyph, so the bezel cannot be merged into,
+replaced, or masqueraded as, whatever the window geometry. On a display too
+small to afford the gutter the inset falls back to one cell; the refusal still
+holds, so windows never reach the bezel itself.
+
+**Windows** are single-line rectangles. The map is an **x-ray**: a window never
+fills or erases its interior, so a window that is completely covered on the real
+desktop still appears as its own complete rectangle. Where two outlines cross
+they merge into the correct box-drawing junction (`┼`, `┬`, `┤`) rather than one
+erasing the other. This trades the visual "which window is in front" cue — which
+the legend carries authoritatively — for the guarantee that no window silently
+disappears. There is no `(occluded)` state.
+
+So that a rectangle still reads as closed inside all that merging, each window's
+**bottom-right endpoint is restamped as its own `┘` corner** after the outlines
+merge. Two windows wanting the same cell produce the same glyph, so the result
+is order-independent; where a corner lands mid-edge, closure deliberately wins
+over line continuity.
+
+**Labels.** Exactly one window per display — the frontmost drawable one — spells
+out its app and title on the canvas. Every other window keeps its complete
+geometry and its `[n]`, and its identity lives in the legend. Labelling every
+overlapping window is what turns a busy desktop into noise.
+
+Markers are placed front to back. A window's number hugs its own top-left
+corner and walks down its rows before it slides right, so a number always reads
+as belonging to the rectangle it sits inside. A marker may overwrite an outline;
+identity wins over line continuity. Every legend row then resolves to exactly
+one of four honest states:
+
+| Legend note | Meaning |
+|-------------|---------|
+| *(none)* | `[n]` is on the canvas |
+| `(small)` | The window had room for a bare `n` but not `[n]`. Numbers are never truncated — a bare marker also reserves a non-digit cell on each side so `10` and `12` cannot run together |
+| `(too small to label)` | The outline is drawn but no numeral fits anywhere inside it |
+| `(off-canvas)` | The window clipped away entirely and was not drawn |
+
+Labels inside the fixed-width canvas use a one-cell-safe projection; the legend
+preserves cleaned Unicode app names and titles and includes exact global
+geometry.
+
+The canvas still uses box-drawing characters, which are East Asian *Ambiguous*
+width. Under a CJK locale, or a terminal configured to render ambiguous-width
+characters as double width, the grid will shear. A pure-ASCII drawing mode is
+the fix for that and is not implemented.
 
 ## Options
 
 | Option | Effect |
 |--------|--------|
 | `--display <n>` | Include only the zero-based display index `n` |
-| `--width <n>` | Set terminal width; clamped to 32–120 columns |
-| `--height <n>` | Set terminal height; clamped to 8–40 rows |
+| `--width <n>` | Set the maximum canvas width; clamped to 32–120 columns |
+| `--height <n>` | Set the maximum canvas height; clamped to 8–40 rows |
 | `--json` | Emit the versioned current-Space snapshot instead of a diagram |
 | `-h`, `--help` | Print command help without contacting the daemon |
 
 Without `--width`, the command uses the terminal width when available and 72
-columns otherwise. Without `--height`, it derives the height from each
-display's aspect ratio. Numeric options must be non-negative integers.
+columns otherwise. Without `--height`, the canvas is capped at 24 rows. The
+desktop is scaled uniformly to fit within both maxima, so one bound can remain
+partly unused rather than distorting the topology. Numeric options must be
+non-negative integers.
 
 ## JSON for agents
 
@@ -107,7 +188,11 @@ not the unfiltered response from `windows.list`:
 
 Each display nests only windows that are on-screen, belong to its current
 Space, and intersect its usable frame. `zIndex: 0` is frontmost within that
-display snapshot. `--display` filters both terminal and JSON output. For every
+display snapshot; it is per-display and zero-based, whereas the terminal
+legend's `[n]` is continuous across displays and one-based. The two are not
+interchangeable — join on `wid`, which is stable across both. `[n]` also
+renumbers under `--display`, so a window the full map calls `[5]` becomes `[1]`
+in `map --display 1`. `--display` filters both terminal and JSON output. For every
 known window, including hidden and off-Space windows, call `windows.list`
 directly instead. The versioned projection copies the documented display,
 Space, and window fields explicitly rather than passing through arbitrary
@@ -176,6 +261,22 @@ The current API cannot enumerate or force-dismiss Lattices-owned transient
 HUD/Studio panels, so there is no honest structured proof that every such panel
 has torn down. That lifecycle API is a follow-up, not something agents should
 approximate with screenshots.
+
+## Acting on the map
+
+Every legend row carries the window's `wid`. That id feeds the movement
+commands directly, without any visible Lattices surface:
+
+```bash
+lattices window move 4182 --display 1                    # keep normalized frame
+lattices window move 4182 --display 1 --placement right  # snap into a slot
+lattices window place 4182 top-left                      # slot on current display
+lattices window move 4182 --display 0 --dry-run --json   # plan without moving
+```
+
+Both commands require an explicit wid — a malformed id is an error, never a
+frontmost fallback — and return the daemon's execution receipt with before,
+target, and after frames. Verify afterward with `lattices map --json`.
 
 ## Agent workflow and cleanup guarantees
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arach/lattices",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Tile windows, search your screen, keep tmux sessions alive, and let AI agents control your Mac — CLI + daemon API",
   "homepage": "https://lattices.dev",
   "bugs": {

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -14,6 +14,9 @@ const daemonClientUrl = pathToFileURL(
 ).href;
 
 const { isDaemonRunning } = await import(daemonClientUrl);
+const { createWorkspaceMapSnapshot, parseMapOptions, renderWorkspaceMap } = await import(
+  pathToFileURL(path.join(repoRoot, "bin/cli/map.ts")).href
+);
 
 /** @type {boolean} */
 let daemonRunning = false;
@@ -58,9 +61,11 @@ function runCliRaw(args) {
 // ── session hash parity ──────────────────────────────────────────────
 
 test("session hash: known repo path produces stable session name", () => {
-  const session = toSessionName(repoRoot);
+  // Keep the parity fixture independent of the checkout/worktree location.
+  const knownRepoPath = "/Users/art/dev/lattices";
+  const session = toSessionName(knownRepoPath);
   assert.equal(session, "lattices-c36f74");
-  assert.equal(pathHash(repoRoot), "c36f74");
+  assert.equal(pathHash(knownRepoPath), "c36f74");
 });
 
 test("session hash: format is basename-6hex", () => {
@@ -99,6 +104,89 @@ test("default command: prints home screen guidance", () => {
 test("help: mentions lattices start", () => {
   const out = runCli(["help"]);
   assert.match(out, /lattices start/);
+});
+
+test("map renderer: draws current-space windows and a useful legend", () => {
+  const out = renderWorkspaceMap(
+    [{ displayIndex: 1, name: "Samsung", currentSpaceId: 7, visibleFrame: { x: 100, y: 20, w: 2000, h: 1000 } }],
+    [
+      { wid: 10, app: "Simulator", title: "iPhone 16", frame: { x: 100, y: 20, w: 1000, h: 500 }, spaceIds: [7], isOnScreen: true },
+      { wid: 11, app: "Chrome", title: "iii console", frame: { x: 1100, y: 20, w: 1000, h: 1000 }, spaceIds: [7], isOnScreen: true },
+      { wid: 12, app: "Chrome", title: "hidden space", frame: { x: 100, y: 520, w: 1000, h: 500 }, spaceIds: [5], isOnScreen: false },
+    ],
+    { width: 60, height: 14 },
+  );
+  assert.match(out, /Display 1 · Samsung · Space 7/);
+  assert.match(out, /Simulator · iPhone 16/);
+  assert.match(out, /Chrome · iii console/);
+  assert.doesNotMatch(out, /hidden space/);
+  assert.match(out, /wid:10/);
+});
+
+test("map renderer: foreground windows occlude the back and labels stay cell-safe", () => {
+  const out = renderWorkspaceMap(
+    [{ displayIndex: 0, name: "Main 📺", currentSpaceId: 7, visibleFrame: { x: 0, y: 0, w: 100, h: 100 } }],
+    [
+      { wid: 2, app: "Front\u001b[31m", title: "前\u001b[31m", frame: { x: 40, y: 40, w: 60, h: 60 }, spaceIds: [7], isOnScreen: true },
+      { wid: 1, app: "Back", title: "background", frame: { x: 0, y: 0, w: 100, h: 100 }, spaceIds: [7], isOnScreen: true },
+    ],
+    { width: 40, height: 12 },
+  );
+  const framedLines = out.split("\n").filter((line) => /^[┌│└]/u.test(line));
+  assert.ok(framedLines.every((line) => line.length === 40), out);
+  assert.match(out, /1 Front - \?/);
+  assert.doesNotMatch(out, /\u001b/);
+  assert.doesNotMatch(out, /┼/u, "occluded borders should not bleed through the foreground window");
+});
+
+test("map options: accept split and equals forms and reject malformed input", () => {
+  assert.deepEqual(parseMapOptions(["--display", "1", "--width=80", "--height", "20", "--json"]), {
+    display: 1,
+    width: 80,
+    height: 20,
+    json: true,
+  });
+  assert.throws(() => parseMapOptions(["--width"]), /--width expects a non-negative integer/);
+  assert.throws(() => parseMapOptions(["--display", "-1"]), /--display expects a non-negative integer/);
+  assert.throws(() => parseMapOptions(["--bogus"]), /Unknown option: --bogus/);
+});
+
+test("map JSON snapshot: filters by display and current Space in front-to-back order", () => {
+  const displays = [
+    { displayIndex: 0, displayId: "main", currentSpaceId: 7, visibleFrame: { x: 0, y: 24, w: 1000, h: 776 } },
+    { displayIndex: 1, displayId: "above", currentSpaceId: 8, spaces: [{ id: 8, index: 1, display: 1, isCurrent: true, rawOnly: "omit" }], visibleFrame: { x: -500, y: -900, w: 1200, h: 900 }, rawOnly: "omit" },
+    { displayIndex: 2, displayId: "below", currentSpaceId: 9, visibleFrame: { x: 0, y: 800, w: 1000, h: 700 } },
+  ];
+  const windows = [
+    { wid: 20, app: "Front", title: "above front", frame: { x: -400, y: -800, w: 600, h: 400 }, spaceIds: [8], isOnScreen: true, rawOnly: "omit" },
+    { wid: 21, app: "Back", title: "above back", frame: { x: 100, y: -500, w: 500, h: 400 }, spaceIds: [8], isOnScreen: true },
+    { wid: 22, app: "Hidden", title: "other Space", frame: { x: -400, y: -800, w: 600, h: 400 }, spaceIds: [99], isOnScreen: false },
+    { wid: 23, app: "Below", title: "below", frame: { x: 0, y: 900, w: 500, h: 400 }, spaceIds: [9], isOnScreen: true },
+  ];
+
+  const snapshot = createWorkspaceMapSnapshot(displays, windows, { display: 1 });
+  assert.deepEqual(snapshot.coordinateSystem, {
+    origin: "top-left",
+    units: "points",
+    reference: "global-desktop",
+  });
+  assert.equal(snapshot.version, 1);
+  assert.equal(snapshot.displays.length, 1);
+  assert.equal(snapshot.displays[0].displayId, "above");
+  assert.deepEqual(snapshot.displays[0].spaces, [{ id: 8, index: 1, display: 1, isCurrent: true }]);
+  assert.equal("rawOnly" in snapshot.displays[0], false);
+  assert.equal("rawOnly" in snapshot.displays[0].spaces[0], false);
+  assert.equal("rawOnly" in snapshot.displays[0].windows[0], false);
+  assert.deepEqual(snapshot.displays[0].windows.map(({ wid, zIndex }) => ({ wid, zIndex })), [
+    { wid: 20, zIndex: 0 },
+    { wid: 21, zIndex: 1 },
+  ]);
+});
+
+test("map --help: works without a running daemon", () => {
+  const out = runCli(["map", "--help"]);
+  assert.match(out, /Render the current Space/);
+  assert.match(out, /--display <n>/);
 });
 
 // ── search --deep ────────────────────────────────────────────────────

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -17,6 +17,21 @@ const { isDaemonRunning } = await import(daemonClientUrl);
 const { createWorkspaceMapSnapshot, parseMapOptions, renderWorkspaceMap } = await import(
   pathToFileURL(path.join(repoRoot, "bin/cli/map.ts")).href
 );
+const {
+  createDesktopMapReference,
+  intersectMapFrames,
+  projectMapFrame,
+  unionMapFrames,
+} = await import(pathToFileURL(path.join(repoRoot, "bin/cli/map-reference.ts")).href);
+const { displaysMissingGeometry } = await import(
+  pathToFileURL(path.join(repoRoot, "bin/cli/map.ts")).href
+);
+const {
+  describeMoveReceipt,
+  normalizePlacement,
+  parseWindowMoveArgs,
+  parseWindowPlaceArgs,
+} = await import(pathToFileURL(path.join(repoRoot, "bin/cli/window.ts")).href);
 
 /** @type {boolean} */
 let daemonRunning = false;
@@ -56,6 +71,65 @@ function runCliRaw(args) {
       status: err.status ?? 1,
     };
   }
+}
+
+// ── workspace map helpers ────────────────────────────────────────────
+
+// The drawn grid only: from the first display row to the row before the Key
+// block. Anchoring on "Key ·" keeps these assertions honest when the summary,
+// key, or legend gains a line.
+function canvasOf(out) {
+  const lines = out.split("\n");
+  const keyAt = lines.findIndex((line) => line.startsWith("Key ·"));
+  assert.ok(keyAt > 2, `expected a Key block:\n${out}`);
+  return lines.slice(2, keyAt - 1);
+}
+
+function windowLegendOf(out) {
+  const lines = out.split("\n");
+  const start = lines.findIndex((line) => line.startsWith("Windows ·"));
+  assert.ok(start > 0, `expected a window legend:\n${out}`);
+  return lines
+    .slice(start + 1)
+    .filter((line) => line.trim())
+    .map((line) => ({
+      index: Number(line.trim().split(/\s+/)[0]),
+      note: line.match(/\((?:small|too small to label|off-canvas)\)$/u)?.[0] ?? "",
+      line,
+    }));
+}
+
+// The identity invariant: every legend row resolves to exactly one honest
+// state — "[n]" on the canvas, an un-truncated bare "n" plus (small), or a note
+// explaining the absence. A silent unlabeled box is the failure this catches.
+function assertWindowIdentity(out, context) {
+  const canvas = canvasOf(out).join("\n");
+  const rows = windowLegendOf(out);
+  assert.ok(rows.length > 0, `${context}: expected window legend rows\n${out}`);
+  for (const { index, note } of rows) {
+    if (note === "") {
+      assert.ok(
+        canvas.includes(`[${index}]`),
+        `${context}: window ${index} carries no note but has no [${index}] on the canvas\n${out}`
+      );
+      continue;
+    }
+    if (note === "(small)") {
+      // The whole number, never a prefix of it: "12" clipped to "1" would be
+      // silently indistinguishable from window 1.
+      assert.match(
+        canvas,
+        new RegExp(`(?<![0-9])${index}(?![0-9])`, "u"),
+        `${context}: window ${index} is marked (small) but its bare number is not on the canvas\n${out}`
+      );
+      continue;
+    }
+    assert.ok(
+      note === "(too small to label)" || note === "(off-canvas)",
+      `${context}: window ${index} has an unrecognized note ${note}\n${out}`
+    );
+  }
+  return rows;
 }
 
 // ── session hash parity ──────────────────────────────────────────────
@@ -123,7 +197,114 @@ test("map renderer: draws current-space windows and a useful legend", () => {
   assert.match(out, /wid:10/);
 });
 
-test("map renderer: foreground windows occlude the back and labels stay cell-safe", () => {
+test("map reference: preserves one global desktop with negative and stacked offsets", () => {
+  const frames = [
+    { x: 0, y: 0, w: 3440, h: 1440 },
+    { x: 3440, y: 0, w: 3840, h: 2160 },
+    { x: -1280, y: -1024, w: 1280, h: 1024 },
+  ];
+  assert.deepEqual(unionMapFrames(frames), { x: -1280, y: -1024, w: 8560, h: 3184 });
+
+  const reference = createDesktopMapReference(frames, { maxColumns: 100, maxRows: 30 });
+  assert.ok(reference);
+  assert.ok(reference.columns <= 100);
+  assert.ok(reference.rows <= 30);
+
+  const left = projectMapFrame(reference, frames[2]);
+  const primary = projectMapFrame(reference, frames[0]);
+  const right = projectMapFrame(reference, frames[1]);
+  assert.equal(left.left, 0);
+  assert.equal(left.top, 0);
+  assert.equal(left.right, primary.left, "a shared world x edge must project to one canvas column");
+  assert.equal(primary.right, right.left, "adjacent displays must remain adjacent after projection");
+  assert.ok(primary.top > left.top, "a display above the primary must remain above it");
+  assert.ok(right.right <= reference.columns - 1);
+  assert.ok(right.bottom <= reference.rows - 1);
+});
+
+test("map reference: uses one scale and compensates for terminal cell aspect ratio", () => {
+  const landscape = { x: 0, y: 0, w: 2000, h: 1000 };
+  const portrait = { x: 2000, y: 0, w: 1000, h: 2000 };
+  const reference = createDesktopMapReference([landscape, portrait], {
+    maxColumns: 80,
+    maxRows: 24,
+    cellAspectRatio: 2,
+  });
+  assert.ok(reference);
+
+  const landscapeCells = projectMapFrame(reference, landscape);
+  const portraitCells = projectMapFrame(reference, portrait);
+  const landscapeWidth = landscapeCells.right - landscapeCells.left;
+  const landscapePhysicalHeight = (landscapeCells.bottom - landscapeCells.top) * 2;
+  const portraitWidth = portraitCells.right - portraitCells.left;
+  const portraitPhysicalHeight = (portraitCells.bottom - portraitCells.top) * 2;
+
+  assert.ok(Math.abs(landscapeWidth / landscapePhysicalHeight - 2) < 0.12);
+  assert.ok(Math.abs(portraitWidth / portraitPhysicalHeight - 0.5) < 0.12);
+  assert.equal(landscapeCells.right, portraitCells.left);
+});
+
+test("map reference: clips frames in global point coordinates before projection", () => {
+  assert.deepEqual(
+    intersectMapFrames(
+      { x: 100, y: 50, w: 400, h: 300 },
+      { x: 0, y: 0, w: 300, h: 200 },
+    ),
+    { x: 100, y: 50, w: 200, h: 150 },
+  );
+  assert.equal(
+    intersectMapFrames(
+      { x: 0, y: 0, w: 100, h: 100 },
+      { x: 100, y: 0, w: 100, h: 100 },
+    ),
+    undefined,
+  );
+});
+
+test("map renderer: composes offset displays in one proportional desktop canvas", () => {
+  const out = renderWorkspaceMap(
+    [
+      { displayIndex: 0, name: "Wide", currentSpaceId: 1, frame: { x: 0, y: 0, w: 2000, h: 1000 }, visibleFrame: { x: 0, y: 20, w: 2000, h: 980 } },
+      { displayIndex: 1, name: "Tall", currentSpaceId: 7, frame: { x: 2000, y: 250, w: 1000, h: 1500 }, visibleFrame: { x: 2000, y: 270, w: 1000, h: 1480 } },
+    ],
+    [
+      { wid: 10, app: "Editor", title: "main", frame: { x: 0, y: 20, w: 1000, h: 980 }, spaceIds: [1], isOnScreen: true },
+      { wid: 20, app: "Preview", title: "phone", frame: { x: 2200, y: 700, w: 400, h: 800 }, spaceIds: [7], isOnScreen: true },
+    ],
+    { width: 80, height: 24 },
+  );
+  const lines = out.split("\n");
+  const d0Top = lines.findIndex((line) => line.includes("D0 · Wide"));
+  const d1Top = lines.findIndex((line) => line.includes("D1 · Tall"));
+  assert.ok(d0Top >= 0 && d1Top > d0Top, out);
+  assert.ok(canvasOf(out).every((line) => line.length <= 80), out);
+  assert.match(out, /Desktop 3000×1750 @ 0,0 · 2 displays · 2 windows/);
+  assert.match(out, /1\s+D0\s+Editor · main\s+wid:10/);
+  assert.match(out, /2\s+D1\s+Preview · phone\s+wid:20/);
+});
+
+test("map renderer: retains negative display coordinates and stable display filtering", () => {
+  const displays = [
+    { displayIndex: 2, name: "Above", currentSpaceId: 8, frame: { x: -1200, y: -900, w: 1200, h: 900 } },
+    { displayIndex: 0, name: "Primary", currentSpaceId: 1, frame: { x: 0, y: 0, w: 1600, h: 1000 } },
+  ];
+  const windows = [
+    { wid: 30, app: "Top", title: "negative", frame: { x: -1200, y: -900, w: 600, h: 900 }, spaceIds: [8], isOnScreen: true },
+    { wid: 40, app: "Main", title: "origin", frame: { x: 0, y: 0, w: 800, h: 1000 }, spaceIds: [1], isOnScreen: true },
+  ];
+
+  const all = renderWorkspaceMap(displays, windows, { width: 72, height: 24 });
+  assert.match(all, /Desktop 2800×1900 @ -1200,-900/);
+  assert.ok(all.indexOf("D2 · Above") < all.indexOf("D0 · Primary"), all);
+
+  const selected = renderWorkspaceMap(displays, windows, { display: 0, width: 72, height: 24 });
+  assert.match(selected, /Desktop 1600×1000 @ 0,0 · 1 display · 1 window/);
+  assert.match(selected, /D0 · Primary/);
+  assert.match(selected, /1\s+D0\s+Main · origin\s+wid:40/);
+  assert.doesNotMatch(selected, /D2 · Above|wid:30/);
+});
+
+test("map renderer: overlapping windows stay identifiable and labels stay cell-safe", () => {
   const out = renderWorkspaceMap(
     [{ displayIndex: 0, name: "Main 📺", currentSpaceId: 7, visibleFrame: { x: 0, y: 0, w: 100, h: 100 } }],
     [
@@ -132,11 +313,251 @@ test("map renderer: foreground windows occlude the back and labels stay cell-saf
     ],
     { width: 40, height: 12 },
   );
-  const framedLines = out.split("\n").filter((line) => /^[┌│└]/u.test(line));
-  assert.ok(framedLines.every((line) => line.length === 40), out);
-  assert.match(out, /1 Front - \?/);
+  // The canvas is a fixed grid: every row must be the same number of terminal
+  // columns, and never wider than the requested maximum. Anchoring on the
+  // display border (╔/║/╚) matters — filtering on window glyphs alone matches
+  // nothing here and silently makes this assertion vacuous.
+  const canvas = canvasOf(out);
+  assert.ok(canvas.length > 0 && /^╔/u.test(canvas[0]), out);
+  const widths = new Set(canvas.map((line) => line.length));
+  assert.equal(widths.size, 1, `every canvas row must span the same columns: ${[...widths]}`);
+  assert.ok(Math.max(...widths) <= 40, out);
+  assert.match(out, /\[1\] Front/);
   assert.doesNotMatch(out, /\u001b/);
-  assert.doesNotMatch(out, /┼/u, "occluded borders should not bleed through the foreground window");
+  // The window the foreground covers keeps its own numbered rectangle: the map
+  // is an x-ray floor plan, so nothing is painted out. It is a secondary
+  // window, so it carries its number only — its identity is in the legend.
+  const drawn = canvas.join("\n");
+  assert.ok(drawn.includes("[2]"), out);
+  assert.ok(!drawn.includes("[2] Back"), `only the primary window is labelled:\n${out}`);
+  assertWindowIdentity(out, "overlapping pair");
+  assert.match(out, /Key · ╔═ display ═╗   ┌\[1\] frontmost window ─┐/u);
+});
+
+test("map renderer: exactly one labelled primary window per display", () => {
+  const out = renderWorkspaceMap(
+    [
+      { displayIndex: 0, name: "Left", currentSpaceId: 1, frame: { x: 0, y: 0, w: 2000, h: 1200 } },
+      { displayIndex: 1, name: "Right", currentSpaceId: 2, frame: { x: 2000, y: 0, w: 2000, h: 1200 } },
+    ],
+    [
+      // Front to back within each display.
+      { wid: 1, app: "Alpha", title: "one", frame: { x: 100, y: 100, w: 1200, h: 900 }, spaceIds: [1], isOnScreen: true },
+      { wid: 2, app: "Bravo", title: "two", frame: { x: 400, y: 300, w: 1200, h: 800 }, spaceIds: [1], isOnScreen: true },
+      { wid: 3, app: "Charlie", title: "three", frame: { x: 2100, y: 100, w: 1200, h: 900 }, spaceIds: [2], isOnScreen: true },
+      { wid: 4, app: "Delta", title: "four", frame: { x: 2400, y: 300, w: 1200, h: 800 }, spaceIds: [2], isOnScreen: true },
+    ],
+    { width: 110, height: 24 },
+  );
+  const canvas = canvasOf(out).join("\n");
+
+  // The frontmost window of each display spells out its app; the others do not.
+  assert.ok(canvas.includes("[1] Alpha"), `D0's primary should be labelled:\n${out}`);
+  assert.ok(canvas.includes("[3] Charlie"), `D1's primary should be labelled:\n${out}`);
+  assert.ok(canvas.includes("[2]") && canvas.includes("[4]"), out);
+  assert.doesNotMatch(canvas, /Bravo|Delta/u, `secondary windows must not be labelled:\n${out}`);
+  // Their identity is still available, in the legend.
+  assert.match(out, /2\s+D0\s+Bravo · two/u);
+  assert.match(out, /4\s+D1\s+Delta · four/u);
+  assertWindowIdentity(out, "one primary per display");
+});
+
+test("map renderer: every drawable window terminates in its own bottom-right corner", () => {
+  const out = renderWorkspaceMap(
+    [{ displayIndex: 0, name: "Main", currentSpaceId: 1, frame: { x: 0, y: 0, w: 2000, h: 1200 } }],
+    [
+      // Three windows whose bottom edges land on the same canvas row. Without a
+      // closure pass their corners merge away into one ┴──┴── rail.
+      { wid: 1, app: "A", title: "a", frame: { x: 100, y: 100, w: 500, h: 900 }, spaceIds: [1], isOnScreen: true },
+      { wid: 2, app: "B", title: "b", frame: { x: 500, y: 100, w: 500, h: 900 }, spaceIds: [1], isOnScreen: true },
+      { wid: 3, app: "C", title: "c", frame: { x: 900, y: 100, w: 500, h: 900 }, spaceIds: [1], isOnScreen: true },
+    ],
+    { width: 100, height: 22 },
+  );
+  const canvas = canvasOf(out);
+  const corners = canvas.join("").split("┘").length - 1;
+  assert.equal(corners, 3, `each of the 3 windows needs its own ┘ termination:\n${out}`);
+  assertWindowIdentity(out, "closure corners");
+});
+
+test("map renderer: a gutter separates the display bezel from every window", () => {
+  const bezel = /[═║╔╗╚╝╠╣╦╩╬]/u;
+  const windowGlyph = /[─│┌┐└┘├┤┬┴┼]/u;
+  const fixtures = [
+    {
+      label: "maximized window",
+      displays: [{ displayIndex: 0, name: "Main", currentSpaceId: 1, frame: { x: 0, y: 0, w: 2000, h: 1200 } }],
+      // Flush with the display on every side, and larger than it.
+      windows: [{ wid: 1, app: "Full", title: "max", frame: { x: -100, y: -100, w: 2200, h: 1400 }, spaceIds: [1], isOnScreen: true }],
+      size: [80, 20],
+    },
+    {
+      label: "adjacent displays",
+      displays: [
+        { displayIndex: 0, name: "L", currentSpaceId: 1, frame: { x: 0, y: 0, w: 2000, h: 1200 } },
+        { displayIndex: 1, name: "R", currentSpaceId: 2, frame: { x: 2000, y: 0, w: 2000, h: 1200 } },
+      ],
+      windows: [
+        { wid: 1, app: "L1", title: "a", frame: { x: 0, y: 0, w: 2000, h: 1200 }, spaceIds: [1], isOnScreen: true },
+        { wid: 2, app: "R1", title: "b", frame: { x: 2000, y: 0, w: 2000, h: 1200 }, spaceIds: [2], isOnScreen: true },
+      ],
+      size: [110, 24],
+    },
+  ];
+
+  for (const { label, displays, windows, size } of fixtures) {
+    const out = renderWorkspaceMap(displays, windows, { width: size[0], height: size[1] });
+    const canvas = canvasOf(out);
+    for (let y = 0; y < canvas.length; y++) {
+      for (let x = 0; x < canvas[y].length; x++) {
+        if (!bezel.test(canvas[y][x])) continue;
+        // No window glyph may sit on a bezel cell or in any cell touching one:
+        // "║┌" reads as one thick frame, which is the confusion the gutter and
+        // the paint refusal exist to prevent.
+        for (const [dy, dx] of [[0, 0], [-1, 0], [1, 0], [0, -1], [0, 1]]) {
+          const neighbour = canvas[y + dy]?.[x + dx];
+          if (neighbour === undefined) continue;
+          assert.doesNotMatch(
+            neighbour,
+            windowGlyph,
+            `${label}: window glyph ${neighbour} at ${y + dy},${x + dx} touches the bezel at ${y},${x}\n${out}`
+          );
+        }
+      }
+    }
+    assertWindowIdentity(out, label);
+  }
+});
+
+test("map renderer: x-ray keeps a fully covered window and merges crossing outlines", () => {
+  const out = renderWorkspaceMap(
+    [{ displayIndex: 0, name: "Main", currentSpaceId: 1, visibleFrame: { x: 0, y: 0, w: 1000, h: 1000 } }],
+    [
+      // Front to back. [1] covers the whole display, so [2] sits entirely
+      // underneath it, and [3] straddles [2]'s left and right edges.
+      { wid: 1, app: "Cover", title: "front", frame: { x: 0, y: 0, w: 1000, h: 1000 }, spaceIds: [1], isOnScreen: true },
+      { wid: 2, app: "Inner", title: "buried", frame: { x: 300, y: 300, w: 400, h: 400 }, spaceIds: [1], isOnScreen: true },
+      { wid: 3, app: "Cross", title: "band", frame: { x: 200, y: 400, w: 600, h: 200 }, spaceIds: [1], isOnScreen: true },
+    ],
+    { width: 60, height: 20 },
+  );
+  const canvas = canvasOf(out).join("\n");
+
+  // The regression this test exists for: a window with no uncovered pixel on
+  // the real desktop is still a complete numbered rectangle on the map.
+  assert.ok(canvas.includes("[2]"), `fully covered window lost its marker:\n${out}`);
+  assert.ok(canvas.includes("[1]") && canvas.includes("[3]"), out);
+  assert.match(canvas, /┼/u, `crossing outlines should merge into a junction:\n${out}`);
+  // Interiors are never cleared, so no window is ever reported as painted out.
+  assert.doesNotMatch(out, /\(occluded\)/u);
+  assertWindowIdentity(out, "fully covered window");
+});
+
+test("map renderer: every window is marked, marked (small), or explained", () => {
+  const display = { displayIndex: 0, name: "Main", currentSpaceId: 1, frame: { x: 0, y: 0, w: 1000, h: 600 } };
+  const narrow = Array.from({ length: 12 }, (_unused, i) => ({
+    wid: 100 + i,
+    app: `App${i}`,
+    title: "t",
+    frame: { x: i * 80, y: 20, w: 60, h: 400 },
+    spaceIds: [1],
+    isOnScreen: true,
+  }));
+
+  const out = renderWorkspaceMap([display], narrow, { width: 40, height: 12 });
+  const rows = assertWindowIdentity(out, "12 narrow windows at 40x12");
+  assert.equal(rows.length, 12, out);
+  // The invariant above is what matters, but a canvas that fell back to bare
+  // numbers everywhere would satisfy it and still be hard to read.
+  assert.ok(canvasOf(out).join("\n").match(/\[\d+\]/gu).length >= 8, out);
+
+  // Sub-cell windows with two-digit indices: never a truncated numeral, since
+  // "12" clipped to "1" is silently indistinguishable from window 1.
+  const slivers = Array.from({ length: 14 }, (_unused, i) => ({
+    wid: 200 + i,
+    app: `S${i}`,
+    title: "",
+    frame: { x: i * 70, y: 20, w: 20, h: 60 },
+    spaceIds: [1],
+    isOnScreen: true,
+  }));
+  for (const [width, height] of [[44, 10], [32, 8]]) {
+    assertWindowIdentity(
+      renderWorkspaceMap([display], slivers, { width, height }),
+      `14 slivers at ${width}x${height}`
+    );
+  }
+});
+
+test("map renderer: window painting never touches a display border", () => {
+  const out = renderWorkspaceMap(
+    [
+      { displayIndex: 0, name: "A", currentSpaceId: 1, frame: { x: 0, y: 0, w: 1000, h: 600 } },
+      { displayIndex: 1, name: "B", currentSpaceId: 2, frame: { x: 0, y: 600, w: 1000, h: 600 } },
+      { displayIndex: 2, name: "C", currentSpaceId: 3, frame: { x: 0, y: 1200, w: 1000, h: 600 } },
+    ],
+    [
+      // Each window is flush with its display's top-left corner and wider than
+      // the display, so an unguarded painter would sit on the border.
+      { wid: 1, app: "One", title: "a", frame: { x: 0, y: 0, w: 1200, h: 600 }, spaceIds: [1], isOnScreen: true },
+      { wid: 2, app: "Two", title: "b", frame: { x: 0, y: 600, w: 1200, h: 600 }, spaceIds: [2], isOnScreen: true },
+      { wid: 3, app: "Three", title: "c", frame: { x: 0, y: 1200, w: 1200, h: 600 }, spaceIds: [3], isOnScreen: true },
+    ],
+    { width: 60, height: 8 },
+  );
+  for (const line of canvasOf(out)) {
+    assert.doesNotMatch(
+      line[0],
+      /[─│┌┐└┘├┤┬┴┼]/u,
+      `a window glyph reached a display's left border:\n${out}`
+    );
+    // A display's horizontal rules carry only double line, corners, and the
+    // display header text — never a window glyph.
+    if (/^[╔╠╚]/u.test(line)) {
+      assert.doesNotMatch(line, /[─│┌┐└┘├┤┬┴┼]/u, `a window glyph broke a display border:\n${out}`);
+    }
+  }
+  assertWindowIdentity(out, "three stacked displays at 60x8");
+});
+
+test("map renderer: the live two-monitor fixture stays readable at every size", () => {
+  const displays = [
+    { displayIndex: 0, name: "AW3425DWM", currentSpaceId: 1, frame: { x: 0, y: 0, w: 3440, h: 1440 }, visibleFrame: { x: 0, y: 30, w: 3440, h: 1410 } },
+    { displayIndex: 1, name: "U32J59x", currentSpaceId: 7, frame: { x: 3440, y: 235, w: 3840, h: 2160 }, visibleFrame: { x: 3440, y: 265, w: 3840, h: 2130 } },
+  ];
+  const windows = [
+    { wid: 114, app: "ChatGPT", title: "ChatGPT", frame: { x: 593, y: 30, w: 2847, h: 1410 }, spaceIds: [1], isOnScreen: true },
+    { wid: 208, app: "iTerm", title: "lattices", frame: { x: 0, y: 30, w: 1235, h: 1255 }, spaceIds: [1], isOnScreen: true },
+    { wid: 4104, app: "Scout", title: "broker", frame: { x: 1244, y: 32, w: 1815, h: 1326 }, spaceIds: [1], isOnScreen: true },
+    { wid: 4047, app: "System Settings", title: "Displays", frame: { x: 1868, y: 624, w: 723, h: 690 }, spaceIds: [1], isOnScreen: true },
+    { wid: 3874, app: "Chrome", title: "API docs", frame: { x: 3440, y: 265, w: 1920, h: 2130 }, spaceIds: [7], isOnScreen: true },
+    { wid: 4236, app: "Chrome", title: "PR review", frame: { x: 5360, y: 265, w: 1440, h: 1000 }, spaceIds: [7], isOnScreen: true },
+    { wid: 146, app: "Simulator", title: "iPhone 16", frame: { x: 5783, y: 913, w: 447, h: 950 }, spaceIds: [7], isOnScreen: true },
+  ];
+
+  for (const [width, height] of [[120, 40], [80, 24], [60, 16], [40, 12], [32, 8]]) {
+    const out = renderWorkspaceMap(displays, windows, { width, height });
+    const canvas = canvasOf(out);
+    const label = `live fixture at ${width}x${height}`;
+    assert.ok(canvas.every((line) => line.length <= width), `${label}: canvas row overflows\n${out}`);
+
+    // D1 is right of and lower than D0 — the two-adjacent-monitors claim.
+    const d0Row = canvas.findIndex((line) => line.includes("D0"));
+    const d1Row = canvas.findIndex((line) => line.includes("D1"));
+    assert.ok(d0Row >= 0 && d1Row > d0Row, `${label}: D1 should start on a lower row than D0\n${out}`);
+    assert.ok(
+      canvas[d1Row].indexOf("D1") > canvas[d0Row].indexOf("D0"),
+      `${label}: D1 should start right of D0\n${out}`
+    );
+    assertWindowIdentity(out, label);
+  }
+
+  // At the operator's working size every window keeps a full "[n]".
+  const at80 = renderWorkspaceMap(displays, windows, { width: 80, height: 24 });
+  const canvas80 = canvasOf(at80).join("\n");
+  for (let index = 1; index <= windows.length; index++) {
+    assert.ok(canvas80.includes(`[${index}]`), `80x24 lost marker [${index}]:\n${at80}`);
+  }
 });
 
 test("map options: accept split and equals forms and reject malformed input", () => {
@@ -187,6 +608,114 @@ test("map --help: works without a running daemon", () => {
   const out = runCli(["map", "--help"]);
   assert.match(out, /Render the current Space/);
   assert.match(out, /--display <n>/);
+});
+
+test("map JSON guard: flags displays whose daemon payload has no geometry", () => {
+  const withGeometry = { displayIndex: 0, currentSpaceId: 1, visibleFrame: { x: 0, y: 0, w: 1000, h: 800 } };
+  const legacy = { displayIndex: 1, currentSpaceId: 2 };
+  const zeroed = { displayIndex: 2, currentSpaceId: 3, frame: { x: 0, y: 0, w: 0, h: 0 } };
+
+  assert.deepEqual(displaysMissingGeometry([withGeometry]), []);
+  assert.deepEqual(
+    displaysMissingGeometry([withGeometry, legacy, zeroed]).map((d) => d.displayIndex),
+    [1, 2],
+  );
+  // The --display filter scopes the guard the same way it scopes the snapshot.
+  assert.deepEqual(displaysMissingGeometry([withGeometry, legacy], { display: 0 }), []);
+  assert.deepEqual(
+    displaysMissingGeometry([withGeometry, legacy], { display: 1 }).map((d) => d.displayIndex),
+    [1],
+  );
+});
+
+// ── window move / place ──────────────────────────────────────────────
+
+test("window move parsing: split and equals flags, dry-run, json", () => {
+  assert.deepEqual(parseWindowMoveArgs(["4182", "--display", "1"]), {
+    wid: 4182, display: 1, placement: undefined, json: false, dryRun: false,
+  });
+  assert.deepEqual(parseWindowMoveArgs(["4182", "--display=1", "--placement=right", "--json", "--dry-run"]), {
+    wid: 4182, display: 1, placement: "right", json: true, dryRun: true,
+  });
+  // Alias and grid slots normalize to what the daemon accepts.
+  assert.equal(parseWindowMoveArgs(["7", "--placement", "left-half"]).placement, "left");
+  assert.equal(parseWindowMoveArgs(["7", "--placement", "grid:4x4:0,0-1,1"]).placement, "grid:4x4:0,0-1,1");
+  assert.equal(parseWindowMoveArgs(["7", "--placement", "2x2:1,1"]).placement, "2x2:1,1");
+});
+
+test("window move parsing: malformed wid is an error, never a fallback", () => {
+  assert.throws(() => parseWindowMoveArgs(["--display", "1"]), /window id is required/i);
+  assert.throws(() => parseWindowMoveArgs(["abc", "--display", "1"]), /Invalid window id: abc/);
+  assert.throws(() => parseWindowMoveArgs(["-4182", "--display", "1"]), /Invalid window id: -4182/);
+  assert.throws(() => parseWindowMoveArgs(["4182.5", "--display", "1"]), /Invalid window id/);
+  assert.throws(() => parseWindowMoveArgs(["0", "--display", "1"]), /Invalid window id/);
+});
+
+test("window move parsing: rejects incomplete or unknown input", () => {
+  assert.throws(() => parseWindowMoveArgs(["4182"]), /requires --display <n> and\/or --placement/);
+  assert.throws(() => parseWindowMoveArgs(["4182", "--display"]), /--display expects a value/);
+  assert.throws(() => parseWindowMoveArgs(["4182", "--display", "x"]), /--display expects a non-negative/);
+  assert.throws(() => parseWindowMoveArgs(["4182", "--display", "1", "--placement", "diagonal"]), /Unknown placement slot: diagonal/);
+  assert.throws(() => parseWindowMoveArgs(["4182", "--display", "1", "--space", "3"]), /Unknown option: --space/);
+  assert.throws(() => parseWindowMoveArgs(["4182", "extra", "--display", "1"]), /Unexpected argument: extra/);
+});
+
+test("window place parsing: wid plus slot with optional display", () => {
+  assert.deepEqual(parseWindowPlaceArgs(["4182", "top-left"]), {
+    wid: 4182, display: undefined, placement: "top-left", json: false, dryRun: false,
+  });
+  assert.equal(parseWindowPlaceArgs(["4182", "MAX", "--display=1"]).placement, "maximize");
+  assert.throws(() => parseWindowPlaceArgs(["4182"]), /requires a slot/);
+  assert.throws(() => parseWindowPlaceArgs(["nope", "left"]), /Invalid window id: nope/);
+  assert.throws(() => parseWindowPlaceArgs(["4182", "sideways"]), /Unknown placement slot: sideways/);
+  assert.throws(() => parseWindowPlaceArgs(["4182", "left", "--placement", "right"]), /Unknown option: --placement/);
+});
+
+test("placement normalization: named slots, aliases, and grid forms", () => {
+  assert.equal(normalizePlacement("bottom-right"), "bottom-right");
+  assert.equal(normalizePlacement("Top_Center Third"), "top-center-third");
+  assert.equal(normalizePlacement("max"), "maximize");
+  assert.equal(normalizePlacement("upper-third"), "top-third");
+  assert.equal(normalizePlacement("grid:4.5"), "grid:4.5");
+  assert.equal(normalizePlacement("grid:3x2:2,0"), "grid:3x2:2,0");
+  assert.equal(normalizePlacement("banana"), undefined);
+  assert.equal(normalizePlacement("4x4"), undefined);
+});
+
+test("window move receipt rendering: ok, planned, blocked, failed", () => {
+  const base = {
+    app: "Safari",
+    wid: 4182,
+    display: { name: "U32J59x" },
+    mutations: [{ from: { x: 0, y: 0, w: 800, h: 600 }, to: { x: 3440, y: 265, w: 800, h: 600 }, after: { x: 3440, y: 265, w: 800, h: 600 } }],
+    receiptId: "exec_1",
+  };
+  const ok = describeMoveReceipt({ ...base, status: "ok", verified: true });
+  assert.match(ok, /Moved Safari \(wid:4182\) on U32J59x/);
+  assert.match(ok, /800×600 @ 0,0 → 800×600 @ 3440,265/);
+  assert.match(ok, /verified/);
+  assert.match(ok, /receipt exec_1/);
+
+  assert.match(describeMoveReceipt({ ...base, status: "planned" }), /Planned .*dry run, not executed/);
+  const blocked = describeMoveReceipt({ ...base, status: "blocked", blockedReason: "accessibility-not-trusted", requiredPermissions: ["accessibility"] });
+  assert.match(blocked, /Blocked Safari/);
+  assert.match(blocked, /accessibility-not-trusted/);
+  assert.match(describeMoveReceipt({ ...base, status: "failed" }), /did not verify/);
+});
+
+test("window move: malformed wid exits non-zero without touching the daemon", () => {
+  const { status, stdout, stderr } = runCliRaw(["window", "move", "abc", "--display", "1"]);
+  const combined = `${stdout}\n${stderr}`;
+  assert.equal(status, 1, `expected exit 1, got ${status}: ${combined}`);
+  assert.match(combined, /Invalid window id: abc/);
+  assert.doesNotMatch(combined, /Daemon not running/);
+});
+
+test("window move --help: lists slots without a running daemon", () => {
+  const out = runCli(["window", "move", "--help"]);
+  assert.match(out, /lattices window move <wid> --display <n>/);
+  assert.match(out, /grid:CxR:c,r/);
+  assert.match(out, /bottom-right/);
 });
 
 // ── search --deep ────────────────────────────────────────────────────

--- a/tests/e2e-daemon.test.mjs
+++ b/tests/e2e-daemon.test.mjs
@@ -195,3 +195,127 @@ test("CLI search --json returns structured quick-search results", () => {
     assert.ok(Array.isArray(first.reasons));
   }
 });
+
+// ── window.move contract ─────────────────────────────────────────────
+//
+// These tests exercise validation and dry-run planning only; none of them
+// moves a real window.
+
+test("window.move rejects a missing target instead of falling back to frontmost", async () => {
+  await assert.rejects(
+    daemonCall("window.move", { display: 0 }),
+    /wid or session/,
+  );
+});
+
+test("window.move rejects a call with no operation", async () => {
+  await assert.rejects(
+    daemonCall("window.move", { wid: 999999999 }),
+    /display, placement, or spaceId/,
+  );
+});
+
+test("window.move rejects spaceId combined with display or placement", async () => {
+  await assert.rejects(
+    daemonCall("window.move", { wid: 999999999, spaceId: 1, display: 0 }),
+    /spaceId cannot be combined/,
+  );
+  await assert.rejects(
+    daemonCall("window.move", { wid: 999999999, spaceId: 1, placement: "left" }),
+    /spaceId cannot be combined/,
+  );
+});
+
+test("window.move rejects an unknown placement synchronously", async () => {
+  await assert.rejects(
+    daemonCall("window.move", { wid: 999999999, placement: "diagonal" }),
+    /Unknown placement/,
+  );
+});
+
+test("window.move rejects an unknown wid", async () => {
+  await assert.rejects(
+    daemonCall("window.move", { wid: 999999999, display: 0 }),
+    /Not found: window/,
+  );
+});
+
+test("window.move dry run plans a display move with structured geometry", async () => {
+  const windows = await daemonCall("windows.list");
+  const candidate = (Array.isArray(windows) ? windows : []).find((w) => w.isOnScreen);
+  if (!candidate) return; // headless desktop — nothing to plan against
+
+  const receipt = await daemonCall("window.move", { wid: candidate.wid, display: 0, dryRun: true });
+  assert.equal(receipt.ok, true);
+  assert.equal(receipt.status, "planned");
+  assert.equal(receipt.dryRun, true);
+  assert.equal(receipt.wid, candidate.wid);
+  assert.equal(receipt.action?.type, "window.move");
+  assert.equal(receipt.targetResolution, "wid");
+  assert.equal(typeof receipt.display?.name, "string");
+  assert.equal(typeof receipt.sourceDisplay?.name, "string");
+
+  const mutation = receipt.mutations?.[0];
+  assert.equal(mutation?.kind, "moveWindowToDisplay");
+  for (const key of ["from", "to"]) {
+    for (const field of ["x", "y", "w", "h"]) {
+      assert.equal(typeof mutation[key]?.[field], "number", `${key}.${field} should be numeric`);
+    }
+  }
+  assert.equal("after" in mutation, false, "dry run must not report an after frame");
+
+  const fractions = receipt.fractions;
+  for (const field of ["x", "y", "w", "h"]) {
+    assert.equal(typeof fractions?.[field], "number");
+    assert.ok(fractions[field] >= 0 && fractions[field] <= 1, `fraction ${field} in [0,1]`);
+  }
+});
+
+test("window.move dry run with placement routes through canonical window.place", async () => {
+  const windows = await daemonCall("windows.list");
+  const candidate = (Array.isArray(windows) ? windows : []).find((w) => w.isOnScreen);
+  if (!candidate) return;
+
+  const receipt = await daemonCall("window.move", {
+    wid: candidate.wid,
+    display: 0,
+    placement: "left",
+    dryRun: true,
+  });
+  assert.equal(receipt.status, "planned");
+  assert.equal(receipt.action?.type, "window.place");
+  assert.equal(receipt.compatibilityMethod, "window.move");
+  assert.equal(receipt.placement?.kind, "tile");
+  assert.equal(receipt.placement?.value, "left");
+});
+
+test("window.move placement rejects an explicit unknown display", async () => {
+  const windows = await daemonCall("windows.list");
+  const candidate = (Array.isArray(windows) ? windows : []).find((w) => w.isOnScreen);
+  if (!candidate) return;
+
+  await assert.rejects(
+    daemonCall("window.move", {
+      wid: candidate.wid,
+      display: 999999,
+      placement: "left",
+      dryRun: true,
+    }),
+    /Not found: display 999999/,
+  );
+});
+
+test("window.place dry run resolves an explicit wid without mutating", async () => {
+  const windows = await daemonCall("windows.list");
+  const candidate = (Array.isArray(windows) ? windows : []).find((w) => w.isOnScreen);
+  if (!candidate) return;
+
+  const receipt = await daemonCall("window.place", {
+    wid: candidate.wid,
+    placement: "bottom-right",
+    dryRun: true,
+  });
+  assert.equal(receipt.status, "planned");
+  assert.equal(receipt.wid, candidate.wid);
+  assert.equal(receipt.targetResolution, "wid");
+});

--- a/tests/e2e-daemon.test.mjs
+++ b/tests/e2e-daemon.test.mjs
@@ -121,6 +121,15 @@ test("spaces.list returns displays with ordered spaces and a current space", asy
 
   for (const display of displays) {
     assert.equal(typeof display.displayIndex, "number");
+    assert.equal(typeof display.name, "string");
+    assert.equal(typeof display.frame, "object");
+    assert.equal(typeof display.visibleFrame, "object");
+    for (const frame of [display.frame, display.visibleFrame]) {
+      assert.equal(typeof frame.x, "number");
+      assert.equal(typeof frame.y, "number");
+      assert.ok(frame.w > 0);
+      assert.ok(frame.h > 0);
+    }
     assert.ok(Array.isArray(display.spaces), "display.spaces must be an array");
     assert.ok(display.spaces.length > 0, "display should list at least one space");
     assert.equal(typeof display.currentSpaceId, "number");


### PR DESCRIPTION
## Summary

- add `lattices map` with a proportional, readable terminal workspace map and a stable versioned `--json` snapshot
- preserve the real multi-display topology, display bezels/gutters, window z-order, primary labels, numbered secondary windows, and a compact legend
- add `lattices window move <wid> --display <n>` to move a specific window between monitors while preserving normalized geometry
- add `lattices window place <wid> <slot> [--display <n>]` plus `--placement` on `window move` for every canonical named/grid slot
- expand the localhost API `window.move` contract for WID/session targets, display moves, placement moves, dry runs, and WID-to-Space moves while preserving the legacy session-to-Space contract
- match SkyLight display indices to `NSScreen` by UUID and reject explicit unknown displays instead of silently moving on the wrong monitor

## CLI examples

```bash
lattices map --width 84
lattices window move 4182 --display 1
lattices window move 4182 --display 1 --placement right
lattices window place 4182 top-left --display 0
lattices window move 4182 --display 1 --dry-run --json
```

Fractional typed placements remain available through `lattices call window.place`.

## API behavior

- `window.move { wid, display }` preserves/clamps normalized `x/y/w/h` on the target display
- `window.move { wid, display?, placement }` routes through canonical `window.place`
- `window.move { wid, spaceId }` performs a synchronous CGS Space move when available
- `window.move { session, spaceId }` preserves the legacy fire-and-forget contract
- explicit malformed targets, placements, display indices, and conflicting Space/geometry requests fail safely
- geometry receipts include plan/trace/events, before/target/after frames, verification, permissions, and undo metadata

## Verification

- `bun run check:types`
- `bun run test:cli` — 34 passed, 1 expected daemon-state skip
- `bun run test:dependencies` — 2 passed
- `swift test --package-path apps/mac` — 78 passed, 13 environment-dependent Stage Manager tests skipped
- `bun run check:app`
- `bun run test:e2e` — 18 passed against the branch-built app on `127.0.0.1:9399`
- live CLI dry-runs on the real two-display desktop for display 0 → 1 normalized movement and right-half placement
- `git diff --check`

## Notes

- release version is prepared as `0.11.0`
- live smoke commands used `--dry-run`; no user window was moved
- unrelated Desktop Inventory / Studio contextual-menu work is intentionally not included
