### PR TITLE
🐛 Clear the IOHID Caps Lock latch on teardown

### DIFF
--- a/apps/mac/Sources/AppShell/AppDelegate.swift
+++ b/apps/mac/Sources/AppShell/AppDelegate.swift
@@ -12,6 +12,7 @@ extension Notification.Name {
 class AppDelegate: NSObject, NSApplicationDelegate {
     private var notificationObservers: [NSObjectProtocol] = []
     private var systemSettingsWasFrontmost = false
+    private var terminationSignalSources: [DispatchSourceSignal] = []
 
     static func updateActivationPolicy() {
         AppActivationCoordinator.shared.refresh()
@@ -45,6 +46,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         MouseGestureController.shared.start()
         KeyboardRemapController.shared.start()
         SecureEventInputMonitor.shared.start()
+        installTerminationSignalHandlers()
 
         if !OnboardingWindowController.shared.showIfNeeded() {
             PermissionChecker.shared.check()
@@ -95,6 +97,31 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let trace = "BUILD TRACE | channel=\(LatticesRuntime.buildChannel) version=\(version) build=\(build) revision=\(revision) builtAt=\(timestamp) pid=\(ProcessInfo.processInfo.processIdentifier) bundleID=\(bundleID) bundle=\(bundlePath) executable=\(executablePath)"
         HudLogger(category: "build").info(trace)
         NSLog("%@", trace)
+    }
+
+    /// `applicationWillTerminate` only runs for a graceful quit. The dev loop
+    /// (`bin/lattices-app.ts`) stops the app with `pkill -x Lattices`, i.e.
+    /// SIGTERM, whose default disposition kills us without ever reaching
+    /// AppKit's terminate path — so global input state we set is left behind.
+    /// The visible symptom is a Caps Lock latch that survives the rebuild and
+    /// reads as "the Hyper key is stuck".
+    ///
+    /// SIGKILL (the `pkill -9` escalation) is uncatchable by design; nothing
+    /// can be done for that case, which is the more reason to make the
+    /// catchable one clean.
+    private func installTerminationSignalHandlers() {
+        for sig in [SIGTERM, SIGINT] {
+            // Ignore the default disposition so the process survives long
+            // enough for the dispatch source below to run.
+            signal(sig, SIG_IGN)
+            let source = DispatchSource.makeSignalSource(signal: sig, queue: .global(qos: .userInitiated))
+            source.setEventHandler {
+                KeyboardRemapController.shared.flushGlobalStateForAbruptTermination()
+                exit(128 + sig)
+            }
+            source.resume()
+            terminationSignalSources.append(source)
+        }
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/apps/mac/Sources/Core/Input/KeyboardRemapController.swift
+++ b/apps/mac/Sources/Core/Input/KeyboardRemapController.swift
@@ -80,10 +80,35 @@ final class KeyboardRemapController: ObservableObject {
     }
 
     func stop() {
+        let hadCapsLayer = capsLayerActive
+        let hyperEnabled = readTapConfig().hyper
         removeEventTap()
         capsLockTransport.disable()
         capsLockTransportActive = capsLockTransport.isActive
         clearCapsLayer()
+        // clearCapsLayer() only resets process-local bookkeeping. The IOHID Caps
+        // Lock latch is global state that outlives the process: tear down with it
+        // set and it stays set, with no tap left to translate it into Hyper.
+        // Synchronous on purpose — latchQueue will not drain during termination.
+        if hyperEnabled || hadCapsLayer {
+            clearCapsLockLatch(reason: "shutdown")
+        }
+    }
+
+    /// Last-ditch cleanup for paths that bypass `applicationWillTerminate`
+    /// (SIGTERM/SIGINT from a dev rebuild). Deliberately does one thing: drop
+    /// the IOHID Caps Lock latch, which is a single IOKit call touching no
+    /// shared mutable state and is therefore safe from a signal-source queue.
+    ///
+    /// The HID transport remap is *not* torn down here — `disable()` mutates
+    /// non-atomic instance state with no queue guarantee, and racing it during
+    /// termination risks a torn write to the system-wide mapping. It does not
+    /// need us: ownership and the original mappings are persisted to
+    /// UserDefaults, so the next launch restores them via `enable()`. The latch
+    /// has no such recovery path, which is why it is the one thing worth doing
+    /// on the way out.
+    func flushGlobalStateForAbruptTermination() {
+        clearCapsLockLatch(reason: "signal")
     }
 
     func resetForSystemInputBoundary(reason: String) {


### PR DESCRIPTION
## Symptom

Hyper key "sticks" after a dev rebuild — Caps Lock stays latched on with no tap running to translate it.

## Cause

Pressing Caps Lock latches it on at the hardware level. The Hyper layer depends on that latch being dropped again, which `scheduleCapsLockLatchRelease` does async on `latchQueue` at +0/+40/+140ms. Two paths left it set:

1. **`stop()` never cleared it.** It called `clearCapsLayer()`, which only resets process-local booleans (`capsLayerActive`, `capsUsedAsModifier`, …). The IOHID latch is global state that outlives the process, so even a graceful quit with the layer up left Caps latched.

2. **`stop()` only runs from `applicationWillTerminate`, which SIGTERM never reaches.** `bin/lattices-app.ts:182` stops the app with `pkill -x Lattices`, escalating to `pkill -9` at :187. So every dev rebuild skipped teardown entirely.

Worth noting what is *not* the cause: the controller never posts standalone modifier events — it rewrites flags on in-flight events (`event.flags = normalizedFlags(event.flags).union(.latticesHyper)`). Flags that only exist on passing events cannot be stranded by a kill. The latch is the only piece of global state involved.

## Fix

- `stop()` clears the latch synchronously (`latchQueue` will not drain during termination), guarded on `hyperEnabled || hadCapsLayer` so it cannot stomp a genuine Caps Lock when the remap is off.
- `AppDelegate` installs SIGTERM/SIGINT dispatch sources that flush the latch before exiting.

The signal path deliberately touches **only** the latch. Tearing down the HID transport there would race `disable()`, which mutates non-atomic instance state with no queue guarantee — risking a torn write to the system-wide Caps→F18 mapping. That mapping does not need rescuing: ownership and original mappings persist to UserDefaults and `enable()` restores them on next launch. The latch has no such recovery path.

SIGKILL remains uncatchable by design; nothing can be done for the `pkill -9` escalation, which is the more reason to make the catchable signal clean.

## Testing

`swift build --package-path apps/mac` passes on this base. No behavioural change to the hot tap path — both edits are on teardown paths only.