### PR TITLE
✨ Add voice turn metadata and error mapping to DeckKit

### DIFF
--- a/swift/Sources/DeckKit/DeckRuntimeSnapshot.swift
+++ b/swift/Sources/DeckKit/DeckRuntimeSnapshot.swift
@@ -46,6 +46,26 @@ public struct DeckRuntimeSnapshot: Codable, Equatable, Sendable {
     }
 }
 
+/// How much work a voice turn is expected to do — drives iPad copy and pacing.
+public enum DeckVoiceTurnKind: String, Codable, CaseIterable, Sendable {
+    /// Local rule match — ack + execute, typically sub-second.
+    case quick
+    /// Model inference with actions — narrate then execute.
+    case standard
+    /// Spoken reply only, no desktop actions.
+    case conversation
+}
+
+/// Fine-grained stage within an in-flight turn. Cleared when the turn completes.
+public enum DeckVoiceTurnStage: String, Codable, CaseIterable, Sendable {
+    case acknowledging
+    case understanding
+    case planning
+    case narrating
+    case executing
+    case confirming
+}
+
 public struct DeckVoiceState: Codable, Equatable, Sendable {
     public var phase: DeckVoicePhase
     public var transcript: String?
@@ -54,6 +74,12 @@ public struct DeckVoiceState: Codable, Equatable, Sendable {
     public var provider: String?
     public var error: DeckVoiceError?       // currently-active error (cleared on recovery)
     public var lastError: DeckVoiceError?   // sticky most-recent error for the activity tape
+    /// Quick vs standard vs conversation — from the worker `_meta` contract.
+    public var turnKind: DeckVoiceTurnKind?
+    /// In-flight stage for turn-by-turn UI (ack → plan → narrate → execute).
+    public var turnStage: DeckVoiceTurnStage?
+    /// Human-readable status for relay clients; overrides generic phase captions when set.
+    public var statusLine: String?
 
     public init(
         phase: DeckVoicePhase,
@@ -62,7 +88,10 @@ public struct DeckVoiceState: Codable, Equatable, Sendable {
         responseSummary: String? = nil,
         provider: String? = nil,
         error: DeckVoiceError? = nil,
-        lastError: DeckVoiceError? = nil
+        lastError: DeckVoiceError? = nil,
+        turnKind: DeckVoiceTurnKind? = nil,
+        turnStage: DeckVoiceTurnStage? = nil,
+        statusLine: String? = nil
     ) {
         self.phase = phase
         self.transcript = transcript
@@ -71,6 +100,9 @@ public struct DeckVoiceState: Codable, Equatable, Sendable {
         self.provider = provider
         self.error = error
         self.lastError = lastError
+        self.turnKind = turnKind
+        self.turnStage = turnStage
+        self.statusLine = statusLine
     }
 }
 

--- a/swift/Sources/DeckKit/DeckVoiceErrorMapper.swift
+++ b/swift/Sources/DeckKit/DeckVoiceErrorMapper.swift
@@ -1,0 +1,276 @@
+import Foundation
+
+/// Maps Mac voice-runtime strings onto the shared `DeckVoiceError` model.
+/// Pure logic — safe to unit test without the macOS app target.
+public enum DeckVoiceErrorMapper {
+    public static func resolve(
+        phase: DeckVoicePhase,
+        executionResult: String?,
+        executionError: String?,
+        providerError: String?,
+        isWarmingUp: Bool
+    ) -> DeckVoiceError? {
+        if isWarmingUp || isProgressMessage(executionResult) {
+            return nil
+        }
+
+        if let executionError, !executionError.isEmpty {
+            return map(message: executionError, detail: executionError)
+        }
+
+        if let providerError, !providerError.isEmpty, phase == .idle {
+            return map(message: providerError, detail: providerError)
+        }
+
+        if let result = normalized(executionResult), isErrorMessage(result) {
+            return map(message: result, detail: result)
+        }
+
+        return nil
+    }
+
+    public static func isProgressMessage(_ value: String?) -> Bool {
+        guard let value = normalized(value) else { return false }
+        switch value {
+        case "Connecting to voice runtime...",
+             "Transcribing...",
+             "thinking...",
+             "fixing...":
+            return true
+        default:
+            return false
+        }
+    }
+
+    public static func isErrorMessage(_ value: String) -> Bool {
+        let lower = value.lowercased()
+        if lower.hasPrefix("couldn't run:") { return true }
+        if lower.hasPrefix("transcription failed:") { return true }
+        if lower.contains("voice runtime") { return true }
+        if lower.contains("no voice provider") { return true }
+        if lower == "no speech detected" { return true }
+        if lower == "transcription timed out" { return true }
+        if lower.contains("mic in use") || lower.contains("mic busy") { return true }
+        if lower.contains("live_session_busy") { return true }
+        if lower.contains("unauthorized") { return true }
+        if lower.contains("access denied") || lower.contains("accessibility") { return true }
+        if lower.contains("intent not found") || lower.contains("intent unresolved") { return true }
+        if lower == "voice cancelled" { return true }
+        if lower.contains("no active live session") { return true }
+        return false
+    }
+
+    public static func map(message: String, detail: String?) -> DeckVoiceError {
+        let lower = message.lowercased()
+
+        if lower.contains("live_session_busy") {
+            return DeckVoiceError(
+                code: .micBusy,
+                severity: .warning,
+                recoverable: true,
+                retry: .immediate,
+                source: .vox,
+                owner: "Lattices",
+                message: "Voice session still open — tap Cancel, then try again",
+                remediation: .retryVoice,
+                detail: detail
+            )
+        }
+
+        if lower.contains("no active live session") {
+            return DeckVoiceError(
+                code: .transcriptionFailed,
+                severity: .warning,
+                recoverable: true,
+                retry: .immediate,
+                source: .vox,
+                message: "Voice capture wasn't ready — wait for listening, then try again",
+                remediation: .retryVoice,
+                detail: detail
+            )
+        }
+
+        if lower.contains("mic in use") || lower.contains("mic busy") {
+            let owner = micOwner(from: message) ?? "another app"
+            return DeckVoiceError(
+                code: .micBusy,
+                severity: .warning,
+                recoverable: true,
+                retry: .userAction,
+                source: .vox,
+                owner: owner,
+                message: "Mic in use by \(owner) — finish recording first",
+                remediation: .retryVoice,
+                detail: detail
+            )
+        }
+
+        if lower.contains("mic denied") || (lower.contains("microphone") && lower.contains("denied")) {
+            return DeckVoiceError(
+                code: .micDenied,
+                severity: .blocked,
+                recoverable: false,
+                retry: .userAction,
+                source: .mac,
+                message: "Microphone access denied on your Mac",
+                remediation: .openSystemSettings(kind: "microphone"),
+                detail: detail
+            )
+        }
+
+        if lower.contains("accessibility") && (lower.contains("denied") || lower.contains("access")) {
+            return DeckVoiceError(
+                code: .accessibilityDenied,
+                severity: .blocked,
+                recoverable: false,
+                retry: .userAction,
+                source: .mac,
+                message: "Accessibility access required on your Mac",
+                remediation: .openSystemSettings(kind: "accessibility"),
+                detail: detail
+            )
+        }
+
+        if lower.contains("no voice provider") {
+            return DeckVoiceError(
+                code: .voxNotRunning,
+                severity: .error,
+                recoverable: true,
+                retry: .afterLaunch,
+                source: .mac,
+                message: "Voice runtime not available in this build",
+                remediation: .openDiagnostics,
+                detail: detail
+            )
+        }
+
+        if lower.contains("unauthorized") {
+            return DeckVoiceError(
+                code: .voxUnreachable,
+                severity: .error,
+                recoverable: true,
+                retry: .afterLaunch,
+                source: .vox,
+                message: "Voice runtime rejected Lattices",
+                remediation: .openVox,
+                detail: detail
+            )
+        }
+
+        if lower.contains("voice runtime unavailable") || lower.contains("voice runtime not running") {
+            return DeckVoiceError(
+                code: .voxUnreachable,
+                severity: .error,
+                recoverable: true,
+                retry: .afterLaunch,
+                source: .vox,
+                message: "Voice runtime offline — starting",
+                remediation: .openVox,
+                detail: detail
+            )
+        }
+
+        if lower.contains("connection lost") || lower.contains("network connection was lost") {
+            return DeckVoiceError(
+                code: .connectionLost,
+                severity: .error,
+                recoverable: true,
+                retry: .immediate,
+                source: .vox,
+                message: "Connection lost — press again",
+                remediation: .retryVoice,
+                detail: detail
+            )
+        }
+
+        if lower == "no speech detected" {
+            return DeckVoiceError(
+                code: .emptyTranscript,
+                severity: .warning,
+                recoverable: true,
+                retry: .immediate,
+                source: .vox,
+                message: "No speech detected — try again",
+                remediation: .retryVoice,
+                detail: detail
+            )
+        }
+
+        if lower == "transcription timed out" || lower.hasPrefix("transcription failed:") {
+            return DeckVoiceError(
+                code: .transcriptionFailed,
+                severity: .warning,
+                recoverable: true,
+                retry: .immediate,
+                source: .vox,
+                message: "Transcription failed — try again",
+                remediation: .retryVoice,
+                detail: detail
+            )
+        }
+
+        if lower.hasPrefix("couldn't run:") {
+            return DeckVoiceError(
+                code: .actionFailed,
+                severity: .error,
+                recoverable: true,
+                retry: .immediate,
+                source: .intent,
+                message: message,
+                remediation: .retryVoice,
+                detail: detail
+            )
+        }
+
+        if lower.contains("intent not found") || lower.contains("intent unresolved") {
+            return DeckVoiceError(
+                code: .intentUnresolved,
+                severity: .warning,
+                recoverable: true,
+                retry: .immediate,
+                source: .intent,
+                message: "Intent not found — try rephrasing",
+                remediation: .retryVoice,
+                detail: detail
+            )
+        }
+
+        if lower == "voice cancelled" {
+            return DeckVoiceError(
+                code: .emptyTranscript,
+                severity: .info,
+                recoverable: true,
+                retry: .immediate,
+                source: .mac,
+                message: "Voice cancelled",
+                remediation: .retryVoice,
+                detail: detail
+            )
+        }
+
+        return DeckVoiceError(
+            code: .actionFailed,
+            severity: .error,
+            recoverable: true,
+            retry: .immediate,
+            source: .mac,
+            message: message,
+            remediation: .retryVoice,
+            detail: detail
+        )
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func micOwner(from message: String) -> String? {
+        if let range = message.range(of: "by ", options: .caseInsensitive) {
+            let tail = message[range.upperBound...].trimmingCharacters(in: .whitespacesAndNewlines)
+            if !tail.isEmpty { return tail }
+        }
+        return nil
+    }
+}

--- a/swift/Tests/DeckKitTests/DeckKitTests.swift
+++ b/swift/Tests/DeckKitTests/DeckKitTests.swift
@@ -343,4 +343,66 @@ final class DeckKitTests: XCTestCase {
         XCTAssertEqual(decoded.cockpitMode?.mode, .replay)
         XCTAssertEqual(decoded.activityLog?.first?.tag, "DECK")
     }
+
+    func testVoiceErrorMapperMapsRuntimeUnavailable() {
+        let error = DeckVoiceErrorMapper.map(
+            message: "Voice runtime unavailable",
+            detail: "Voice runtime unavailable"
+        )
+        XCTAssertEqual(error.code, .voxUnreachable)
+        XCTAssertEqual(error.remediation, .openVox)
+    }
+
+    func testVoiceErrorMapperIgnoresProgressMessages() {
+        XCTAssertNil(
+            DeckVoiceErrorMapper.resolve(
+                phase: .listening,
+                executionResult: "Connecting to voice runtime...",
+                executionError: nil,
+                providerError: nil,
+                isWarmingUp: true
+            )
+        )
+    }
+
+    func testVoiceErrorMapperMapsEmptyTranscript() {
+        let error = DeckVoiceErrorMapper.resolve(
+            phase: .idle,
+            executionResult: "No speech detected",
+            executionError: nil,
+            providerError: nil,
+            isWarmingUp: false
+        )
+        XCTAssertEqual(error?.code, .emptyTranscript)
+        XCTAssertEqual(error?.remediation, .retryVoice)
+    }
+
+    func testVoiceErrorMapperMapsNoActiveLiveSession() {
+        let error = DeckVoiceErrorMapper.resolve(
+            phase: .idle,
+            executionResult: "No active live session",
+            executionError: nil,
+            providerError: nil,
+            isWarmingUp: false
+        )
+        XCTAssertEqual(error?.code, .transcriptionFailed)
+        XCTAssertEqual(error?.remediation, .retryVoice)
+        XCTAssertTrue(DeckVoiceErrorMapper.isErrorMessage("No active live session"))
+    }
+
+    func testVoiceStateEncodesTurnMetadata() throws {
+        let state = DeckVoiceState(
+            phase: .reasoning,
+            transcript: "tile chrome left",
+            responseSummary: nil,
+            turnKind: .quick,
+            turnStage: .executing,
+            statusLine: "Running command…"
+        )
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(DeckVoiceState.self, from: data)
+        XCTAssertEqual(decoded.turnKind, .quick)
+        XCTAssertEqual(decoded.turnStage, .executing)
+        XCTAssertEqual(decoded.statusLine, "Running command…")
+    }
 }


### PR DESCRIPTION
## Summary

- Add `DeckVoiceTurnKind` (quick / standard / conversation) and `DeckVoiceTurnStage` for turn-by-turn relay UI
- Add `statusLine` on `DeckVoiceState` for iPad captions
- Map `No active live session` race to structured `transcriptionFailed` + `retryVoice`
- Tests: `testVoiceErrorMapperMapsNoActiveLiveSession`, `testVoiceStateEncodesTurnMetadata`

Part of the voice stack — **1/7**. Merge train ends at #106.

**CI deferred** until final merge to `main`.