### PR TITLE
Finish DeckTheme on iPad chrome

### DIFF
--- a/apps/ios/Sources/ContentView.swift
+++ b/apps/ios/Sources/ContentView.swift
@@ -480,7 +480,7 @@ struct LatsHomeView: View {
 
     private var hero: some View {
         VStack(alignment: .leading, spacing: 8) {
-            LatsSectionLabel(text: "lats deck")
+            LatsSectionLabel(text: "Lats Deck")
             Text("Pair your Mac")
                 .font(LatsFont.ui(28, weight: .bold))
                 .foregroundStyle(LatsPalette.text)
@@ -512,7 +512,7 @@ struct LatsHomeView: View {
     private var discoveryCard: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
-                LatsSectionLabel(text: "nearby macs")
+                LatsSectionLabel(text: "Nearby Macs")
                 Spacer()
                 LatsButton(title: "Refresh", icon: "arrow.clockwise", style: .ghost) {
                     store.refreshDiscovery()
@@ -555,7 +555,7 @@ struct LatsHomeView: View {
     private var manualCard: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
-                LatsSectionLabel(text: "manual connection")
+                LatsSectionLabel(text: "Manual connection")
                 Spacer()
             }
             Text("Use this if Bonjour discovery is blocked. Enter the Mac's Bonjour host, such as `mini.local`, or its local network name.")
@@ -568,7 +568,7 @@ struct LatsHomeView: View {
                 LatsField(placeholder: "Port", text: $store.manualPort, keyboardType: .numberPad)
             }
 
-            LatsButton(title: "Connect", icon: "bolt.fill", style: .primary(.green)) {
+            LatsButton(title: "Connect", icon: "bolt.fill", style: .primary(.amber)) {
                 store.connectManually()
             }
             .frame(maxWidth: .infinity)
@@ -588,7 +588,7 @@ struct LatsHomeView: View {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .font(.system(size: 11))
                     .foregroundStyle(LatsPalette.red)
-                LatsSectionLabel(text: "connection issue", tint: LatsPalette.red)
+                LatsSectionLabel(text: "Connection issue", tint: LatsPalette.red, attention: true)
             }
             Text(message)
                 .font(LatsFont.mono(11))
@@ -872,7 +872,7 @@ struct LatsConnectedHome: View {
     private var surfacesSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack {
-                LatsSectionLabel(text: "surfaces")
+                LatsSectionLabel(text: "Surfaces")
                 Spacer()
                 Text("legacy · will fold into deck")
                     .font(LatsFont.mono(9))
@@ -920,8 +920,9 @@ struct LatsConnectedHome: View {
                 Circle()
                     .fill(result.ok ? LatsPalette.green : LatsPalette.red)
                     .frame(width: 6, height: 6)
-                LatsSectionLabel(text: result.ok ? "last action" : "action failed",
-                                 tint: result.ok ? LatsPalette.green : LatsPalette.red)
+                LatsSectionLabel(text: result.ok ? "Last action" : "Action failed",
+                                 tint: result.ok ? LatsPalette.textDim : LatsPalette.red,
+                                 attention: !result.ok)
             }
             Text(result.summary)
                 .font(LatsFont.ui(13, weight: .semibold))
@@ -1064,7 +1065,7 @@ struct LatsSettingsView: View {
     private var macsCard: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
-                LatsSectionLabel(text: "macs")
+                LatsSectionLabel(text: "Macs")
                 Spacer()
                 LatsButton(title: "Refresh", icon: "arrow.clockwise", style: .ghost) {
                     store.refreshDiscovery()
@@ -1201,7 +1202,7 @@ struct LatsSettingsView: View {
 
     private var activeDetailCard: some View {
         VStack(alignment: .leading, spacing: 8) {
-            LatsSectionLabel(text: "active session")
+            LatsSectionLabel(text: "Active session")
             if let endpoint = store.activeEndpoint {
                 LatsKVRow(key: "host", value: endpoint.host, valueColor: LatsPalette.green)
                 LatsKVRow(key: "port", value: "\(endpoint.port)")
@@ -1229,7 +1230,7 @@ struct LatsSettingsView: View {
 
     private var disconnectCard: some View {
         VStack(alignment: .leading, spacing: 10) {
-            LatsSectionLabel(text: "device")
+            LatsSectionLabel(text: "Device")
             Text("Disconnecting clears the active session. Re-pair to re-encrypt this device with the Mac.")
                 .font(LatsFont.mono(10))
                 .foregroundStyle(LatsPalette.textDim)
@@ -1251,7 +1252,7 @@ struct LatsSettingsView: View {
 
     private var aboutCard: some View {
         VStack(alignment: .leading, spacing: 6) {
-            LatsSectionLabel(text: "about")
+            LatsSectionLabel(text: "About")
             LatsKVRow(key: "build", value: "lats deck · v0.1")
             LatsKVRow(key: "device", value: UIDevice.current.model)
             LatsKVRow(key: "system", value: "iOS \(UIDevice.current.systemVersion)")
@@ -1323,7 +1324,7 @@ struct LatsCockpitSurface: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            LatsSectionLabel(text: "command deck")
+            LatsSectionLabel(text: "Command deck")
             Text("Open the cockpit for the full Lats Deck experience.")
                 .font(LatsFont.mono(11))
                 .foregroundStyle(LatsPalette.textDim)
@@ -1395,7 +1396,7 @@ struct LatsVoiceSurface: View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 8) {
                 Circle().fill(phaseColor).frame(width: 8, height: 8)
-                LatsSectionLabel(text: store.snapshot?.voice?.provider?.uppercased() ?? "VOICE",
+                LatsSectionLabel(text: store.snapshot?.voice?.provider ?? "Voice",
                                  tint: phaseColor)
             }
             Text(phaseLabel)
@@ -1432,9 +1433,9 @@ struct LatsVoiceSurface: View {
     private var transcriptCard: some View {
         if let transcript = store.snapshot?.voice?.transcript, !transcript.isEmpty {
             VStack(alignment: .leading, spacing: 8) {
-                LatsSectionLabel(text: "transcript")
+                LatsSectionLabel(text: "Transcript")
                 Text("\u{201C}\(transcript)\u{201D}")
-                    .font(LatsFont.ui(15))
+                    .font(DeckTheme.said)
                     .foregroundStyle(LatsPalette.text)
                     .lineSpacing(2)
             }
@@ -1450,9 +1451,9 @@ struct LatsVoiceSurface: View {
 
         if let summary = store.snapshot?.voice?.responseSummary, !summary.isEmpty {
             VStack(alignment: .leading, spacing: 8) {
-                LatsSectionLabel(text: "response")
+                LatsSectionLabel(text: "Response")
                 Text(summary)
-                    .font(LatsFont.mono(11))
+                    .font(DeckTheme.saidSecondary)
                     .foregroundStyle(LatsPalette.text)
                     .lineSpacing(3)
                     .fixedSize(horizontal: false, vertical: true)
@@ -1476,7 +1477,7 @@ struct LatsVoiceSurface: View {
             "Switch to my review layer",
         ]
         return VStack(alignment: .leading, spacing: 8) {
-            LatsSectionLabel(text: "try saying")
+            LatsSectionLabel(text: "Try saying")
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 200), spacing: 6)], spacing: 6) {
                 ForEach(examples, id: \.self) { e in
                     Text(e)
@@ -1569,7 +1570,7 @@ struct LatsLayoutSurface: View {
 
     private var placementsCard: some View {
         VStack(alignment: .leading, spacing: 8) {
-            LatsSectionLabel(text: "placements")
+            LatsSectionLabel(text: "Placements")
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 140), spacing: 6)], spacing: 6) {
                 ForEach(placements, id: \.1) { p in
                     Button {
@@ -1606,7 +1607,7 @@ struct LatsLayoutSurface: View {
     private func previewCard(preview: DeckLayoutPreview) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack {
-                LatsSectionLabel(text: "stage")
+                LatsSectionLabel(text: "Stage")
                 Spacer()
                 Text("tap a window to focus")
                     .font(LatsFont.mono(9))

--- a/apps/ios/Sources/FleetDeck/FleetDeckCommandBay.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckCommandBay.swift
@@ -51,7 +51,7 @@ struct FleetCommandBay: View {
         HStack(spacing: 8) {
             ScrollView(.horizontal) {
                 HStack(spacing: 8) {
-                    FleetLabel(text: "COMMANDS")
+                    FleetLabel(text: "Commands")
                         .padding(.trailing, 4)
 
                     ForEach(Array(sets.enumerated()), id: \.element.id) { index, set in

--- a/apps/ios/Sources/FleetDeck/FleetDeckTheme.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckTheme.swift
@@ -282,9 +282,8 @@ struct FleetLabel: View {
     var color: Color = FleetV6.fg3
 
     var body: some View {
-        Text(text.uppercased())
+        Text(text)
             .font(FleetV6.mono(size, .medium))
-            .tracking(size * 0.18)
             .foregroundStyle(color)
     }
 }

--- a/apps/ios/Sources/FleetDeck/FleetDeckView.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckView.swift
@@ -55,10 +55,9 @@ struct FleetDeckView: View {
         FleetWell {
             HStack(spacing: 8) {
                 HStack(spacing: 7) {
-                    FleetDot(color: isOnline ? FleetV6.green : FleetV6.fg4, size: 6, glow: isOnline)
-                    Text("LATS DECK")
-                        .font(FleetV6.mono(11, .bold))
-                        .tracking(1.2)
+                    FleetDot(color: isOnline ? FleetV6.fg2 : FleetV6.fg4, size: 6, glow: false)
+                    Text("Lats Deck")
+                        .font(DeckTheme.secondary(.semibold))
                         .foregroundStyle(FleetV6.fg)
                 }
                 .padding(.leading, 10)
@@ -83,8 +82,8 @@ struct FleetDeckView: View {
                     Button {
                         withAnimation(.easeOut(duration: 0.18)) { model.focusAttention() }
                     } label: {
-                        Text("ATTN \(model.attentionIndices.count)")
-                            .font(FleetV6.mono(10, .semibold))
+                        Text("Needs you · \(model.attentionIndices.count)")
+                            .font(DeckTheme.caption(.semibold))
                             .foregroundStyle(FleetV6.amber)
                             .frame(minWidth: 62, minHeight: 44)
                             .contentShape(Rectangle())

--- a/apps/ios/Sources/FleetDeck/FleetDeckVoiceBar.swift
+++ b/apps/ios/Sources/FleetDeck/FleetDeckVoiceBar.swift
@@ -21,11 +21,11 @@ struct FleetVoiceBar: View {
 
     private var promptLabel: String {
         switch phase {
-        case .listening:    return "LISTENING · RELEASE TO SEND"
-        case .transcribing: return "TRANSCRIBING"
-        case .reasoning:    return "THINKING"
-        case .speaking:     return "SPEAKING"
-        case .idle, .none:  return "HOLD TO TALK"
+        case .listening:    return "Listening · release to send"
+        case .transcribing: return "Transcribing"
+        case .reasoning:    return "Thinking"
+        case .speaking:     return "Speaking"
+        case .idle, .none:  return "Hold to talk"
         }
     }
 
@@ -42,7 +42,7 @@ struct FleetVoiceBar: View {
                             .font(FleetV6.mono(13.5))
                             .foregroundStyle(FleetV6.fg4)
                         Text(transcript.isEmpty ? "—" : transcript)
-                            .font(FleetV6.mono(13.5))
+                            .font(DeckTheme.saidSecondary)
                             .foregroundStyle(FleetV6.fg)
                             .lineLimit(1)
                             .truncationMode(.tail)
@@ -54,7 +54,7 @@ struct FleetVoiceBar: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 HStack(spacing: 8) {
-                    FleetLabel(text: "ROUTE TO", size: 8.5, color: FleetV6.fg3)
+                    FleetLabel(text: "Route to", size: 8.5, color: FleetV6.fg3)
                     routeChips
                 }
             }

--- a/apps/ios/Sources/Home/HomeSyncSection.swift
+++ b/apps/ios/Sources/Home/HomeSyncSection.swift
@@ -214,7 +214,7 @@ private struct HomeSyncRow: View {
                 LatsButton(
                     title: "BROADCAST",
                     icon: "arrow.up.right",
-                    style: .primary(.green),
+                    style: .primary(.amber),
                     action: onBroadcast
                 )
                 .opacity(canBroadcast ? 1.0 : 0.5)

--- a/apps/ios/Sources/Home/HomeTopBar.swift
+++ b/apps/ios/Sources/Home/HomeTopBar.swift
@@ -76,9 +76,8 @@ struct HomeTopBar: View {
 
     private var compactCollapsedBar: some View {
         HStack(spacing: 8) {
-            Text("LATS")
-                .font(LatsFont.mono(11, weight: .bold))
-                .tracking(1.4)
+            Text("Lats Deck")
+                .font(DeckTheme.secondary(.semibold))
                 .foregroundStyle(LatsPalette.text)
                 .fixedSize()
 
@@ -106,9 +105,8 @@ struct HomeTopBar: View {
                         .fixedSize()
                 }
             } else {
-                Text("HOME")
-                    .font(LatsFont.mono(9, weight: .semibold))
-                    .tracking(1)
+                Text("Home")
+                    .font(DeckTheme.caption(.semibold))
                     .foregroundStyle(LatsPalette.textDim)
             }
 
@@ -116,11 +114,11 @@ struct HomeTopBar: View {
 
             if agentsRunning > 0 {
                 HStack(spacing: 4) {
-                    Circle().fill(LatsPalette.violet).frame(width: 5, height: 5)
+                    Circle().fill(DeckTheme.accent).frame(width: 5, height: 5)
                     Text("\(agentsRunning)")
-                        .font(LatsFont.mono(9, weight: .bold))
+                        .font(DeckTheme.caption(.semibold))
                 }
-                .foregroundStyle(LatsPalette.violet)
+                .foregroundStyle(DeckTheme.accent)
                 .fixedSize()
             }
 
@@ -133,14 +131,12 @@ struct HomeTopBar: View {
 
     private var productMark: some View {
         HStack(spacing: 8) {
-            Text("LATS")
-                .font(LatsFont.mono(11, weight: .bold))
-                .tracking(1.5)
+            Text("Lats Deck")
+                .font(DeckTheme.secondary(.semibold))
                 .foregroundStyle(LatsPalette.text)
             Text("·").foregroundStyle(LatsPalette.textFaint)
-            Text("home")
-                .font(LatsFont.mono(11))
-                .tracking(1)
+            Text("Home")
+                .font(DeckTheme.secondary())
                 .foregroundStyle(LatsPalette.textDim)
         }
         .fixedSize()
@@ -171,23 +167,21 @@ struct HomeTopBar: View {
     private var agentBadge: some View {
         HStack(spacing: 5) {
             Circle()
-                .fill(LatsPalette.violet)
+                .fill(DeckTheme.accent)
                 .frame(width: 5, height: 5)
             Text("\(agentsRunning) agents")
-                .font(LatsFont.mono(9, weight: .semibold))
-                .tracking(0.6)
-                .textCase(.uppercase)
+                .font(DeckTheme.caption(.semibold))
         }
-        .foregroundStyle(LatsPalette.violet)
+        .foregroundStyle(DeckTheme.accent)
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
         .background(
             RoundedRectangle(cornerRadius: 4)
-                .fill(LatsPalette.violet.opacity(0.14))
+                .fill(DeckTheme.accentFill)
         )
         .overlay(
             RoundedRectangle(cornerRadius: 4)
-                .stroke(LatsPalette.violet.opacity(0.34), lineWidth: 1)
+                .stroke(DeckTheme.accent.opacity(0.34), lineWidth: 1)
         )
     }
 

--- a/apps/ios/Sources/Home/HomeView.swift
+++ b/apps/ios/Sources/Home/HomeView.swift
@@ -110,13 +110,13 @@ struct HomeView: View {
         } label: {
             Image(systemName: "mic.fill")
                 .font(.system(size: 18, weight: .semibold))
-                .foregroundStyle(LatsPalette.text)
+                .foregroundStyle(DeckTheme.text)
                 .frame(width: 52, height: 52)
                 .background(
-                    Circle().fill(LatsPalette.violet.opacity(0.22))
+                    Circle().fill(DeckTheme.accentFill)
                 )
                 .overlay(
-                    Circle().stroke(LatsPalette.violet.opacity(0.6), lineWidth: 1)
+                    Circle().stroke(DeckTheme.accent.opacity(0.55), lineWidth: 1)
                 )
         }
         .buttonStyle(.plain)

--- a/apps/ios/Sources/Home/HomeVoiceOverlay.swift
+++ b/apps/ios/Sources/Home/HomeVoiceOverlay.swift
@@ -261,7 +261,7 @@ struct HomeVoiceOverlay: View {
         HStack(spacing: 12) {
             switch phase {
             case .idle:
-                LatsButton(title: "Start", icon: "mic.fill", style: .primary(.green), action: onStart)
+                LatsButton(title: "Start", icon: "mic.fill", style: .primary(.amber), action: onStart)
                 LatsButton(title: "Close", icon: "xmark", style: .ghost, action: onClose)
 
             case .listening:

--- a/apps/ios/Sources/Home/HomeVoicePanel.swift
+++ b/apps/ios/Sources/Home/HomeVoicePanel.swift
@@ -52,8 +52,7 @@ struct HomeVoicePanel: View {
                     headerRow
 
                     Text(caption)
-                        .font(LatsFont.mono(11))
-                        .tracking(0.4)
+                        .font(DeckTheme.secondary())
                         .foregroundStyle(LatsPalette.textDim)
                         .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -82,9 +81,8 @@ struct HomeVoicePanel: View {
 
     private var headerRow: some View {
         HStack(spacing: 8) {
-            Text(macLabel.lowercased())
-                .font(LatsFont.mono(11))
-                .tracking(0.5)
+            Text(macLabel)
+                .font(DeckTheme.secondary())
                 .foregroundStyle(LatsPalette.textDim)
                 .lineLimit(1)
 
@@ -127,10 +125,10 @@ struct HomeVoicePanel: View {
     private func transcriptInline(_ text: String) -> some View {
         HStack(alignment: .top, spacing: 8) {
             Text("›")
-                .font(LatsFont.mono(12, weight: .semibold))
-                .foregroundStyle(LatsPalette.green.opacity(0.8))
+                .font(DeckTheme.saidSecondary)
+                .foregroundStyle(DeckTheme.textTertiary)
             Text(text)
-                .font(LatsFont.mono(12))
+                .font(DeckTheme.saidSecondary)
                 .foregroundStyle(LatsPalette.text)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .multilineTextAlignment(.leading)
@@ -144,7 +142,7 @@ struct HomeVoicePanel: View {
                 .foregroundStyle(LatsPalette.green)
                 .frame(width: 12)
             Text(text)
-                .font(LatsFont.ui(12))
+                .font(DeckTheme.saidSecondary)
                 .foregroundStyle(LatsPalette.text)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }

--- a/apps/ios/Sources/Home/HomeZeroState.swift
+++ b/apps/ios/Sources/Home/HomeZeroState.swift
@@ -39,24 +39,21 @@ struct HomeZeroState: View {
 
     private var hero: some View {
         VStack(spacing: 14) {
-            Text("LATS")
-                .font(LatsFont.mono(34, weight: .bold))
-                .tracking(8)
+            Text("Lats Deck")
+                .font(DeckTheme.title(.semibold))
                 .foregroundStyle(LatsPalette.text)
 
-            Text("your iPad cockpit for a fleet of Macs")
-                .font(LatsFont.mono(12))
-                .tracking(0.5)
+            Text("Your iPad remote for paired Macs")
+                .font(DeckTheme.secondary())
                 .foregroundStyle(LatsPalette.textDim)
 
             HStack(spacing: 8) {
                 Circle()
-                    .fill(LatsPalette.green)
+                    .fill(DeckTheme.accent)
                     .frame(width: 6, height: 6)
                     .opacity(pulse ? 1.0 : 0.25)
-                Text("scanning network…")
-                    .font(LatsFont.mono(10))
-                    .tracking(0.4)
+                Text("Looking for Macs on this network")
+                    .font(DeckTheme.caption())
                     .foregroundStyle(LatsPalette.textFaint)
             }
             .padding(.top, 6)
@@ -71,7 +68,7 @@ struct HomeZeroState: View {
                 Rectangle()
                     .fill(LatsPalette.hairline2)
                     .frame(width: 18, height: 1)
-                LatsSectionLabel(text: "preview · once connected")
+                LatsSectionLabel(text: "Preview · once connected")
                 Rectangle()
                     .fill(LatsPalette.hairline2)
                     .frame(height: 1)
@@ -150,23 +147,21 @@ struct HomeZeroState: View {
             LatsButton(
                 title: "Add a host",
                 icon: "plus.circle",
-                style: .primary(.green)
-            ) {
+                style: .primary(.amber)
+            ) {}
                 onPair?()
             }
 
             Button(action: { onSettings?() }) {
                 Text("Open settings")
-                    .font(LatsFont.mono(11))
-                    .tracking(0.4)
+                    .font(DeckTheme.secondary())
                     .foregroundStyle(LatsPalette.textDim)
                     .underline(false)
             }
             .buttonStyle(.plain)
 
-            Text("looks like you don't have any paired Macs yet")
-                .font(LatsFont.mono(9))
-                .tracking(0.5)
+            Text("No paired Macs yet")
+                .font(DeckTheme.caption())
                 .foregroundStyle(LatsPalette.textFaint)
                 .padding(.top, 4)
         }

--- a/apps/ios/Sources/Home/HomeZeroState.swift
+++ b/apps/ios/Sources/Home/HomeZeroState.swift
@@ -148,7 +148,7 @@ struct HomeZeroState: View {
                 title: "Add a host",
                 icon: "plus.circle",
                 style: .primary(.amber)
-            ) {}
+            ) {
                 onPair?()
             }
 

--- a/apps/ios/Sources/LatsDeckScreen.swift
+++ b/apps/ios/Sources/LatsDeckScreen.swift
@@ -271,10 +271,9 @@ struct LatsTopChrome: View {
 
     private var compactChrome: some View {
         HStack(spacing: 10) {
-            Text("LATS · DECK")
-                .font(LatsFont.mono(11, weight: .bold))
+            Text("Lats Deck")
+                .font(DeckTheme.secondary(.semibold))
                 .foregroundStyle(LatsPalette.text)
-                .tracking(1.3)
                 .fixedSize()
 
             Button(action: onSwitcher) {
@@ -312,10 +311,9 @@ struct LatsTopChrome: View {
     private var regularChrome: some View {
         HStack(spacing: 0) {
             HStack(spacing: 12) {
-                Text("LATS · DECK")
-                    .font(LatsFont.mono(11, weight: .bold))
+                Text("Lats Deck")
+                    .font(DeckTheme.secondary(.semibold))
                     .foregroundStyle(LatsPalette.text)
-                    .tracking(1.5)
                 Text("·").foregroundStyle(LatsPalette.textFaint)
                 Button(action: onSwitcher) {
                     HStack(spacing: 6) {

--- a/apps/ios/Sources/LatsDesignSystem.swift
+++ b/apps/ios/Sources/LatsDesignSystem.swift
@@ -110,15 +110,13 @@ struct LatsInset<Content: View>: View {
 
 struct LatsSectionLabel: View {
     let text: String
-    // Source design uses amber (~#d9a05b) for all section headers — gives the
-    // surface its tactical-HUD feel and visually anchors each section above
-    // the dim mono subtitles that sit alongside.
-    var tint: Color = LatsPalette.amber
+    /// Amber is attention, not a section style. Default is secondary text.
+    var tint: Color = LatsPalette.textDim
+    var attention: Bool = false
     var body: some View {
-        Text(text.uppercased())
-            .font(LatsFont.mono(9, weight: .bold))
-            .tracking(2.0)
-            .foregroundStyle(tint)
+        Text(text)
+            .font(LatsFont.ui(13, weight: .medium))
+            .foregroundStyle(attention ? LatsPalette.amber : tint)
     }
 }
 
@@ -149,7 +147,7 @@ struct LatsButton: View {
         Button(action: action) {
             HStack(spacing: 8) {
                 if let icon { Image(systemName: icon).font(.system(size: 12, weight: .semibold)) }
-                Text(title).font(LatsFont.mono(12, weight: .semibold)).tracking(0.5)
+                Text(title).font(LatsFont.ui(13, weight: .semibold))
             }
             .foregroundStyle(foreground)
             .padding(.horizontal, 14)


### PR DESCRIPTION
## Why
DeckTheme already said amber is attention and chrome should look like a remote, not a HUD. The screens still used tracked caps and dead tint aliases.

## What
- `LatsSectionLabel` is sentence-case secondary text; amber only when `attention`
- Product chrome says **Lats Deck**
- Transcripts and agent replies use `DeckTheme.said`
- Mic FAB and primary CTAs use accent, not flattened violet/green
- Fleet “Needs you” stays amber

## Out of scope
Does not include the unrelated pre-existing `LatsDeckScreen` rewrite still sitting locally. Only the two chrome title hunks from that file are here.