### PR TITLE
✨ Right-click window movement in Desktop Inventory and Studio

### DIFF
--- a/apps/mac/Sources/Core/Desktop/WindowMovementService.swift
+++ b/apps/mac/Sources/Core/Desktop/WindowMovementService.swift
@@ -1,0 +1,388 @@
+import AppKit
+import SwiftUI
+
+// MARK: - Menu Model (pure)
+
+/// Pure description of the immediate window-movement context menu shared by
+/// Desktop Inventory and Studio. Holds no AppKit state so the cycle/wrap,
+/// current-display, and multi-selection rules are unit-testable.
+struct WindowMoveMenuModel: Equatable {
+    struct Display: Equatable {
+        /// API display index (SkyLight topology order), as accepted by
+        /// `window.move` / `window.place`.
+        let index: Int
+        let name: String
+        /// True when this is the clicked window's display.
+        let isCurrent: Bool
+    }
+
+    struct Target: Equatable {
+        let wid: UInt32
+        let pid: Int32
+    }
+
+    let displays: [Display]
+    let targets: [Target]
+
+    /// Slot presets offered by Move & Place: the canonical named
+    /// `PlacementSpec` positions kept to a scannable set (maximize, center,
+    /// halves, quarters, thirds). The full catalog stays available through
+    /// Tile Window, the CLI, and the API.
+    static let placementSlots: [TilePosition] = [
+        .maximize, .center,
+        .left, .right, .top, .bottom,
+        .topLeft, .topRight, .bottomLeft, .bottomRight,
+        .leftThird, .centerThird, .rightThird,
+    ]
+
+    /// Right-click target rule shared by Inventory and Studio: a click on a
+    /// member of an existing multi-selection targets the whole selection; any
+    /// other click targets just the clicked window.
+    static func resolveTargets(clicked: Target, selection: [Target]) -> [Target] {
+        if selection.count > 1, selection.contains(clicked) { return selection }
+        return [clicked]
+    }
+
+    /// Cross-monitor movement only exists with two or more displays; callers
+    /// render nothing (no orphan separators) when this is false.
+    var isAvailable: Bool { displays.count > 1 && !targets.isEmpty }
+
+    var targetCount: Int { targets.count }
+
+    var currentDisplay: Display? { displays.first(where: \.isCurrent) }
+
+    /// Deterministic next display: one step through the display topology from
+    /// the clicked window's display, wrapping at the end. When the anchor
+    /// display cannot be resolved, cycling starts from the first display.
+    var nextDisplay: Display? {
+        guard isAvailable else { return nil }
+        guard let position = displays.firstIndex(where: \.isCurrent) else {
+            return displays.first
+        }
+        return displays[(position + 1) % displays.count]
+    }
+
+    private var countPrefix: String {
+        targetCount > 1 ? "Move \(targetCount) Windows" : "Move"
+    }
+
+    var nextMonitorTitle: String { "\(countPrefix) to Next Monitor" }
+    var moveToMonitorTitle: String { "\(countPrefix) to Monitor" }
+    var movePlaceTitle: String { "Move & Place" }
+
+    /// Move & Place is single-window only: several windows sent to the same
+    /// slot would stack into one overlapping pile.
+    var includesPlacement: Bool { isAvailable && targetCount == 1 }
+
+    func moveAccessibilityLabel(to display: Display) -> String {
+        targetCount > 1
+            ? "Move \(targetCount) windows to \(display.name)"
+            : "Move window to \(display.name)"
+    }
+
+    func placeAccessibilityLabel(slot: TilePosition, on display: Display) -> String {
+        "Move window to \(display.name) and place \(slot.label)"
+    }
+}
+
+// MARK: - Movement Service
+
+/// Shared immediate-movement engine for the UI surfaces. Inventory and Studio
+/// both build a `WindowMoveMenuModel` here and execute through the same
+/// canonical `ActionRuntime` paths as `window.move` / `window.place`, so the
+/// app, CLI, and API cannot drift.
+enum WindowMovementService {
+    struct Outcome {
+        let ok: Bool
+        let message: String
+    }
+
+    /// Live display topology in API index order, resolved through SkyLight +
+    /// UUID matching (never `NSScreen.screens` positional assumptions). Main
+    /// thread only. `anchorScreen` marks the clicked window's display.
+    static func displays(anchorScreen: NSScreen?) -> [WindowMoveMenuModel.Display] {
+        let screens = NSScreen.screens
+        let anchorNumber = screenNumber(anchorScreen)
+        let spaces = WindowTiler.getDisplaySpaces().sorted { $0.displayIndex < $1.displayIndex }
+        guard !spaces.isEmpty else {
+            // SkyLight unavailable — API display indices fall back to AppKit
+            // order, matching DisplayGeometryMapper's index fallback.
+            return screens.enumerated().map { offset, screen in
+                WindowMoveMenuModel.Display(
+                    index: offset,
+                    name: screen.localizedName,
+                    isCurrent: anchorNumber != nil && screenNumber(screen) == anchorNumber
+                )
+            }
+        }
+        return spaces.map { display in
+            let screen = DisplayGeometryMapper.screen(for: display, in: screens)
+            return WindowMoveMenuModel.Display(
+                index: display.displayIndex,
+                name: screen?.localizedName ?? "Display \(display.displayIndex + 1)",
+                isCurrent: anchorNumber != nil && screenNumber(screen) == anchorNumber
+            )
+        }
+    }
+
+    /// Menu model anchored on a window's global top-left frame (Inventory).
+    static func menuModel(windowFrame: WindowFrame, targets: [WindowMoveMenuModel.Target]) -> WindowMoveMenuModel {
+        WindowMoveMenuModel(
+            displays: displays(anchorScreen: WindowTiler.screenForWindowFrame(windowFrame)),
+            targets: targets
+        )
+    }
+
+    /// Menu model anchored on an `NSScreen.screens` index (Studio entries).
+    static func menuModel(nsScreenIndex: Int, targets: [WindowMoveMenuModel.Target]) -> WindowMoveMenuModel {
+        let screens = NSScreen.screens
+        let anchor = screens.indices.contains(nsScreenIndex) ? screens[nsScreenIndex] : nil
+        return WindowMoveMenuModel(displays: displays(anchorScreen: anchor), targets: targets)
+    }
+
+    /// Move each target to `display`, preserving each window's own normalized
+    /// frame — canonical `window.move` display-only semantics, one receipt per
+    /// window. Runs off the main thread; `completion` is delivered on main.
+    static func moveTargets(
+        _ targets: [WindowMoveMenuModel.Target],
+        to display: WindowMoveMenuModel.Display,
+        completion: @escaping (Outcome) -> Void
+    ) {
+        run(completion: completion) {
+            var okCount = 0
+            var blocked = false
+            for target in targets {
+                let params = JSON.object([
+                    "wid": .int(Int(target.wid)),
+                    "display": .int(display.index),
+                ])
+                do {
+                    let receipt = try ActionRuntime.shared.executeWindowMove(params: params, source: "app.context-menu")
+                    switch receipt["status"]?.stringValue {
+                    case "ok": okCount += 1
+                    case "blocked": blocked = true
+                    default: break
+                    }
+                } catch {
+                    DiagnosticLog.shared.error("[Move] wid \(target.wid) → display \(display.index): \(error)")
+                }
+            }
+            return moveOutcome(okCount: okCount, total: targets.count, blocked: blocked, displayName: display.name)
+        }
+    }
+
+    /// Move one window to `display` and place it into a canonical slot —
+    /// `window.place` semantics through the same runtime as the API.
+    static func placeTarget(
+        _ target: WindowMoveMenuModel.Target,
+        on display: WindowMoveMenuModel.Display,
+        slot: TilePosition,
+        completion: @escaping (Outcome) -> Void
+    ) {
+        run(completion: completion) {
+            let params = JSON.object([
+                "wid": .int(Int(target.wid)),
+                "display": .int(display.index),
+                "placement": .string(slot.rawValue),
+            ])
+            do {
+                let receipt = try ActionRuntime.shared.executeWindowPlace(params: params, source: "app.context-menu")
+                switch receipt["status"]?.stringValue {
+                case "ok":
+                    return Outcome(ok: true, message: "Placed \(slot.label) on \(display.name)")
+                case "blocked":
+                    return Outcome(ok: false, message: "Grant Accessibility to move windows")
+                default:
+                    return Outcome(ok: false, message: "Placement not verified on \(display.name)")
+                }
+            } catch {
+                DiagnosticLog.shared.error("[Place] wid \(target.wid) → display \(display.index) \(slot.rawValue): \(error)")
+                return Outcome(ok: false, message: "Placement failed: \(shortError(error))")
+            }
+        }
+    }
+
+    /// Truthful receipt text: full success, blocked-on-permissions, partial,
+    /// and executed-but-unverified are reported as what they are.
+    static func moveOutcome(okCount: Int, total: Int, blocked: Bool, displayName: String) -> Outcome {
+        if okCount == total {
+            let message = total > 1
+                ? "Moved \(total) windows to \(displayName)"
+                : "Moved to \(displayName)"
+            return Outcome(ok: true, message: message)
+        }
+        if blocked, okCount == 0 {
+            return Outcome(ok: false, message: "Grant Accessibility to move windows")
+        }
+        if okCount > 0 {
+            return Outcome(ok: false, message: "Moved \(okCount)/\(total) windows to \(displayName)")
+        }
+        return Outcome(ok: false, message: "Move not verified — window may not have reached \(displayName)")
+    }
+
+    private static func run(
+        completion: @escaping (Outcome) -> Void,
+        work: @escaping () -> Outcome
+    ) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let outcome = work()
+            DispatchQueue.main.async { completion(outcome) }
+        }
+    }
+
+    private static func screenNumber(_ screen: NSScreen?) -> NSNumber? {
+        screen?.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber
+    }
+
+    private static func shortError(_ error: Error) -> String {
+        error.localizedDescription
+    }
+}
+
+// MARK: - SwiftUI menu section
+
+/// The shared movement section rendered inside a SwiftUI `contextMenu`.
+/// Renders nothing on a single-display machine; callers gate their own
+/// dividers on `model.isAvailable` so no orphan separators remain.
+struct WindowMovementMenuSection: View {
+    let model: WindowMoveMenuModel
+    let onMove: (WindowMoveMenuModel.Display) -> Void
+    var onPlace: ((WindowMoveMenuModel.Display, TilePosition) -> Void)? = nil
+
+    var body: some View {
+        if model.isAvailable {
+            if let next = model.nextDisplay {
+                Button {
+                    onMove(next)
+                } label: {
+                    Label(model.nextMonitorTitle, systemImage: "arrow.right.square")
+                }
+                .accessibilityLabel(model.moveAccessibilityLabel(to: next))
+            }
+
+            Menu(model.moveToMonitorTitle) {
+                ForEach(model.displays, id: \.index) { display in
+                    Button {
+                        onMove(display)
+                    } label: {
+                        if display.isCurrent {
+                            Label(display.name, systemImage: "checkmark")
+                        } else {
+                            Text(display.name)
+                        }
+                    }
+                    .disabled(display.isCurrent)
+                    .accessibilityLabel(model.moveAccessibilityLabel(to: display))
+                }
+            }
+
+            if model.includesPlacement, let onPlace, let target = model.targets.first {
+                Menu(model.movePlaceTitle) {
+                    ForEach(model.displays, id: \.index) { display in
+                        Menu(display.isCurrent ? "\(display.name) (Current)" : display.name) {
+                            ForEach(WindowMoveMenuModel.placementSlots) { slot in
+                                Button {
+                                    onPlace(display, slot)
+                                } label: {
+                                    Label(slot.label, systemImage: slot.icon)
+                                }
+                                .accessibilityLabel(model.placeAccessibilityLabel(slot: slot, on: display))
+                            }
+                        }
+                    }
+                }
+                .accessibilityLabel("Move window \(target.wid) to a monitor and slot")
+            }
+        }
+    }
+}
+
+// MARK: - AppKit menu section
+
+/// Closure box carried on `NSMenuItem.representedObject`.
+final class WindowMovementMenuAction: NSObject {
+    let run: () -> Void
+    init(_ run: @escaping () -> Void) { self.run = run }
+}
+
+final class WindowMovementMenuTarget: NSObject {
+    static let shared = WindowMovementMenuTarget()
+
+    @objc func perform(_ sender: NSMenuItem) {
+        (sender.representedObject as? WindowMovementMenuAction)?.run()
+    }
+}
+
+/// AppKit twin of `WindowMovementMenuSection` for `NSMenu`-based surfaces
+/// (the Studio canvas). Same model, same ordering, same titles.
+enum WindowMovementMenuBuilder {
+    static func appendSection(
+        to menu: NSMenu,
+        model: WindowMoveMenuModel,
+        onMove: @escaping (WindowMoveMenuModel.Display) -> Void,
+        onPlace: ((WindowMoveMenuModel.Display, TilePosition) -> Void)? = nil
+    ) {
+        guard model.isAvailable else { return }
+
+        if let next = model.nextDisplay {
+            menu.addItem(actionItem(
+                title: model.nextMonitorTitle,
+                accessibilityLabel: model.moveAccessibilityLabel(to: next)
+            ) { onMove(next) })
+        }
+
+        let moveItem = NSMenuItem(title: model.moveToMonitorTitle, action: nil, keyEquivalent: "")
+        let moveSubmenu = NSMenu()
+        for display in model.displays {
+            if display.isCurrent {
+                // No action → auto-disabled; checkmark marks the current display.
+                let item = NSMenuItem(title: display.name, action: nil, keyEquivalent: "")
+                item.state = .on
+                item.setAccessibilityLabel("\(display.name), current display")
+                moveSubmenu.addItem(item)
+            } else {
+                moveSubmenu.addItem(actionItem(
+                    title: display.name,
+                    accessibilityLabel: model.moveAccessibilityLabel(to: display)
+                ) { onMove(display) })
+            }
+        }
+        moveItem.submenu = moveSubmenu
+        menu.addItem(moveItem)
+
+        guard model.includesPlacement, let onPlace else { return }
+        let placeItem = NSMenuItem(title: model.movePlaceTitle, action: nil, keyEquivalent: "")
+        let placeSubmenu = NSMenu()
+        for display in model.displays {
+            let title = display.isCurrent ? "\(display.name) (Current)" : display.name
+            let displayItem = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+            let slotSubmenu = NSMenu()
+            for slot in WindowMoveMenuModel.placementSlots {
+                slotSubmenu.addItem(actionItem(
+                    title: slot.label,
+                    accessibilityLabel: model.placeAccessibilityLabel(slot: slot, on: display)
+                ) { onPlace(display, slot) })
+            }
+            displayItem.submenu = slotSubmenu
+            placeSubmenu.addItem(displayItem)
+        }
+        placeItem.submenu = placeSubmenu
+        menu.addItem(placeItem)
+    }
+
+    private static func actionItem(
+        title: String,
+        accessibilityLabel: String,
+        run: @escaping () -> Void
+    ) -> NSMenuItem {
+        let item = NSMenuItem(
+            title: title,
+            action: #selector(WindowMovementMenuTarget.perform(_:)),
+            keyEquivalent: ""
+        )
+        item.target = WindowMovementMenuTarget.shared
+        item.representedObject = WindowMovementMenuAction(run)
+        item.setAccessibilityLabel(accessibilityLabel)
+        return item
+    }
+}

--- a/apps/mac/Sources/Core/Desktop/WindowMovementService.swift
+++ b/apps/mac/Sources/Core/Desktop/WindowMovementService.swift
@@ -95,6 +95,10 @@ enum WindowMovementService {
     struct Outcome {
         let ok: Bool
         let message: String
+        /// Windows whose move actually executed and verified (`status == "ok"`).
+        /// Blocked/failed/unverified targets are excluded so callers reconcile
+        /// only windows that truly changed.
+        let movedWids: [UInt32]
     }
 
     /// Live display topology in API index order, resolved through SkyLight +
@@ -149,7 +153,7 @@ enum WindowMovementService {
         completion: @escaping (Outcome) -> Void
     ) {
         run(completion: completion) {
-            var okCount = 0
+            var okWids: [UInt32] = []
             var blocked = false
             for target in targets {
                 let params = JSON.object([
@@ -159,7 +163,7 @@ enum WindowMovementService {
                 do {
                     let receipt = try ActionRuntime.shared.executeWindowMove(params: params, source: "app.context-menu")
                     switch receipt["status"]?.stringValue {
-                    case "ok": okCount += 1
+                    case "ok": okWids.append(target.wid)
                     case "blocked": blocked = true
                     default: break
                     }
@@ -167,7 +171,7 @@ enum WindowMovementService {
                     DiagnosticLog.shared.error("[Move] wid \(target.wid) → display \(display.index): \(error)")
                 }
             }
-            return moveOutcome(okCount: okCount, total: targets.count, blocked: blocked, displayName: display.name)
+            return moveOutcome(okWids: okWids, total: targets.count, blocked: blocked, displayName: display.name)
         }
     }
 
@@ -189,35 +193,37 @@ enum WindowMovementService {
                 let receipt = try ActionRuntime.shared.executeWindowPlace(params: params, source: "app.context-menu")
                 switch receipt["status"]?.stringValue {
                 case "ok":
-                    return Outcome(ok: true, message: "Placed \(slot.label) on \(display.name)")
+                    return Outcome(ok: true, message: "Placed \(slot.label) on \(display.name)", movedWids: [target.wid])
                 case "blocked":
-                    return Outcome(ok: false, message: "Grant Accessibility to move windows")
+                    return Outcome(ok: false, message: "Grant Accessibility to move windows", movedWids: [])
                 default:
-                    return Outcome(ok: false, message: "Placement not verified on \(display.name)")
+                    return Outcome(ok: false, message: "Placement not verified on \(display.name)", movedWids: [])
                 }
             } catch {
                 DiagnosticLog.shared.error("[Place] wid \(target.wid) → display \(display.index) \(slot.rawValue): \(error)")
-                return Outcome(ok: false, message: "Placement failed: \(shortError(error))")
+                return Outcome(ok: false, message: "Placement failed: \(shortError(error))", movedWids: [])
             }
         }
     }
 
-    /// Truthful receipt text: full success, blocked-on-permissions, partial,
-    /// and executed-but-unverified are reported as what they are.
-    static func moveOutcome(okCount: Int, total: Int, blocked: Bool, displayName: String) -> Outcome {
+    /// Truthful receipt: full success, blocked-on-permissions, partial, and
+    /// executed-but-unverified are reported as what they are, and only the
+    /// wids that verifiably moved are carried for reconciliation.
+    static func moveOutcome(okWids: [UInt32], total: Int, blocked: Bool, displayName: String) -> Outcome {
+        let okCount = okWids.count
         if okCount == total {
             let message = total > 1
                 ? "Moved \(total) windows to \(displayName)"
                 : "Moved to \(displayName)"
-            return Outcome(ok: true, message: message)
+            return Outcome(ok: true, message: message, movedWids: okWids)
         }
         if blocked, okCount == 0 {
-            return Outcome(ok: false, message: "Grant Accessibility to move windows")
+            return Outcome(ok: false, message: "Grant Accessibility to move windows", movedWids: [])
         }
         if okCount > 0 {
-            return Outcome(ok: false, message: "Moved \(okCount)/\(total) windows to \(displayName)")
+            return Outcome(ok: false, message: "Moved \(okCount)/\(total) windows to \(displayName)", movedWids: okWids)
         }
-        return Outcome(ok: false, message: "Move not verified — window may not have reached \(displayName)")
+        return Outcome(ok: false, message: "Move not verified — window may not have reached \(displayName)", movedWids: [])
     }
 
     private static func run(

--- a/apps/mac/Sources/Core/Desktop/WindowMovementService.swift
+++ b/apps/mac/Sources/Core/Desktop/WindowMovementService.swift
@@ -74,6 +74,14 @@ struct WindowMoveMenuModel: Equatable {
     /// slot would stack into one overlapping pile.
     var includesPlacement: Bool { isAvailable && targetCount == 1 }
 
+    /// The anchor display is unpickable only for a single-window menu. A
+    /// multi-selection can span monitors, so its members may legitimately
+    /// gather onto the clicked window's display; it stays checked as the
+    /// anchor but remains selectable.
+    func isDisabled(_ display: Display) -> Bool {
+        display.isCurrent && targetCount == 1
+    }
+
     func moveAccessibilityLabel(to display: Display) -> String {
         targetCount > 1
             ? "Move \(targetCount) windows to \(display.name)"
@@ -135,13 +143,6 @@ enum WindowMovementService {
             displays: displays(anchorScreen: WindowTiler.screenForWindowFrame(windowFrame)),
             targets: targets
         )
-    }
-
-    /// Menu model anchored on an `NSScreen.screens` index (Studio entries).
-    static func menuModel(nsScreenIndex: Int, targets: [WindowMoveMenuModel.Target]) -> WindowMoveMenuModel {
-        let screens = NSScreen.screens
-        let anchor = screens.indices.contains(nsScreenIndex) ? screens[nsScreenIndex] : nil
-        return WindowMoveMenuModel(displays: displays(anchorScreen: anchor), targets: targets)
     }
 
     /// Move each target to `display`, preserving each window's own normalized
@@ -277,7 +278,7 @@ struct WindowMovementMenuSection: View {
                             Text(display.name)
                         }
                     }
-                    .disabled(display.isCurrent)
+                    .disabled(model.isDisabled(display))
                     .accessibilityLabel(model.moveAccessibilityLabel(to: display))
                 }
             }
@@ -340,17 +341,19 @@ enum WindowMovementMenuBuilder {
         let moveItem = NSMenuItem(title: model.moveToMonitorTitle, action: nil, keyEquivalent: "")
         let moveSubmenu = NSMenu()
         for display in model.displays {
-            if display.isCurrent {
+            if model.isDisabled(display) {
                 // No action → auto-disabled; checkmark marks the current display.
                 let item = NSMenuItem(title: display.name, action: nil, keyEquivalent: "")
                 item.state = .on
                 item.setAccessibilityLabel("\(display.name), current display")
                 moveSubmenu.addItem(item)
             } else {
-                moveSubmenu.addItem(actionItem(
+                let item = actionItem(
                     title: display.name,
                     accessibilityLabel: model.moveAccessibilityLabel(to: display)
-                ) { onMove(display) })
+                ) { onMove(display) }
+                if display.isCurrent { item.state = .on }
+                moveSubmenu.addItem(item)
             }
         }
         moveItem.submenu = moveSubmenu

--- a/apps/mac/Sources/Core/Overlays/CommandMode/CommandModeState.swift
+++ b/apps/mac/Sources/Core/Overlays/CommandMode/CommandModeState.swift
@@ -1216,6 +1216,13 @@ final class CommandModeState: ObservableObject {
         }
     }
 
+    /// Rebuild the desktop inventory snapshot in place after a window
+    /// mutation. Clearing the snapshot instead would leave the pane blank:
+    /// nothing observes a nil snapshot to trigger a rebuild.
+    func refreshDesktopInventory() {
+        desktopSnapshot = buildDesktopInventory()
+    }
+
     /// Copy a text representation of the desktop inventory to clipboard
     func copyInventoryToClipboard() {
         guard let snapshot = desktopSnapshot else { return }

--- a/apps/mac/Sources/Core/Overlays/CommandMode/CommandModeView.swift
+++ b/apps/mac/Sources/Core/Overlays/CommandMode/CommandModeView.swift
@@ -1034,6 +1034,11 @@ struct CommandModeView: View {
     private func windowContextMenu(for window: DesktopInventorySnapshot.InventoryWindowInfo) -> some View {
         let multiSelected = state.selectedWindowIds.count > 1 && state.isSelected(window.id)
         let selCount = state.selectedWindowIds.count
+        let moveTargets = WindowMoveMenuModel.resolveTargets(
+            clicked: .init(wid: window.id, pid: window.pid),
+            selection: selectedWindows.map { .init(wid: $0.id, pid: $0.pid) }
+        )
+        let moveModel = WindowMovementService.menuModel(windowFrame: window.frame, targets: moveTargets)
 
         if multiSelected {
             // Multi-select context menu
@@ -1053,6 +1058,15 @@ struct CommandModeView: View {
                 state.distributeSelected()
             } label: {
                 Label("Distribute (\(selCount))", systemImage: "rectangle.split.3x1")
+            }
+
+            if moveModel.isAvailable {
+                Divider()
+
+                WindowMovementMenuSection(
+                    model: moveModel,
+                    onMove: { display in moveSelection(moveModel.targets, to: display) }
+                )
             }
 
             Divider()
@@ -1115,6 +1129,16 @@ struct CommandModeView: View {
 
             Divider()
 
+            if moveModel.isAvailable {
+                WindowMovementMenuSection(
+                    model: moveModel,
+                    onMove: { display in moveSelection(moveModel.targets, to: display) },
+                    onPlace: { display, slot in placeWindow(moveModel.targets, on: display, slot: slot) }
+                )
+
+                Divider()
+            }
+
             Menu("Tile Window") {
                 ForEach(TilePosition.allCases) { tile in
                     Button {
@@ -1144,6 +1168,24 @@ struct CommandModeView: View {
             } label: {
                 Label("Copy Info", systemImage: "doc.on.doc")
             }
+        }
+    }
+
+    /// Immediate cross-monitor move through the canonical `window.move`
+    /// engine; flashes a truthful receipt and refreshes the inventory while
+    /// the selection (tracked by wid) survives the reload.
+    private func moveSelection(_ targets: [WindowMoveMenuModel.Target], to display: WindowMoveMenuModel.Display) {
+        WindowMovementService.moveTargets(targets, to: display) { outcome in
+            state.flash(outcome.message)
+            state.desktopSnapshot = nil
+        }
+    }
+
+    private func placeWindow(_ targets: [WindowMoveMenuModel.Target], on display: WindowMoveMenuModel.Display, slot: TilePosition) {
+        guard let target = targets.first else { return }
+        WindowMovementService.placeTarget(target, on: display, slot: slot) { outcome in
+            state.flash(outcome.message)
+            state.desktopSnapshot = nil
         }
     }
 

--- a/apps/mac/Sources/Core/Overlays/CommandMode/CommandModeView.swift
+++ b/apps/mac/Sources/Core/Overlays/CommandMode/CommandModeView.swift
@@ -1144,7 +1144,7 @@ struct CommandModeView: View {
                     Button {
                         WindowTiler.tileWindowById(wid: window.id, pid: window.pid, to: tile)
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                            state.desktopSnapshot = nil
+                            state.refreshDesktopInventory()
                         }
                     } label: {
                         Label(tile.label, systemImage: tile.icon)
@@ -1177,7 +1177,7 @@ struct CommandModeView: View {
     private func moveSelection(_ targets: [WindowMoveMenuModel.Target], to display: WindowMoveMenuModel.Display) {
         WindowMovementService.moveTargets(targets, to: display) { outcome in
             state.flash(outcome.message)
-            state.desktopSnapshot = nil
+            state.refreshDesktopInventory()
         }
     }
 
@@ -1185,7 +1185,7 @@ struct CommandModeView: View {
         guard let target = targets.first else { return }
         WindowMovementService.placeTarget(target, on: display, slot: slot) { outcome in
             state.flash(outcome.message)
-            state.desktopSnapshot = nil
+            state.refreshDesktopInventory()
         }
     }
 

--- a/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapState.swift
+++ b/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapState.swift
@@ -143,6 +143,32 @@ enum CanvasDragMode {
 // MARK: - Screen Map Editor State
 
 final class ScreenMapEditorState: ObservableObject {
+    /// Pure merge for the immediate-movement reconcile path: entries whose id
+    /// appears in `movedFrames` are rebuilt from that live frame (original,
+    /// edited, and virtual frames reset; display recomputed; staged edits
+    /// cleared because the real window now defines truth). Every other entry
+    /// is returned untouched, so unrelated staged frame/layer/canvas edits
+    /// survive by construction.
+    static func updatingMovedWindows(
+        _ windows: [ScreenMapWindowEntry],
+        movedFrames: [UInt32: CGRect],
+        displayIndexForFrame: (CGRect) -> Int?
+    ) -> [ScreenMapWindowEntry] {
+        windows.map { old in
+            guard let frame = movedFrames[old.id] else { return old }
+            return ScreenMapWindowEntry(
+                id: old.id, pid: old.pid, app: old.app, title: old.title,
+                originalFrame: frame, editedFrame: frame, virtualFrame: frame,
+                zIndex: old.zIndex, layer: old.layer,
+                displayIndex: displayIndexForFrame(frame) ?? old.displayIndex,
+                isOnScreen: old.isOnScreen,
+                latticesSession: old.latticesSession,
+                tmuxCommand: old.tmuxCommand,
+                tmuxPaneTitle: old.tmuxPaneTitle
+            )
+        }
+    }
+
     @Published var windows: [ScreenMapWindowEntry]
     @Published var selectedLayers: Set<Int> = []  // empty = show all
     @Published var draggingWindowId: UInt32? = nil
@@ -1696,29 +1722,10 @@ final class ScreenMapController: ObservableObject {
         let screens = NSScreen.screens
         let primaryHeight = screens.first?.frame.height ?? 0
 
+        let displayCGRects = Self.displayCGRects(screens: screens, primaryHeight: primaryHeight)
+
         func displayIndex(for frame: CGRect) -> Int {
-            let centerX = frame.midX
-            let centerY = frame.midY
-            for (i, screen) in screens.enumerated() {
-                let cgOriginY = primaryHeight - screen.frame.maxY
-                let cgRect = CGRect(x: screen.frame.origin.x, y: cgOriginY,
-                                    width: screen.frame.width, height: screen.frame.height)
-                if cgRect.contains(CGPoint(x: centerX, y: centerY)) {
-                    return i
-                }
-            }
-            var bestIdx = 0
-            var bestDist = CGFloat.infinity
-            for (i, screen) in screens.enumerated() {
-                let cgOriginY = primaryHeight - screen.frame.maxY
-                let cgRect = CGRect(x: screen.frame.origin.x, y: cgOriginY,
-                                    width: screen.frame.width, height: screen.frame.height)
-                let dx = centerX - cgRect.midX
-                let dy = centerY - cgRect.midY
-                let dist = dx * dx + dy * dy
-                if dist < bestDist { bestDist = dist; bestIdx = i }
-            }
-            return bestIdx
+            Self.displayIndex(forCGFrame: frame, displayCGRects: displayCGRects)
         }
 
         var ordered: [CGWin] = []
@@ -1872,6 +1879,73 @@ final class ScreenMapController: ObservableObject {
                   self.editor?.activeViewportPreset == .overview else { return }
             self.focusViewportPreset(.overview, flashView: false)
         }
+    }
+
+    /// NSScreen frames converted to the CG top-left global coordinate space
+    /// used by window bounds, in `NSScreen.screens` order.
+    static func displayCGRects(screens: [NSScreen], primaryHeight: CGFloat) -> [CGRect] {
+        screens.map { screen in
+            CGRect(
+                x: screen.frame.origin.x,
+                y: primaryHeight - screen.frame.maxY,
+                width: screen.frame.width,
+                height: screen.frame.height
+            )
+        }
+    }
+
+    /// Which display (by `NSScreen.screens` index) owns a CG top-left frame:
+    /// midpoint containment first, nearest display center as fallback.
+    static func displayIndex(forCGFrame frame: CGRect, displayCGRects: [CGRect]) -> Int {
+        let center = CGPoint(x: frame.midX, y: frame.midY)
+        for (i, cgRect) in displayCGRects.enumerated() where cgRect.contains(center) {
+            return i
+        }
+        var bestIdx = 0
+        var bestDist = CGFloat.infinity
+        for (i, cgRect) in displayCGRects.enumerated() {
+            let dx = center.x - cgRect.midX
+            let dy = center.y - cgRect.midY
+            let dist = dx * dx + dy * dy
+            if dist < bestDist { bestDist = dist; bestIdx = i }
+        }
+        return bestIdx
+    }
+
+    /// Refresh only the windows an immediate move touched: their entries are
+    /// rebuilt from live desktop geometry (frames reset, display recomputed)
+    /// while every other entry — staged frame edits, layer reassignments,
+    /// canvas positions — and the selection stay untouched.
+    func applyLiveFrames(for wids: Set<UInt32>) {
+        guard let editor, !wids.isEmpty else { return }
+        let frames = Self.liveWindowFrames(for: wids)
+        guard !frames.isEmpty else { return }
+        let screens = NSScreen.screens
+        let primaryHeight = screens.first?.frame.height ?? 0
+        let displayCGRects = Self.displayCGRects(screens: screens, primaryHeight: primaryHeight)
+        editor.windows = ScreenMapEditorState.updatingMovedWindows(
+            editor.windows,
+            movedFrames: frames,
+            displayIndexForFrame: { Self.displayIndex(forCGFrame: $0, displayCGRects: displayCGRects) }
+        )
+        objectWillChange.send()
+    }
+
+    private static func liveWindowFrames(for wids: Set<UInt32>) -> [UInt32: CGRect] {
+        guard let windowList = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID
+        ) as? [[String: Any]] else { return [:] }
+        var frames: [UInt32: CGRect] = [:]
+        for info in windowList {
+            guard let wid = info[kCGWindowNumber as String] as? UInt32,
+                  wids.contains(wid),
+                  let boundsDict = info[kCGWindowBounds as String] as? NSDictionary else { continue }
+            var rect = CGRect.zero
+            if CGRectMakeWithDictionaryRepresentation(boundsDict, &rect) {
+                frames[wid] = rect
+            }
+        }
+        return frames
     }
 
     /// Re-snapshot, preserving display/layer context

--- a/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapState.swift
+++ b/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapState.swift
@@ -109,6 +109,25 @@ struct ScreenMapWindowEntry: Identifiable {
     var tmuxPaneTitle: String?  // tmux pane title (often cwd or custom label)
     var hasEdits: Bool { originalFrame != editedFrame }
 
+    /// Snapshot of every field the Studio user can stage on an entry. Captured
+    /// when an immediate move starts so its async completion can detect edits
+    /// made while verification was pending.
+    struct StagingFingerprint: Equatable {
+        let editedFrame: CGRect
+        let virtualFrame: CGRect
+        let layer: Int
+        let displayIndex: Int
+    }
+
+    var stagingFingerprint: StagingFingerprint {
+        StagingFingerprint(
+            editedFrame: editedFrame,
+            virtualFrame: virtualFrame,
+            layer: layer,
+            displayIndex: displayIndex
+        )
+    }
+
     /// Rich search key combining all available metadata.
     /// Format: m{spatial}.L{layer}.{layerName}.{app}.{title}.{session}.{command}.{paneTitle}.{state}
     /// Example: m1.L0.primary.terminal.~/dev/lattices.session:myproject.cmd:vim.visible
@@ -149,13 +168,38 @@ final class ScreenMapEditorState: ObservableObject {
     /// cleared because the real window now defines truth). Every other entry
     /// is returned untouched, so unrelated staged frame/layer/canvas edits
     /// survive by construction.
+    ///
+    /// `expectedFingerprints` carries each target's staged state (edited and
+    /// virtual frames, layer, display) captured when the move was requested:
+    /// the async verification takes up to ~0.8s per window, and the entry
+    /// stays editable meanwhile. If the fingerprint still matches, the entry
+    /// resets fully to live truth. If the user staged anything newer during
+    /// the wait, the verified live frame still becomes the new
+    /// `originalFrame` baseline (the real move did happen — reset/undo and
+    /// `hasEdits` must not compare against the stale pre-move origin) while
+    /// the newer staged fields stay pending.
     static func updatingMovedWindows(
         _ windows: [ScreenMapWindowEntry],
         movedFrames: [UInt32: CGRect],
+        expectedFingerprints: [UInt32: ScreenMapWindowEntry.StagingFingerprint] = [:],
         displayIndexForFrame: (CGRect) -> Int?
     ) -> [ScreenMapWindowEntry] {
         windows.map { old in
             guard let frame = movedFrames[old.id] else { return old }
+            if let expected = expectedFingerprints[old.id], expected != old.stagingFingerprint {
+                return ScreenMapWindowEntry(
+                    id: old.id, pid: old.pid, app: old.app, title: old.title,
+                    originalFrame: frame,
+                    editedFrame: old.editedFrame,
+                    virtualFrame: old.virtualFrame,
+                    zIndex: old.zIndex, layer: old.layer,
+                    displayIndex: old.displayIndex,
+                    isOnScreen: old.isOnScreen,
+                    latticesSession: old.latticesSession,
+                    tmuxCommand: old.tmuxCommand,
+                    tmuxPaneTitle: old.tmuxPaneTitle
+                )
+            }
             return ScreenMapWindowEntry(
                 id: old.id, pid: old.pid, app: old.app, title: old.title,
                 originalFrame: frame, editedFrame: frame, virtualFrame: frame,
@@ -1915,8 +1959,13 @@ final class ScreenMapController: ObservableObject {
     /// Refresh only the windows an immediate move touched: their entries are
     /// rebuilt from live desktop geometry (frames reset, display recomputed)
     /// while every other entry — staged frame edits, layer reassignments,
-    /// canvas positions — and the selection stay untouched.
-    func applyLiveFrames(for wids: Set<UInt32>) {
+    /// canvas positions — and the selection stay untouched. Entries the user
+    /// re-staged after `expectedFingerprints` was captured keep their newer
+    /// staged state over the fresh live baseline.
+    func applyLiveFrames(
+        for wids: Set<UInt32>,
+        expectedFingerprints: [UInt32: ScreenMapWindowEntry.StagingFingerprint] = [:]
+    ) {
         guard let editor, !wids.isEmpty else { return }
         let frames = Self.liveWindowFrames(for: wids)
         guard !frames.isEmpty else { return }
@@ -1926,6 +1975,7 @@ final class ScreenMapController: ObservableObject {
         editor.windows = ScreenMapEditorState.updatingMovedWindows(
             editor.windows,
             movedFrames: frames,
+            expectedFingerprints: expectedFingerprints,
             displayIndexForFrame: { Self.displayIndex(forCGFrame: $0, displayCGRects: displayCGRects) }
         )
         objectWillChange.send()

--- a/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapView.swift
+++ b/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapView.swift
@@ -4027,25 +4027,42 @@ struct ScreenMapView: View {
     }
 
     private func moveStudioTargets(_ targets: [WindowMoveMenuModel.Target], to display: WindowMoveMenuModel.Display) {
+        let fingerprints = stagedFingerprints(for: targets)
         WindowMovementService.moveTargets(targets, to: display) { outcome in
-            finishStudioMovement(outcome)
+            finishStudioMovement(outcome, expectedFingerprints: fingerprints)
         }
     }
 
     private func placeStudioTarget(_ targets: [WindowMoveMenuModel.Target], on display: WindowMoveMenuModel.Display, slot: TilePosition) {
         guard let target = targets.first else { return }
+        let fingerprints = stagedFingerprints(for: [target])
         WindowMovementService.placeTarget(target, on: display, slot: slot) { outcome in
-            finishStudioMovement(outcome)
+            finishStudioMovement(outcome, expectedFingerprints: fingerprints)
+        }
+    }
+
+    /// Per-target staging fingerprint (edited/virtual frames, layer, display)
+    /// captured at action start so the completion can tell whether the user
+    /// staged anything on a target while the async verification was pending.
+    private func stagedFingerprints(for targets: [WindowMoveMenuModel.Target]) -> [UInt32: ScreenMapWindowEntry.StagingFingerprint] {
+        guard let editor = controller.editor else { return [:] }
+        let wids = Set(targets.map(\.wid))
+        return editor.windows.reduce(into: [UInt32: ScreenMapWindowEntry.StagingFingerprint]()) { acc, win in
+            if wids.contains(win.id) { acc[win.id] = win.stagingFingerprint }
         }
     }
 
     /// Targeted reconcile after an immediate move: only windows that
     /// verifiably moved (`outcome.movedWids`) are refreshed from live desktop
-    /// geometry — a failed or blocked target keeps its staged edits, and
-    /// unrelated staged frame/layer/canvas edits, the selection, search, and
-    /// the viewport all stay exactly as they were. Then flash the receipt.
-    private func finishStudioMovement(_ outcome: WindowMovementService.Outcome) {
-        controller.applyLiveFrames(for: Set(outcome.movedWids))
+    /// geometry — a failed or blocked target keeps its staged edits; a target
+    /// re-staged while verification was pending keeps its newer staged state
+    /// on a fresh live `originalFrame` baseline; and unrelated staged edits,
+    /// the selection, search, and the viewport all stay exactly as they were.
+    private func finishStudioMovement(
+        _ outcome: WindowMovementService.Outcome,
+        expectedFingerprints: [UInt32: ScreenMapWindowEntry.StagingFingerprint]
+    ) {
+        controller.applyLiveFrames(for: Set(outcome.movedWids), expectedFingerprints: expectedFingerprints)
         controller.flash(outcome.message)
     }
 

--- a/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapView.swift
+++ b/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapView.swift
@@ -1939,9 +1939,35 @@ struct ScreenMapView: View {
         .highPriorityGesture(TapGesture().onEnded {
             controller.selectSingle(win.id)
         })
+        .contextMenu { sidebarWindowContextMenu(win: win) }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(win.title.isEmpty ? win.app : "\(win.app), \(win.title)")
         .accessibilityAddTraits(.isButton)
+    }
+
+    /// Context menu for Studio sidebar window rows: the same immediate
+    /// movement section as the canvas, plus Show on Screen so the menu is
+    /// never empty on a single-display machine.
+    @ViewBuilder
+    private func sidebarWindowContextMenu(win: ScreenMapWindowEntry) -> some View {
+        Button {
+            controller.focusWindowOnScreen(win.id)
+        } label: {
+            Label("Show on Screen", systemImage: "macwindow")
+        }
+
+        if let editor = controller.editor {
+            let model = studioMoveModel(for: win, editor: editor)
+            if model.isAvailable {
+                Divider()
+
+                WindowMovementMenuSection(
+                    model: model,
+                    onMove: { display in moveStudioTargets(model.targets, to: display) },
+                    onPlace: { display, slot in placeStudioTarget(model.targets, on: display, slot: slot) }
+                )
+            }
+        }
     }
 
     @ViewBuilder
@@ -2007,6 +2033,7 @@ struct ScreenMapView: View {
                         .simultaneousGesture(TapGesture().onEnded {
                             selectSidebarWindow(win.id)
                         })
+                        .contextMenu { sidebarWindowContextMenu(win: win) }
                     }
                 }
                 .padding(.leading, 4)
@@ -3976,6 +4003,44 @@ struct ScreenMapView: View {
 
     // MARK: - Context Menu
 
+    /// Shared movement model for Studio surfaces: a right-click on a member
+    /// of a multi-selection targets the whole selection, otherwise just the
+    /// clicked window. Display topology comes from the shared service.
+    private func studioMoveModel(for win: ScreenMapWindowEntry, editor: ScreenMapEditorState) -> WindowMoveMenuModel {
+        let selection = controller.selectedWindowIds
+        let selectionTargets = editor.windows
+            .filter { selection.contains($0.id) }
+            .map { WindowMoveMenuModel.Target(wid: $0.id, pid: $0.pid) }
+        let targets = WindowMoveMenuModel.resolveTargets(
+            clicked: WindowMoveMenuModel.Target(wid: win.id, pid: win.pid),
+            selection: selectionTargets
+        )
+        return WindowMovementService.menuModel(nsScreenIndex: win.displayIndex, targets: targets)
+    }
+
+    private func moveStudioTargets(_ targets: [WindowMoveMenuModel.Target], to display: WindowMoveMenuModel.Display) {
+        WindowMovementService.moveTargets(targets, to: display) { outcome in
+            finishStudioMovement(outcome)
+        }
+    }
+
+    private func placeStudioTarget(_ targets: [WindowMoveMenuModel.Target], on display: WindowMoveMenuModel.Display, slot: TilePosition) {
+        guard let target = targets.first else { return }
+        WindowMovementService.placeTarget(target, on: display, slot: slot) { outcome in
+            finishStudioMovement(outcome)
+        }
+    }
+
+    /// Re-snapshot the map so the canvas reflects the real desktop, restore
+    /// the selection (tracked by wid), then flash the truthful receipt.
+    /// `ScreenMapController.refresh()` is synchronous.
+    private func finishStudioMovement(_ outcome: WindowMovementService.Outcome) {
+        let selection = controller.selectedWindowIds
+        controller.refresh()
+        controller.selectedWindowIds = selection
+        controller.flash(outcome.message)
+    }
+
     private func showLayerContextMenu(for windowId: UInt32, at point: NSPoint, in window: NSWindow, editor: ScreenMapEditorState) {
         guard let winIdx = editor.windows.firstIndex(where: { $0.id == windowId }) else { return }
         let win = editor.windows[winIdx]
@@ -3995,6 +4060,19 @@ struct ScreenMapView: View {
         menu.addItem(focusItem)
 
         menu.addItem(.separator())
+
+        // Immediate cross-monitor movement — same canonical engine as
+        // window.move / window.place. Absent on single-display machines.
+        let moveModel = studioMoveModel(for: win, editor: editor)
+        if moveModel.isAvailable {
+            WindowMovementMenuBuilder.appendSection(
+                to: menu,
+                model: moveModel,
+                onMove: { display in moveStudioTargets(moveModel.targets, to: display) },
+                onPlace: { display, slot in placeStudioTarget(moveModel.targets, on: display, slot: slot) }
+            )
+            menu.addItem(.separator())
+        }
 
         // Move to Layer → submenu
         let moveItem = NSMenuItem(title: "Move to Layer", action: nil, keyEquivalent: "")

--- a/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapView.swift
+++ b/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapView.swift
@@ -4005,7 +4005,9 @@ struct ScreenMapView: View {
 
     /// Shared movement model for Studio surfaces: a right-click on a member
     /// of a multi-selection targets the whole selection, otherwise just the
-    /// clicked window. Display topology comes from the shared service.
+    /// clicked window. The anchor display is resolved from the window's real
+    /// (snapshot-time) geometry, not `displayIndex` — staged cross-display
+    /// edits mutate the latter before any real move happens.
     private func studioMoveModel(for win: ScreenMapWindowEntry, editor: ScreenMapEditorState) -> WindowMoveMenuModel {
         let selection = controller.selectedWindowIds
         let selectionTargets = editor.windows
@@ -4015,7 +4017,13 @@ struct ScreenMapView: View {
             clicked: WindowMoveMenuModel.Target(wid: win.id, pid: win.pid),
             selection: selectionTargets
         )
-        return WindowMovementService.menuModel(nsScreenIndex: win.displayIndex, targets: targets)
+        let liveFrame = WindowFrame(
+            x: win.originalFrame.origin.x,
+            y: win.originalFrame.origin.y,
+            w: win.originalFrame.width,
+            h: win.originalFrame.height
+        )
+        return WindowMovementService.menuModel(windowFrame: liveFrame, targets: targets)
     }
 
     private func moveStudioTargets(_ targets: [WindowMoveMenuModel.Target], to display: WindowMoveMenuModel.Display) {

--- a/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapView.swift
+++ b/apps/mac/Sources/Core/Overlays/ScreenMap/ScreenMapView.swift
@@ -4031,13 +4031,13 @@ struct ScreenMapView: View {
         }
     }
 
-    /// Re-snapshot the map so the canvas reflects the real desktop, restore
-    /// the selection (tracked by wid), then flash the truthful receipt.
-    /// `ScreenMapController.refresh()` is synchronous.
+    /// Targeted reconcile after an immediate move: only windows that
+    /// verifiably moved (`outcome.movedWids`) are refreshed from live desktop
+    /// geometry — a failed or blocked target keeps its staged edits, and
+    /// unrelated staged frame/layer/canvas edits, the selection, search, and
+    /// the viewport all stay exactly as they were. Then flash the receipt.
     private func finishStudioMovement(_ outcome: WindowMovementService.Outcome) {
-        let selection = controller.selectedWindowIds
-        controller.refresh()
-        controller.selectedWindowIds = selection
+        controller.applyLiveFrames(for: Set(outcome.movedWids))
         controller.flash(outcome.message)
     }
 

--- a/apps/mac/Tests/CommandModeInventoryRefreshTests.swift
+++ b/apps/mac/Tests/CommandModeInventoryRefreshTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import Lattices
+
+/// Regression guard for the Inventory movement completion: refreshing the
+/// desktop inventory must assign a fresh snapshot (never leave it nil/blank)
+/// and must not disturb the selection.
+final class CommandModeInventoryRefreshTests: XCTestCase {
+    func testRefreshDesktopInventoryProducesSnapshotAndKeepsSelection() {
+        let state = CommandModeState()
+        state.selectedWindowIds = [42, 7]
+        XCTAssertNil(state.desktopSnapshot)
+
+        state.refreshDesktopInventory()
+
+        XCTAssertNotNil(state.desktopSnapshot)
+        XCTAssertEqual(state.selectedWindowIds, [42, 7])
+    }
+}

--- a/apps/mac/Tests/ScreenMapMovedWindowTests.swift
+++ b/apps/mac/Tests/ScreenMapMovedWindowTests.swift
@@ -1,0 +1,184 @@
+import CoreGraphics
+import XCTest
+@testable import Lattices
+
+/// Regression coverage for the Studio immediate-movement reconcile path:
+/// `ScreenMapEditorState.updatingMovedWindows` must refresh moved entries
+/// from live geometry while leaving every unrelated staged frame/layer/canvas
+/// edit untouched — no editor rebuild, deterministic without GUI automation.
+final class ScreenMapMovedWindowTests: XCTestCase {
+    private func entry(
+        id: UInt32,
+        frame: CGRect,
+        edited: CGRect? = nil,
+        virtualFrame: CGRect? = nil,
+        layer: Int = 0,
+        displayIndex: Int = 0
+    ) -> ScreenMapWindowEntry {
+        ScreenMapWindowEntry(
+            id: id, pid: Int32(id) + 100, app: "App\(id)", title: "Title \(id)",
+            originalFrame: frame,
+            editedFrame: edited ?? frame,
+            virtualFrame: virtualFrame ?? frame,
+            zIndex: Int(id), layer: layer, displayIndex: displayIndex,
+            isOnScreen: true,
+            latticesSession: "sess-\(id)",
+            tmuxCommand: "vim",
+            tmuxPaneTitle: "pane-\(id)"
+        )
+    }
+
+    func testMovedWindowAdoptsLiveFrameAndDisplay() {
+        let old = CGRect(x: 100, y: 100, width: 800, height: 600)
+        let live = CGRect(x: 3600, y: 400, width: 900, height: 700)
+        let updated = ScreenMapEditorState.updatingMovedWindows(
+            [entry(id: 1, frame: old, displayIndex: 0)],
+            movedFrames: [1: live],
+            displayIndexForFrame: { _ in 1 }
+        )
+        XCTAssertEqual(updated[0].originalFrame, live)
+        XCTAssertEqual(updated[0].editedFrame, live)
+        XCTAssertEqual(updated[0].virtualFrame, live)
+        XCTAssertEqual(updated[0].displayIndex, 1)
+        XCTAssertFalse(updated[0].hasEdits)
+    }
+
+    func testUnrelatedStagedEditsSurviveUntouched() {
+        let base = CGRect(x: 0, y: 0, width: 500, height: 400)
+        let staged = CGRect(x: 40, y: 40, width: 640, height: 480)
+        let canvasSpot = CGRect(x: 9000, y: 9000, width: 500, height: 400)
+        let untouched = entry(
+            id: 2, frame: base, edited: staged, virtualFrame: canvasSpot,
+            layer: 3, displayIndex: 0
+        )
+        let updated = ScreenMapEditorState.updatingMovedWindows(
+            [entry(id: 1, frame: base), untouched],
+            movedFrames: [1: CGRect(x: 3600, y: 300, width: 500, height: 400)],
+            displayIndexForFrame: { _ in 1 }
+        )
+        XCTAssertEqual(updated[1].editedFrame, staged)
+        XCTAssertEqual(updated[1].virtualFrame, canvasSpot)
+        XCTAssertEqual(updated[1].layer, 3)
+        XCTAssertEqual(updated[1].originalFrame, base)
+        XCTAssertTrue(updated[1].hasEdits)
+    }
+
+    func testMovedWindowStagedEditIsReplacedByLiveTruth() {
+        let base = CGRect(x: 0, y: 0, width: 500, height: 400)
+        let staged = CGRect(x: 10, y: 10, width: 300, height: 200)
+        let live = CGRect(x: 3500, y: 300, width: 500, height: 400)
+        let updated = ScreenMapEditorState.updatingMovedWindows(
+            [entry(id: 1, frame: base, edited: staged)],
+            movedFrames: [1: live],
+            displayIndexForFrame: { _ in 1 }
+        )
+        XCTAssertEqual(updated[0].editedFrame, live)
+        XCTAssertFalse(updated[0].hasEdits)
+    }
+
+    func testMissingLiveFrameLeavesEntryUntouched() {
+        let base = CGRect(x: 0, y: 0, width: 500, height: 400)
+        let original = entry(id: 1, frame: base, layer: 2)
+        let updated = ScreenMapEditorState.updatingMovedWindows(
+            [original],
+            movedFrames: [99: CGRect(x: 1, y: 1, width: 2, height: 2)],
+            displayIndexForFrame: { _ in 1 }
+        )
+        XCTAssertEqual(updated[0].originalFrame, base)
+        XCTAssertEqual(updated[0].layer, 2)
+        XCTAssertEqual(updated[0].displayIndex, 0)
+    }
+
+    func testUnresolvableDisplayKeepsOldIndex() {
+        let live = CGRect(x: 3600, y: 300, width: 500, height: 400)
+        let updated = ScreenMapEditorState.updatingMovedWindows(
+            [entry(id: 1, frame: .init(x: 0, y: 0, width: 500, height: 400), displayIndex: 0)],
+            movedFrames: [1: live],
+            displayIndexForFrame: { _ in nil }
+        )
+        XCTAssertEqual(updated[0].displayIndex, 0)
+    }
+
+    func testMovedEntryKeepsIdentityMetadata() {
+        let live = CGRect(x: 3600, y: 300, width: 500, height: 400)
+        let updated = ScreenMapEditorState.updatingMovedWindows(
+            [entry(id: 7, frame: .init(x: 0, y: 0, width: 500, height: 400))],
+            movedFrames: [7: live],
+            displayIndexForFrame: { _ in 1 }
+        )
+        XCTAssertEqual(updated[0].id, 7)
+        XCTAssertEqual(updated[0].latticesSession, "sess-7")
+        XCTAssertEqual(updated[0].tmuxCommand, "vim")
+        XCTAssertEqual(updated[0].zIndex, 7)
+    }
+
+    func testFailedMoveReconcilesNothingAndKeepsAllStagedEdits() {
+        // A failed/blocked move produces an empty movedWids set — the
+        // reconcile pass must be an identity, even for the requested target.
+        let base = CGRect(x: 0, y: 0, width: 500, height: 400)
+        let staged = CGRect(x: 25, y: 25, width: 700, height: 500)
+        let requested = entry(id: 1, frame: base, edited: staged, layer: 4)
+        let bystander = entry(id: 2, frame: base, edited: staged)
+        let updated = ScreenMapEditorState.updatingMovedWindows(
+            [requested, bystander],
+            movedFrames: [:],
+            displayIndexForFrame: { _ in 1 }
+        )
+        XCTAssertEqual(updated[0].editedFrame, staged)
+        XCTAssertEqual(updated[0].layer, 4)
+        XCTAssertTrue(updated[0].hasEdits)
+        XCTAssertEqual(updated[1].editedFrame, staged)
+    }
+
+    func testPartialMoveRefreshesOnlySuccessfulTarget() {
+        // Batch of two where only wid 1 verifiably moved: wid 1 adopts live
+        // state, wid 2 (failed) keeps its staged edit untouched.
+        let base = CGRect(x: 0, y: 0, width: 500, height: 400)
+        let staged = CGRect(x: 25, y: 25, width: 700, height: 500)
+        let live = CGRect(x: 3600, y: 300, width: 500, height: 400)
+        let updated = ScreenMapEditorState.updatingMovedWindows(
+            [entry(id: 1, frame: base, edited: staged), entry(id: 2, frame: base, edited: staged)],
+            movedFrames: [1: live],
+            displayIndexForFrame: { _ in 1 }
+        )
+        XCTAssertEqual(updated[0].editedFrame, live)
+        XCTAssertFalse(updated[0].hasEdits)
+        XCTAssertEqual(updated[0].displayIndex, 1)
+        XCTAssertEqual(updated[1].editedFrame, staged)
+        XCTAssertTrue(updated[1].hasEdits)
+        XCTAssertEqual(updated[1].displayIndex, 0)
+    }
+
+    // MARK: - Display index resolution (hoisted from the snapshot path)
+
+    // Two displays in CG top-left space: primary 3440×1440 at origin,
+    // secondary 3840×2160 to its right, vertically offset (the layout the
+    // live smoke ran against).
+    private let displayRects = [
+        CGRect(x: 0, y: 0, width: 3440, height: 1440),
+        CGRect(x: 3440, y: 235, width: 3840, height: 2160),
+    ]
+
+    func testDisplayIndexByMidpointContainment() {
+        let onSecond = CGRect(x: 3600, y: 400, width: 800, height: 600)
+        XCTAssertEqual(
+            ScreenMapController.displayIndex(forCGFrame: onSecond, displayCGRects: displayRects),
+            1
+        )
+        let onFirst = CGRect(x: 100, y: 100, width: 800, height: 600)
+        XCTAssertEqual(
+            ScreenMapController.displayIndex(forCGFrame: onFirst, displayCGRects: displayRects),
+            0
+        )
+    }
+
+    func testDisplayIndexFallsBackToNearestCenter() {
+        // Straddling far off the top of the second display: contained by
+        // neither rect, but the second display's center is nearer.
+        let offscreen = CGRect(x: 5000, y: -400, width: 400, height: 300)
+        XCTAssertEqual(
+            ScreenMapController.displayIndex(forCGFrame: offscreen, displayCGRects: displayRects),
+            1
+        )
+    }
+}

--- a/apps/mac/Tests/ScreenMapMovedWindowTests.swift
+++ b/apps/mac/Tests/ScreenMapMovedWindowTests.swift
@@ -149,6 +149,101 @@ final class ScreenMapMovedWindowTests: XCTestCase {
         XCTAssertEqual(updated[1].displayIndex, 0)
     }
 
+    // MARK: - Edits staged while the async move was pending
+
+    func testUnchangedFingerprintResetsEntryToLiveTruth() {
+        let base = CGRect(x: 0, y: 0, width: 500, height: 400)
+        let live = CGRect(x: 3600, y: 300, width: 500, height: 400)
+        let target = entry(id: 1, frame: base)
+        let updated = ScreenMapEditorState.updatingMovedWindows(
+            [target],
+            movedFrames: [1: live],
+            expectedFingerprints: [1: target.stagingFingerprint],
+            displayIndexForFrame: { _ in 1 }
+        )
+        XCTAssertEqual(updated[0].originalFrame, live)
+        XCTAssertEqual(updated[0].editedFrame, live)
+        XCTAssertEqual(updated[0].virtualFrame, live)
+        XCTAssertEqual(updated[0].displayIndex, 1)
+        XCTAssertFalse(updated[0].hasEdits)
+    }
+
+    func testEditDuringPendingMoveKeepsNewerStagedStateOnLiveBaseline() {
+        // Fingerprint was captured before the user dragged the entry again:
+        // the verified live frame must still become the new originalFrame
+        // (the real move happened), while the newer staged fields survive.
+        let base = CGRect(x: 0, y: 0, width: 500, height: 400)
+        let live = CGRect(x: 3600, y: 300, width: 500, height: 400)
+        let newerEdit = CGRect(x: 50, y: 60, width: 640, height: 480)
+        let canvasSpot = CGRect(x: 9000, y: 9000, width: 500, height: 400)
+        let preMove = entry(id: 1, frame: base)
+        let reEdited = entry(
+            id: 1, frame: base, edited: newerEdit, virtualFrame: canvasSpot,
+            layer: 5, displayIndex: 1
+        )
+        let updated = ScreenMapEditorState.updatingMovedWindows(
+            [reEdited],
+            movedFrames: [1: live],
+            expectedFingerprints: [1: preMove.stagingFingerprint],
+            displayIndexForFrame: { _ in 0 }
+        )
+        XCTAssertEqual(updated[0].originalFrame, live)
+        XCTAssertEqual(updated[0].editedFrame, newerEdit)
+        XCTAssertEqual(updated[0].virtualFrame, canvasSpot)
+        XCTAssertEqual(updated[0].layer, 5)
+        XCTAssertEqual(updated[0].displayIndex, 1)
+        XCTAssertTrue(updated[0].hasEdits)
+    }
+
+    func testLayerChangeDuringPendingMoveIsPreserved() {
+        // A layer-only re-stage (frames untouched) must also defeat the full
+        // reset — the fingerprint covers every stageable field.
+        let base = CGRect(x: 0, y: 0, width: 500, height: 400)
+        let live = CGRect(x: 3600, y: 300, width: 500, height: 400)
+        let preMove = entry(id: 1, frame: base, layer: 0)
+        let reLayered = entry(id: 1, frame: base, layer: 3)
+        let updated = ScreenMapEditorState.updatingMovedWindows(
+            [reLayered],
+            movedFrames: [1: live],
+            expectedFingerprints: [1: preMove.stagingFingerprint],
+            displayIndexForFrame: { _ in 1 }
+        )
+        XCTAssertEqual(updated[0].originalFrame, live)
+        XCTAssertEqual(updated[0].layer, 3)
+        XCTAssertEqual(updated[0].editedFrame, base)
+    }
+
+    func testPartialSuccessWithMidFlightEditOnlyTouchesVerifiedTargets() {
+        // wid 1 verified and untouched → full reset; wid 2 verified but
+        // re-edited mid-flight → live baseline + newer edit; wid 3 failed →
+        // completely untouched.
+        let base = CGRect(x: 0, y: 0, width: 500, height: 400)
+        let live1 = CGRect(x: 3600, y: 300, width: 500, height: 400)
+        let live2 = CGRect(x: 4200, y: 300, width: 500, height: 400)
+        let newerEdit = CGRect(x: 5, y: 5, width: 300, height: 200)
+        let staged = CGRect(x: 25, y: 25, width: 700, height: 500)
+        let pristine = entry(id: 1, frame: base)
+        let reEdited = entry(id: 2, frame: base, edited: newerEdit)
+        let preMove2 = entry(id: 2, frame: base)
+        let failed = entry(id: 3, frame: base, edited: staged)
+        let updated = ScreenMapEditorState.updatingMovedWindows(
+            [pristine, reEdited, failed],
+            movedFrames: [1: live1, 2: live2],
+            expectedFingerprints: [
+                1: pristine.stagingFingerprint,
+                2: preMove2.stagingFingerprint,
+            ],
+            displayIndexForFrame: { _ in 1 }
+        )
+        XCTAssertEqual(updated[0].editedFrame, live1)
+        XCTAssertFalse(updated[0].hasEdits)
+        XCTAssertEqual(updated[1].originalFrame, live2)
+        XCTAssertEqual(updated[1].editedFrame, newerEdit)
+        XCTAssertTrue(updated[1].hasEdits)
+        XCTAssertEqual(updated[2].originalFrame, base)
+        XCTAssertEqual(updated[2].editedFrame, staged)
+    }
+
     // MARK: - Display index resolution (hoisted from the snapshot path)
 
     // Two displays in CG top-left space: primary 3440×1440 at origin,

--- a/apps/mac/Tests/WindowMoveMenuModelTests.swift
+++ b/apps/mac/Tests/WindowMoveMenuModelTests.swift
@@ -98,6 +98,25 @@ final class WindowMoveMenuModelTests: XCTestCase {
         XCTAssertFalse(model.includesPlacement)
     }
 
+    func testCurrentDisplayDisabledOnlyForSingleTarget() {
+        // Single window: its own display is not a meaningful target.
+        let single = WindowMoveMenuModel(
+            displays: [display(0, current: true), display(1)],
+            targets: [target(1)]
+        )
+        XCTAssertTrue(single.isDisabled(single.displays[0]))
+        XCTAssertFalse(single.isDisabled(single.displays[1]))
+
+        // Multi-selection may span monitors — the anchor display must stay
+        // selectable so the whole selection can gather onto it.
+        let multi = WindowMoveMenuModel(
+            displays: [display(0, current: true), display(1)],
+            targets: [target(1), target(2)]
+        )
+        XCTAssertFalse(multi.isDisabled(multi.displays[0]))
+        XCTAssertFalse(multi.isDisabled(multi.displays[1]))
+    }
+
     func testPlacementSlotsCoverCanonicalNamedPositions() {
         let slots = WindowMoveMenuModel.placementSlots
         XCTAssertTrue(slots.contains(.maximize))

--- a/apps/mac/Tests/WindowMoveMenuModelTests.swift
+++ b/apps/mac/Tests/WindowMoveMenuModelTests.swift
@@ -1,0 +1,199 @@
+import XCTest
+@testable import Lattices
+
+/// Pure-model coverage for the shared right-click movement menu used by
+/// Desktop Inventory and Studio: display cycling/wrap, current-display
+/// handling, single-display hiding, multi-selection titles and targeting,
+/// and truthful receipt summaries.
+final class WindowMoveMenuModelTests: XCTestCase {
+    private func display(_ index: Int, name: String? = nil, current: Bool = false) -> WindowMoveMenuModel.Display {
+        WindowMoveMenuModel.Display(index: index, name: name ?? "Display \(index + 1)", isCurrent: current)
+    }
+
+    private func target(_ wid: UInt32) -> WindowMoveMenuModel.Target {
+        WindowMoveMenuModel.Target(wid: wid, pid: Int32(wid) + 1000)
+    }
+
+    // MARK: - Availability
+
+    func testSingleDisplayHidesMovement() {
+        let model = WindowMoveMenuModel(displays: [display(0, current: true)], targets: [target(1)])
+        XCTAssertFalse(model.isAvailable)
+        XCTAssertNil(model.nextDisplay)
+        XCTAssertFalse(model.includesPlacement)
+    }
+
+    func testNoTargetsHidesMovement() {
+        let model = WindowMoveMenuModel(displays: [display(0, current: true), display(1)], targets: [])
+        XCTAssertFalse(model.isAvailable)
+        XCTAssertNil(model.nextDisplay)
+    }
+
+    func testTwoDisplaysShowMovement() {
+        let model = WindowMoveMenuModel(displays: [display(0, current: true), display(1)], targets: [target(1)])
+        XCTAssertTrue(model.isAvailable)
+        XCTAssertTrue(model.includesPlacement)
+    }
+
+    // MARK: - Next-display cycling
+
+    func testNextDisplayStepsThroughTopology() {
+        let model = WindowMoveMenuModel(
+            displays: [display(0), display(1, current: true), display(2)],
+            targets: [target(1)]
+        )
+        XCTAssertEqual(model.nextDisplay?.index, 2)
+    }
+
+    func testNextDisplayWrapsFromLastToFirst() {
+        let model = WindowMoveMenuModel(
+            displays: [display(0), display(1), display(2, current: true)],
+            targets: [target(1)]
+        )
+        XCTAssertEqual(model.nextDisplay?.index, 0)
+    }
+
+    func testNextDisplayFallsBackToFirstWhenAnchorUnresolved() {
+        // No display is marked current (anchor could not be resolved) —
+        // cycling still yields a deterministic target.
+        let model = WindowMoveMenuModel(displays: [display(0), display(1)], targets: [target(1)])
+        XCTAssertEqual(model.nextDisplay?.index, 0)
+    }
+
+    func testCurrentDisplayIsMarked() {
+        let model = WindowMoveMenuModel(
+            displays: [display(0), display(1, current: true)],
+            targets: [target(1)]
+        )
+        XCTAssertEqual(model.currentDisplay?.index, 1)
+    }
+
+    // MARK: - Titles
+
+    func testSingleWindowTitles() {
+        let model = WindowMoveMenuModel(displays: [display(0, current: true), display(1)], targets: [target(1)])
+        XCTAssertEqual(model.nextMonitorTitle, "Move to Next Monitor")
+        XCTAssertEqual(model.moveToMonitorTitle, "Move to Monitor")
+    }
+
+    func testMultiWindowTitlesCountTargets() {
+        let model = WindowMoveMenuModel(
+            displays: [display(0, current: true), display(1)],
+            targets: [target(1), target(2), target(3)]
+        )
+        XCTAssertEqual(model.nextMonitorTitle, "Move 3 Windows to Next Monitor")
+        XCTAssertEqual(model.moveToMonitorTitle, "Move 3 Windows to Monitor")
+    }
+
+    // MARK: - Placement gating
+
+    func testMultiSelectionOmitsPlacement() {
+        // Several windows sent to one slot would overlap; Move & Place must
+        // disappear for multi-target menus.
+        let model = WindowMoveMenuModel(
+            displays: [display(0, current: true), display(1)],
+            targets: [target(1), target(2)]
+        )
+        XCTAssertTrue(model.isAvailable)
+        XCTAssertFalse(model.includesPlacement)
+    }
+
+    func testPlacementSlotsCoverCanonicalNamedPositions() {
+        let slots = WindowMoveMenuModel.placementSlots
+        XCTAssertTrue(slots.contains(.maximize))
+        XCTAssertTrue(slots.contains(.center))
+        for half: TilePosition in [.left, .right, .top, .bottom] {
+            XCTAssertTrue(slots.contains(half))
+        }
+        for quarter: TilePosition in [.topLeft, .topRight, .bottomLeft, .bottomRight] {
+            XCTAssertTrue(slots.contains(quarter))
+        }
+        for third: TilePosition in [.leftThird, .centerThird, .rightThird] {
+            XCTAssertTrue(slots.contains(third))
+        }
+    }
+
+    // MARK: - Right-click target rule
+
+    func testClickOutsideSelectionTargetsClickedWindowOnly() {
+        let clicked = target(9)
+        let selection = [target(1), target(2)]
+        XCTAssertEqual(WindowMoveMenuModel.resolveTargets(clicked: clicked, selection: selection), [clicked])
+    }
+
+    func testClickInsideMultiSelectionTargetsWholeSelection() {
+        let selection = [target(1), target(2), target(3)]
+        XCTAssertEqual(
+            WindowMoveMenuModel.resolveTargets(clicked: target(2), selection: selection),
+            selection
+        )
+    }
+
+    func testClickOnSoleSelectedWindowTargetsItAlone() {
+        let clicked = target(1)
+        XCTAssertEqual(WindowMoveMenuModel.resolveTargets(clicked: clicked, selection: [clicked]), [clicked])
+    }
+
+    // MARK: - Accessibility labels
+
+    func testAccessibilityLabelsNameActionAndTarget() {
+        let model = WindowMoveMenuModel(
+            displays: [display(0, current: true), display(1, name: "Studio Display")],
+            targets: [target(1), target(2)]
+        )
+        XCTAssertEqual(
+            model.moveAccessibilityLabel(to: model.displays[1]),
+            "Move 2 windows to Studio Display"
+        )
+    }
+
+    func testSingleWindowAccessibilityLabelNamesTargetDisplay() {
+        let model = WindowMoveMenuModel(
+            displays: [display(0, current: true), display(1, name: "Studio Display")],
+            targets: [target(1)]
+        )
+        XCTAssertEqual(
+            model.moveAccessibilityLabel(to: model.displays[1]),
+            "Move window to Studio Display"
+        )
+    }
+
+    func testPlacementAccessibilityLabelNamesSlotAndDisplay() {
+        let model = WindowMoveMenuModel(
+            displays: [display(0, current: true), display(1, name: "Studio Display")],
+            targets: [target(1)]
+        )
+        let label = model.placeAccessibilityLabel(slot: .bottomRight, on: model.displays[1])
+        XCTAssertEqual(label, "Move window to Studio Display and place \(TilePosition.bottomRight.label)")
+    }
+
+    // MARK: - Truthful receipts
+
+    func testMoveOutcomeFullSuccess() {
+        let single = WindowMovementService.moveOutcome(okCount: 1, total: 1, blocked: false, displayName: "DELL U2720Q")
+        XCTAssertTrue(single.ok)
+        XCTAssertEqual(single.message, "Moved to DELL U2720Q")
+
+        let multi = WindowMovementService.moveOutcome(okCount: 3, total: 3, blocked: false, displayName: "DELL U2720Q")
+        XCTAssertTrue(multi.ok)
+        XCTAssertEqual(multi.message, "Moved 3 windows to DELL U2720Q")
+    }
+
+    func testMoveOutcomeBlockedIsNotSuccess() {
+        let outcome = WindowMovementService.moveOutcome(okCount: 0, total: 1, blocked: true, displayName: "DELL")
+        XCTAssertFalse(outcome.ok)
+        XCTAssertTrue(outcome.message.contains("Accessibility"))
+    }
+
+    func testMoveOutcomePartialReportsCounts() {
+        let outcome = WindowMovementService.moveOutcome(okCount: 1, total: 3, blocked: false, displayName: "DELL")
+        XCTAssertFalse(outcome.ok)
+        XCTAssertTrue(outcome.message.contains("1/3"))
+    }
+
+    func testMoveOutcomeUnverifiedIsNotReportedAsMoved() {
+        let outcome = WindowMovementService.moveOutcome(okCount: 0, total: 1, blocked: false, displayName: "DELL")
+        XCTAssertFalse(outcome.ok)
+        XCTAssertTrue(outcome.message.contains("not verified"))
+    }
+}

--- a/apps/mac/Tests/WindowMoveMenuModelTests.swift
+++ b/apps/mac/Tests/WindowMoveMenuModelTests.swift
@@ -170,30 +170,35 @@ final class WindowMoveMenuModelTests: XCTestCase {
     // MARK: - Truthful receipts
 
     func testMoveOutcomeFullSuccess() {
-        let single = WindowMovementService.moveOutcome(okCount: 1, total: 1, blocked: false, displayName: "DELL U2720Q")
+        let single = WindowMovementService.moveOutcome(okWids: [11], total: 1, blocked: false, displayName: "DELL U2720Q")
         XCTAssertTrue(single.ok)
         XCTAssertEqual(single.message, "Moved to DELL U2720Q")
+        XCTAssertEqual(single.movedWids, [11])
 
-        let multi = WindowMovementService.moveOutcome(okCount: 3, total: 3, blocked: false, displayName: "DELL U2720Q")
+        let multi = WindowMovementService.moveOutcome(okWids: [1, 2, 3], total: 3, blocked: false, displayName: "DELL U2720Q")
         XCTAssertTrue(multi.ok)
         XCTAssertEqual(multi.message, "Moved 3 windows to DELL U2720Q")
+        XCTAssertEqual(multi.movedWids, [1, 2, 3])
     }
 
     func testMoveOutcomeBlockedIsNotSuccess() {
-        let outcome = WindowMovementService.moveOutcome(okCount: 0, total: 1, blocked: true, displayName: "DELL")
+        let outcome = WindowMovementService.moveOutcome(okWids: [], total: 1, blocked: true, displayName: "DELL")
         XCTAssertFalse(outcome.ok)
         XCTAssertTrue(outcome.message.contains("Accessibility"))
+        XCTAssertTrue(outcome.movedWids.isEmpty)
     }
 
-    func testMoveOutcomePartialReportsCounts() {
-        let outcome = WindowMovementService.moveOutcome(okCount: 1, total: 3, blocked: false, displayName: "DELL")
+    func testMoveOutcomePartialCarriesOnlySuccessfulWids() {
+        let outcome = WindowMovementService.moveOutcome(okWids: [7], total: 3, blocked: false, displayName: "DELL")
         XCTAssertFalse(outcome.ok)
         XCTAssertTrue(outcome.message.contains("1/3"))
+        XCTAssertEqual(outcome.movedWids, [7])
     }
 
-    func testMoveOutcomeUnverifiedIsNotReportedAsMoved() {
-        let outcome = WindowMovementService.moveOutcome(okCount: 0, total: 1, blocked: false, displayName: "DELL")
+    func testMoveOutcomeUnverifiedIsNotReportedAsMovedAndCarriesNoWids() {
+        let outcome = WindowMovementService.moveOutcome(okWids: [], total: 1, blocked: false, displayName: "DELL")
         XCTAssertFalse(outcome.ok)
         XCTAssertTrue(outcome.message.contains("not verified"))
+        XCTAssertTrue(outcome.movedWids.isEmpty)
     }
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -1727,7 +1727,7 @@ synchronously:
 (`ok`/`planned`/`blocked`/`failed`), before/target/after frames in `mutations`,
 `sourceDisplay` and `display` (name, index, visible frame), `targetResolution`,
 `verified`, `trace`, and undo metadata. Successful moves are undoable via
-`action.undo`.
+`actions.undo`.
 
 ```js
 // Move window 4182 to display 1, keeping its relative size and position

--- a/docs/app.md
+++ b/docs/app.md
@@ -153,6 +153,42 @@ frontmost window.
 | Right Third  | Right third                     |
 | Center       | 80% width, 80% height, centered (20% margin all sides) |
 
+## Moving windows between monitors
+
+Window movement is a right-click action wherever a window is listed.
+Both surfaces share one movement engine — the same canonical
+`window.move` / `window.place` semantics the CLI and daemon API use —
+so moving from the app, the CLI, or the API always behaves identically.
+
+Right-click a window in either surface:
+
+- **Desktop Inventory** — window rows in the inventory list.
+- **Studio** — window shapes on the canvas and window rows in the
+  sidebar (both the visible-windows list and the layer trees).
+
+The menu offers, top to bottom:
+
+- **Move to Next Monitor** — one click; cycles deterministically
+  through the display topology and wraps. The window keeps its
+  normalized position and size on the target display's visible frame,
+  clamped to fit.
+- **Move to Monitor** — submenu listing each display by name; the
+  current display is checked and disabled.
+- **Move & Place** — single-window only; pick an exact display, then a
+  canonical slot (maximize, center, halves, quarters, thirds).
+
+Right-clicking a member of a multi-selection moves the whole selection
+("Move 3 Windows to Next Monitor"); each window keeps its own
+normalized frame, so selections never collapse into one slot. Move &
+Place is omitted for multi-selections because a single slot would
+stack the windows. On a single-display machine the movement section
+disappears entirely.
+
+Moves happen immediately — no dialog. A short flash reports the
+truthful outcome (moved, partially moved, unverified, or blocked on
+the Accessibility permission), and the list or canvas refreshes with
+the selection preserved.
+
 ## Space navigation
 
 "Go to" commands can switch macOS Spaces to reach a window on a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arach/lattices",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Tile windows, search your screen, keep tmux sessions alive, and let AI agents control your Mac — CLI + daemon API",
   "homepage": "https://lattices.dev",
   "bugs": {


### PR DESCRIPTION
Completes the window-movement shipment started in #88: movement is now a first-class native-app interaction, not just CLI/API.

## What's here

- **Shared engine, zero drift**: one pure `WindowMoveMenuModel` + `WindowMovementService` (Core/Desktop) used by every surface, executing through the same canonical `ActionRuntime` `window.move` / `window.place` paths as the daemon API and CLI.
- **Desktop Inventory**: window-row context menus gain *Move to Next Monitor*, *Move to Monitor* (current display checked/disabled), and single-window *Move & Place* (exact display + canonical slot). Multi-select rows get selection-aware fast actions ("Move 3 Windows to Next Monitor").
- **Studio**: same movement section on canvas window shapes (AppKit `NSMenu`) and sidebar window rows (SwiftUI context menu, both the visible list and layer trees). Staged/Hyperspace semantics untouched — the immediate section sits above the staged *Move to Layer* menu.
- **Semantics**: right-click an unselected window → targets only it; right-click inside a multi-selection → targets the selection, each window preserving its own normalized frame (no overlap into one slot; Move & Place is single-window only). Next-monitor cycling is deterministic through SkyLight topology order and wraps. Display identity resolves via `DisplayGeometryMapper` UUID matching, never `NSScreen.screens` order.
- **Receipts**: truthful non-blocking flashes (moved / partial / unverified / blocked-on-Accessibility); surfaces refresh and selection survives by wid.
- **Accessibility**: SwiftUI and AppKit items both carry explicit labels naming action + target display (+ slot).
- **Tests**: 21 pure model tests (cycle/wrap, current display, single-display hiding, selection titles/targeting, placement omission, receipt truthfulness, a11y labels) alongside the retained 10 geometry tests.
- **Docs**: `docs/app.md` documents both right-click surfaces; fixed `actions.undo` method name in `docs/api.md`.

## Validation

- `bun run check:types`, `bun run test:cli` (34 pass / 1 expected daemon-down skip), `git diff --check`
- `swift test` full suite: 97 pass; `bun run check:app` release build
- Daemon e2e: 18/18 against the feature build
- Live two-monitor smoke (AW3425DWM ↔ U32J59x, vertically offset): dry-run plan, geometry-preserving cross-monitor move (verified), Move & Place slot (verified), `actions.undo` restoration to exact original frames; truthful `failed` receipts confirmed for off-Space and size-constrained windows
- Known gap: native context-menu click-through was not driven synthetically; menu structure is covered by the pure model tests and both wirings compile against the same service the smokes exercised

🤖 Generated with [Claude Code](https://claude.com/claude-code)