### PR TITLE
✨ Route iPad voice through HandsOff with Kokoro TTS

### DIFF
--- a/apps/mac/Sources/Core/Companion/LatticesDeckHost.swift
+++ b/apps/mac/Sources/Core/Companion/LatticesDeckHost.swift
@@ -1,6 +1,9 @@
 import AppKit
 import DeckKit
 import Foundation
+#if LATTICES_VOICE && canImport(HudsonVoice)
+import HudsonVoice
+#endif
 
 enum LatticesDeckHostError: LocalizedError {
     case unsupportedAction(String)
@@ -276,31 +279,34 @@ private extension LatticesDeckHost {
                 suggestedActions: voiceSuggestions(for: .idle)
             )
 
-        // Single-shot voice command path (transcribe → match intent → execute).
-        // Distinct from voice.toggle / voice.cancel which drive the chat-style
-        // HandsOffSession. Lives here so the iPad companion can fire dictation
-        // on the active Mac via the existing /deck/perform bridge.
+        // iPad companion voice relay — same HandsOff session as the Mac menu
+        // voice mode. The iPad never captures audio; it arms the Mac microphone.
         case "voice.command.start":
             try MainActorSync.run {
-                AudioLayer.shared.startVoiceCommand()
+                self.startRemoteVoiceListening()
             }
             return try voiceOutcome()
 
         case "voice.command.stop":
             try MainActorSync.run {
-                AudioLayer.shared.stopVoiceCommand()
+                self.finishRemoteVoiceListening()
             }
             return try voiceOutcome()
 
         case "voice.command.toggle":
             try MainActorSync.run {
-                if AudioLayer.shared.isListening {
-                    AudioLayer.shared.stopVoiceCommand()
-                } else {
-                    AudioLayer.shared.startVoiceCommand()
-                }
+                HandsOffSession.shared.setAudibleFeedbackEnabled(true)
+                HandsOffSession.shared.toggle()
             }
             return try voiceOutcome()
+
+        case "voice.runtime.warm":
+            warmVoiceRuntime()
+            return ActionOutcome(
+                summary: "Warming voice runtime",
+                detail: "Preparing the Mac voice engine for capture.",
+                suggestedActions: []
+            )
 
         case "talkie.perform":
             guard let shortcutID = request.payload["shortcutID"]?.stringValue else {
@@ -529,6 +535,52 @@ private extension LatticesDeckHost {
         }
     }
 
+
+    func warmVoiceRuntime() {
+        #if LATTICES_VOICE && canImport(HudsonVoice)
+        Task {
+            _ = LatticesVoiceRuntime.ensureRunning()
+            guard let runtime = HudsonVoiceRuntimeResolver.resolve(clientId: "lattices") else { return }
+            do {
+                _ = try await HudVoxProbe.health(
+                    endpoint: runtime.endpoint,
+                    clientId: runtime.options.clientId,
+                    authToken: runtime.options.authToken ?? runtime.authToken
+                )
+            } catch {
+                DiagnosticLog.shared.warn(
+                    "DeckHost: voice runtime warm-up probe failed — \(error.localizedDescription)"
+                )
+            }
+        }
+        #endif
+    }
+
+    @MainActor
+    func startRemoteVoiceListening() {
+        let handsOff = HandsOffSession.shared
+        handsOff.setAudibleFeedbackEnabled(true)
+        switch handsOff.state {
+        case .idle:
+            handsOff.toggle()
+        case .listening:
+            break
+        case .thinking, .connecting:
+            handsOff.cancel()
+            handsOff.toggle()
+        }
+    }
+
+    @MainActor
+    func finishRemoteVoiceListening() {
+        let handsOff = HandsOffSession.shared
+        if handsOff.state == .listening {
+            handsOff.finishListening()
+        } else if handsOff.state == .thinking {
+            handsOff.cancel()
+        }
+    }
+
     func voiceOutcome() throws -> ActionOutcome {
         let phase = try MainActorSync.run { self.currentVoicePhase() }
         let summary: String
@@ -692,13 +744,7 @@ private extension LatticesDeckHost {
         let spacesState = buildSpacesState()
         let currentSpaceIndex = spacesState.currentSpaceIndex
         let currentSpaceName = spacesState.currentSpaceName
-        let voice = DeckVoiceState(
-            phase: currentVoicePhase(),
-            transcript: handsOff.lastTranscript ?? audio.lastTranscript,
-            transcriptLines: buildTranscriptLines(handsOff: handsOff, audio: audio),
-            responseSummary: handsOff.lastResponse ?? audio.executionResult,
-            provider: audio.providerName == "none" ? "voice-runtime" : audio.providerName
-        )
+        let voice = buildDeckVoiceState(handsOff: handsOff, audio: audio)
         let desktop = DeckDesktopSummary(
             activeLayerName: activeLayerName(),
             activeAppName: visibleWindows.first?.app ?? NSWorkspace.shared.frontmostApplication?.localizedName,
@@ -905,18 +951,74 @@ private extension LatticesDeckHost {
     }
 
     @MainActor
+    func buildDeckVoiceState(handsOff: HandsOffSession, audio: AudioLayer) -> DeckVoiceState {
+        let phase = currentVoicePhase(handsOff: handsOff, audio: audio)
+        let rawSummary = handsOff.state == .idle
+            ? (handsOff.lastResponse ?? audio.executionResult)
+            : handsOff.lastResponse
+        let responseSummary = DeckVoiceErrorMapper.isProgressMessage(rawSummary) ? nil : rawSummary
+        let error = DeckVoiceErrorMapper.resolve(
+            phase: phase,
+            executionResult: rawSummary,
+            executionError: audio.executionError,
+            providerError: audio.provider?.lastErrorMessage,
+            isWarmingUp: handsOff.state == .connecting
+        )
+        let summary = error == nil ? responseSummary : nil
+        return DeckVoiceState(
+            phase: phase,
+            transcript: handsOff.lastTranscript ?? audio.lastTranscript,
+            transcriptLines: buildTranscriptLines(handsOff: handsOff, audio: audio),
+            responseSummary: summary,
+            provider: audio.providerName == "none" ? "voice-runtime" : audio.providerName,
+            error: error,
+            lastError: error,
+            turnKind: handsOff.lastTurnKind,
+            turnStage: handsOff.turnStage,
+            statusLine: voiceStatusLine(handsOff: handsOff)
+        )
+    }
+
+    @MainActor
+    func voiceStatusLine(handsOff: HandsOffSession) -> String? {
+        switch handsOff.turnStage {
+        case .acknowledging: return "Got it…"
+        case .understanding: return "Understanding what you said…"
+        case .planning:
+            return handsOff.lastTurnKind == .quick ? "Running command…" : "Planning on your Mac…"
+        case .narrating: return "Explaining what I'll do…"
+        case .executing:
+            return handsOff.lastTurnKind == .quick ? "Running command…" : "Updating your desktop…"
+        case .confirming: return "Done."
+        case .none: return nil
+        }
+    }
+
+    @MainActor
     func currentVoicePhase() -> DeckVoicePhase {
-        let handsOff = HandsOffSession.shared
+        currentVoicePhase(handsOff: HandsOffSession.shared, audio: AudioLayer.shared)
+    }
+
+    @MainActor
+    func currentVoicePhase(handsOff: HandsOffSession, audio: AudioLayer) -> DeckVoicePhase {
         switch handsOff.state {
-        case .idle:
-            break
         case .connecting, .listening:
             return .listening
         case .thinking:
-            return .reasoning
+            switch handsOff.turnStage {
+            case .acknowledging, .narrating, .confirming:
+                return .speaking
+            case .understanding:
+                return .transcribing
+            case .planning, .executing:
+                return .reasoning
+            case .none:
+                return .reasoning
+            }
+        case .idle:
+            break
         }
 
-        let audio = AudioLayer.shared
         if audio.isListening {
             return .listening
         }

--- a/apps/mac/Sources/Core/Voice/AudioProvider.swift
+++ b/apps/mac/Sources/Core/Voice/AudioProvider.swift
@@ -1,4 +1,5 @@
 import AppKit
+import DeckKit
 #if LATTICES_VOICE && canImport(HudsonVoice)
 import HudsonVoice
 #endif
@@ -51,6 +52,8 @@ final class AudioLayer: ObservableObject {
 
     private var pendingVoiceStart = false
     private var voiceConnectionRetry: DispatchWorkItem?
+    /// Capture was requested but the provider is still warming up.
+    var isWarmingUp: Bool { pendingVoiceStart && !isListening }
 
     private init() {
         #if LATTICES_VOICE && canImport(HudsonVoice)
@@ -246,12 +249,11 @@ final class AudioLayer: ObservableObject {
 
         } else if shouldAnswerWithAssistant(text) {
             DiagnosticLog.shared.info("AudioLayer: route → Assistant question")
-            DiagnosticLog.shared.info("AudioLayer: question-like voice request, handing to Assistant")
             matchedIntent = nil
             matchedSlots = [:]
             executionResult = "thinking..."
             executionData = nil
-            handoffToAssistant(prompt: IntentHeuristics.assistantPromptText(text))
+            answerVoiceQuestion(text)
 
         } else {
             // No local match — ask the selected Assistant provider.
@@ -280,11 +282,44 @@ final class AudioLayer: ObservableObject {
             self.agentResponse = response
             if let commentary = response.commentary {
                 DiagnosticLog.shared.info("AudioLayer: Assistant advisor says — \(commentary)")
+                if self.shouldSurfaceAdvisorCommentary() {
+                    self.setFinalResult(commentary)
+                }
             }
             if let suggestion = response.suggestion {
                 DiagnosticLog.shared.info("AudioLayer: Assistant advisor suggests — \(suggestion.label) → \(suggestion.intent)")
             }
         }
+    }
+
+    private func answerVoiceQuestion(_ text: String) {
+        let assistant = WorkspaceAssistantSession.shared
+        guard assistant.isProviderInferenceReady else {
+            DiagnosticLog.shared.info("AudioLayer: Assistant provider not ready for question")
+            handoffToAssistant(prompt: IntentHeuristics.assistantPromptText(text))
+            return
+        }
+
+        assistant.answerVoiceQuestion(text) { [weak self] response in
+            guard let self else { return }
+            if let commentary = response?.commentary?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !commentary.isEmpty {
+                self.agentResponse = response
+                self.setFinalResult(commentary)
+                return
+            }
+            self.handoffToAssistant(prompt: IntentHeuristics.assistantPromptText(text))
+        }
+    }
+
+    private func shouldSurfaceAdvisorCommentary() -> Bool {
+        guard let result = executionResult?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !result.isEmpty else {
+            return true
+        }
+        if result == "ok" { return true }
+        if DeckVoiceErrorMapper.isProgressMessage(result) { return true }
+        return false
     }
 
     private func assistantFallback(transcription: Transcription) {
@@ -410,6 +445,36 @@ final class AudioLayer: ObservableObject {
             DiagnosticLog.shared.warn("AudioLayer: final outcome — \(message)")
         } else {
             DiagnosticLog.shared.info("AudioLayer: final outcome — \(message)")
+            speakVoiceOutcome(message: message)
+        }
+    }
+
+    private func speakVoiceOutcome(message: String) {
+        let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        if DeckVoiceErrorMapper.isProgressMessage(trimmed) { return }
+        if trimmed == "Sent to Assistant" { return }
+
+        if let intent = matchedIntent, let cue = cachedCuePhrase(for: intent) {
+            HandsOffSession.shared.playRemoteCachedCue(cue)
+            return
+        }
+
+        let spoken = trimmed == "ok" ? "Done." : trimmed
+        HandsOffSession.shared.speakRemoteResponse(spoken)
+    }
+
+    private func cachedCuePhrase(for intent: String) -> String? {
+        switch intent {
+        case "tile_window": return "Tiled."
+        case "focus": return "Focused."
+        case "distribute": return "Distributed."
+        case "search": return "Searching."
+        case "switch_layer": return "Switched."
+        case "create_layer": return "Done."
+        case "launch": return "Done."
+        case "kill": return "Done."
+        default: return nil
         }
     }
 

--- a/apps/mac/Sources/Core/Voice/HandsOffSession.swift
+++ b/apps/mac/Sources/Core/Voice/HandsOffSession.swift
@@ -1,4 +1,5 @@
 import AppKit
+import DeckKit
 #if LATTICES_VOICE && canImport(HudsonVoice)
 import HudsonVoice
 #endif
@@ -56,6 +57,10 @@ final class HandsOffSession: ObservableObject {
     @Published private(set) var stateChangedAt: Date = Date()
     @Published var lastTranscript: String?
     @Published var lastResponse: String?
+    /// In-flight turn stage streamed from the worker (ack → plan → narrate → execute).
+    @Published private(set) var turnStage: DeckVoiceTurnStage?
+    /// Kind of the most recently completed turn — drives relay UI copy on the iPad.
+    @Published private(set) var lastTurnKind: DeckVoiceTurnKind?
     @Published var audibleFeedbackEnabled: Bool = false
 
     /// Recently executed actions — shown as playback in the HUD bottom bar
@@ -161,11 +166,26 @@ final class HandsOffSession: ObservableObject {
 
     func playCachedCue(_ phrase: String) {
         guard audibleFeedbackEnabled else { return }
+        playRemoteCachedCue(phrase)
+    }
+
+    /// Cached cue for iPad voice relay and other remote paths outside hands-off.
+    func playRemoteCachedCue(_ phrase: String) {
+        let trimmed = phrase.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
         let now = Date()
         guard now.timeIntervalSince(lastCueAt) >= 0.2 else { return }
         lastCueAt = now
         startWorker()
-        sendToWorker(["cmd": "play_cached", "text": phrase])
+        sendToWorker(["cmd": "play_cached", "text": trimmed])
+    }
+
+    /// Fire-and-forget spoken feedback for remote voice commands (iPad relay).
+    func speakRemoteResponse(_ text: String) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        startWorker()
+        sendToWorker(["cmd": "ack", "text": trimmed])
     }
 
     /// Append a full turn record to the JSONL log
@@ -330,6 +350,19 @@ final class HandsOffSession: ObservableObject {
 
             DiagnosticLog.shared.info("HandsOff: worker response → \(trimmed)")
 
+            // Mid-turn progress — update stage without completing the turn callback.
+            if let progress = json["progress"] as? String {
+                let stage = DeckVoiceTurnStage(rawValue: progress)
+                let kind = (json["turnKind"] as? String).flatMap(DeckVoiceTurnKind.init(rawValue:))
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { return }
+                    if let stage { self.turnStage = stage }
+                    if let kind { self.lastTurnKind = kind }
+                    if self.state != .thinking { self.state = .thinking }
+                }
+                continue
+            }
+
             // Parse everything on the background thread, then do ONE main-queue dispatch
             // to update all @Published properties atomically. Scattered dispatches cause
             // Combine deadlocks (os_unfair_lock contention with SwiftUI rendering).
@@ -374,6 +407,10 @@ final class HandsOffSession: ObservableObject {
                         self.recentActions = actions
                         self.executeActions(actions)
                     }
+                    if let meta = dataObj?["_meta"] as? [String: Any] {
+                        self.lastTurnKind = Self.parseTurnKind(meta)
+                    }
+                    self.turnStage = nil
                     self.state = .idle
                 }
                 cb?(json)
@@ -406,6 +443,7 @@ final class HandsOffSession: ObservableObject {
         turnTimeoutWork?.cancel()
         turnTimeoutWork = nil
         pendingCallback = nil
+        turnStage = nil
         state = .idle
         DiagnosticLog.shared.warn("HandsOff: turn cancelled by user")
         playSound("Funk")
@@ -675,6 +713,8 @@ final class HandsOffSession: ObservableObject {
     // MARK: - Turn processing (delegates to worker)
 
     private func processTurn(_ transcript: String) {
+        turnStage = .understanding
+        lastTurnKind = nil
         state = .thinking
         guard startWorker() else {
             state = .idle
@@ -733,6 +773,16 @@ final class HandsOffSession: ObservableObject {
                 }
             }
         }
+    }
+
+    private static func parseTurnKind(_ meta: [String: Any]) -> DeckVoiceTurnKind? {
+        if let kind = meta["turnKind"] as? String {
+            return DeckVoiceTurnKind(rawValue: kind)
+        }
+        if let path = meta["path"] as? String, path == "quick" {
+            return .quick
+        }
+        return nil
     }
 
     // MARK: - Desktop snapshot (full context — all windows, all screens)

--- a/apps/mac/Sources/Core/Voice/LatticesVoiceEngineLoader.swift
+++ b/apps/mac/Sources/Core/Voice/LatticesVoiceEngineLoader.swift
@@ -1,0 +1,162 @@
+#if LATTICES_VOICE && canImport(HudsonVoice)
+import Foundation
+import HudsonSpeechEngine
+import VoxCore
+import VoxService
+
+/// Boots the embedded Vox engines with Kokoro TTS + Parakeet ASR for Lattices voice.
+enum LatticesVoiceEngineLoader {
+    static let kokoroModelId = "mlx-community/Kokoro-82M-bf16"
+    static let kokoroVoiceId = "af_heart"
+
+    static func loadEngines(runtimeHome: URL) throws -> (EngineManager, TTSEngineManager, String) {
+        try seedRuntimeHome(runtimeHome)
+
+        let configURL = runtimeHome.appendingPathComponent("providers.json")
+        if FileManager.default.fileExists(atPath: configURL.path) {
+            do {
+                let config = try ProvidersConfig.load(from: configURL)
+                let asrConfig = config.providers.contains(where: { $0.resolvedKind == .asr })
+                    ? config
+                    : defaultASRConfig()
+                let ttsConfig = config.providers.contains(where: { $0.resolvedKind == .tts })
+                    ? config.mergingMissingTTSDefaults()
+                    : defaultTTSConfig()
+                return (
+                    EngineManager(provider: ProviderRegistry(config: asrConfig)),
+                    TTSEngineManager(provider: TTSProviderRegistry(config: ttsConfig)),
+                    resolveDefaultSynthesisModelId(for: ttsConfig)
+                )
+            } catch {
+                DiagnosticLog.shared.warn(
+                    "HudsonVoice: failed to parse providers.json — \(error.localizedDescription); using defaults"
+                )
+            }
+        }
+
+        let ttsConfig = defaultTTSConfig()
+        return (
+            EngineManager(provider: ProviderRegistry(config: defaultASRConfig())),
+            TTSEngineManager(provider: TTSProviderRegistry(config: ttsConfig)),
+            resolveDefaultSynthesisModelId(for: ttsConfig)
+        )
+    }
+
+    private static func resolveDefaultSynthesisModelId(for config: ProvidersConfig) -> String {
+        let models = config.providers
+            .filter { $0.resolvedKind == .tts }
+            .flatMap { $0.models ?? [] }
+        if models.contains(kokoroModelId) {
+            return kokoroModelId
+        }
+        return TTSDefaultModelSelector.defaultModelId(for: config)
+    }
+
+    private static func seedRuntimeHome(_ runtimeHome: URL) throws {
+        try FileManager.default.createDirectory(at: runtimeHome, withIntermediateDirectories: true)
+
+        let providersURL = runtimeHome.appendingPathComponent("providers.json")
+        if !FileManager.default.fileExists(atPath: providersURL.path) {
+            let userProviders = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".vox/providers.json")
+            if FileManager.default.fileExists(atPath: userProviders.path) {
+                try FileManager.default.copyItem(at: userProviders, to: providersURL)
+            } else {
+                try writeDefaultProviders(to: providersURL)
+            }
+        }
+
+        let preferencesURL = runtimeHome.appendingPathComponent("preferences.json")
+        var preferences = (try? VoxPreferences.load(from: preferencesURL)) ?? VoxPreferences()
+        if preferences.speech.preferredSynthesisModelId?.isEmpty != false {
+            preferences.speech.preferredSynthesisModelId = kokoroModelId
+        }
+        if preferences.speech.preferredSynthesisVoiceId?.isEmpty != false {
+            preferences.speech.preferredSynthesisVoiceId = kokoroVoiceId
+        }
+        try preferences.save(to: preferencesURL)
+    }
+
+    private static func writeDefaultProviders(to url: URL) throws {
+        let payload: [String: Any] = [
+            "providers": [
+                [
+                    "id": "parakeet",
+                    "kind": "asr",
+                    "builtin": true,
+                    "models": ["parakeet:v3"],
+                ],
+                [
+                    "id": "mlx-audio",
+                    "kind": "tts",
+                    "builtin": true,
+                    "models": [kokoroModelId],
+                    "env": [
+                        "VOX_MLX_AUDIO_USE_UV": "1",
+                        "VOX_MLX_AUDIO_TTS_MODELS": kokoroModelId,
+                        "VOX_MLX_AUDIO_TTS_DEFAULT_VOICE": kokoroVoiceId,
+                        "VOX_PROVIDER_CALL_TIMEOUT_SECONDS": "300",
+                    ],
+                ],
+                [
+                    "id": "avspeech",
+                    "kind": "tts",
+                    "builtin": true,
+                    "models": [AVSpeechSynthesizerProvider.modelID],
+                ],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: url, options: .atomic)
+    }
+
+    static func defaultASRConfig() -> ProvidersConfig {
+        ProvidersConfig(providers: [
+            ProviderEntry(
+                id: "parakeet",
+                kind: .asr,
+                builtin: true,
+                models: ["parakeet:v3"]
+            ),
+        ])
+    }
+
+    static func defaultTTSConfig() -> ProvidersConfig {
+        ProvidersConfig(providers: [
+            ProviderEntry(
+                id: "mlx-audio",
+                kind: .tts,
+                builtin: true,
+                models: [kokoroModelId],
+                env: [
+                    "VOX_MLX_AUDIO_USE_UV": "1",
+                    "VOX_MLX_AUDIO_TTS_MODELS": kokoroModelId,
+                    "VOX_MLX_AUDIO_TTS_DEFAULT_VOICE": kokoroVoiceId,
+                    "VOX_PROVIDER_CALL_TIMEOUT_SECONDS": "300",
+                ]
+            ),
+            ProviderEntry(
+                id: "avspeech",
+                kind: .tts,
+                builtin: true,
+                models: [AVSpeechSynthesizerProvider.modelID]
+            ),
+        ])
+    }
+}
+
+private extension ProvidersConfig {
+    func mergingMissingTTSDefaults() -> ProvidersConfig {
+        let existingProviderIds = Set(
+            providers
+                .filter { $0.resolvedKind == .tts }
+                .map { $0.id.lowercased() }
+        )
+        let additionalProviders = LatticesVoiceEngineLoader.defaultTTSConfig().providers.filter { entry in
+            entry.resolvedKind == .tts && !existingProviderIds.contains(entry.id.lowercased())
+        }
+        guard !additionalProviders.isEmpty else { return self }
+        return ProvidersConfig(providers: providers + additionalProviders)
+    }
+}
+#endif

--- a/apps/mac/Sources/Core/Voice/LatticesVoiceRuntime.swift
+++ b/apps/mac/Sources/Core/Voice/LatticesVoiceRuntime.swift
@@ -57,6 +57,15 @@ enum LatticesVoiceRuntime {
         #endif
     }
 
+    /// Drop any orphaned live capture session owned by the embedded runtime.
+    /// Used when Vox reports `live_session_busy` after a dropped client handle.
+    static func resetEmbeddedRuntime() {
+        #if LATTICES_VOICE && canImport(HudsonVoice)
+        stop()
+        _ = ensureRunning()
+        #endif
+    }
+
     #if LATTICES_VOICE && canImport(HudsonVoice)
     /// True when this process is currently hosting the voice WebSocket.
     static var isRunning: Bool { Host.shared.isRunning }
@@ -121,9 +130,19 @@ private final class Host: @unchecked Sendable {
         try configureEnvironment(authToken: authToken)
         try persistPreferences()
 
+        let (asrEngine, ttsEngine, defaultSynthesisModelId) = try LatticesVoiceEngineLoader.loadEngines(
+            runtimeHome: runtimeHomeURL
+        )
+        DiagnosticLog.shared.info(
+            "HudsonVoice: synthesis default \(defaultSynthesisModelId) (\(LatticesVoiceEngineLoader.kokoroVoiceId))"
+        )
+
         let service = VoxRuntimeService(
             port: port,
             bindAddress: bindAddress,
+            engine: asrEngine,
+            ttsEngine: ttsEngine,
+            defaultSynthesisModelId: defaultSynthesisModelId,
             authToken: authToken
         )
         do {
@@ -166,7 +185,10 @@ private final class Host: @unchecked Sendable {
     }
 
     private func persistPreferences() throws {
-        let preferences = (try? HudsonVoicePreferences.load()) ?? HudsonVoicePreferences()
+        var preferences = (try? HudsonVoicePreferences.load()) ?? HudsonVoicePreferences()
+        if preferences.preferredSynthesisModelId?.isEmpty != false {
+            preferences.preferredSynthesisModelId = LatticesVoiceEngineLoader.kokoroModelId
+        }
         try preferences.normalized().save()
     }
 

--- a/bin/handsoff-worker.ts
+++ b/bin/handsoff-worker.ts
@@ -65,63 +65,28 @@ async function inferSmart(prompt: string, options: any): Promise<{ data: any; ra
 import { readFileSync } from "fs";
 import { join } from "path";
 import { spawn } from "child_process";
+import {
+  AVSPEECH_MODEL_ID,
+  describeVoxRuntime,
+  KOKORO_MODEL_ID,
+  KOKORO_VOICE_ID,
+  playCachedWav,
+  resolveVoxRuntime,
+  speakWithVox,
+  synthesizeWithVox,
+} from "./vox-tts.ts";
 
-// ── Streaming TTS via OpenAI API → ffplay ──────────────────────────
+// ── TTS via Hudson/Vox (Kokoro) → avspeech → say ───────────────────
 
-const OPENAI_TTS_URL = "https://api.openai.com/v1/audio/speech";
-const ttsConfig = loadTTSConfig();
-let remoteTTSDisabledReason: string | null = ttsConfig.apiKey ? null : "OPENAI_API_KEY is not configured";
+let voxTTSDisabledReason: string | null = resolveVoxRuntime() ? null : "Hudson voice runtime unavailable";
 
-function loadTTSConfig() {
-  return {
-    apiKey: process.env.OPENAI_API_KEY || "",
-    voice: "nova",
-  };
+function disableVoxTTS(reason: string) {
+  if (voxTTSDisabledReason) return;
+  voxTTSDisabledReason = reason;
+  log(`Hudson TTS disabled for this worker: ${reason}`);
 }
 
-class RemoteTTSUnavailableError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "RemoteTTSUnavailableError";
-  }
-}
-
-function disableRemoteTTS(reason: string) {
-  if (remoteTTSDisabledReason) return;
-  remoteTTSDisabledReason = reason;
-  log(`remote TTS disabled for this worker: ${reason}; using macOS speech`);
-}
-
-async function requestRemoteSpeech(text: string): Promise<Response> {
-  if (remoteTTSDisabledReason) {
-    throw new RemoteTTSUnavailableError(remoteTTSDisabledReason);
-  }
-
-  const res = await fetch(OPENAI_TTS_URL, {
-    method: "POST",
-    headers: {
-      "Authorization": `Bearer ${ttsConfig.apiKey}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      model: "tts-1",
-      voice: ttsConfig.voice,
-      input: text,
-      response_format: "pcm",
-      speed: 1.1,
-    }),
-  });
-
-  if (!res.ok) {
-    const reason = `OpenAI TTS error: ${res.status} ${res.statusText}`;
-    if (res.status === 401 || res.status === 403) disableRemoteTTS(reason);
-    throw new RemoteTTSUnavailableError(reason);
-  }
-
-  return res;
-}
-
-/** On-device fallback that keeps voice useful when cloud TTS is unavailable. */
+/** Last-resort macOS speech when Hudson voice runtime is unavailable. */
 async function localSpeak(text: string): Promise<number> {
   const start = performance.now();
   return new Promise((resolve, reject) => {
@@ -140,59 +105,31 @@ async function localSpeak(text: string): Promise<number> {
 }
 
 async function speak(text: string): Promise<number> {
-  if (!remoteTTSDisabledReason) {
+  if (!voxTTSDisabledReason) {
     try {
-      return await streamSpeak(text);
+      const ms = await speakWithVox(text, {
+        modelId: KOKORO_MODEL_ID,
+        voiceId: KOKORO_VOICE_ID,
+      });
+      log(`Kokoro spoke "${text.slice(0, 40)}" in ${ms}ms`);
+      return ms;
     } catch (error: any) {
-      log(`remote TTS unavailable: ${error.message}; falling back to macOS speech`);
+      log(`Kokoro TTS unavailable: ${error.message}`);
+      disableVoxTTS(error.message);
     }
   }
-  return localSpeak(text);
-}
 
-/** Stream TTS: fetch audio from OpenAI and pipe directly to ffplay. Playback starts immediately. */
-async function streamSpeak(text: string): Promise<number> {
-  const start = performance.now();
-  const res = await requestRemoteSpeech(text);
-
-  const ttfb = Math.round(performance.now() - start);
-  log(`TTS first byte in ${ttfb}ms`);
-
-  // Pipe response body directly to ffplay — playback starts as chunks arrive
-  return new Promise((resolve, reject) => {
-    const player = spawn("ffplay", [
-      "-nodisp",      // no video window
-      "-autoexit",    // quit when done
-      "-loglevel", "quiet",
-      "-f", "s16le",   // PCM signed 16-bit little-endian
-      "-ar", "24000",  // OpenAI TTS outputs 24kHz
-      "-ch_layout", "mono",
-      "-",            // read from stdin
-    ], { stdio: ["pipe", "ignore", "ignore"] });
-
-    const reader = res.body?.getReader();
-    if (!reader) {
-      reject(new Error("No response body"));
-      return;
+  if (resolveVoxRuntime()) {
+    try {
+      const ms = await speakWithVox(text, { modelId: AVSPEECH_MODEL_ID });
+      log(`avspeech spoke "${text.slice(0, 40)}" in ${ms}ms`);
+      return ms;
+    } catch (error: any) {
+      log(`avspeech fallback failed: ${error.message}`);
     }
+  }
 
-    // Pump chunks from fetch → ffplay stdin
-    (async () => {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        player.stdin.write(value);
-      }
-      player.stdin.end();
-    })().catch(reject);
-
-    player.on("close", () => {
-      const ms = Math.round(performance.now() - start);
-      resolve(ms);
-    });
-
-    player.on("error", reject);
-  });
+  return localSpeak(text);
 }
 
 // ── Pre-cached ack sounds (no API call needed) ────────────────────
@@ -235,7 +172,8 @@ async function ensureVoiceCache() {
 
   for (const phrase of allPhrases) {
     const safeName = phrase.replace(/[^a-z]/gi, "_").toLowerCase();
-    const filePath = join(ackCacheDir, `voice_${safeName}.pcm`);
+    const filePath = join(ackCacheDir, `kokoro_${safeName}.wav`);
+    const legacyPath = join(ackCacheDir, `voice_${safeName}.pcm`);
 
     if (existsSync(filePath)) {
       ackCache.set(phrase, filePath);
@@ -243,18 +181,25 @@ async function ensureVoiceCache() {
       continue;
     }
 
-    // Generate and cache. Authentication failures disable remote TTS once for
-    // this worker instead of retrying the same credential for every cue.
+    if (existsSync(legacyPath)) {
+      try {
+        const { unlinkSync } = await import("fs");
+        unlinkSync(legacyPath);
+      } catch {}
+    }
+
     try {
-      const res = await requestRemoteSpeech(phrase);
-      const buf = Buffer.from(await res.arrayBuffer());
-      writeFileSync(filePath, buf);
+      const { wav } = await synthesizeWithVox(phrase, {
+        modelId: KOKORO_MODEL_ID,
+        voiceId: KOKORO_VOICE_ID,
+      });
+      writeFileSync(filePath, wav);
       ackCache.set(phrase, filePath);
       generated++;
       log(`cached: "${phrase}"`);
     } catch (e: any) {
       log(`cache failed for "${phrase}": ${e.message}`);
-      if (remoteTTSDisabledReason) break;
+      if (voxTTSDisabledReason) break;
     }
   }
   log(`voice cache: ${cached} hit, ${generated} generated, ${allPhrases.length} total`);
@@ -271,28 +216,14 @@ async function playCached(phrase: string): Promise<number> {
   }
 
   log(`playing cached: "${phrase}"`);
-  return new Promise((resolve, reject) => {
-    const player = spawn("ffplay", [
-      "-nodisp", "-autoexit", "-loglevel", "quiet",
-      "-f", "s16le", "-ar", "24000", "-ch_layout", "mono",
-      filePath,
-    ], { stdio: ["ignore", "ignore", "pipe"] });
-
-    let stderr = "";
-    player.stderr?.on("data", (d: Buffer) => { stderr += d.toString(); });
-
-    player.on("close", (code: number) => {
-      const ms = Math.round(performance.now() - start);
-      if (code !== 0) log(`ffplay error (code ${code}): ${stderr.slice(0, 100)}`);
-      else log(`played "${phrase}" in ${ms}ms`);
-      resolve(ms);
-    });
-
-    player.on("error", (err: Error) => {
-      log(`ffplay spawn error: ${err.message}`);
-      reject(err);
-    });
-  });
+  try {
+    const ms = await playCachedWav(filePath);
+    log(`played "${phrase}" in ${ms}ms`);
+    return ms;
+  } catch (err: any) {
+    log(`cached playback failed: ${err.message}`);
+    return speak(phrase);
+  }
 }
 
 /** Play a random ack phrase from cache. */
@@ -317,7 +248,7 @@ function playConfirm(intent: string): Promise<number> {
 // Warm up cache on startup
 ensureVoiceCache().then(() => log("voice cache ready"));
 
-log(`worker started, TTS=${remoteTTSDisabledReason ? "macOS local" : "OpenAI with macOS fallback"}`);
+log(`worker started, TTS=${voxTTSDisabledReason ? "macOS say fallback" : `Hudson Kokoro (${KOKORO_VOICE_ID})`} @ ${describeVoxRuntime()}`);
 
 // ── Load system prompt once ────────────────────────────────────────
 
@@ -447,23 +378,14 @@ async function processLine(line: string) {
       break;
 
     case "turn": {
-      // Full orchestrated turn — parallel where possible.
-      //
-      // Timeline:
-      //   t=0  ──┬── ack TTS (fire & forget)
-      //          └── model inference
-      //   t=~600ms ─┬── narrate TTS (what we're doing)
-      //             └── execute actions (in parallel with narrate)
-      //   t=done ── respond with results
-      //
       const turnStart = performance.now();
       const transcript = cmd.transcript;
       const snap = cmd.snapshot ?? {};
       const history = cmd.history ?? [];
 
       log(`⏱ turn start: "${transcript.slice(0, 50)}"`);
+      progress("acknowledging", turnStart);
 
-      // Fire cached ack sound + inference in PARALLEL
       const ackPromise = playAck().catch((e) => log(`ack error: ${e.message}`));
 
       const messages = history.map((h: any) => ({
@@ -474,9 +396,10 @@ async function processLine(line: string) {
       let inferResult: any = null;
       const localPlan = tryLocalAssistantPlan(transcript, snap);
       if (localPlan) {
-        inferResult = localPlan;
-        log("local planner matched");
+        inferResult = { ...localPlan, _meta: turnMeta("quick", "quick", true) };
+        log("local planner matched — quick path");
       } else {
+        progress("planning", turnStart, "standard");
         const userMessage = buildAssistantContextMessage(transcript, snap);
         try {
           const { data, raw } = await inferSmart(userMessage, {
@@ -489,35 +412,60 @@ async function processLine(line: string) {
             tag: "hands-off",
           });
           const plan = normalizeAssistantPlan(data, transcript);
-          inferResult = { ...plan, _meta: { ...plan._meta, provider: raw.provider, model: raw.model, durationMs: raw.durationMs, tokens: raw.usage?.totalTokens } };
+          const hasActions = Array.isArray(plan.actions) && plan.actions.length > 0;
+          const turnKind = hasActions ? "standard" : "conversation";
+          inferResult = {
+            ...plan,
+            _meta: {
+              ...plan._meta,
+              ...turnMeta("standard", turnKind, false),
+              provider: raw.provider,
+              model: raw.model,
+              durationMs: raw.durationMs,
+              tokens: raw.usage?.totalTokens,
+            },
+          };
           log(`⏱ inference done in ${raw.durationMs}ms`);
         } catch (err: any) {
           log(`⏱ inference error: ${err.message}`);
-          inferResult = { actions: [], spoken: "Sorry, I had trouble with that.", _meta: { error: err.message } };
+          inferResult = {
+            actions: [],
+            spoken: "Sorry, I had trouble with that.",
+            _meta: { ...turnMeta("standard", "conversation", false), error: err.message },
+          };
         }
       }
 
-      // Wait for ack to finish before narrating (don't overlap speech)
-      await ackPromise;
-
-      // Step 2: Narrate + execute in PARALLEL
       const hasActions = Array.isArray(inferResult.actions) && inferResult.actions.length > 0;
       const spokenText = inferResult.spoken;
+      const isQuick = inferResult._meta?.path === "quick" && hasActions;
+
+      if (isQuick) {
+        await ackPromise;
+        progress("executing", turnStart, "quick");
+        const turnMs = Math.round(performance.now() - turnStart);
+        log(`⏱ quick turn response at ${turnMs}ms`);
+        respond({ ok: true, data: inferResult, turnMs });
+        progress("confirming", turnStart, "quick");
+        const intent = inferResult.actions?.[0]?.intent as string | undefined;
+        playConfirm(intent ?? "done").catch(() => {});
+        break;
+      }
+
+      await ackPromise;
 
       if (hasActions && spokenText) {
-        // SPEAK FIRST — user must hear what's about to happen before windows move
+        progress("narrating", turnStart, "standard");
         log(`⏱ narrating: "${spokenText.slice(0, 50)}"`);
         await speak(spokenText).catch((e) => log(`narrate error: ${e.message}`));
-
-        // NOW respond with actions — Swift executes after user heard the plan
+        progress("executing", turnStart, "standard");
         const turnMs = Math.round(performance.now() - turnStart);
         log(`⏱ turn response at ${turnMs}ms — actions sent after narration`);
         respond({ ok: true, data: inferResult, turnMs });
-
-        // Confirm
+        progress("confirming", turnStart, "standard");
         await playCached("Done.").catch(() => {});
       } else if (spokenText) {
-        // Conversation only — speak and respond
+        progress("narrating", turnStart, "conversation");
         await speak(spokenText).catch((e) => log(`speak error: ${e.message}`));
         const turnMs = Math.round(performance.now() - turnStart);
         respond({ ok: true, data: inferResult, turnMs });
@@ -555,6 +503,20 @@ async function processLine(line: string) {
 function respond(obj: any) {
   console.log(JSON.stringify(obj));
 }
+
+function progress(stage: string, turnStart: number, turnKind?: "quick" | "standard" | "conversation") {
+  respond({
+    ok: true,
+    progress: stage,
+    turnKind,
+    turnMs: Math.round(performance.now() - turnStart),
+  });
+}
+
+function turnMeta(path: "quick" | "standard", turnKind: "quick" | "standard" | "conversation", localMatch = false) {
+  return { path, turnKind, localMatch };
+}
+
 
 function log(msg: string) {
   const ts = new Date().toISOString().slice(11, 23);

--- a/bin/vox-tts.ts
+++ b/bin/vox-tts.ts
@@ -1,0 +1,236 @@
+/**
+ * Hudson / Vox on-device TTS client for Lattices workers.
+ *
+ * Speaks through the embedded Lattices voice runtime (Kokoro via mlx-audio by default).
+ */
+
+import { existsSync, readFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+import { spawn } from "child_process";
+
+export const KOKORO_MODEL_ID = "mlx-community/Kokoro-82M-bf16";
+export const KOKORO_VOICE_ID = "af_heart";
+export const AVSPEECH_MODEL_ID = "avspeech:system";
+
+const DEFAULT_CAPABILITY_PATH = join(
+  homedir(),
+  "Library/Application Support/Lattices/Voice/hudson-voice-runtime.json"
+);
+
+type Capability = {
+  webSocketUrl?: string;
+  host?: string;
+  port?: number;
+  authToken?: string;
+};
+
+type VoxRuntime = {
+  capability: Capability;
+  wsUrl: string;
+  authToken: string;
+};
+
+let cachedRuntime: VoxRuntime | null | undefined;
+let requestCounter = 0;
+
+function resolveCapabilityPath(): string {
+  return process.env.LATTICES_VOICE_CAPABILITY?.trim() || DEFAULT_CAPABILITY_PATH;
+}
+
+function loadCapability(): Capability | null {
+  const path = resolveCapabilityPath();
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as Capability;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveVoxRuntime(): VoxRuntime | null {
+  if (cachedRuntime !== undefined) return cachedRuntime;
+
+  const capability = loadCapability();
+  if (!capability) {
+    cachedRuntime = null;
+    return null;
+  }
+
+  const wsUrl =
+    capability.webSocketUrl?.trim() ||
+    (capability.host && capability.port
+      ? `ws://${capability.host}:${capability.port}`
+      : process.env.LATTICES_VOICE_WS_URL?.trim() || "ws://127.0.0.1:9398");
+
+  const authToken = capability.authToken?.trim() || process.env.VOX_AUTH_TOKEN?.trim() || "";
+  if (!authToken) {
+    cachedRuntime = null;
+    return null;
+  }
+
+  cachedRuntime = { capability, wsUrl, authToken };
+  return cachedRuntime;
+}
+
+export function resetVoxRuntimeCache() {
+  cachedRuntime = undefined;
+}
+
+function playWavFile(filePath: string): Promise<number> {
+  const start = performance.now();
+  return new Promise((resolve, reject) => {
+    const player = spawn("/usr/bin/afplay", [filePath], {
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let stderr = "";
+    player.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    player.on("close", (code) => {
+      const ms = Math.round(performance.now() - start);
+      if (code === 0) resolve(ms);
+      else reject(new Error(`afplay failed (${code ?? "unknown"}): ${stderr.slice(0, 160)}`));
+    });
+    player.on("error", reject);
+  });
+}
+
+async function voxRpc(
+  runtime: VoxRuntime,
+  method: string,
+  params: Record<string, unknown>,
+  timeoutMs = 120_000
+): Promise<Record<string, unknown>> {
+  const id = `handsoff-${++requestCounter}`;
+  const ws = new WebSocket(runtime.wsUrl);
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      try {
+        ws.close();
+      } catch {}
+      reject(new Error(`Vox ${method} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    const cleanup = () => clearTimeout(timer);
+
+    ws.addEventListener("open", () => {
+      ws.send(
+        JSON.stringify({
+          id,
+          method,
+          authToken: runtime.authToken,
+          params: {
+            clientId: "handsoff-worker",
+            ...params,
+          },
+        })
+      );
+    });
+
+    ws.addEventListener("message", (event) => {
+      let payload: any;
+      try {
+        payload = JSON.parse(String(event.data));
+      } catch {
+        return;
+      }
+      if (payload.id !== id) return;
+
+      cleanup();
+      try {
+        ws.close();
+      } catch {}
+
+      if (payload.error) {
+        reject(new Error(String(payload.error)));
+        return;
+      }
+      resolve((payload.result ?? {}) as Record<string, unknown>);
+    });
+
+    ws.addEventListener("error", () => {
+      cleanup();
+      reject(new Error(`Could not connect to Hudson voice runtime at ${runtime.wsUrl}`));
+    });
+  });
+}
+
+export async function synthesizeWithVox(
+  text: string,
+  options: {
+    modelId?: string;
+    voiceId?: string;
+    format?: string;
+  } = {}
+): Promise<{ wav: Buffer; elapsedMs: number; modelId: string; voiceId: string }> {
+  const runtime = resolveVoxRuntime();
+  if (!runtime) {
+    throw new Error("Hudson voice runtime capability is unavailable");
+  }
+
+  const result = await voxRpc(runtime, "synthesize.generate", {
+    text,
+    modelId: options.modelId,
+    voiceId: options.voiceId,
+    format: options.format ?? "wav",
+  });
+
+  const audioBase64 = String(result.audioBase64 ?? "");
+  if (!audioBase64) {
+    throw new Error("Vox synthesize.generate returned no audio");
+  }
+
+  const wav = Buffer.from(audioBase64, "base64");
+  return {
+    wav,
+    elapsedMs: Number(result.elapsedMs ?? 0),
+    modelId: String(result.modelId ?? options.modelId ?? KOKORO_MODEL_ID),
+    voiceId: String(result.voiceId ?? options.voiceId ?? KOKORO_VOICE_ID),
+  };
+}
+
+export async function speakWithVox(
+  text: string,
+  options: {
+    modelId?: string;
+    voiceId?: string;
+    cachePath?: string;
+  } = {}
+): Promise<number> {
+  const { wav, elapsedMs } = await synthesizeWithVox(text, {
+    modelId: options.modelId,
+    voiceId: options.voiceId,
+  });
+
+  if (options.cachePath) {
+    const { writeFileSync } = await import("fs");
+    writeFileSync(options.cachePath, wav);
+    return elapsedMs;
+  }
+
+  const { mkdtempSync, writeFileSync, rmSync } = await import("fs");
+  const { tmpdir } = await import("os");
+  const dir = mkdtempSync(join(tmpdir(), "lattices-vox-tts-"));
+  const filePath = join(dir, "speech.wav");
+  writeFileSync(filePath, wav);
+  try {
+    const playbackMs = await playWavFile(filePath);
+    return Math.max(playbackMs, elapsedMs);
+  } finally {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {}
+  }
+}
+
+export async function playCachedWav(filePath: string): Promise<number> {
+  return playWavFile(filePath);
+}
+
+export function describeVoxRuntime(): string {
+  const runtime = resolveVoxRuntime();
+  if (!runtime) return "unavailable";
+  return runtime.wsUrl;
+}


### PR DESCRIPTION
## Summary

- Relay `voice.command.start/stop` to `HandsOffSession` instead of `AudioLayer`
- Add `voice.runtime.warm` preflight and 50ms runtime resolve retries
- Stream `turnKind` / `turnStage` progress into `DeckVoiceState`
- Kokoro TTS via Hudson Vox (`mlx-audio`, `af_heart`) with avspeech + `say` fallbacks
- `handsoff-worker.ts` turn-by-turn workflow (quick / standard / conversation)
- Seed embedded Vox providers via `LatticesVoiceEngineLoader`

Part of the voice stack — **2/7**. Base: `feat/deckkit-voice-metadata`.

**CI deferred** until final merge to `main`.