### PR TITLE
Route site analytics to Lattices

### DIFF
--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -24,12 +24,12 @@
     <meta property="twitter:description" content="When your desktop is full of windows, terminals, and agents, Lattices gives you one place to arrange, launch, and control all of it — by hand or from code." />
     <meta property="twitter:image" content="https://lattices.dev/og.png" />
 
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-GSHDZPFRZG"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-25C3DG2J2D"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-GSHDZPFRZG');
+      gtag('config', 'G-25C3DG2J2D');
     </script>
 
     <script>


### PR DESCRIPTION
## Summary

- replace the shared Arach.dev Google tag with the dedicated Lattices GA4 stream
- stop future Lattices traffic from being attributed to Peal
- activate the GA-side download_click key event once deployed

## Verification

- bun install --frozen-lockfile
- bun run build
- git diff --check
- verified generated dist/index.html contains G-25C3DG2J2D and not the shared tag