### PR TITLE
✨ Refine and widen the Lattices homepage

### DIFF
--- a/apps/site/src/components/LandingPage.tsx
+++ b/apps/site/src/components/LandingPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { motion, useReducedMotion } from "motion/react";
 import { ThemeToggle } from "./ThemeToggle";
 import { GestureMatrix } from "./GestureMatrix";
 import { ProductsMenu } from "./SiteChrome";
@@ -605,44 +605,39 @@ function HeroWorkspaceStage() {
             </span>
             <pre className="hero-harness-map" aria-hidden="true">{heroDesktopMaps[phase]}</pre>
           </motion.div>
-          <AnimatePresence>
-            {driver === "agent" && (
-              <motion.span
-                key="turn2-user"
-                className="hero-harness-user"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0, transition: { duration: 0.25, delay: 0 } }}
-                transition={{ duration: 0.3, delay: 0.9 }}
-              >
-                <b>&gt;</b> put codex on the left half, stack the rest on the right
-              </motion.span>
-            )}
-            {driver === "agent" && (
-              <motion.span
-                key="turn2-tool"
-                className="hero-harness-tool"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0, transition: { duration: 0.25, delay: 0 } }}
-                transition={{ duration: 0.3, delay: 2.1 }}
-              >
-                <i aria-hidden="true">⏺</i> lattices — space.optimize
-              </motion.span>
-            )}
-            {driver === "agent" && organized && (
-              <motion.span
-                key="turn2-result"
-                className="hero-harness-result"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0, transition: { duration: 0.25, delay: 0 } }}
-                transition={{ duration: 0.3, delay: 0.9 }}
-              >
-                <b aria-hidden="true">⎿</b> codex left half · 3 stacked right · done
-              </motion.span>
-            )}
-          </AnimatePresence>
+          <motion.span
+            className="hero-harness-user"
+            initial={false}
+            animate={{ opacity: driver === "agent" ? 1 : 0 }}
+            transition={{ duration: driver === "agent" ? 0.3 : 0.2, delay: driver === "agent" ? 0.9 : 0 }}
+            style={{ visibility: driver === "agent" ? "visible" : "hidden" }}
+            aria-hidden={driver !== "agent"}
+          >
+            <b>&gt;</b> put codex on the left half, stack the rest on the right
+          </motion.span>
+          <motion.span
+            className="hero-harness-tool"
+            initial={false}
+            animate={{ opacity: driver === "agent" ? 1 : 0 }}
+            transition={{ duration: driver === "agent" ? 0.3 : 0.2, delay: driver === "agent" ? 2.1 : 0 }}
+            style={{ visibility: driver === "agent" ? "visible" : "hidden" }}
+            aria-hidden={driver !== "agent"}
+          >
+            <i aria-hidden="true">⏺</i> lattices — space.optimize
+          </motion.span>
+          <motion.span
+            className="hero-harness-result"
+            initial={false}
+            animate={{ opacity: driver === "agent" && organized ? 1 : 0 }}
+            transition={{
+              duration: driver === "agent" && organized ? 0.3 : 0.2,
+              delay: driver === "agent" && organized ? 0.9 : 0,
+            }}
+            style={{ visibility: driver === "agent" && organized ? "visible" : "hidden" }}
+            aria-hidden={driver !== "agent" || !organized}
+          >
+            <b aria-hidden="true">⎿</b> codex left half · 3 stacked right · done
+          </motion.span>
         </div>
       </div>
     </div>
@@ -699,6 +694,52 @@ function HandsOnSection() {
         </div>
       </div>
     </section>
+  );
+}
+
+function HeroGestureDemo() {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const reducedMotion = useReducedMotion() ?? false;
+
+  const playPreview = () => {
+    if (reducedMotion) return;
+    void videoRef.current?.play();
+  };
+
+  const resetPreview = () => {
+    const video = videoRef.current;
+    if (!video) return;
+    video.pause();
+    video.currentTime = 0;
+  };
+
+  return (
+    <a
+      className="hero-demo-peek"
+      href="/blog/gesture-completion-matrix"
+      aria-label="Watch the 12-second mouse gesture demo"
+      onMouseEnter={playPreview}
+      onMouseLeave={resetPreview}
+      onFocus={playPreview}
+      onBlur={resetPreview}
+    >
+      <video
+        ref={videoRef}
+        className="hero-demo-peek-media"
+        muted
+        playsInline
+        preload="metadata"
+        poster="/blog/gesture-completion-matrix-poster.png"
+        aria-hidden="true"
+      >
+        <source src="/blog/gesture-completion-matrix.mp4" type="video/mp4" />
+      </video>
+      <span className="hero-demo-peek-copy">
+        <span className="hero-demo-peek-label">12 sec demo</span>
+        <strong>Draw a gesture. Lattices does the rest.</strong>
+        <span className="hero-demo-peek-link">Watch the demo &rarr;</span>
+      </span>
+    </a>
   );
 }
 
@@ -781,6 +822,7 @@ export default function App() {
               <li>API driven</li>
               <li>Built for macOS</li>
             </ul>
+            <HeroGestureDemo />
           </div>
 
           <div className="hero-apparatus">
@@ -1000,7 +1042,7 @@ export default function App() {
             <span className="workflow-number">01</span>
             <div>
               <h3>Window manager</h3>
-              <h2>Arrange your whole Mac.</h2>
+              <h2>Put every window in its place.</h2>
               <p>
                 Tile windows, group them into layers, launch whole projects,
                 and switch contexts from the app, a shortcut, or a mouse
@@ -1038,10 +1080,12 @@ export default function App() {
         <section className="section" id="config">
           <div className="config-head fade-in fade-in-delay-2">
             <h2 className="config-title">
-              Managed terminal sessions
+              Managed project layouts
             </h2>
             <p className="config-desc">
-              tmux made easy today — configurable panes, tabs, and layouts that save, restore, and fit your workflow.
+              Define a project scene — terminals, browser and editor windows,
+              commands, and placement — then bring the whole workspace back in
+              one step.
             </p>
           </div>
 

--- a/apps/site/src/components/SiteChrome.tsx
+++ b/apps/site/src/components/SiteChrome.tsx
@@ -44,29 +44,19 @@ export function LatticesMark({ size = 20 }: { size?: number }) {
 
 const productLinks = [
   {
-    href: '/#app',
-    title: 'Lattices for Mac',
-    description: 'Launch, arrange, and inspect workspaces',
+    href: '/docs/api',
+    title: 'API',
+    description: 'Unified workspace control for agents and scripts',
   },
   {
     href: '/action',
     title: 'Action',
-    description: 'Inspectable computer use on the Mac',
+    description: 'Unified computer use on the Mac',
   },
   {
     href: '/blink',
     title: 'Blink',
     description: 'Spatial notes that live on your desktop',
-  },
-  {
-    href: '/blog/lats-dev-ipad-companion',
-    title: 'Companion Deck',
-    description: 'Control your Mac workspace from iPad',
-  },
-  {
-    href: '/docs/api',
-    title: 'Agent API',
-    description: 'Programmatic workspace control',
   },
 ]
 

--- a/apps/site/src/index.css
+++ b/apps/site/src/index.css
@@ -7,6 +7,7 @@
 }
 
 :root {
+  --content-rail: clamp(1120px, calc(100% - 160px), 1320px);
   --bg: #111113;
   --surface: #1c1c1e;
   --surface-hover: #2c2c2e;
@@ -102,7 +103,7 @@ code {
 /* ── Shell ─────────────────────────────────────────── */
 
 .shell {
-  max-width: 960px;
+  max-width: var(--content-rail);
   margin: 0 auto;
   padding: 0 24px;
 }
@@ -119,7 +120,7 @@ code {
 }
 
 .nav-inner {
-  max-width: 960px;
+  max-width: var(--content-rail);
   margin: 0 auto;
   padding: 14px 24px;
   display: flex;
@@ -3503,6 +3504,73 @@ button.nav-link {
   color: var(--hero-accent);
 }
 
+.hero-demo-peek {
+  display: grid;
+  grid-template-columns: 118px minmax(0, 1fr);
+  gap: 14px;
+  width: min(100%, 390px);
+  margin-top: 28px;
+  padding-top: 14px;
+  border-top: 1px solid var(--hero-rule);
+  color: var(--hero-ink);
+  text-decoration: none;
+}
+
+.hero-demo-peek:focus-visible {
+  outline: 2px solid var(--hero-accent);
+  outline-offset: 5px;
+}
+
+.hero-demo-peek-media {
+  display: block;
+  width: 118px;
+  aspect-ratio: 8 / 5;
+  border: 1px solid var(--hero-rule);
+  border-radius: 2px;
+  background: var(--hero-ink);
+  object-fit: cover;
+  transition: border-color 180ms ease, filter 180ms ease;
+}
+
+.hero-demo-peek-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+}
+
+.hero-demo-peek-label,
+.hero-demo-peek-link {
+  color: var(--hero-ink-dim);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.hero-demo-peek-copy strong {
+  max-width: 23ch;
+  font-size: 13px;
+  line-height: 1.32;
+}
+
+.hero-demo-peek-link {
+  color: var(--hero-accent);
+  transition: color 180ms ease;
+}
+
+.hero-demo-peek:hover .hero-demo-peek-media,
+.hero-demo-peek:focus-visible .hero-demo-peek-media {
+  border-color: var(--hero-accent);
+  filter: contrast(1.04);
+}
+
+.hero-demo-peek:hover .hero-demo-peek-link,
+.hero-demo-peek:focus-visible .hero-demo-peek-link {
+  color: var(--hero-ink);
+}
+
 /* Apparatus scaffolding — measurement, not ornament. */
 
 .hero-apparatus {
@@ -3662,32 +3730,9 @@ button.nav-link {
   text-transform: uppercase;
 }
 
-.hero-plinth::before {
-  content: "";
-  position: absolute;
-  right: 3%;
-  bottom: calc(100% + 9px);
-  left: 4%;
-  height: 17px;
-  border: 1px solid var(--hero-etch);
-  background:
-    repeating-linear-gradient(135deg, transparent 0 5px, var(--hero-etch-faint) 5px 6px, transparent 6px 10px),
-    color-mix(in srgb, var(--hero-ground) 82%, transparent);
-  clip-path: polygon(0 0, 100% 0, 100% 48%, 88% 48%, 88% 100%, 13% 100%, 13% 58%, 0 58%);
-  opacity: 0.9;
-  pointer-events: none;
-}
-
+.hero-plinth::before,
 .hero-plinth::after {
-  content: "";
-  position: absolute;
-  right: 17%;
-  bottom: calc(100% + 4px);
-  left: 18%;
-  height: 1px;
-  background: var(--hero-etch);
-  box-shadow: 19px 4px 0 var(--hero-etch-faint);
-  pointer-events: none;
+  content: none;
 }
 
 .hero-plinth-state {
@@ -3723,6 +3768,11 @@ button.nav-link {
     -3px 4px 0 -2px var(--hero-etch),
     4px -3px 0 -3px var(--hero-etch-faint),
     inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.hero-apparatus .hero-desktop-screen {
+  /* Follow the inner edge of the 12px frame after its 1px border. */
+  border-radius: 11px;
 }
 
 .hero-apparatus .hero-workspace-stage::before {


### PR DESCRIPTION
## Summary
- stabilize and enrich the homepage hero with a compact gesture-demo teaser
- simplify Products to API, Action, and Blink
- widen the header and lower-page content fluidly on large displays while preserving the compact layout through 1280px

## Verification
- bun run lint
- bun test ./src/lib/asciiBoxMap.test.ts (16 tests)
- bunx tsc --noEmit -p tsconfig.app.json
- bun run build
- browser-verified at 1920px and 390px with no horizontal overflow