### PR TITLE
✨ Ship Products nav, generated hero map, and mascot

### DIFF
--- a/apps/site/src/components/LandingPage.tsx
+++ b/apps/site/src/components/LandingPage.tsx
@@ -3,6 +3,9 @@ import type { CSSProperties, ReactNode } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { ThemeToggle } from "./ThemeToggle";
 import { GestureMatrix } from "./GestureMatrix";
+import { ProductsMenu } from "./SiteChrome";
+import { heroDesktopMaps, heroWindowLayouts, heroWindowMeta } from "./heroDesktopMap";
+import type { HeroDesktopPhase, HeroWindowId } from "./heroDesktopMap";
 
 export function LatticesLogo({ size = 20 }: { size?: number }) {
   // 3×3 grid with L-shape pattern (left column + bottom row bright, rest dim)
@@ -58,34 +61,165 @@ function trackCta(action: string, destination: string) {
   }
 }
 
-const MASCOT_ROWS = [
-  "#.....#...",
-  "##...##...",
-  "##########",
-  "#.##.##..#",
-  "##########",
-  ".########.",
-  ".#######.#",
-  ".#######.#",
-  ".#######.#",
-  ".#.....#..",
+// 12x12 pixel cat: solid body, eyes cut as negative space, tail drawn separately
+// so it can flick without disturbing the silhouette.
+const MASCOT_BODY = [
+  "#....#......",
+  "##..##......",
+  "######......",
+  "#.##.#......",
+  "######......",
+  ".####.......",
+  ".#####......",
+  ".######.....",
+  ".######.....",
+  ".#######....",
+  ".#######....",
+  ".##..##.....",
 ];
 
+// Eye holes, filled in to close the lids on a blink.
+const MASCOT_EYES: Array<[number, number]> = [
+  [1, 3],
+  [4, 3],
+];
+
+// Tail poses, low to high. Base pixel stays welded to the haunch.
+const MASCOT_TAILS: Array<Array<[number, number]>> = [
+  [[8, 10], [9, 10], [10, 10], [10, 9]],
+  [[8, 10], [9, 10], [10, 9], [10, 8]],
+  [[8, 10], [9, 9], [10, 8], [10, 7], [10, 6]],
+];
+
+const MASCOT_W = MASCOT_BODY[0].length;
+const MASCOT_H = MASCOT_BODY.length;
+
 function PixelMascot() {
+  const wrapRef = useRef<HTMLSpanElement>(null);
+  const reducedMotion = useReducedMotion() ?? false;
+  const [blinking, setBlinking] = useState(false);
+  const [tail, setTail] = useState(0);
+
+  // Pointer lean — a few pixels, capped hard on the right so the cat stays
+  // on the plinth.
+  useEffect(() => {
+    const wrap = wrapRef.current;
+    if (!wrap || reducedMotion) return;
+
+    const maxLeft = 8;
+    const maxRight = 2;
+    const maxY = 4;
+    const ease = 0.14;
+    let targetX = 0;
+    let targetY = 0;
+    let currentX = 0;
+    let currentY = 0;
+    let raf = 0;
+
+    const tick = () => {
+      currentX += (targetX - currentX) * ease;
+      currentY += (targetY - currentY) * ease;
+      wrap.style.setProperty("--cat-x", `${currentX.toFixed(2)}px`);
+      wrap.style.setProperty("--cat-y", `${currentY.toFixed(2)}px`);
+      wrap.style.setProperty("--cat-rotate", `${(currentX * 0.4).toFixed(2)}deg`);
+      if (Math.abs(targetX - currentX) > 0.04 || Math.abs(targetY - currentY) > 0.04) {
+        raf = requestAnimationFrame(tick);
+      } else {
+        raf = 0;
+      }
+    };
+
+    const kick = () => {
+      if (!raf) raf = requestAnimationFrame(tick);
+    };
+
+    const onMove = (event: PointerEvent) => {
+      const rect = wrap.getBoundingClientRect();
+      const nx = (event.clientX - (rect.left + rect.width / 2)) / Math.max(window.innerWidth * 0.5, 1);
+      const ny = (event.clientY - (rect.top + rect.height / 2)) / Math.max(window.innerHeight * 0.5, 1);
+      targetX = Math.max(-maxLeft, Math.min(maxRight, nx * 7));
+      targetY = Math.max(-maxY, Math.min(maxY, ny * maxY));
+      kick();
+    };
+
+    window.addEventListener("pointermove", onMove, { passive: true });
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("pointermove", onMove);
+    };
+  }, [reducedMotion]);
+
+  // Idle blink — irregular gaps, occasional double blink.
+  useEffect(() => {
+    if (reducedMotion) return;
+    let timer: ReturnType<typeof setTimeout>;
+    const queue = (delay: number, fn: () => void) => {
+      timer = setTimeout(fn, delay);
+    };
+    const shut = (remaining: number) => {
+      setBlinking(true);
+      queue(110, () => {
+        setBlinking(false);
+        if (remaining > 0) queue(150, () => shut(remaining - 1));
+        else schedule();
+      });
+    };
+    const schedule = () => {
+      queue(3200 + Math.random() * 5600, () => shut(Math.random() < 0.18 ? 1 : 0));
+    };
+    schedule();
+    return () => clearTimeout(timer);
+  }, [reducedMotion]);
+
+  // Idle tail — mostly still, then a short flick back down to rest.
+  useEffect(() => {
+    if (reducedMotion) return;
+    let timer: ReturnType<typeof setTimeout>;
+    const run = (steps: Array<[number, number]>, i: number) => {
+      if (i >= steps.length) {
+        schedule();
+        return;
+      }
+      const [pose, hold] = steps[i];
+      setTail(pose);
+      timer = setTimeout(() => run(steps, i + 1), hold);
+    };
+    const schedule = () => {
+      timer = setTimeout(() => {
+        const big = Math.random() < 0.45;
+        run(
+          big
+            ? [[1, 130], [2, 210], [1, 120], [2, 170], [1, 150], [0, 0]]
+            : [[1, 190], [0, 0]],
+          0,
+        );
+      }, 4200 + Math.random() * 7000);
+    };
+    schedule();
+    return () => clearTimeout(timer);
+  }, [reducedMotion]);
+
   return (
-    <svg
-      aria-hidden="true"
-      className="pixel-mascot"
-      viewBox={`0 0 ${MASCOT_ROWS[0].length} ${MASCOT_ROWS.length}`}
-      shapeRendering="crispEdges"
-      fill="currentColor"
-    >
-      {MASCOT_ROWS.flatMap((row, y) =>
-        [...row].map((cell, x) =>
-          cell === "#" ? <rect key={`${x}-${y}`} x={x} y={y} width={1} height={1} /> : null,
-        ),
-      )}
-    </svg>
+    <span ref={wrapRef} className="pixel-mascot-wrap" aria-hidden="true">
+      <svg
+        className="pixel-mascot"
+        viewBox={`0 0 ${MASCOT_W} ${MASCOT_H}`}
+        shapeRendering="crispEdges"
+        fill="currentColor"
+      >
+        {MASCOT_BODY.flatMap((row, y) =>
+          [...row].map((cell, x) =>
+            cell === "#" ? <rect key={`b${x}-${y}`} x={x} y={y} width={1} height={1} /> : null,
+          ),
+        )}
+        {blinking
+          ? MASCOT_EYES.map(([x, y]) => <rect key={`e${x}`} x={x} y={y} width={1} height={1} />)
+          : null}
+        {MASCOT_TAILS[tail].map(([x, y]) => (
+          <rect key={`t${x}-${y}`} x={x} y={y} width={1} height={1} />
+        ))}
+      </svg>
+    </span>
   );
 }
 
@@ -228,73 +362,6 @@ const cuaSteps: Array<{
 ];
 
 const showLatsDevTeaser = import.meta.env.PUBLIC_SHOW_LATS_DEV_TEASER === "true";
-
-type HeroDesktopPhase = "messy" | "organized";
-type HeroWindowId = "agent" | "editor" | "browser" | "terminal";
-
-type HeroWindowLayout = {
-  left: number;
-  top: number;
-  width: number;
-  height: number;
-  z: number;
-};
-
-const heroWindowLayouts: Record<HeroWindowId, Record<HeroDesktopPhase, HeroWindowLayout>> = {
-  agent: {
-    messy: { left: 18, top: 22, width: 49, height: 56, z: 6 },
-    organized: { left: 1.6, top: 10.5, width: 58, height: 86, z: 6 },
-  },
-  editor: {
-    messy: { left: 6, top: 14, width: 35, height: 29, z: 3 },
-    organized: { left: 61, top: 10.5, width: 37.4, height: 28, z: 3 },
-  },
-  browser: {
-    messy: { left: 54, top: 11, width: 41, height: 42, z: 2 },
-    organized: { left: 61, top: 41.5, width: 37.4, height: 32, z: 2 },
-  },
-  terminal: {
-    messy: { left: 46, top: 55, width: 38, height: 29, z: 4 },
-    organized: { left: 61, top: 76.5, width: 37.4, height: 20, z: 4 },
-  },
-};
-
-const heroWindowMeta: Record<HeroWindowId, { app: string; title: string; tint: string; focused?: boolean }> = {
-  agent: { app: "Terminal", title: "atlas — codex", tint: "#d277ff", focused: true },
-  editor: { app: "Code", title: "session.ts — atlas", tint: "#62a0ff" },
-  browser: { app: "Browser", title: "localhost:5173", tint: "#f3c969" },
-  terminal: { app: "Terminal", title: "atlas — bun dev", tint: "#34d399" },
-};
-
-// `lattices map` of the fictional hero desktop — same four windows, same frames.
-const heroDesktopMaps: Record<HeroDesktopPhase, string> = {
-  messy: `\
-┌ Display 0 · MacBook Pro · Space 1 ───────────────────────────────┐
-│                                                                  │
-│    ┌3 Code · session.ts───┐       ┌4 Browser · localhost─────┐   │
-│    │       ┌1 Terminal · codex────┼────────┐                 │   │
-│    │       │                               │                 │   │
-│    └───────┼                               │                 │   │
-│            │                               │          ┬──────┘   │
-│            │                               │          │          │
-│            └─────────────────┼─────────────┘          │          │
-│                              └────────────────────────┘          │
-│                                                                  │
-└──────────────────────────────────────────────────────────────────┘`,
-  organized: `\
-┌ Display 0 · MacBook Pro · Space 1 ───────────────────────────────┐
-│                                                                  │
-│ ┌1 Terminal · codex───────────────────┐┌3 Code · session.ts────┐ │
-│ │                                     ││                       │ │
-│ │                                     │└───────────────────────┘ │
-│ │                                     │┌4 Browser · localhost──┐ │
-│ │                                     ││                       │ │
-│ │                                     ││                       │ │
-│ │                                     │├2 Terminal · bun dev───┤ │
-│ │                                     ││                       │ │
-│ └─────────────────────────────────────┘└───────────────────────┘ │
-└──────────────────────────────────────────────────────────────────┘`,
-};
 
 function HeroWindowContent({ id }: { id: HeroWindowId }) {
   if (id === "agent") {
@@ -660,31 +727,13 @@ export default function App() {
             <span className="nav-name">lattices</span>
           </a>
           <div className="nav-links">
-            <a href="/blog" className="nav-link">
+            <a href="/blog" className="nav-link nav-blog-link">
               Blog
             </a>
             <a href="/docs/overview" className="nav-link">
               Docs
             </a>
-            <a href="/docs/api" className="nav-link">
-              API
-            </a>
-            <a href="/action" className="nav-link">
-              Action
-            </a>
-            <a href="#hands" className="nav-link nav-optional-mobile">
-              Keys
-            </a>
-            <a href="#config" className="nav-link nav-optional-mobile">
-              Config
-            </a>
-            <a href="#app" className="nav-link nav-optional-mobile">
-              App
-            </a>
-            <ThemeToggle
-              theme={theme}
-              onToggle={() => setTheme(theme === "dark" ? "light" : "dark")}
-            />
+            <ProductsMenu />
             <a
               href="https://github.com/arach/lattices"
               target="_blank"
@@ -694,6 +743,10 @@ export default function App() {
               <GitHubIcon />
               <span className="github-label">GitHub</span>
             </a>
+            <ThemeToggle
+              theme={theme}
+              onToggle={() => setTheme(theme === "dark" ? "light" : "dark")}
+            />
           </div>
         </div>
       </nav>

--- a/apps/site/src/components/SiteChrome.tsx
+++ b/apps/site/src/components/SiteChrome.tsx
@@ -42,6 +42,89 @@ export function LatticesMark({ size = 20 }: { size?: number }) {
   )
 }
 
+const productLinks = [
+  {
+    href: '/#app',
+    title: 'Lattices for Mac',
+    description: 'Launch, arrange, and inspect workspaces',
+  },
+  {
+    href: '/action',
+    title: 'Action',
+    description: 'Inspectable computer use on the Mac',
+  },
+  {
+    href: '/blog/lats-dev-ipad-companion',
+    title: 'Companion Deck',
+    description: 'Control your Mac workspace from iPad',
+  },
+  {
+    href: '/docs/api',
+    title: 'Agent API',
+    description: 'Programmatic workspace control',
+  },
+]
+
+export function ProductsMenu() {
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false)
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      setOpen(false)
+      triggerRef.current?.focus()
+    }
+
+    document.addEventListener('pointerdown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [open])
+
+  return (
+    <div className="products-menu" ref={rootRef}>
+      <button
+        ref={triggerRef}
+        type="button"
+        className="nav-link products-menu-trigger"
+        aria-expanded={open}
+        aria-haspopup="true"
+        aria-controls="products-menu-panel"
+        onClick={() => setOpen((current) => !current)}
+      >
+        Products
+        <svg className="products-menu-chevron" viewBox="0 0 12 12" aria-hidden="true">
+          <path d="m3 4.5 3 3 3-3" />
+        </svg>
+      </button>
+      {open ? (
+        <div id="products-menu-panel" className="products-menu-panel" aria-label="Products">
+          {productLinks.map((product) => (
+            <a
+              key={product.href}
+              href={product.href}
+              className="products-menu-link"
+              onClick={() => setOpen(false)}
+            >
+              <span>{product.title}</span>
+              <small>{product.description}</small>
+            </a>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
 export function SiteHeader() {
   const [searchOpen, setSearchOpen] = useState(false)
   // The initial theme is set synchronously by the inline script in index.html
@@ -77,9 +160,9 @@ export function SiteHeader() {
             <span>lattices</span>
           </a>
           <nav className="site-links" aria-label="Primary navigation">
-            <a href="/blog">Blog</a>
+            <a href="/blog" className="nav-blog-link">Blog</a>
             <a href="/docs/overview">Docs</a>
-            <a href="/docs/api">API</a>
+            <ProductsMenu />
             <button type="button" onClick={() => setSearchOpen(true)} aria-label="Open search (Cmd+K)">
               Search
               <span aria-hidden="true">⌘K</span>

--- a/apps/site/src/components/ThemeToggle.tsx
+++ b/apps/site/src/components/ThemeToggle.tsx
@@ -8,15 +8,23 @@ export function ThemeToggle({
   onToggle: () => void;
 }) {
   const next = theme === "dark" ? "light" : "dark";
+
   return (
     <button
       type="button"
       className="theme-toggle"
       onClick={onToggle}
-      aria-label={`Switch to ${next} mode`}
-      title={`Switch to ${next} mode`}
+      role="switch"
+      aria-label="Dark theme"
+      aria-checked={theme === "dark"}
+      title={`Switch to ${next} theme`}
     >
-      {theme === "dark" ? <SunIcon /> : <MoonIcon />}
+      <span className={`theme-toggle-option${theme === "light" ? " is-active" : ""}`}>
+        <SunIcon />
+      </span>
+      <span className={`theme-toggle-option${theme === "dark" ? " is-active" : ""}`}>
+        <MoonIcon />
+      </span>
     </button>
   );
 }

--- a/apps/site/src/components/heroDesktopMap.ts
+++ b/apps/site/src/components/heroDesktopMap.ts
@@ -1,0 +1,87 @@
+/**
+ * The hero desktop's four windows, in one place.
+ *
+ * Both surfaces that describe this fictional desktop read from here: the styled
+ * window chrome in `LandingPage`, and the `lattices — map` transcript below it.
+ * The map used to be a hand-drawn string literal, which is why its outlines and
+ * junctions drifted away from the frames they claimed to describe. Now it is
+ * rasterised from these same percentages, so the two can no longer disagree.
+ */
+import {
+  assertBoxGrid,
+  buildBoxGrid,
+  gridToText,
+  rectFromPercent,
+  type BoxGrid,
+  type BoxRect,
+} from "../lib/asciiBoxMap";
+
+export type HeroDesktopPhase = "messy" | "organized";
+export type HeroWindowId = "agent" | "editor" | "browser" | "terminal";
+
+export type HeroWindowLayout = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+  z: number;
+};
+
+export const heroWindowLayouts: Record<HeroWindowId, Record<HeroDesktopPhase, HeroWindowLayout>> = {
+  agent: {
+    messy: { left: 18, top: 22, width: 49, height: 56, z: 6 },
+    organized: { left: 1.6, top: 10.5, width: 58, height: 86, z: 6 },
+  },
+  editor: {
+    messy: { left: 6, top: 14, width: 35, height: 29, z: 3 },
+    organized: { left: 61, top: 10.5, width: 37.4, height: 28, z: 3 },
+  },
+  browser: {
+    messy: { left: 54, top: 11, width: 41, height: 42, z: 2 },
+    organized: { left: 61, top: 41.5, width: 37.4, height: 32, z: 2 },
+  },
+  terminal: {
+    messy: { left: 46, top: 55, width: 38, height: 29, z: 4 },
+    organized: { left: 61, top: 76.5, width: 37.4, height: 20, z: 4 },
+  },
+};
+
+export const heroWindowMeta: Record<
+  HeroWindowId,
+  { app: string; title: string; tint: string; focused?: boolean; mapLabel: string }
+> = {
+  agent: { app: "Terminal", title: "atlas — codex", tint: "#d277ff", focused: true, mapLabel: "1 Terminal · codex" },
+  editor: { app: "Code", title: "session.ts — atlas", tint: "#62a0ff", mapLabel: "3 Code · session.ts" },
+  browser: { app: "Browser", title: "localhost:5173", tint: "#f3c969", mapLabel: "4 Browser · localhost" },
+  terminal: { app: "Terminal", title: "atlas — bun dev", tint: "#34d399", mapLabel: "2 Terminal · bun dev" },
+};
+
+/** Character dimensions of the rendered map, including the display border. */
+const MAP_WIDTH = 68;
+const MAP_HEIGHT = 15;
+
+/** The area inside the display border that windows are placed into. */
+const SCREEN_AREA = { x: 1, y: 1, w: MAP_WIDTH - 2, h: MAP_HEIGHT - 2 };
+
+const DISPLAY_LABEL = " Display 0 · MacBook Pro · Space 1";
+
+function buildHeroDesktopGrid(phase: HeroDesktopPhase): BoxGrid {
+  const windows = (Object.keys(heroWindowLayouts) as HeroWindowId[]).map((id) => {
+    const frame = heroWindowLayouts[id][phase];
+    return rectFromPercent(frame, SCREEN_AREA, { label: heroWindowMeta[id].mapLabel, z: frame.z });
+  });
+
+  const display: BoxRect = { x: 0, y: 0, w: MAP_WIDTH, h: MAP_HEIGHT, label: DISPLAY_LABEL, z: -1 };
+
+  return assertBoxGrid(buildBoxGrid([display, ...windows], MAP_WIDTH, MAP_HEIGHT), `hero desktop map "${phase}"`);
+}
+
+export const heroDesktopGrids: Record<HeroDesktopPhase, BoxGrid> = {
+  messy: buildHeroDesktopGrid("messy"),
+  organized: buildHeroDesktopGrid("organized"),
+};
+
+export const heroDesktopMaps: Record<HeroDesktopPhase, string> = {
+  messy: gridToText(heroDesktopGrids.messy),
+  organized: gridToText(heroDesktopGrids.organized),
+};

--- a/apps/site/src/index.css
+++ b/apps/site/src/index.css
@@ -182,31 +182,150 @@ button.nav-link {
   background: color-mix(in srgb, var(--text) 6%, transparent);
 }
 
+.products-menu {
+  position: relative;
+}
+
+.products-menu-trigger {
+  display: inline-flex;
+  min-height: 32px;
+  align-items: center;
+  gap: 5px;
+}
+
+.products-menu-chevron {
+  width: 12px;
+  height: 12px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.5;
+  transition: transform 0.16s ease;
+}
+
+.products-menu-trigger[aria-expanded="true"] .products-menu-chevron {
+  transform: rotate(180deg);
+}
+
+.products-menu-trigger:focus-visible {
+  outline: 2px solid var(--green);
+  outline-offset: 3px;
+}
+
+.products-menu-panel {
+  position: absolute;
+  z-index: 40;
+  top: calc(100% + 9px);
+  right: 0;
+  width: 292px;
+  padding: 6px;
+  border: 1px solid var(--border-lit);
+  border-radius: 10px;
+  background: var(--surface);
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.18);
+}
+
+.products-menu .products-menu-link {
+  display: block;
+  min-height: 0;
+  padding: 10px 12px;
+  border-radius: 7px;
+  color: var(--text-dim);
+  text-align: left;
+  transition: color 0.15s, background-color 0.15s;
+}
+
+.products-menu .products-menu-link:hover,
+.products-menu .products-menu-link:focus-visible {
+  color: var(--text);
+  background: color-mix(in srgb, var(--text) 6%, transparent);
+  outline: none;
+}
+
+.products-menu-link > span,
+.products-menu-link > small {
+  display: block;
+}
+
+.products-menu-link > span {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.products-menu-link > small {
+  margin-top: 2px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 400;
+  line-height: 1.35;
+}
+
 .theme-toggle {
   display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
+  position: relative;
+  width: 54px;
   height: 32px;
-  margin-left: 4px;
-  padding: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2px;
   border: 1px solid var(--border-lit);
   border-radius: 999px;
-  background: transparent;
-  color: var(--text-dim);
+  padding: 3px;
+  background: color-mix(in srgb, var(--surface) 76%, transparent);
+  color: var(--text-muted);
   cursor: pointer;
-  transition: color 0.15s, border-color 0.15s, background-color 0.15s;
+  transition: border-color 0.16s, background-color 0.16s, color 0.16s;
+}
+
+.theme-toggle::before {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--text);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.16);
+  content: "";
+  transition: transform 0.18s ease;
+}
+
+.theme-toggle[aria-checked="true"]::before {
+  transform: translateX(24px);
 }
 
 .theme-toggle:hover {
-  color: var(--text);
   border-color: var(--text-muted);
-  background: color-mix(in srgb, var(--text) 6%, transparent);
+  color: var(--text-dim);
 }
 
 .theme-toggle:focus-visible {
   outline: 2px solid var(--green);
-  outline-offset: 2px;
+  outline-offset: 3px;
+}
+
+.theme-toggle-option {
+  z-index: 1;
+  display: grid;
+  width: 22px;
+  height: 24px;
+  place-items: center;
+  color: var(--text-muted);
+}
+
+.theme-toggle-option.is-active {
+  color: var(--surface);
+}
+
+.theme-toggle-option svg {
+  width: 13px;
+  height: 13px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.7;
 }
 
 .nav-github {
@@ -885,6 +1004,11 @@ button.nav-link {
   padding-left: 0;
 }
 
+.hero-harness-body > [aria-hidden="true"] {
+  pointer-events: none;
+  user-select: none;
+}
+
 .hero-harness-map {
   margin: 0;
   overflow-x: auto;
@@ -893,10 +1017,15 @@ button.nav-link {
   padding: 8px 10px;
   background: color-mix(in srgb, var(--text) 4%, var(--bg));
   color: var(--text);
-  font-family: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  /* Google Fonts' JetBrains Mono subsets omit U+2500–U+257F. Mixing its label
+     metrics with fallback box glyphs leaves stippled vertical joins, so keep
+     the complete map in one box-capable system monospace. */
+  font-family: ui-monospace, "SFMono-Regular", "SF Mono", Menlo, Monaco, monospace;
   font-size: 10px;
+  font-weight: 500;
   font-variant-ligatures: none;
-  line-height: 1.22;
+  letter-spacing: 0;
+  line-height: 1;
   white-space: pre;
   -webkit-overflow-scrolling: touch;
 }
@@ -3566,10 +3695,19 @@ button.nav-link {
   margin-right: 8px;
 }
 
+.pixel-mascot-wrap {
+  margin-left: auto;
+  display: block;
+  padding: 6px;
+  transform: translate3d(var(--cat-x, 0px), var(--cat-y, 0px), 0)
+    rotate(var(--cat-rotate, 0deg));
+  transform-origin: 50% 100%;
+}
+
 .pixel-mascot {
+  display: block;
   width: 24px;
   height: auto;
-  margin-left: auto;
   color: var(--hero-ink-dim);
 }
 
@@ -3728,6 +3866,10 @@ button.nav-link {
 }
 
 @media (max-width: 640px) {
+  .products-menu-panel {
+    width: min(292px, calc(100vw - 24px));
+  }
+
   .hero {
     padding: 52px 20px 48px;
   }
@@ -4215,6 +4357,14 @@ button.nav-link {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .products-menu-chevron,
+  .theme-toggle,
+  .theme-toggle::before,
+  .pixel-mascot-wrap {
+    transition: none;
+    transform: none;
+  }
+
   .fade-in {
     animation: none;
   }

--- a/apps/site/src/lib/asciiBoxMap.test.ts
+++ b/apps/site/src/lib/asciiBoxMap.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Geometry checks for the box-drawing renderer. Run with `bun test` from
+ * `apps/site` (or `bun test src/lib/asciiBoxMap.test.ts` for just this file).
+ */
+import { describe, expect, test } from "bun:test";
+
+import { assertBoxGrid, buildBoxGrid, gridToText, parseBoxMap, validateBoxGrid } from "./asciiBoxMap";
+import { heroDesktopGrids, heroDesktopMaps } from "../components/heroDesktopMap";
+
+const rowsOf = (text: string) => text.split("\n");
+
+/** Build, assert continuity, and render — the same path the hero map takes. */
+const render = (rects: Parameters<typeof buildBoxGrid>[0], w: number, h: number) =>
+  gridToText(assertBoxGrid(buildBoxGrid(rects, w, h), "test map"));
+
+describe("box grid rendering", () => {
+  test("draws a lone rectangle with the four corner glyphs", () => {
+    expect(render([{ x: 0, y: 0, w: 5, h: 3 }], 5, 3)).toBe(["┌───┐", "│   │", "└───┘"].join("\n"));
+  });
+
+  test("resolves a vertical edge crossing a horizontal edge as ┼", () => {
+    // A tall box straddles a wide box, so both of the wide box's horizontal
+    // edges are pierced twice.
+    const text = render(
+      [
+        { x: 0, y: 1, w: 7, h: 3 },
+        { x: 2, y: 0, w: 3, h: 5 },
+      ],
+      7,
+      5,
+    );
+    expect(rowsOf(text)).toEqual(["  ┌─┐  ", "┌─┼─┼─┐", "│ │ │ │", "└─┼─┼─┘", "  └─┘  "]);
+  });
+
+  test("resolves a box hanging below another box's edge as ┬", () => {
+    const text = render(
+      [
+        { x: 0, y: 0, w: 7, h: 3 },
+        { x: 2, y: 2, w: 3, h: 3 },
+      ],
+      7,
+      5,
+    );
+    expect(rowsOf(text)).toEqual(["┌─────┐", "│     │", "└─┬─┬─┘", "  │ │  ", "  └─┘  "]);
+  });
+
+  test("resolves a box sitting above another box's edge as ┴", () => {
+    const text = render(
+      [
+        { x: 0, y: 2, w: 7, h: 3 },
+        { x: 2, y: 0, w: 3, h: 3 },
+      ],
+      7,
+      5,
+    );
+    expect(rowsOf(text)).toEqual(["  ┌─┐  ", "  │ │  ", "┌─┴─┴─┐", "│     │", "└─────┘"]);
+  });
+
+  test("keeps a stacked column joined with ├ and ┤", () => {
+    const text = render(
+      [
+        { x: 0, y: 0, w: 6, h: 3 },
+        { x: 0, y: 2, w: 6, h: 3 },
+      ],
+      6,
+      5,
+    );
+    expect(rowsOf(text)[2]).toBe("├────┤");
+  });
+
+  test("refuses a grid that is not continuous", () => {
+    const grid = buildBoxGrid([{ x: 0, y: 0, w: 4, h: 3 }], 4, 3);
+    // Sever the top edge by hand; the validator must notice both sides.
+    grid.masks[1] = 0;
+    expect(validateBoxGrid(grid).length).toBeGreaterThan(0);
+    expect(() => render([{ x: 0, y: 0, w: 1, h: 3 }], 4, 3)).toThrow();
+  });
+
+  test("labels occlude the top edge without disturbing the geometry", () => {
+    const grid = buildBoxGrid([{ x: 0, y: 0, w: 12, h: 3, label: "atlas" }], 12, 3);
+    expect(validateBoxGrid(grid)).toEqual([]);
+    expect(rowsOf(gridToText(grid))[0]).toBe("┌atlas─────┐");
+  });
+
+  test("clips a label that cannot fit inside its box", () => {
+    const grid = buildBoxGrid([{ x: 0, y: 0, w: 6, h: 3, label: "far too long" }], 6, 3);
+    expect(rowsOf(gridToText(grid))[0]).toBe("┌far─┐");
+    expect(validateBoxGrid(grid)).toEqual([]);
+  });
+});
+
+describe("hero desktop maps", () => {
+  for (const [phase, text] of Object.entries(heroDesktopMaps)) {
+    test(`${phase}: every row is the same width`, () => {
+      const rows = rowsOf(text);
+      const widths = new Set(rows.map((row) => [...row].length));
+      expect([...widths]).toHaveLength(1);
+    });
+
+    test(`${phase}: every junction connects to a neighbour that connects back`, () => {
+      expect(validateBoxGrid(heroDesktopGrids[phase as keyof typeof heroDesktopGrids])).toEqual([]);
+    });
+
+    test(`${phase}: the rendered text re-parses to the same continuous geometry`, () => {
+      // Reading the shipped string back proves the glyph table round-trips —
+      // no junction is drawn as a character that means something else.
+      const problems = validateBoxGrid(parseBoxMap(text)).filter(
+        // The display caption opens with a space, which reads as blank on the
+        // way back in; every other cell must still connect.
+        (p) => !(p.y === 0 && p.x <= 1),
+      );
+      expect(problems).toEqual([]);
+    });
+
+    test(`${phase}: the display frame is closed on all four sides`, () => {
+      const rows = rowsOf(text);
+      const last = rows.length - 1;
+      const width = [...rows[0]].length;
+      expect(rows[0][0]).toBe("┌");
+      expect(rows[0][width - 1]).toBe("┐");
+      expect(rows[last][0]).toBe("└");
+      expect(rows[last][width - 1]).toBe("┘");
+      expect(rows[last]).toBe(`└${"─".repeat(width - 2)}┘`);
+      for (const row of rows.slice(1, last)) {
+        expect(row[0]).toBe("│");
+        expect(row[width - 1]).toBe("│");
+      }
+    });
+  }
+});

--- a/apps/site/src/lib/asciiBoxMap.ts
+++ b/apps/site/src/lib/asciiBoxMap.ts
@@ -1,0 +1,317 @@
+/**
+ * Deterministic Unicode box-drawing renderer.
+ *
+ * The hero's `lattices — map` used to be a hand-authored string literal, so its
+ * corners, T-junctions and crossings drifted out of sync with the window frames
+ * they were supposed to describe: outlines stopped mid-run, a `┬` sat where a
+ * `┘` belonged, and overlaps were faked with gaps. This module removes the class
+ * of bug instead of patching glyphs — rectangles go in, a character grid comes
+ * out, and every junction glyph is *derived* from which of its four neighbours
+ * an edge actually continues into.
+ *
+ * The invariant that makes it correct: a cell's glyph encodes a set of
+ * directions, and for every direction it claims, the neighbouring cell must
+ * claim the opposite direction back. `validateBoxGrid` checks exactly that, so
+ * a broken outline is a test failure rather than something you have to spot by
+ * eye.
+ */
+
+/** Direction bits, in the order used by the glyph table below. */
+const UP = 1;
+const RIGHT = 2;
+const DOWN = 4;
+const LEFT = 8;
+
+const BLANK = " ";
+
+/** Light box-drawing glyph for each direction mask. Index === mask. */
+const GLYPH_BY_MASK: readonly string[] = [
+  BLANK, // 0  ────
+  "╵", // 1  U    (stub — only produced by malformed input)
+  "╶", // 2  R    (stub)
+  "└", // 3  U R
+  "╷", // 4  D    (stub)
+  "│", // 5  U D
+  "┌", // 6  R D
+  "├", // 7  U R D
+  "╴", // 8  L    (stub)
+  "┘", // 9  U L
+  "─", // 10 R L
+  "┴", // 11 U R L
+  "┐", // 12 D L
+  "┤", // 13 U D L
+  "┬", // 14 R D L
+  "┼", // 15 U R D L
+];
+
+const MASK_BY_GLYPH = new Map<string, number>();
+GLYPH_BY_MASK.forEach((glyph, mask) => {
+  if (mask !== 0) MASK_BY_GLYPH.set(glyph, mask);
+});
+
+/** A cell whose glyph carries exactly one direction is a dangling line end. */
+const STUB_MASKS = new Set([UP, RIGHT, DOWN, LEFT]);
+
+export type BoxRect = {
+  /** Left column, inclusive. */
+  x: number;
+  /** Top row, inclusive. */
+  y: number;
+  /** Total width in cells, including both vertical edges. */
+  w: number;
+  /** Total height in cells, including both horizontal edges. */
+  h: number;
+  /** Optional caption stamped into the top edge, starting one cell in. */
+  label?: string;
+  /** Higher values stamp their label last, so the front window's title wins. */
+  z?: number;
+};
+
+export type BoxGrid = {
+  width: number;
+  height: number;
+  /** Direction mask per cell, row-major. */
+  masks: Uint8Array;
+  /** True where a label character occludes the frame, row-major. */
+  labelled: Uint8Array;
+};
+
+export type BoxGridProblem = {
+  x: number;
+  y: number;
+  message: string;
+};
+
+function idx(grid: { width: number }, x: number, y: number) {
+  return y * grid.width + x;
+}
+
+function inBounds(grid: { width: number; height: number }, x: number, y: number) {
+  return x >= 0 && y >= 0 && x < grid.width && y < grid.height;
+}
+
+/**
+ * Rasterise rectangles into direction masks.
+ *
+ * Each edge contributes a *run* of connections rather than a per-cell glyph:
+ * a horizontal run gives every cell RIGHT except its last and LEFT except its
+ * first, so corners, tees and crossings all fall out of the accumulated mask
+ * without a single special case.
+ */
+export function buildBoxGrid(rects: readonly BoxRect[], width: number, height: number): BoxGrid {
+  if (width <= 0 || height <= 0) {
+    throw new Error(`box grid must be non-empty, got ${width}×${height}`);
+  }
+
+  const grid: BoxGrid = {
+    width,
+    height,
+    masks: new Uint8Array(width * height),
+    labelled: new Uint8Array(width * height),
+  };
+
+  const connect = (x: number, y: number, bits: number) => {
+    if (!inBounds(grid, x, y)) return;
+    grid.masks[idx(grid, x, y)] |= bits;
+  };
+
+  for (const rect of rects) {
+    if (rect.w < 2 || rect.h < 2) {
+      throw new Error(`rect ${rect.label ?? "(untitled)"} must be at least 2×2, got ${rect.w}×${rect.h}`);
+    }
+
+    const x0 = rect.x;
+    const y0 = rect.y;
+    const x1 = rect.x + rect.w - 1;
+    const y1 = rect.y + rect.h - 1;
+
+    for (let x = x0; x <= x1; x += 1) {
+      if (x > x0) {
+        connect(x, y0, LEFT);
+        connect(x, y1, LEFT);
+      }
+      if (x < x1) {
+        connect(x, y0, RIGHT);
+        connect(x, y1, RIGHT);
+      }
+    }
+
+    for (let y = y0; y <= y1; y += 1) {
+      if (y > y0) {
+        connect(x0, y, UP);
+        connect(x1, y, UP);
+      }
+      if (y < y1) {
+        connect(x0, y, DOWN);
+        connect(x1, y, DOWN);
+      }
+    }
+  }
+
+  // Labels are stamped after every outline exists, so a title only ever hides
+  // junctions that were already drawn correctly underneath it.
+  const labelled = [...rects]
+    .map((rect, order) => ({ rect, order }))
+    .sort((a, b) => (a.rect.z ?? 0) - (b.rect.z ?? 0) || a.order - b.order);
+
+  for (const { rect } of labelled) {
+    if (!rect.label) continue;
+    // Leave the two corners and at least one trailing `─` so the top edge still
+    // reads as an edge rather than as free-floating text.
+    const room = rect.w - 3;
+    if (room <= 0) continue;
+    const text = [...rect.label].slice(0, room);
+    text.forEach((char, i) => {
+      const x = rect.x + 1 + i;
+      if (!inBounds(grid, x, rect.y)) return;
+      grid.labelled[idx(grid, x, rect.y)] = char.codePointAt(0) ?? 32;
+    });
+  }
+
+  return grid;
+}
+
+/** Glyph for a mask, ignoring labels. */
+function glyphForMask(mask: number): string {
+  return GLYPH_BY_MASK[mask & 15] ?? BLANK;
+}
+
+/**
+ * Check that the grid is geometrically continuous.
+ *
+ * Reports a problem when a cell claims a direction its neighbour does not claim
+ * back (a broken outline or a mismatched junction), or when a cell carries a
+ * single direction (a dangling line end). Labels are ignored: they occlude, they
+ * do not connect.
+ */
+export function validateBoxGrid(grid: BoxGrid): BoxGridProblem[] {
+  const problems: BoxGridProblem[] = [];
+  const neighbours: Array<[number, number, number, number]> = [
+    // [bit, dx, dy, opposite bit]
+    [UP, 0, -1, DOWN],
+    [RIGHT, 1, 0, LEFT],
+    [DOWN, 0, 1, UP],
+    [LEFT, -1, 0, RIGHT],
+  ];
+
+  for (let y = 0; y < grid.height; y += 1) {
+    for (let x = 0; x < grid.width; x += 1) {
+      const mask = grid.masks[idx(grid, x, y)];
+      if (mask === 0) continue;
+
+      if (STUB_MASKS.has(mask)) {
+        problems.push({ x, y, message: `dangling line end "${glyphForMask(mask)}"` });
+      }
+
+      for (const [bit, dx, dy, opposite] of neighbours) {
+        if ((mask & bit) === 0) continue;
+        const nx = x + dx;
+        const ny = y + dy;
+        if (!inBounds(grid, nx, ny)) {
+          problems.push({ x, y, message: `"${glyphForMask(mask)}" runs off the grid` });
+          continue;
+        }
+        const ni = idx(grid, nx, ny);
+        // A label hides the frame beneath it; the line still runs underneath,
+        // so a connection into a caption is not a break.
+        if (grid.labelled[ni]) continue;
+        const neighbour = grid.masks[ni];
+        if ((neighbour & opposite) === 0) {
+          problems.push({
+            x,
+            y,
+            message: `"${glyphForMask(mask)}" connects to "${glyphForMask(neighbour)}" at ${nx},${ny} which does not connect back`,
+          });
+        }
+      }
+    }
+  }
+
+  return problems;
+}
+
+/** Render the grid to text. Every row is padded to the full grid width. */
+export function gridToText(grid: BoxGrid): string {
+  const rows: string[] = [];
+  for (let y = 0; y < grid.height; y += 1) {
+    let row = "";
+    for (let x = 0; x < grid.width; x += 1) {
+      const i = idx(grid, x, y);
+      const label = grid.labelled[i];
+      row += label ? String.fromCodePoint(label) : glyphForMask(grid.masks[i]);
+    }
+    rows.push(row);
+  }
+  return rows.join("\n");
+}
+
+/**
+ * Throw if the grid is not continuous, naming the offending cells.
+ *
+ * Callers use this at module load so a layout that tears the diagram fails
+ * loudly in dev instead of shipping a broken outline to the page.
+ */
+export function assertBoxGrid(grid: BoxGrid, context: string): BoxGrid {
+  const problems = validateBoxGrid(grid);
+  if (problems.length > 0) {
+    const detail = problems
+      .slice(0, 8)
+      .map((p) => `  (${p.x},${p.y}) ${p.message}`)
+      .join("\n");
+    throw new Error(`${context} is not continuous:\n${detail}`);
+  }
+  return grid;
+}
+
+/** Parse rendered text back into masks, for validating strings from elsewhere. */
+export function parseBoxMap(text: string): BoxGrid {
+  const rows = text.split("\n");
+  const height = rows.length;
+  const width = Math.max(...rows.map((row) => [...row].length));
+  const grid: BoxGrid = {
+    width,
+    height,
+    masks: new Uint8Array(width * height),
+    labelled: new Uint8Array(width * height),
+  };
+  rows.forEach((row, y) => {
+    [...row].forEach((char, x) => {
+      const mask = MASK_BY_GLYPH.get(char);
+      if (mask) grid.masks[idx(grid, x, y)] = mask;
+      else if (char !== BLANK) grid.labelled[idx(grid, x, y)] = char.codePointAt(0) ?? 32;
+    });
+  });
+  return grid;
+}
+
+/**
+ * Place a rectangle given as percentages of a container into the cell grid.
+ *
+ * The hero desktop stores window frames as CSS percentages; this keeps the map
+ * and the rendered windows reading off the same numbers instead of drifting.
+ *
+ * Both *edges* are snapped independently rather than snapping the origin and
+ * then adding a rounded extent: two windows that share a percentage boundary
+ * (a tiled column, a common bottom) then land on the same cell instead of
+ * missing each other by one row and rendering as a near-miss.
+ */
+export function rectFromPercent(
+  frame: { left: number; top: number; width: number; height: number },
+  area: { x: number; y: number; w: number; h: number },
+  extras: { label?: string; z?: number } = {},
+): BoxRect {
+  const maxX = area.x + area.w - 1;
+  const maxY = area.y + area.h - 1;
+
+  const snap = (percent: number, origin: number, span: number, limit: number) =>
+    Math.min(limit, Math.max(origin, origin + Math.round((percent / 100) * (span - 1))));
+
+  let x0 = snap(frame.left, area.x, area.w, maxX);
+  let y0 = snap(frame.top, area.y, area.h, maxY);
+  const x1 = Math.max(x0 + 1, snap(frame.left + frame.width, area.x, area.w, maxX));
+  const y1 = Math.max(y0 + 1, snap(frame.top + frame.height, area.y, area.h, maxY));
+  x0 = Math.min(x0, x1 - 1);
+  y0 = Math.min(y0, y1 - 1);
+
+  return { x: x0, y: y0, w: x1 - x0 + 1, h: y1 - y0 + 1, ...extras };
+}

--- a/apps/site/src/styles/docs.css
+++ b/apps/site/src/styles/docs.css
@@ -144,6 +144,39 @@
   letter-spacing: 0.12em;
 }
 
+.site-links .products-menu-trigger {
+  gap: 5px;
+}
+
+.site-links .products-menu-chevron {
+  width: 12px;
+  height: 12px;
+}
+
+.site-links .products-menu-panel {
+  border-color: var(--docs-border);
+  background: var(--docs-surface);
+}
+
+.site-links .products-menu-link {
+  display: block;
+  min-height: 0;
+  padding: 10px 12px;
+  color: var(--docs-text);
+}
+
+.site-links .products-menu-link small {
+  color: var(--docs-muted);
+  font-size: 11px;
+  letter-spacing: 0;
+}
+
+.site-links .products-menu-link:hover,
+.site-links .products-menu-link:focus-visible {
+  color: var(--docs-text);
+  background: color-mix(in srgb, var(--docs-text) 6%, transparent);
+}
+
 .site-links a:hover,
 .site-links button:hover,
 .post-nav-links a:hover {
@@ -152,18 +185,21 @@
 }
 
 .site-links .theme-toggle {
-  width: 32px;
-  height: 32px;
-  margin-left: 4px;
-  padding: 0;
-  border: 1px solid var(--border-lit);
-  border-radius: 999px;
+  flex: 0 0 auto;
+  min-height: 0;
+  padding: 3px;
+  border-color: var(--docs-border);
+  background: color-mix(in srgb, var(--docs-surface) 76%, transparent);
   color: var(--docs-muted);
 }
 
 .site-links .theme-toggle:hover {
+  border-color: var(--docs-text);
   color: var(--docs-text);
-  border-color: var(--text-muted);
+}
+
+.site-links .theme-toggle-option.is-active {
+  color: var(--docs-surface);
 }
 
 .docs-shell {
@@ -939,8 +975,7 @@
 }
 
 @media (max-width: 820px) {
-  .site-links a:nth-child(3),
-  .site-links button {
+  .site-links > button:not(.theme-toggle) {
     display: none;
   }
 

--- a/apps/site/tsconfig.app.json
+++ b/apps/site/tsconfig.app.json
@@ -25,5 +25,8 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  /* Tests run under `bun test`, which supplies its own globals; they are not
+     part of the app bundle. */
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
## Summary
- Group Lattices, Action, Companion, and the Agent API behind a Products menu in the site header, with a sun/moon theme switch.
- Rasterise the hero `lattices — map` from the same window percentages as the desktop frames so the two can no longer disagree.
- Give the pixel cat idle blink, tail, and pointer lean.

## Test plan
- [x] `bun test apps/site/src/lib/asciiBoxMap.test.ts` — 16 pass
- [x] `bunx tsc --noEmit -p apps/site/tsconfig.app.json`
- [x] Landing and docs routes 200 on local Vite
- [x] Products menu lists Lattices, Action, Companion, Agent API on `/` and `/docs/overview`
- [x] Hero map first row is a generated display frame; mascot wrap is present