### PR TITLE
📝 Remove stray README whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-
-
 ![lattices](https://lattices.dev/og.png)
 
 # lattices


### PR DESCRIPTION
Removes the two leading blank lines introduced by #87 while retaining the accurate Node 18+/Bun requirement.\n\nThis is intentionally a follow-up cleanup rather than a history rewrite.