### PR TITLE
✨ Ctrl+Option pointer HUD for tiling

### DIFF
--- a/apps/mac/Sources/AppShell/AppDelegate.swift
+++ b/apps/mac/Sources/AppShell/AppDelegate.swift
@@ -43,6 +43,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         DispatchQueue.main.async { ScreenOverlayCanvasController.shared.warmUp() }
 
         WindowDragSnapController.shared.start()
+        TilePointerController.shared.start()
         MouseGestureController.shared.start()
         KeyboardRemapController.shared.start()
         SecureEventInputMonitor.shared.start()

--- a/apps/mac/Sources/AppShell/HotkeyBootstrap.swift
+++ b/apps/mac/Sources/AppShell/HotkeyBootstrap.swift
@@ -28,10 +28,16 @@ enum HotkeyBootstrap {
         store.register(action: .hud) { HUDController.shared.toggle() }
         store.register(action: .mouseFinder) { MouseFinder.shared.find() }
         store.register(action: .overlayActors) { ScreenOverlayCanvasController.shared.toggleAgentActorsVisibility() }
-        store.register(action: .gridPlacement) { GridPlacementWindow.shared.toggle() }
+        store.register(action: .gridPlacement) {
+            TilePointerController.shared.cancelApply()
+            GridPlacementWindow.shared.toggle()
+        }
         // The single command-surface hotkey: opens the merged bar (browse +
         // search; "/" for slash commands).
-        store.register(action: .commandBar) { UnifiedCommandBarWindow.shared.toggle(mode: .search) }
+        store.register(action: .commandBar) {
+            TilePointerController.shared.cancelApply()
+            UnifiedCommandBarWindow.shared.toggle(mode: .search)
+        }
         store.register(action: .focusMode) { FocusModeController.shared.toggle() }
         store.register(action: .activityLog) {
             DiagnosticLog.shared.info("Hotkey: activityLog triggered")
@@ -75,6 +81,11 @@ enum HotkeyBootstrap {
         ]
         for (action, position) in tileMap {
             store.register(action: action) {
+                TilePointerController.shared.cancelApply()
+                if WindowMotionMode.shared.tileCurrentTarget(to: position) { return }
+                let screen = NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) })
+                    ?? NSScreen.main
+                TileZoneOverlay.shared.show(position: position, on: screen, autoHideAfter: 0.28)
                 WindowTiler.tileFrontmostViaAX(to: position)
             }
         }
@@ -90,6 +101,7 @@ enum HotkeyBootstrap {
             CommandModeWindow.shared.show(launchMode: .organize(appName: appName))
         }
         store.register(action: .tileOpenCell) {
+            TilePointerController.shared.cancelApply()
             FrontWindowPlacer.fillOpenGridCell()
         }
         store.register(action: .motionMode) {

--- a/apps/mac/Sources/AppShell/Preferences.swift
+++ b/apps/mac/Sources/AppShell/Preferences.swift
@@ -22,6 +22,20 @@ enum MouseGestureHUDStyle: String, CaseIterable, Identifiable {
     }
 }
 
+enum TilePointerHUDStyle: String, CaseIterable, Identifiable {
+    case loop
+    case matrix
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .loop: return "Loop"
+        case .matrix: return "Matrix"
+        }
+    }
+}
+
 class Preferences: ObservableObject {
     static let shared = Preferences()
 
@@ -84,6 +98,10 @@ class Preferences: ObservableObject {
 
     @Published var mouseGestureHUDStyle: MouseGestureHUDStyle {
         didSet { UserDefaults.standard.set(mouseGestureHUDStyle.rawValue, forKey: "mouseGestures.hud.style") }
+    }
+
+    @Published var tilePointerHUDStyle: TilePointerHUDStyle {
+        didSet { UserDefaults.standard.set(tilePointerHUDStyle.rawValue, forKey: "tilePointer.hud.style") }
     }
 
     @Published var cursorMarkerShape: CursorMarkerShape {
@@ -227,6 +245,13 @@ class Preferences: ObservableObject {
             self.mouseGestureHUDStyle = style
         } else {
             self.mouseGestureHUDStyle = .technical
+        }
+
+        if let savedTileStyle = UserDefaults.standard.string(forKey: "tilePointer.hud.style"),
+           let style = TilePointerHUDStyle(rawValue: savedTileStyle) {
+            self.tilePointerHUDStyle = style
+        } else {
+            self.tilePointerHUDStyle = .matrix
         }
 
         if let savedShape = UserDefaults.standard.string(forKey: "cursorMarker.shape"),

--- a/apps/mac/Sources/AppShell/SettingsView.swift
+++ b/apps/mac/Sources/AppShell/SettingsView.swift
@@ -555,6 +555,16 @@ struct SettingsContentView: View {
                 }
 
                 settingsPrefRow(
+                    "Ctrl+Option HUD",
+                    caption: "Loop is the radial ring. Matrix is the Lattices 3×3."
+                ) {
+                    SettingsChoiceBar(
+                        selection: $prefs.tilePointerHUDStyle,
+                        options: TilePointerHUDStyle.allCases.map { ($0, $0.label) }
+                    )
+                }
+
+                settingsPrefRow(
                     "Middle-click gestures",
                     caption: "Switch Spaces, open the Screen Map, or trigger dictation."
                 ) {

--- a/apps/mac/Sources/Core/Desktop/TilePointerController.swift
+++ b/apps/mac/Sources/Core/Desktop/TilePointerController.swift
@@ -1,0 +1,313 @@
+import AppKit
+import CoreGraphics
+
+/// Hold Ctrl+Option and move the mouse to aim. Dead-center is cancel;
+/// the rest of the center cell is maximize; outer cells are sectors.
+/// Release Ctrl+Option to apply the current aim, or stay in the dead
+/// zone to do nothing. A key chord during the hold cancels the picker.
+final class TilePointerController {
+    static let shared = TilePointerController()
+
+    private var flagsMonitor: Any?
+    private var mouseMonitor: Any?
+    private var keyMonitor: Any?
+    private var localFlagsMonitor: Any?
+    private var localMouseMonitor: Any?
+    private var localKeyMonitor: Any?
+
+    private var armed = false
+    private var origin: NSPoint?
+    private var aimPoint: NSPoint?
+    private var currentPosition: TilePosition?
+    private var currentScreen: NSScreen?
+    private var pollTimer: Timer?
+    private var pendingDisarm: DispatchWorkItem?
+
+    private static let modifierKeyCodes: Set<UInt16> = [54, 55, 56, 57, 58, 59, 60, 61, 62, 63]
+
+    /// Loop `MouseInteractionObserver`: inner dead zone, then maximize
+    /// until the ring, then 8 wedges.
+    static let noActionDistance: CGFloat = 10
+    static let directionalDistance: CGFloat = 50
+    private static let edgePin: CGFloat = 1
+    static let wedges: [TilePosition] = [
+        .top, .topRight, .right, .bottomRight,
+        .bottom, .bottomLeft, .left, .topLeft,
+    ]
+
+    private init() {}
+
+    func start() {
+        guard flagsMonitor == nil else { return }
+
+        flagsMonitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
+            self?.handleFlags(event.modifierFlags)
+        }
+        localFlagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
+            self?.handleFlags(event.modifierFlags)
+            return event
+        }
+        mouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.mouseMoved, .leftMouseDragged]) { [weak self] event in
+            self?.handleMouseMoved(event)
+        }
+        localMouseMonitor = NSEvent.addLocalMonitorForEvents(matching: [.mouseMoved, .leftMouseDragged]) { [weak self] event in
+            self?.handleMouseMoved(event)
+            return event
+        }
+        keyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            self?.handleKeyDown(event)
+        }
+        localKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            self?.handleKeyDown(event)
+            return event
+        }
+
+        DiagnosticLog.shared.info("TilePointer: Ctrl+Option mouse aiming started")
+    }
+
+    func stop() {
+        for monitor in [flagsMonitor, mouseMonitor, keyMonitor, localFlagsMonitor, localMouseMonitor, localKeyMonitor] {
+            if let monitor { NSEvent.removeMonitor(monitor) }
+        }
+        flagsMonitor = nil
+        mouseMonitor = nil
+        keyMonitor = nil
+        localFlagsMonitor = nil
+        localMouseMonitor = nil
+        localKeyMonitor = nil
+        pendingDisarm?.cancel()
+        pendingDisarm = nil
+        dismiss(apply: false)
+    }
+
+    /// Keyboard chords and other Ctrl+Option hotkeys own the hold.
+    func cancelApply() {
+        dismiss(apply: false)
+    }
+
+    private func handleKeyDown(_ event: NSEvent) {
+        guard !Self.modifierKeyCodes.contains(event.keyCode) else { return }
+        cancelApply()
+    }
+
+    private func handleFlags(_ flags: NSEvent.ModifierFlags) {
+        if Self.ctrlOptionHeld(flags) {
+            pendingDisarm?.cancel()
+            pendingDisarm = nil
+            if !armed {
+                DiagnosticLog.shared.info("TilePointer: arm flags=\(flags.rawValue)")
+                arm()
+            }
+            return
+        }
+        guard armed else { return }
+        scheduleDisarm()
+    }
+
+    private func scheduleDisarm() {
+        guard pendingDisarm == nil else { return }
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.pendingDisarm = nil
+            guard self.armed, !Self.ctrlOptionHeld(NSEvent.modifierFlags) else { return }
+            let shouldApply = self.currentPosition != nil && !WindowDragSnapController.shared.isSnapping
+            DiagnosticLog.shared.info("TilePointer: disarm apply=\(shouldApply) pos=\(self.currentPosition?.rawValue ?? "nil")")
+            self.dismiss(apply: shouldApply)
+        }
+        pendingDisarm = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08, execute: work)
+    }
+
+    private func handleMouseMoved(_ event: NSEvent? = nil) {
+        guard armed, !WindowDragSnapController.shared.isSnapping else { return }
+        if origin == nil {
+            origin = NSEvent.mouseLocation
+        }
+        guard let origin else { return }
+        let location = resolveAimPoint(event, origin: origin)
+
+        guard let screen = NSScreen.screens.first(where: { $0.frame.contains(origin) })
+                ?? NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) })
+                ?? NSScreen.main else { return }
+        currentScreen = screen
+        let position = Self.position(at: location, origin: origin)
+        showHUD(at: origin, position: position)
+        guard position != currentPosition else { return }
+        currentPosition = position
+        DiagnosticLog.shared.info("TilePointer: aim \(position?.rawValue ?? "idle") on \(screen.localizedName)")
+        if let position {
+            TileZoneOverlay.shared.show(position: position, on: screen)
+        } else {
+            TileZoneOverlay.shared.dismiss()
+        }
+    }
+
+    /// When the origin sits against a display edge, macOS pins the cursor.
+    /// Keep integrating event deltas past that pin so outward cells stay reachable
+    /// — the same absolute-mouse compensation Loop uses on its radial menu.
+    private func resolveAimPoint(_ event: NSEvent?, origin: NSPoint) -> NSPoint {
+        let current = NSEvent.mouseLocation
+        guard let bounds = NSScreen.screens.first(where: { $0.frame.contains(origin) })?.frame else {
+            aimPoint = current
+            return current
+        }
+
+        let nearEdge = abs(origin.x - bounds.minX) < Self.directionalDistance
+            || abs(origin.x - bounds.maxX) < Self.directionalDistance
+            || abs(origin.y - bounds.minY) < Self.directionalDistance
+            || abs(origin.y - bounds.maxY) < Self.directionalDistance
+        guard nearEdge else {
+            aimPoint = current
+            return current
+        }
+
+        guard let event else {
+            return aimPoint ?? current
+        }
+
+        let atMinX = abs(current.x - bounds.minX) < Self.edgePin
+        let atMaxX = abs(current.x - bounds.maxX) < Self.edgePin
+        let atMinY = abs(current.y - bounds.minY) < Self.edgePin
+        let atMaxY = abs(current.y - bounds.maxY) < Self.edgePin
+        var resolved = current
+        let last = aimPoint ?? current
+        let maxOffset = Self.directionalDistance
+        if atMinX || atMaxX {
+            resolved.x = min(max(last.x + event.deltaX, bounds.minX - maxOffset), bounds.maxX + maxOffset)
+        }
+        if atMinY || atMaxY {
+            resolved.y = min(max(last.y + event.deltaY, bounds.minY - maxOffset), bounds.maxY + maxOffset)
+        }
+        aimPoint = resolved
+        return resolved
+    }
+
+    private func arm() {
+        armed = true
+        origin = NSEvent.mouseLocation
+        aimPoint = origin
+        currentPosition = nil
+        currentScreen = NSScreen.screens.first(where: { $0.frame.contains(origin ?? .zero) }) ?? NSScreen.main
+        startPolling()
+        if let origin {
+            showHUD(at: origin, position: nil)
+        }
+        handleMouseMoved(nil)
+    }
+
+    private func startPolling() {
+        pollTimer?.invalidate()
+        let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
+            guard self?.armed == true else { return }
+            self?.handleMouseMoved(nil)
+        }
+        timer.tolerance = 0.004
+        RunLoop.main.add(timer, forMode: .common)
+        pollTimer = timer
+    }
+
+    private func dismiss(apply: Bool) {
+        pendingDisarm?.cancel()
+        pendingDisarm = nil
+        pollTimer?.invalidate()
+        pollTimer = nil
+        let position = currentPosition
+        let screen = currentScreen
+        armed = false
+        origin = nil
+        aimPoint = nil
+        currentPosition = nil
+        currentScreen = nil
+
+        hideHUD()
+        if apply, let position {
+            if WindowMotionMode.shared.tileCurrentTarget(to: position) {
+                return
+            }
+            TileZoneOverlay.shared.show(position: position, on: screen, autoHideAfter: 0.28)
+            WindowTiler.tileFrontmostViaAX(to: position)
+            return
+        }
+        TileZoneOverlay.shared.dismiss()
+    }
+
+    private var hudStyle: TilePointerHUDStyle {
+        Preferences.shared.tilePointerHUDStyle
+    }
+
+    private func showHUD(at origin: NSPoint, position: TilePosition?) {
+        switch hudStyle {
+        case .loop:
+            TilePointerMatrixHUD.shared.hide()
+            TilePointerRadialHUD.shared.show(at: origin, position: position)
+        case .matrix:
+            TilePointerRadialHUD.shared.hide()
+            TilePointerMatrixHUD.shared.show(at: origin, position: position)
+        }
+    }
+
+    private func hideHUD() {
+        TilePointerRadialHUD.shared.hide()
+        TilePointerMatrixHUD.shared.hide()
+    }
+
+    private static func ctrlOptionHeld(_ flags: NSEvent.ModifierFlags) -> Bool {
+        let mods = flags.intersection(.deviceIndependentFlagsMask)
+        return mods.contains(.control)
+            && mods.contains(.option)
+            && mods.intersection([.command, .shift]).isEmpty
+    }
+
+    static func wedgeIndex(for position: TilePosition) -> Int? {
+        wedges.firstIndex(of: position)
+    }
+
+    static func position(at point: NSPoint, origin: NSPoint) -> TilePosition? {
+        switch Preferences.shared.tilePointerHUDStyle {
+        case .loop:
+            return loopPosition(at: point, origin: origin)
+        case .matrix:
+            return matrixPosition(at: point, origin: origin)
+        }
+    }
+
+    /// Loop `MouseInteractionObserver.processNewMouseLocation`:
+    /// `-atan2(dy, dx) + π/2` so 0° is up, then 8 wedges clockwise.
+    static func loopPosition(at point: NSPoint, origin: NSPoint) -> TilePosition? {
+        let dx = point.x - origin.x
+        let dy = point.y - origin.y
+        let distance = hypot(dx, dy)
+        if distance < noActionDistance { return nil }
+        let ringThreshold = directionalDistance - TilePointerRadialHUD.thickness
+        if distance <= ringThreshold {
+            return .maximize
+        }
+
+        var degrees = (-atan2(dy, dx) + .pi / 2) * 180 / .pi
+        if degrees < 0 { degrees += 360 }
+        let span = 360.0 / CGFloat(wedges.count)
+        let index = Int((degrees + span / 2) / span) % wedges.count
+        return wedges[index]
+    }
+
+    /// Same three bands as Loop, mapped onto the matrix: inner dead zone,
+    /// rest of the center cell = maximize, then unbounded 3×3 sectors.
+    static func matrixPosition(at point: NSPoint, origin: NSPoint) -> TilePosition? {
+        let dx = point.x - origin.x
+        let dy = point.y - origin.y
+        let cell = TilePointerMatrixHUD.cellSize
+        let half = cell / 2
+        let inCenter = abs(dx) <= half && abs(dy) <= half
+        if inCenter {
+            if hypot(dx, dy) < cell * 0.34 { return nil }
+            return .maximize
+        }
+        let col = dx < 0 ? 0 : 2
+        let row = dy > 0 ? 0 : 2
+        let onVertical = abs(dx) <= half
+        let onHorizontal = abs(dy) <= half
+        if onVertical { return dy > 0 ? .top : .bottom }
+        if onHorizontal { return dx < 0 ? .left : .right }
+        return TilePointerMatrixHUD.cells.first { $0.col == col && $0.row == row }?.position
+    }
+}

--- a/apps/mac/Sources/Core/Desktop/TilePointerMatrixHUD.swift
+++ b/apps/mac/Sources/Core/Desktop/TilePointerMatrixHUD.swift
@@ -1,0 +1,199 @@
+import AppKit
+
+/// Lattices matrix picker: a tight 3×3 of mark-cells at the cursor. No
+/// letters — the grid is the map. Destination preview stays on
+/// `TileZoneOverlay`.
+final class TilePointerMatrixHUD {
+    static let shared = TilePointerMatrixHUD()
+
+    static let panelSize: CGFloat = 116
+    static let pad: CGFloat = 8
+    static let gap: CGFloat = 3
+    static var cellSize: CGFloat {
+        (panelSize - pad * 2 - gap * 2) / 3
+    }
+
+    static let cells: [(col: Int, row: Int, position: TilePosition)] = [
+        (0, 0, .topLeft), (1, 0, .top), (2, 0, .topRight),
+        (0, 1, .left), (1, 1, .maximize), (2, 1, .right),
+        (0, 2, .bottomLeft), (1, 2, .bottom), (2, 2, .bottomRight),
+    ]
+
+    private var panel: NSPanel?
+    private var matrixView: TilePointerMatrixView?
+
+    private init() {}
+
+    func show(at origin: NSPoint, position: TilePosition?) {
+        let frame = CGRect(
+            x: origin.x - Self.panelSize / 2,
+            y: origin.y - Self.panelSize / 2,
+            width: Self.panelSize,
+            height: Self.panelSize
+        )
+        let (panel, view) = ensurePanel()
+        view.position = position
+        if panel.frame != frame {
+            panel.setFrame(frame, display: true)
+        }
+        if !panel.isVisible {
+            view.alphaValue = 0
+            panel.alphaValue = 1
+            panel.orderFrontRegardless()
+            NSAnimationContext.runAnimationGroup { ctx in
+                ctx.duration = 0.08
+                ctx.timingFunction = CAMediaTimingFunction(controlPoints: 0.16, 1.00, 0.30, 1.00)
+                view.animator().alphaValue = 1
+            }
+        }
+    }
+
+    func hide() {
+        guard let panel, panel.isVisible else { return }
+        NSAnimationContext.runAnimationGroup({ ctx in
+            ctx.duration = 0.08
+            panel.animator().alphaValue = 0
+        }, completionHandler: { [weak self] in
+            panel.orderOut(nil)
+            panel.alphaValue = 1
+            self?.matrixView?.position = nil
+        })
+    }
+
+    static func cellRect(col: Int, row: Int, in bounds: CGRect = CGRect(origin: .zero, size: CGSize(width: panelSize, height: panelSize))) -> CGRect {
+        let size = cellSize
+        return CGRect(
+            x: bounds.minX + pad + CGFloat(col) * (size + gap),
+            y: bounds.maxY - pad - CGFloat(row + 1) * size - CGFloat(row) * gap,
+            width: size,
+            height: size
+        )
+    }
+
+    private func ensurePanel() -> (NSPanel, TilePointerMatrixView) {
+        if let panel, let matrixView { return (panel, matrixView) }
+
+        let view = TilePointerMatrixView(frame: NSRect(
+            origin: .zero,
+            size: CGSize(width: Self.panelSize, height: Self.panelSize)
+        ))
+        let panel = NSPanel(
+            contentRect: view.frame,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false
+        panel.hidesOnDeactivate = false
+        panel.isReleasedWhenClosed = false
+        panel.isMovable = false
+        panel.ignoresMouseEvents = true
+        panel.animationBehavior = .none
+        panel.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.maximumWindow)) + 1)
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary, .ignoresCycle]
+        panel.contentView = view
+
+        self.panel = panel
+        self.matrixView = view
+        return (panel, view)
+    }
+}
+
+private final class TilePointerMatrixView: NSView {
+    var position: TilePosition? {
+        didSet {
+            if oldValue != position {
+                needsDisplay = true
+            }
+        }
+    }
+
+    override var isOpaque: Bool { false }
+    override var wantsDefaultClipping: Bool { false }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.clear.cgColor
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        for cell in TilePointerMatrixHUD.cells {
+            let rect = TilePointerMatrixHUD.cellRect(col: cell.col, row: cell.row, in: bounds)
+            let selected = cell.position == position
+            drawCell(rect, selected: selected, isMark: cell.position == .maximize)
+        }
+    }
+
+    private func drawCell(_ rect: CGRect, selected: Bool, isMark: Bool) {
+        let inset: CGFloat = selected ? 0 : 1.2
+        let box = rect.insetBy(dx: inset, dy: inset)
+        let radius = max(1.6, min(box.width, box.height) * 0.22)
+        let path = NSBezierPath(roundedRect: box, xRadius: radius, yRadius: radius)
+
+        let shadow = NSShadow()
+        shadow.shadowBlurRadius = selected ? 12 : 6
+        shadow.shadowOffset = NSSize(width: 0, height: -1)
+        shadow.shadowColor = selected
+            ? NSColor(calibratedRed: 0.20, green: 0.78, blue: 0.45, alpha: 0.42)
+            : NSColor.black.withAlphaComponent(0.22)
+        NSGraphicsContext.saveGraphicsState()
+        shadow.set()
+
+        if selected {
+            NSColor(calibratedRed: 0.20, green: 0.78, blue: 0.45, alpha: 0.94).setFill()
+        } else {
+            NSColor(calibratedWhite: 0.12, alpha: 0.72).setFill()
+        }
+        path.fill()
+        NSGraphicsContext.restoreGraphicsState()
+
+        let lip = CGRect(x: box.minX + 1.5, y: box.maxY - 1.8, width: box.width - 3, height: 1.1)
+        if lip.width > 0 {
+            let lipPath = NSBezierPath(roundedRect: lip, xRadius: 0.6, yRadius: 0.6)
+            NSColor.white.withAlphaComponent(selected ? 0.30 : 0.10).setFill()
+            lipPath.fill()
+        }
+
+        path.lineWidth = selected ? 1.0 : 0.6
+        NSColor.white.withAlphaComponent(selected ? 0.22 : 0.08).setStroke()
+        path.stroke()
+
+        guard isMark else { return }
+        let ink = selected
+            ? NSColor(calibratedRed: 0.04, green: 0.06, blue: 0.09, alpha: 0.94)
+            : NSColor.white.withAlphaComponent(0.72)
+        drawMark(in: box.insetBy(dx: box.width * 0.22, dy: box.height * 0.22), tint: ink, dim: selected ? 0.28 : 0.16)
+    }
+
+    /// Same 3×3 L as `LatticesMark`: left column + bottom row.
+    private func drawMark(in rect: CGRect, tint: NSColor, dim: CGFloat) {
+        let on: [Bool] = [true, false, false, true, false, false, true, true, true]
+        let gap = max(0.6, min(rect.width, rect.height) * 0.08)
+        let cell = (min(rect.width, rect.height) - 2 * gap) / 3
+        let origin = CGPoint(
+            x: rect.midX - (cell * 3 + gap * 2) / 2,
+            y: rect.midY - (cell * 3 + gap * 2) / 2
+        )
+        let radius = max(0.45, cell * 0.22)
+        for (index, bright) in on.enumerated() {
+            let col = index % 3
+            let row = 2 - index / 3
+            let box = CGRect(
+                x: origin.x + CGFloat(col) * (cell + gap),
+                y: origin.y + CGFloat(row) * (cell + gap),
+                width: cell,
+                height: cell
+            )
+            let path = NSBezierPath(roundedRect: box, xRadius: radius, yRadius: radius)
+            (bright ? tint : tint.withAlphaComponent(dim)).setFill()
+            path.fill()
+        }
+    }
+}

--- a/apps/mac/Sources/Core/Desktop/TilePointerRadialHUD.swift
+++ b/apps/mac/Sources/Core/Desktop/TilePointerRadialHUD.swift
@@ -1,0 +1,186 @@
+import AppKit
+
+/// Loop-style radial picker: a 100pt ring (180pt panel) pinned to the
+/// modifier origin. Destination preview stays on `TileZoneOverlay`.
+final class TilePointerRadialHUD {
+    static let shared = TilePointerRadialHUD()
+
+    /// Loop: `radialMenuSize` 100, `.padding(40)` → panel `100 + 80`.
+    static let ringSize: CGFloat = 100
+    static let padding: CGFloat = 40
+    static let panelSize: CGFloat = ringSize + padding * 2
+    static let thickness: CGFloat = 20
+    static let cornerRadius: CGFloat = 40
+
+    private var panel: NSPanel?
+    private var ringView: TilePointerRadialView?
+
+    private init() {}
+
+    func show(at origin: NSPoint, position: TilePosition?) {
+        let frame = CGRect(
+            x: origin.x - Self.panelSize / 2,
+            y: origin.y - Self.panelSize / 2,
+            width: Self.panelSize,
+            height: Self.panelSize
+        )
+        let (panel, view) = ensurePanel()
+        view.position = position
+        if panel.frame != frame {
+            panel.setFrame(frame, display: true)
+        }
+        if !panel.isVisible {
+            view.alphaValue = 0
+            panel.alphaValue = 1
+            panel.orderFrontRegardless()
+            NSAnimationContext.runAnimationGroup { ctx in
+                ctx.duration = 0.10
+                ctx.timingFunction = CAMediaTimingFunction(controlPoints: 0.16, 1.00, 0.30, 1.00)
+                view.animator().alphaValue = 1
+            }
+        }
+    }
+
+    func hide() {
+        guard let panel, panel.isVisible else { return }
+        NSAnimationContext.runAnimationGroup({ ctx in
+            ctx.duration = 0.12
+            panel.animator().alphaValue = 0
+        }, completionHandler: { [weak self] in
+            panel.orderOut(nil)
+            panel.alphaValue = 1
+            self?.ringView?.position = nil
+        })
+    }
+
+    private func ensurePanel() -> (NSPanel, TilePointerRadialView) {
+        if let panel, let ringView { return (panel, ringView) }
+
+        let view = TilePointerRadialView(frame: NSRect(origin: .zero, size: CGSize(width: Self.panelSize, height: Self.panelSize)))
+        let panel = NSPanel(
+            contentRect: view.frame,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false
+        panel.hidesOnDeactivate = false
+        panel.isReleasedWhenClosed = false
+        panel.isMovable = false
+        panel.ignoresMouseEvents = true
+        panel.animationBehavior = .none
+        panel.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.maximumWindow)) + 1)
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary, .ignoresCycle]
+        panel.contentView = view
+
+        self.panel = panel
+        self.ringView = view
+        return (panel, view)
+    }
+}
+
+private final class TilePointerRadialView: NSView {
+    var position: TilePosition? {
+        didSet {
+            if oldValue != position {
+                needsDisplay = true
+            }
+        }
+    }
+
+    override var isOpaque: Bool { false }
+    override var wantsDefaultClipping: Bool { false }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.clear.cgColor
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        let ringRect = bounds.insetBy(dx: TilePointerRadialHUD.padding, dy: TilePointerRadialHUD.padding)
+        let radius = TilePointerRadialHUD.cornerRadius
+        let thickness = TilePointerRadialHUD.thickness
+        let fill = position == .maximize
+
+        let outer = NSBezierPath(roundedRect: ringRect, xRadius: radius, yRadius: radius)
+        let innerRect = ringRect.insetBy(dx: thickness, dy: thickness)
+        let innerRadius = max(4, radius - thickness)
+        let inner = NSBezierPath(roundedRect: innerRect, xRadius: innerRadius, yRadius: innerRadius)
+
+        let shadow = NSShadow()
+        shadow.shadowBlurRadius = 12
+        shadow.shadowOffset = NSSize(width: 0, height: -2)
+        shadow.shadowColor = NSColor.black.withAlphaComponent(0.28)
+        NSGraphicsContext.saveGraphicsState()
+        shadow.set()
+
+        let ring = NSBezierPath()
+        ring.append(outer)
+        ring.append(inner)
+        ring.windingRule = .evenOdd
+        NSColor(calibratedWhite: 0.10, alpha: 0.72).setFill()
+        ring.fill()
+        NSGraphicsContext.restoreGraphicsState()
+
+        if fill {
+            NSColor(calibratedWhite: 0.78, alpha: 0.28).setFill()
+            inner.fill()
+        } else if let position, let index = TilePointerController.wedgeIndex(for: position) {
+            NSGraphicsContext.saveGraphicsState()
+            ring.addClip()
+            let center = CGPoint(x: ringRect.midX, y: ringRect.midY)
+            let angle = 90 - CGFloat(index) * 45
+            let wedge = NSBezierPath()
+            wedge.move(to: center)
+            wedge.appendArc(
+                withCenter: center,
+                radius: ringRect.width,
+                startAngle: angle - 22.5,
+                endAngle: angle + 22.5,
+                clockwise: false
+            )
+            wedge.close()
+            NSColor(calibratedWhite: 0.88, alpha: 0.42).setFill()
+            wedge.fill()
+            NSGraphicsContext.restoreGraphicsState()
+        }
+
+        outer.lineWidth = 1.2
+        NSColor.white.withAlphaComponent(position == nil ? 0.10 : 0.22).setStroke()
+        outer.stroke()
+        inner.lineWidth = 1
+        NSColor.white.withAlphaComponent(0.12).setStroke()
+        inner.stroke()
+
+        guard let position else { return }
+        let symbol = NSImage(systemSymbolName: position.icon, accessibilityDescription: position.label)
+        let config = NSImage.SymbolConfiguration(pointSize: 20, weight: .bold)
+        let image = symbol?.withSymbolConfiguration(config)
+        let size = image?.size ?? .zero
+        let iconRect = CGRect(
+            x: bounds.midX - size.width / 2,
+            y: bounds.midY - size.height / 2,
+            width: size.width,
+            height: size.height
+        )
+        image?.tinted(NSColor.white.withAlphaComponent(0.92)).draw(in: iconRect)
+    }
+}
+
+private extension NSImage {
+    func tinted(_ color: NSColor) -> NSImage {
+        let copy = copy() as! NSImage
+        copy.lockFocus()
+        color.set()
+        NSRect(origin: .zero, size: copy.size).fill(using: .sourceAtop)
+        copy.unlockFocus()
+        return copy
+    }
+}

--- a/apps/mac/Sources/Core/Desktop/WindowDragSnapController.swift
+++ b/apps/mac/Sources/Core/Desktop/WindowDragSnapController.swift
@@ -39,6 +39,8 @@ final class WindowDragSnapController {
     private var modifierModeEnabled = false
     private var windowHasMoved = false
 
+    var isSnapping: Bool { activeSession != nil }
+
     private init() {}
 
     func start() {
@@ -203,6 +205,7 @@ final class WindowDragSnapController {
 
     private func hideOverlays() {
         ScreenOverlayCanvasController.shared.removeLayers(owner: .dragSnap)
+        WindowHoverPreview.shared.hide()
     }
 
     private func captureFocusedWindow(at mouseLocation: NSPoint) -> DragWindowCandidate? {
@@ -352,6 +355,11 @@ final class WindowDragSnapController {
         }
 
         ScreenOverlayCanvasController.shared.replaceLayers(owner: .dragSnap, with: layers)
+        if let hoveredZone {
+            WindowHoverPreview.shared.show(frame: hoveredZone.previewRect)
+        } else {
+            WindowHoverPreview.shared.hide()
+        }
     }
 
     private static func screenRect(for fractions: (CGFloat, CGFloat, CGFloat, CGFloat), on screen: NSScreen) -> CGRect {

--- a/apps/mac/Sources/Core/Desktop/WindowHoverPreview.swift
+++ b/apps/mac/Sources/Core/Desktop/WindowHoverPreview.swift
@@ -1,0 +1,251 @@
+import AppKit
+
+/// One gray hover plate for tiling previews. Reveals onto the first frame,
+/// then shape-shifts to the next instead of popping a new overlay per target.
+final class WindowHoverPreview {
+    static let shared = WindowHoverPreview()
+
+    private var overlayWindow: NSWindow?
+    private var plate: CALayer?
+    private var visuallyPresent = false
+    private var currentTarget: NSRect = .null
+    private var generation: UInt64 = 0
+    private var autoHideWork: DispatchWorkItem?
+    private var stickyUntil: CFTimeInterval = 0
+
+    private let plateInset: CGFloat = 3
+    private let shadowPad: CGFloat = 28
+    private let morphDuration: CFTimeInterval = 0.10
+    private let revealDuration: CFTimeInterval = 0.08
+    private let dismissDuration: CFTimeInterval = 0.06
+    private let cornerRadius: CGFloat = 10
+
+    private static let fillColor = NSColor(calibratedWhite: 0.28, alpha: 0.46).cgColor
+    private static let strokeColor = NSColor(calibratedWhite: 1.0, alpha: 0.78).cgColor
+    private static let morphTiming = CAMediaTimingFunction(controlPoints: 0.16, 1.00, 0.30, 1.00)
+
+    func show(frame windowFrame: NSRect, autoHideAfter: TimeInterval? = nil) {
+        let target = windowFrame.insetBy(dx: plateInset, dy: plateInset)
+        guard target.width > 8, target.height > 8 else { return }
+
+        autoHideWork?.cancel()
+        autoHideWork = nil
+        stickyUntil = autoHideAfter.map { CACurrentMediaTime() + $0 } ?? 0
+        generation += 1
+        let (window, plate) = ensureWindow()
+        let reduceMotion = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+
+        if visuallyPresent, similar(currentTarget, target) {
+            scheduleAutoHide(autoHideAfter)
+            return
+        }
+
+        DiagnosticLog.shared.info(
+            "HoverPreview: show frame=\(Int(target.width))x\(Int(target.height)) @(\(Int(target.minX)),\(Int(target.minY))) morph=\(visuallyPresent) reduceMotion=\(reduceMotion)"
+        )
+
+        if visuallyPresent, !reduceMotion {
+            morph(window: window, plate: plate, to: target, generation: generation)
+        } else {
+            reveal(window: window, plate: plate, at: target, reduceMotion: reduceMotion)
+        }
+        window.orderFrontRegardless()
+
+        currentTarget = target
+        visuallyPresent = true
+        scheduleAutoHide(autoHideAfter)
+    }
+
+    func hide(immediately: Bool = false) {
+        if !immediately, CACurrentMediaTime() < stickyUntil { return }
+        autoHideWork?.cancel()
+        autoHideWork = nil
+        stickyUntil = 0
+        guard visuallyPresent || overlayWindow?.isVisible == true else { return }
+        generation += 1
+        let gen = generation
+        currentTarget = .null
+
+        guard let plate, !immediately else {
+            snapHide()
+            return
+        }
+
+        CATransaction.begin()
+        CATransaction.setAnimationDuration(dismissDuration)
+        CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeIn))
+        CATransaction.setCompletionBlock { [weak self] in
+            guard let self, self.generation == gen else { return }
+            self.snapHide()
+        }
+        plate.opacity = 0
+        CATransaction.commit()
+    }
+
+    func clear() {
+        autoHideWork?.cancel()
+        autoHideWork = nil
+        stickyUntil = 0
+        generation += 1
+        snapHide()
+        overlayWindow?.close()
+        overlayWindow = nil
+        plate = nil
+    }
+
+    private func scheduleAutoHide(_ delay: TimeInterval?) {
+        guard let delay else { return }
+        let work = DispatchWorkItem { [weak self] in
+            self?.hide()
+        }
+        autoHideWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+    }
+
+    private func snapHide() {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        plate?.opacity = 0
+        plate?.transform = CATransform3DIdentity
+        CATransaction.commit()
+        overlayWindow?.orderOut(nil)
+        visuallyPresent = false
+        currentTarget = .null
+    }
+
+    private func ensureWindow() -> (NSWindow, CALayer) {
+        if let overlayWindow, let plate { return (overlayWindow, plate) }
+
+        let host = HoverPreviewHostView(frame: .zero)
+        host.wantsLayer = true
+        host.layer?.backgroundColor = NSColor.clear.cgColor
+        host.layer?.masksToBounds = false
+
+        let plate = CALayer()
+        plate.cornerRadius = cornerRadius
+        plate.cornerCurve = .continuous
+        plate.backgroundColor = Self.fillColor
+        plate.borderWidth = 2
+        plate.borderColor = Self.strokeColor
+        plate.shadowColor = NSColor.black.cgColor
+        plate.shadowOpacity = 0.28
+        plate.shadowRadius = 16
+        plate.shadowOffset = CGSize(width: 0, height: -2)
+        plate.opacity = 0
+        plate.allowsEdgeAntialiasing = true
+        host.layer?.addSublayer(plate)
+
+        let window = NSPanel(
+            contentRect: .zero,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.maximumWindow)))
+        window.hasShadow = false
+        window.hidesOnDeactivate = false
+        window.sharingType = .readOnly
+        window.ignoresMouseEvents = true
+        window.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary, .ignoresCycle]
+        window.animationBehavior = .none
+        window.isReleasedWhenClosed = false
+        window.contentView = host
+        window.alphaValue = 1
+
+        self.overlayWindow = window
+        self.plate = plate
+        return (window, plate)
+    }
+
+    private func reveal(window: NSWindow, plate: CALayer, at target: NSRect, reduceMotion: Bool) {
+        let padded = paddedRect(target)
+        placeWindow(window, frame: padded)
+        refreshScale(plate)
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        plate.frame = layerRect(target, in: window)
+        plate.transform = reduceMotion
+            ? CATransform3DIdentity
+            : CATransform3DMakeScale(0.96, 0.96, 1)
+        plate.opacity = 0
+        CATransaction.commit()
+
+        CATransaction.begin()
+        CATransaction.setAnimationDuration(reduceMotion ? 0.07 : revealDuration)
+        CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeOut))
+        plate.opacity = 1
+        plate.transform = CATransform3DIdentity
+        CATransaction.commit()
+    }
+
+    private func morph(window: NSWindow, plate: CALayer, to target: NSRect, generation: UInt64) {
+        let visual = plate.presentation() ?? plate
+        let currentScreen = visual.frame.offsetBy(dx: window.frame.minX, dy: window.frame.minY)
+        let union = paddedRect(currentScreen.union(target))
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        placeWindow(window, frame: union)
+        plate.frame = currentScreen.offsetBy(dx: -union.minX, dy: -union.minY)
+        plate.transform = CATransform3DIdentity
+        plate.opacity = 1
+        CATransaction.commit()
+
+        let dest = target.offsetBy(dx: -union.minX, dy: -union.minY)
+        CATransaction.begin()
+        CATransaction.setAnimationDuration(morphDuration)
+        CATransaction.setAnimationTimingFunction(Self.morphTiming)
+        CATransaction.setCompletionBlock { [weak self] in
+            guard let self, self.generation == generation, self.visuallyPresent else { return }
+            self.tighten(to: target)
+        }
+        plate.frame = dest
+        plate.opacity = 1
+        CATransaction.commit()
+    }
+
+    private func tighten(to target: NSRect) {
+        guard let window = overlayWindow, let plate else { return }
+        let padded = paddedRect(target)
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        placeWindow(window, frame: padded)
+        plate.frame = layerRect(target, in: window)
+        CATransaction.commit()
+    }
+
+    private func placeWindow(_ window: NSWindow, frame: NSRect) {
+        window.setFrame(frame, display: true)
+        window.contentView?.frame = NSRect(origin: .zero, size: frame.size)
+    }
+
+    private func layerRect(_ screenRect: NSRect, in window: NSWindow) -> NSRect {
+        screenRect.offsetBy(dx: -window.frame.minX, dy: -window.frame.minY)
+    }
+
+    private func paddedRect(_ rect: NSRect) -> NSRect {
+        rect.insetBy(dx: -shadowPad, dy: -shadowPad)
+    }
+
+    private func refreshScale(_ plate: CALayer) {
+        let scale = NSScreen.screens.map(\.backingScaleFactor).max() ?? 2
+        plate.contentsScale = scale
+        overlayWindow?.contentView?.layer?.contentsScale = scale
+    }
+
+    private func similar(_ a: NSRect, _ b: NSRect) -> Bool {
+        abs(a.midX - b.midX) < 1.5
+            && abs(a.midY - b.midY) < 1.5
+            && abs(a.width - b.width) < 1.5
+            && abs(a.height - b.height) < 1.5
+    }
+}
+
+private final class HoverPreviewHostView: NSView {
+    override var isOpaque: Bool { false }
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+}
+

--- a/apps/mac/Sources/Core/Overlays/HUD/CheatSheetHUD.swift
+++ b/apps/mac/Sources/Core/Overlays/HUD/CheatSheetHUD.swift
@@ -511,73 +511,32 @@ extension HotkeyAction {
 
 // MARK: - TileZoneOverlay
 
+/// Gray destination plate for Ctrl+Option tiling. One overlay morphs between
+/// cells instead of tearing down a blue panel per chord.
 final class TileZoneOverlay {
     static let shared = TileZoneOverlay()
 
-    private var panel: NSPanel?
+    func show(position: TilePosition, on screen: NSScreen? = nil, autoHideAfter: TimeInterval? = nil) {
+        let targetScreen = screen
+            ?? NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) })
+            ?? NSScreen.main
+            ?? NSScreen.screens.first
+        guard let targetScreen else { return }
+        WindowHoverPreview.shared.show(frame: Self.rect(for: position, on: targetScreen), autoHideAfter: autoHideAfter)
+    }
 
-    func show(position: TilePosition) {
-        // Instant teardown (no animation) when switching between cells
-        if let p = panel {
-            p.orderOut(nil)
-            self.panel = nil
-        }
+    func dismiss() {
+        WindowHoverPreview.shared.hide()
+    }
 
-        // Use the screen where the mouse is (same as CheatSheetHUD)
-        let mouseLocation = NSEvent.mouseLocation
-        let screen = NSScreen.screens.first(where: { $0.frame.contains(mouseLocation) }) ?? NSScreen.main ?? NSScreen.screens.first!
+    static func rect(for position: TilePosition, on screen: NSScreen) -> NSRect {
         let visible = screen.visibleFrame
-
         let (fx, fy, fw, fh) = position.rect
-        // visibleFrame origin is bottom-left in AppKit coordinates
-        let zoneRect = NSRect(
+        return NSRect(
             x: visible.origin.x + visible.width * fx,
             y: visible.origin.y + visible.height * (1 - fy - fh),
             width: visible.width * fw,
             height: visible.height * fh
         )
-
-        let p = NSPanel(
-            contentRect: zoneRect,
-            styleMask: [.borderless, .nonactivatingPanel],
-            backing: .buffered,
-            defer: false
-        )
-        p.isOpaque = false
-        p.backgroundColor = .clear
-        p.level = .floating
-        p.hasShadow = false
-        p.hidesOnDeactivate = false
-        p.isReleasedWhenClosed = false
-        p.ignoresMouseEvents = true
-
-        let overlay = NSView(frame: NSRect(origin: .zero, size: zoneRect.size))
-        overlay.wantsLayer = true
-        overlay.layer?.backgroundColor = NSColor.systemBlue.withAlphaComponent(0.08).cgColor
-        overlay.layer?.borderColor = NSColor.systemBlue.withAlphaComponent(0.4).cgColor
-        overlay.layer?.borderWidth = 2
-        overlay.layer?.cornerRadius = 8
-        p.contentView = overlay
-
-        p.alphaValue = 0
-        p.orderFrontRegardless()
-
-        NSAnimationContext.runAnimationGroup { ctx in
-            ctx.duration = 0.12
-            p.animator().alphaValue = 1.0
-        }
-
-        self.panel = p
-    }
-
-    func dismiss() {
-        guard let p = panel else { return }
-        NSAnimationContext.runAnimationGroup({ ctx in
-            ctx.duration = 0.1
-            p.animator().alphaValue = 0
-        }) { [weak self] in
-            p.orderOut(nil)
-            self?.panel = nil
-        }
     }
 }

--- a/apps/mac/Sources/Core/Overlays/Motion/WindowMotionMode.swift
+++ b/apps/mac/Sources/Core/Overlays/Motion/WindowMotionMode.swift
@@ -152,6 +152,14 @@ final class WindowMotionMode {
         // clears the spread — the recovery path for the "stuck on top" trap.
         MotionPanel.teardownStrayPanels()
     }
+
+    /// Ctrl+Option tiling while Hyper+G / Hyperspace is open. Lattices is
+    /// frontmost in that mode, so the global tile hotkeys would otherwise no-op.
+    /// Returns true when the overlay consumed the chord.
+    @discardableResult
+    func tileCurrentTarget(to position: TilePosition) -> Bool {
+        panel?.tileCurrentTarget(to: position) ?? false
+    }
 }
 
 // MARK: - Motion key mapping
@@ -1278,6 +1286,22 @@ private final class MotionPanel: NSPanel {
         target.size.width = max(minWidth, target.width)
         target.size.height = max(minHeight, target.height)
         placeActive(to: target)
+    }
+
+    fileprivate func tileCurrentTarget(to position: TilePosition) -> Bool {
+        let selected = pickOrderByScreen[activeScreenID ?? ""] ?? pickOrder
+        let targetWid = inPlaceHoverWid
+            ?? fillAimWid
+            ?? selected.last
+            ?? activeEntry.wid
+        guard let entry = eligible.first(where: { $0.wid == targetWid }),
+              let screen = screen(for: entry) else {
+            NSSound.beep()
+            return true
+        }
+        TileZoneOverlay.shared.show(position: position, on: screen, autoHideAfter: 0.28)
+        placeEntry(entry, to: WindowTiler.tileFrame(for: position, on: screen), label: position.rawValue)
+        return true
     }
 
     /// Place the active window instantly and exactly — snappy, no jittery tween.

--- a/apps/mac/Sources/Core/Overlays/ScreenOverlayCanvasController.swift
+++ b/apps/mac/Sources/Core/Overlays/ScreenOverlayCanvasController.swift
@@ -14,6 +14,7 @@ enum ScreenOverlayOwner: String {
     case hotkeyHints
     case focusHighlight
     case agentApi
+    case tilePointer
 }
 
 enum ScreenOverlayScreenTarget: Equatable {

--- a/docs/app.md
+++ b/docs/app.md
@@ -300,6 +300,7 @@ from Settings > Shortcuts.
 | Ctrl+Option+G      | 4x4 grid placement   |
 | Ctrl+Option+V      | Fill open 3x2 cell   |
 | Ctrl+Option+arrows | Tile halves          |
+| Ctrl+Option+mouse  | Aim HUD; release to tile, stay centered to cancel |
 | Ctrl+Option+1/2/3  | Tile thirds          |
 | Cmd+Option+1/2/3  | Switch workspace layer |
 | Ctrl+B  D         | Detach from session  |

--- a/docs/tiling-reference.md
+++ b/docs/tiling-reference.md
@@ -82,6 +82,12 @@ defaults include:
   3x2 grid on its current screen.
 - `Ctrl+Option+Space`: open the command bar; type `/tile 3x2:3,2` or another
   placement string to place the captured frontmost window precisely.
+- `Ctrl+Option` + mouse: a small HUD sits at the cursor. Stay in the inner
+  center and release to cancel; move a little (still in the center cell) for
+  maximize; move into a sector for that tile. Release Ctrl+Option to apply.
+  Settings → Input Controls can switch Loop ring vs Lattices 3×3 matrix. A
+  Ctrl+Option key chord still wins if you press one during the hold.
+  Command-drag snap keeps large edge/corner drop zones.
 
 ### Placement Contract
 


### PR DESCRIPTION
## Summary
- Hold **Ctrl+Option** and move the mouse to aim a tile. A small HUD sits on the pointer (Lattices **matrix** by default; Loop **ring** as an alternate in Settings → Input Controls).
- Three-zone aim, same idea as [Loop](https://github.com/mrkai77/Loop): inner center is cancel, the rest of the center cell is maximize, outer sectors are halves/corners. Release Ctrl+Option to apply; stay dead-center and release to do nothing.
- Gray destination plate morphs between frames (replaces the old blue per-chord overlay). Command-drag snap still uses large edge drop zones.

## Test plan
- [ ] Hold Ctrl+Option without moving; release — window should not move.
- [ ] Nudge within the center cell; release — maximize.
- [ ] Move into a corner/edge sector; release — that tile.
- [ ] Settings → Input Controls → Ctrl+Option HUD: switch Loop vs Matrix and confirm both aim the same way.
- [ ] Command-drag a window with the snap modifier — large droppables still work.
- [ ] Press a Ctrl+Option tile chord while the HUD is up — chord wins, HUD dismisses.