### PR TITLE
✨ Revamp iPad voice panel with pick-host-first flow

### DIFF
--- a/apps/ios/Sources/ContentView.swift
+++ b/apps/ios/Sources/ContentView.swift
@@ -33,6 +33,8 @@ struct ContentView: View {
     @State private var showSettings = false
     @State private var showAddHost = false
     @State private var trustedBridges: [StoredBridgeTrust] = []
+    @State private var voicePanelOpen = false
+    @State private var voiceTargetMachineID: String?
 
     private var liveMachines: [HomeMachine] {
         HomeDataAdapter.machines(
@@ -40,6 +42,23 @@ struct ContentView: View {
             secondaryStores: fleetStore.secondaryStores,
             trustedBridges: trustedBridges
         )
+    }
+
+    /// Roster machines with voice indicators scoped to the Mac the user picked.
+    /// Other hosts can still report `.listening` in their snapshot from a stale
+    /// relay session; showing that on the wrong tile was the Art's-mini bug.
+    private var voiceAwareMachines: [HomeMachine] {
+        liveMachines.map { machine in
+            var copy = machine
+            guard let targetID = voiceTargetMachineID else {
+                if copy.voice == .listening { copy.voice = .off }
+                return copy
+            }
+            if machine.id != targetID && copy.voice != .off {
+                copy.voice = .off
+            }
+            return copy
+        }
     }
 
     /// Unpaired Macs on the network right now. Home shows the count and does
@@ -74,144 +93,27 @@ struct ContentView: View {
     var body: some View {
         NavigationStack {
             LatsBackground {
-                HomeView(
-                    // Live data — every section with a real source on
-                    // DeckRuntimeSnapshot is wired through HomeDataAdapter.
-                    // Sections still without a backend (terminal/calendar/
-                    // scenes/routines/sync) pass empty arrays; their
-                    // tiles/sections hide themselves.
-                    machines:  liveMachines,
-                    scenes:    [],
-                    routines:  [],
-                    recent:    liveRecent,
-                    sync:      [],
-                    cloud:     liveCloud,
-                    agentFeed: liveAgentFeed,
-                    terminal:  [],
-                    calendar:  [],
-                    attention: liveAttention,
-                    bottomTelemetry: liveBottomTelemetry,
-
-                    onEnterDeck: { machine in
-                        guard machine.status != .offline else { return }
-                        prepareConnection(for: machine)
-                        // Start fetching on the tap rather than on arrival, so
-                        // the request is already in flight while the cover
-                        // animates instead of starting after it.
-                        hostStore(for: machine.id)?.setUIPriority(.fast)
-                        hostStore(for: machine.id)?.refreshSnapshot()
-                        deckDestination = .host(machine.id)
-                    },
-                    onEnterFleet: {
-                        fleetStore.synchronize(with: store)
-                        deckDestination = .fleet(initialMachineID: nil)
-                    },
-                    onAddHost:   { showAddHost = true },
-
-                    // Per-host dictation. Routed to *that machine's* store, not
-                    // the primary — which is the point: the primary is whichever
-                    // trusted host Bonjour listed first, so "who hears me" was
-                    // decided by discovery order rather than by the user.
-                    onMachineVoice: { machine in
-                        hostStore(for: machine.id)?.toggleVoice()
-                    },
-                    nearbyCandidateCount: nearbyCandidateCount,
-                    onPair:      { showAddHost = true },
-                    onSettings:  { showSettings = true },
-
-                    // Voice relay — wired to the active Mac via /deck/perform.
-                    voiceState:        store.snapshot?.voice,
-                    voiceMacLabel:     store.connectionLabel,
-                    isVoicePerforming: store.isPerformingAction,
-                    onVoiceStart:      { store.startVoice() },
-                    onVoiceStop:       { store.stopVoice() },
-                    onVoiceCancel:     { store.stopVoice() },
-                    onVoiceRemediate:  { _ in /* deferred — wired after error pipeline lands */ }
-                )
-                .onAppear {
-                    trustedBridges = DeckBridgeSecurityStore.shared.trustedBridgeList()
-                }
+                homeScreen
             }
             .navigationBarHidden(true)
             .toolbar(.hidden, for: .navigationBar)
             .fullScreenCover(item: $deckDestination) { destination in
-                switch destination {
-                case .host(let machineID):
-                    if let hostStore = hostStore(for: machineID) {
-                        HostDeckHost(store: hostStore, onClose: { deckDestination = nil })
-                    } else {
-                        // Better to say we lost it than to silently open a
-                        // different Mac's cockpit.
-                        LatsBackground {
-                            LatsEmptyState(
-                                title: "That Mac is no longer reachable",
-                                subtitle: "Its connection changed while you were opening it. Go back and pick it again.",
-                                icon: "laptopcomputer.slash"
-                            )
-                            .padding(24)
-                        }
-                        .onTapGesture { deckDestination = nil }
-                    }
-                case .fleet(let machineID):
-                    FleetDeckScreen(
-                        primaryStore: store,
-                        fleetStore: fleetStore,
-                        initialMachineID: machineID
-                    )
-                }
+                deckCover(for: destination)
             }
             .sheet(isPresented: $showSettings) {
-                LatsSettingsView(
-                    store: store,
-                    onForget: {
-                        fleetStore.releaseUntrusted()
-                        trustedBridges = DeckBridgeSecurityStore.shared.trustedBridgeList()
-                    }
-                )
-                .preferredColorScheme(.dark)
+                settingsSheet
             }
             .sheet(isPresented: $showAddHost) {
-                AddHostSheet(
-                    store: store,
-                    onPaired: { endpoint in
-                        // Adding is additive. The Mac on screen does not move
-                        // just because another one joined — the user asked to
-                        // add, not to switch. The only exception is having
-                        // nothing to look at yet.
-                        if store.activeEndpoint == nil {
-                            repointedMachineID = endpoint.id
-                            store.connect(to: endpoint)
-                        } else {
-                            fleetStore.adopt(endpoint)
-                        }
-                        trustedBridges = DeckBridgeSecurityStore.shared.trustedBridgeList()
-                    },
-                    onOpen: { endpoint in
-                        deckDestination = .host(endpoint.id)
-                    }
-                )
-                .preferredColorScheme(.dark)
+                addHostSheet
             }
-            // Adaptive polling: speed up while the user is in the cockpit
-            // (Deck or settings) — Home alone runs in ambient mode.
             .onChange(of: deckDestination) { _, destination in
-                applyPollPriority(for: destination)
-                // The escape hatch below is only good for the presentation that
-                // opened it. Left standing, it would keep vouching for the
-                // primary store long after the primary had been pointed at some
-                // other Mac — which is the exact confusion it exists to prevent.
-                if destination == nil {
-                    repointedMachineID = nil
-                    // A protected request can discover that the saved pairing
-                    // no longer matches while the deck is covering Home. Pull
-                    // the roster again as the cover closes so the stale card is
-                    // replaced by the Add flow immediately.
-                    trustedBridges = DeckBridgeSecurityStore.shared.trustedBridgeList()
-                    fleetStore.releaseUntrusted()
-                }
+                handleDeckDestinationChange(destination)
             }
             .onChange(of: showSettings) { _, isOpen in
                 store.setUIPriority(isOpen ? .fast : .ambient)
+            }
+            .onChange(of: voicePanelOpen) { _, isOpen in
+                handleVoicePanelChange(isOpen)
             }
         }
         .preferredColorScheme(.dark)
@@ -230,6 +132,133 @@ struct ContentView: View {
         ) { _ in
             trustedBridges = DeckBridgeSecurityStore.shared.trustedBridgeList()
             fleetStore.releaseUntrusted()
+        }
+    }
+
+    @ViewBuilder
+    private var homeScreen: some View {
+        HomeView(
+            machines: voiceAwareMachines,
+            recent: liveRecent,
+            cloud: liveCloud,
+            agentFeed: liveAgentFeed,
+            attention: liveAttention,
+            bottomTelemetry: liveBottomTelemetry,
+            onEnterDeck: enterDeck,
+            onEnterFleet: enterFleet,
+            onAddHost: { showAddHost = true },
+            onMachineVoice: { machine in
+                openVoicePanel(prefilling: machine)
+            },
+            nearbyCandidateCount: nearbyCandidateCount,
+            onPair: { showAddHost = true },
+            onSettings: { showSettings = true },
+            voiceState: boundVoiceState,
+            voiceMacLabel: voiceTargetLabel,
+            isVoicePerforming: isVoicePerforming,
+            voiceTargetReachable: isVoiceTargetReachable,
+            onVoiceOpen: { machine in
+                openVoicePanel(prefilling: machine)
+            },
+            onVoiceStart: startVoiceOnTarget,
+            onVoiceStop: { voiceTargetStore?.stopVoice() },
+            onVoiceCancel: { voiceTargetStore?.cancelVoice() },
+            onVoiceRemediate: { handleVoiceRemediation($0) },
+            voiceMachines: voiceAwareMachines,
+            voiceTargetMachineID: voiceTargetMachineID,
+            onSelectVoiceTarget: { machine in
+                switchVoiceTarget(to: machine)
+            },
+            voicePanelOpen: $voicePanelOpen
+        )
+        .onAppear {
+            trustedBridges = DeckBridgeSecurityStore.shared.trustedBridgeList()
+        }
+    }
+
+    @ViewBuilder
+    private func deckCover(for destination: DeckDestination) -> some View {
+        switch destination {
+        case .host(let machineID):
+            if let hostStore = hostStore(for: machineID) {
+                HostDeckHost(store: hostStore, onClose: { deckDestination = nil })
+            } else {
+                LatsBackground {
+                    LatsEmptyState(
+                        title: "That Mac is no longer reachable",
+                        subtitle: "Its connection changed while you were opening it. Go back and pick it again.",
+                        icon: "laptopcomputer.slash"
+                    )
+                    .padding(24)
+                }
+                .onTapGesture { deckDestination = nil }
+            }
+        case .fleet(let machineID):
+            FleetDeckScreen(
+                primaryStore: store,
+                fleetStore: fleetStore,
+                initialMachineID: machineID
+            )
+        }
+    }
+
+    private var settingsSheet: some View {
+        LatsSettingsView(
+            store: store,
+            onForget: {
+                fleetStore.releaseUntrusted()
+                trustedBridges = DeckBridgeSecurityStore.shared.trustedBridgeList()
+            }
+        )
+        .preferredColorScheme(.dark)
+    }
+
+    private var addHostSheet: some View {
+        AddHostSheet(
+            store: store,
+            onPaired: { endpoint in
+                if store.activeEndpoint == nil {
+                    repointedMachineID = endpoint.id
+                    store.connect(to: endpoint)
+                } else {
+                    fleetStore.adopt(endpoint)
+                }
+                trustedBridges = DeckBridgeSecurityStore.shared.trustedBridgeList()
+            },
+            onOpen: { endpoint in
+                deckDestination = .host(endpoint.id)
+            }
+        )
+        .preferredColorScheme(.dark)
+    }
+
+    private func enterDeck(_ machine: HomeMachine) {
+        guard machine.status != .offline else { return }
+        prepareConnection(for: machine)
+        hostStore(for: machine.id)?.setUIPriority(.fast)
+        hostStore(for: machine.id)?.refreshSnapshot()
+        deckDestination = .host(machine.id)
+    }
+
+    private func enterFleet() {
+        fleetStore.synchronize(with: store)
+        deckDestination = .fleet(initialMachineID: nil)
+    }
+
+    private func handleDeckDestinationChange(_ destination: DeckDestination?) {
+        applyPollPriority(for: destination)
+        if destination == nil {
+            repointedMachineID = nil
+            trustedBridges = DeckBridgeSecurityStore.shared.trustedBridgeList()
+            fleetStore.releaseUntrusted()
+        }
+    }
+
+    private func handleVoicePanelChange(_ isOpen: Bool) {
+        if isOpen {
+            voiceTargetStore?.setUIPriority(.fast)
+        } else if deckDestination == nil && !showSettings {
+            voiceTargetStore?.setUIPriority(.ambient)
         }
     }
 
@@ -284,6 +313,156 @@ struct ContentView: View {
         applyPollPriority(for: deckDestination)
     }
 
+    private var boundVoiceState: DeckVoiceState? {
+        guard voiceTargetMachineID != nil else { return nil }
+        return voiceTargetStore?.snapshot?.voice
+    }
+
+    private var isVoicePerforming: Bool {
+        voiceTargetMachineID != nil && (voiceTargetStore?.isPerformingAction ?? false)
+    }
+
+    private var isVoiceTargetReachable: Bool {
+        guard let id = voiceTargetMachineID,
+              let machine = liveMachines.first(where: { $0.id == id }) else { return false }
+        if machine.status == .offline { return false }
+        if let targetStore = voiceTargetStore {
+            return targetStore.health != nil || targetStore.snapshot != nil
+        }
+        // On the network but the DeckStore is still handshaking after adopt.
+        return machine.status == .online || machine.status == .active
+    }
+
+    private var voiceTargetLabel: String {
+        if let id = voiceTargetMachineID,
+           let machine = liveMachines.first(where: { $0.id == id }) {
+            return machine.name
+        }
+        return "your Mac"
+    }
+
+    /// The DeckStore for the Mac the user picked. No fallback — routing to the
+    /// foreground or primary host while the UI shows another name is how we
+    /// ended up with the wrong mic lit on the roster.
+    private var voiceTargetStore: DeckStore? {
+        guard let id = voiceTargetMachineID else { return nil }
+        return hostStore(for: id)
+    }
+
+    private func bridgeEndpoint(for machineID: String) -> BridgeEndpoint? {
+        if store.activeEndpoint?.id == machineID { return store.activeEndpoint }
+        if let bridge = store.discoveredBridges.first(where: { $0.id == machineID }) {
+            return bridge
+        }
+        guard let machine = liveMachines.first(where: { $0.id == machineID }) else { return nil }
+        if let active = store.activeEndpoint,
+           machineNameKey(active.name, host: active.host) == machineNameKey(machine.name, host: machine.host) {
+            return active
+        }
+        return store.discoveredBridges.first {
+            machineNameKey($0.name, host: $0.host) == machineNameKey(machine.name, host: machine.host)
+        }
+    }
+
+    private func machineNameKey(_ name: String, host: String) -> String {
+        let candidate = name.isEmpty ? host : name
+        return candidate.lowercased()
+            .replacingOccurrences(of: ".local", with: "")
+            .replacingOccurrences(of: ".lan", with: "")
+            .unicodeScalars
+            .filter { CharacterSet.alphanumerics.contains($0) }
+            .map(String.init)
+            .joined()
+    }
+
+    private func ensureVoiceRoute(for machine: HomeMachine) {
+        fleetStore.synchronize(with: store)
+        guard let endpoint = bridgeEndpoint(for: machine.id) else { return }
+        fleetStore.adopt(endpoint)
+        guard let matched = hostStore(for: machine.id) else { return }
+        matched.setUIPriority(.fast)
+        if matched.health == nil && matched.snapshot == nil {
+            matched.connect(to: endpoint)
+        } else {
+            matched.refreshSnapshot()
+        }
+    }
+
+    private func openVoicePanel(prefilling machine: HomeMachine?) {
+        if let machine {
+            switchVoiceTarget(to: machine)
+        } else if liveMachines.count == 1, let only = liveMachines.first {
+            ensureVoiceRoute(for: only)
+            voiceTargetMachineID = bridgeEndpoint(for: only.id)?.id ?? only.id
+            cancelVoiceOnOtherHosts(except: voiceTargetMachineID)
+            voiceTargetStore?.setUIPriority(.fast)
+            prewarmVoiceTarget()
+        } else {
+            cancelVoiceOnOtherHosts(except: nil)
+            voiceTargetMachineID = nil
+        }
+        voicePanelOpen = true
+    }
+
+    private func switchVoiceTarget(to machine: HomeMachine) {
+        if let previousID = voiceTargetMachineID, previousID != machine.id {
+            tearDownVoice(on: previousID)
+        }
+        ensureVoiceRoute(for: machine)
+        voiceTargetMachineID = bridgeEndpoint(for: machine.id)?.id ?? machine.id
+        cancelVoiceOnOtherHosts(except: voiceTargetMachineID)
+        voiceTargetStore?.setUIPriority(.fast)
+        prewarmVoiceTarget()
+    }
+
+    private func startVoiceOnTarget() {
+        guard let targetID = voiceTargetMachineID,
+              let targetStore = voiceTargetStore,
+              isVoiceTargetReachable else { return }
+        cancelVoiceOnOtherHosts(except: targetID)
+        targetStore.setUIPriority(.fast)
+        targetStore.startVoice()
+    }
+
+    /// Only one Mac should ever have an open relay mic. Stale sessions on other
+    /// hosts (from earlier routing bugs or a missed stop) must not keep their
+    /// roster card lit while the user is speaking to a different machine.
+    private func tearDownVoice(on machineID: String) {
+        let host = hostStore(for: machineID)
+        host?.stopVoice()
+        host?.cancelVoice()
+    }
+
+    private func cancelVoiceOnOtherHosts(except machineID: String?) {
+        for machine in liveMachines {
+            if let except = machineID, machine.id == except { continue }
+            tearDownVoice(on: machine.id)
+        }
+    }
+
+    private func prewarmVoiceTarget() {
+        guard let targetStore = voiceTargetStore else { return }
+        targetStore.setUIPriority(.fast)
+        targetStore.prewarmVoice()
+    }
+
+    private func handleVoiceRemediation(_ action: DeckRemediationAction) {
+        switch action {
+        case .retryVoice:
+            voicePanelOpen = true
+            startVoiceOnTarget()
+        case .openDiagnostics:
+            showSettings = true
+        case .openVox, .openSystemSettings:
+            voicePanelOpen = true
+            guard let targetStore = voiceTargetStore, isVoiceTargetReachable else { return }
+            targetStore.perform(actionID: "voice.toggle", pageID: "voice")
+        case .chooseTarget:
+            voicePanelOpen = true
+            voiceTargetMachineID = nil
+        }
+    }
+
     /// The session backing one Mac, or nil when we cannot prove we have it.
     ///
     /// `BridgeEndpoint.id` is derived from host:port and is not stable — a Mac
@@ -293,8 +472,26 @@ struct ContentView: View {
     /// host-ownership violation: the user taps one machine and drives another.
     /// The primary is only acceptable when this very tap re-pointed it.
     private func hostStore(for machineID: String) -> DeckStore? {
-        if let match = fleetStore.stores(including: store)
-            .first(where: { $0.activeEndpoint?.id == machineID }) {
+        let candidates = fleetStore.stores(including: store)
+        if let direct = candidates.first(where: { $0.activeEndpoint?.id == machineID }) {
+            return direct
+        }
+        guard let endpoint = bridgeEndpoint(for: machineID) else {
+            return repointedMachineID == machineID ? store : nil
+        }
+        if let fingerprint = endpoint.bridgeFingerprint, !fingerprint.isEmpty,
+           let match = candidates.first(where: {
+               guard let activeFingerprint = $0.activeEndpoint?.bridgeFingerprint, !activeFingerprint.isEmpty else {
+                   return false
+               }
+               return activeFingerprint.caseInsensitiveCompare(fingerprint) == .orderedSame
+           }) {
+            return match
+        }
+        if let match = candidates.first(where: {
+            guard let active = $0.activeEndpoint else { return false }
+            return active.host == endpoint.host && active.port == endpoint.port
+        }) {
             return match
         }
         return repointedMachineID == machineID ? store : nil

--- a/apps/ios/Sources/DeckStore.swift
+++ b/apps/ios/Sources/DeckStore.swift
@@ -265,8 +265,14 @@ final class DeckStore: ObservableObject {
                 if let runtimeSnapshot = result.runtimeSnapshot {
                     snapshot = runtimeSnapshot
                 }
-                try? await Task.sleep(for: .milliseconds(350))
+                let isVoiceCommand = actionID.hasPrefix("voice.")
+                if !isVoiceCommand {
+                    try? await Task.sleep(for: .milliseconds(350))
+                }
                 await refreshSnapshot(endpoint: endpoint)
+                if isVoiceCommand {
+                    await refreshSnapshot(endpoint: endpoint)
+                }
                 errorMessage = nil
             } catch {
                 lastActionResult = nil
@@ -301,11 +307,26 @@ final class DeckStore: ObservableObject {
     var voiceState: DeckVoiceState? { snapshot?.voice }
 
     func startVoice() {
+        setUIPriority(.fast)
         perform(actionID: "voice.command.start", pageID: "home", label: "voice")
+    }
+
+    /// Wake the Mac voice runtime while the user is picking a host so capture
+    /// does not pay cold-start costs on the first mic tap.
+    func prewarmVoice() {
+        guard let endpoint = preferredEndpoint(), let health else { return }
+        Task {
+            let request = DeckActionRequest(pageID: "home", actionID: "voice.runtime.warm", payload: [:])
+            try? await performWithFallback(request: request, preferred: endpoint, health: health)
+        }
     }
 
     func stopVoice() {
         perform(actionID: "voice.command.stop", pageID: "home", label: "voice")
+    }
+
+    func cancelVoice() {
+        perform(actionID: "voice.cancel", pageID: "home", label: "voice")
     }
 
     func toggleVoice() {

--- a/apps/ios/Sources/Home/HomeView.swift
+++ b/apps/ios/Sources/Home/HomeView.swift
@@ -6,10 +6,8 @@ import SwiftUI
 /// Composed of independent sections:
 ///   - HomeTopBar       (chrome — fleet pills, agent count, settings)
 ///   - HomeTargetsRow   (adaptive cards: 1, 2, 3-4 Macs)
-///   - HomeScenesGrid   (instant layout presets)
-///   - HomeRoutinesList (agent recipes)
+///   - HomeScreensRow   (live per-host screen thumbnails)
 ///   - HomeActivityFeed (combined: attention + recent + agent narration)
-///   - HomeSyncSection  (broadcast / fleet ops)
 ///   - HomeVoicePanel   (inline voice — slides in above the cloud strip)
 ///   - HomeCloudStrip   (separate cloud aggregate)
 ///   - HomeBottomBar    (chrome — status, voice/cmd)
@@ -22,15 +20,13 @@ struct HomeView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     let machines: [HomeMachine]
-    let scenes: [HomeScene]
-    let routines: [HomeRoutine]
     let recent: [HomeRecentEntry]
-    let sync: [HomeSyncAction]
     let cloud: HomeCloudStatus
     let agentFeed: [HomeAgentFeedEntry]
-    let terminal: [HomeTerminalLine]
-    let calendar: [HomeCalendarEvent]
     let attention: [HomeAttentionItem]
+    /// Live per-host screen thumbnails, keyed by machine ID. A host joins the
+    /// Screens strip only once it has produced a frame.
+    var screenPreviews: [String: UIImage] = [:]
 
     /// Bottom-bar telemetry. When `.empty` (default), the cluster hides itself
     /// while the rest of the bar (status / version / agent) still renders.
@@ -44,9 +40,6 @@ struct HomeView: View {
     var onMachineVoice: ((HomeMachine) -> Void)? = nil
     /// Unpaired Macs discovery can see right now. Surfaced on the add cell.
     var nearbyCandidateCount: Int = 0
-    var onScene: ((HomeScene) -> Void)? = nil
-    var onRoutine: ((HomeRoutine) -> Void)? = nil
-    var onBroadcast: ((HomeSyncAction, [HomeMachine]) -> Void)? = nil
     var onPair: (() -> Void)? = nil
     var onSettings: (() -> Void)? = nil
 
@@ -54,12 +47,23 @@ struct HomeView: View {
     var voiceState: DeckVoiceState? = nil
     var voiceMacLabel: String = "Mac"
     var isVoicePerforming: Bool = false
+    var voiceTargetReachable: Bool = false
+    /// Opens the voice panel without arming a microphone.
+    var onVoiceOpen: ((HomeMachine?) -> Void)? = nil
     var onVoiceStart: (() -> Void)? = nil
     var onVoiceStop: (() -> Void)? = nil
     var onVoiceCancel: (() -> Void)? = nil
     var onVoiceRemediate: ((DeckRemediationAction) -> Void)? = nil
 
-    @State private var voicePanelOpen: Bool = false
+    /// Fleet roster for choosing which Mac receives voice commands.
+    var voiceMachines: [HomeMachine] = []
+    var voiceTargetMachineID: String? = nil
+    var onSelectVoiceTarget: ((HomeMachine) -> Void)? = nil
+
+    @Binding var voicePanelOpen: Bool
+    /// Screen previews are on-demand: a live strip of every Mac's display
+    /// fights the page for attention, so it stays off until asked for.
+    @AppStorage("deck.home.showScreens") private var showScreens = false
 
     private var foregroundMachine: HomeMachine? {
         machines.first(where: { $0.isForeground })
@@ -72,57 +76,33 @@ struct HomeView: View {
         }.count
     }
 
+    private var hasActiveVoiceSession: Bool {
+        guard let phase = voiceState?.phase else { return false }
+        return phase != .idle || voiceState?.error != nil
+    }
+
     var body: some View {
-        ZStack(alignment: .bottomTrailing) {
-            Group {
-                if machines.isEmpty {
-                    zeroStateLayout
-                } else {
-                    connectedLayout
-                }
-            }
-            if !voicePanelOpen && horizontalSizeClass != .compact {
-                voiceTrigger
-                    .padding(.trailing, 18)
-                    .padding(.bottom, 70) // sit above the HomeBottomBar
+        Group {
+            if machines.isEmpty {
+                zeroStateLayout
+            } else {
+                connectedLayout
             }
         }
-        // Auto-open the panel when the Mac reports active voice work (a
-        // dictation kicked off elsewhere, or an error needs attention). We
-        // don't auto-open just for stale transcripts/responses — closing the
-        // panel must stay closed once the turn is done.
+        // Auto-open only for the Mac the user already picked — not because some
+        // other host's snapshot happened to report voice activity.
         .onChange(of: voiceState?.phase) { _, newPhase in
+            guard voiceTargetMachineID != nil else { return }
             if let newPhase, newPhase != .idle {
                 voicePanelOpen = true
             }
         }
         .onChange(of: voiceState?.error?.code) { _, newCode in
+            guard voiceTargetMachineID != nil else { return }
             if newCode != nil {
                 voicePanelOpen = true
             }
         }
-    }
-
-    private var voiceTrigger: some View {
-        Button {
-            onVoiceStart?()
-            voicePanelOpen = true
-        } label: {
-            Image(systemName: "mic.fill")
-                .font(.system(size: 18, weight: .semibold))
-                .foregroundStyle(DeckTheme.text)
-                .frame(width: 52, height: 52)
-                .background(
-                    Circle().fill(DeckTheme.accentFill)
-                )
-                .overlay(
-                    Circle().stroke(DeckTheme.accent.opacity(0.55), lineWidth: 1)
-                )
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Start voice on \(voiceMacLabel)")
-        .opacity(horizontalSizeClass == .compact ? 0 : 1)
-        .allowsHitTesting(horizontalSizeClass != .compact)
     }
 
     private var foregroundAgentState: HomeAgentState {
@@ -151,18 +131,18 @@ struct HomeView: View {
                     HomeTargetsRow(
                         machines: machines,
                         nearbyCandidateCount: nearbyCandidateCount,
+                        screensVisible: $showScreens,
                         onEnterDeck: onEnterDeck,
                         onEnterFleet: onEnterFleet,
                         onAddHost: onAddHost,
                         onVoice: onMachineVoice
                     )
-
-                    if !scenes.isEmpty {
-                        HomeScenesGrid(scenes: scenes, onScene: onScene)
-                    }
-
-                    if !routines.isEmpty {
-                        HomeRoutinesList(routines: routines, onRun: onRoutine)
+                    if showScreens {
+                        HomeScreensRow(
+                            machines: machines,
+                            previews: screenPreviews,
+                            onEnterDeck: onEnterDeck
+                        )
                     }
 
                     HomeActivityFeed(
@@ -171,13 +151,6 @@ struct HomeView: View {
                         attention: attention
                     )
 
-                    if !sync.isEmpty {
-                        HomeSyncSection(
-                            actions: sync,
-                            machines: machines,
-                            onBroadcast: onBroadcast
-                        )
-                    }
                 }
                 .padding(.horizontal, horizontalSizeClass == .compact ? 14 : 24)
                 .padding(.vertical, horizontalSizeClass == .compact ? 12 : 18)
@@ -189,6 +162,10 @@ struct HomeView: View {
                     voiceState: voiceState,
                     macLabel: voiceMacLabel,
                     isPerforming: isVoicePerforming,
+                    isTargetReachable: voiceTargetReachable,
+                    machines: voiceMachines,
+                    selectedMachineID: voiceTargetMachineID,
+                    onSelectMachine: onSelectVoiceTarget,
                     onStart: { onVoiceStart?() },
                     onStop:  { onVoiceStop?() },
                     onCancel: {
@@ -211,6 +188,8 @@ struct HomeView: View {
                     },
                     onRemediate: { onVoiceRemediate?($0) }
                 )
+                .padding(.horizontal, horizontalSizeClass == .compact ? 14 : 24)
+                .padding(.bottom, DeckTheme.Space.x8)
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             }
 
@@ -223,7 +202,13 @@ struct HomeView: View {
                 onCommand: foregroundMachine.map { machine in
                     { onEnterDeck?(machine) }
                 },
-                onVoice: onVoiceStart
+                onVoice: {
+                    if hasActiveVoiceSession {
+                        voicePanelOpen = true
+                    } else {
+                        onVoiceOpen?(nil)
+                    }
+                }
             )
         }
         .animation(.easeInOut(duration: 0.22), value: voicePanelOpen)
@@ -236,15 +221,11 @@ struct HomeView: View {
     LatsBackground(grid: false) {
         HomeView(
             machines:  HomeMock.fleetFour,
-            scenes:    HomeMock.scenes,
-            routines:  HomeMock.routines,
             recent:    HomeMock.recent,
-            sync:      HomeMock.sync,
             cloud:     HomeMock.cloud,
             agentFeed: HomeMock.agentFeed,
-            terminal:  HomeMock.terminal,
-            calendar:  HomeMock.calendar,
-            attention: HomeMock.attention
+            attention: HomeMock.attention,
+            voicePanelOpen: .constant(false)
         )
     }
     .preferredColorScheme(.dark)
@@ -254,15 +235,11 @@ struct HomeView: View {
     LatsBackground {
         HomeView(
             machines:  HomeMock.fleetTwo,
-            scenes:    HomeMock.scenes,
-            routines:  HomeMock.routines,
             recent:    HomeMock.recent,
-            sync:      HomeMock.sync,
             cloud:     HomeMock.cloud,
             agentFeed: HomeMock.agentFeed,
-            terminal:  HomeMock.terminal,
-            calendar:  HomeMock.calendar,
-            attention: HomeMock.attention
+            attention: HomeMock.attention,
+            voicePanelOpen: .constant(false)
         )
     }
     .preferredColorScheme(.dark)
@@ -272,15 +249,11 @@ struct HomeView: View {
     LatsBackground {
         HomeView(
             machines:  HomeMock.fleetOne,
-            scenes:    HomeMock.scenes,
-            routines:  HomeMock.routines,
             recent:    HomeMock.recent,
-            sync:      HomeMock.sync,
             cloud:     HomeMock.cloud,
             agentFeed: HomeMock.agentFeed,
-            terminal:  HomeMock.terminal,
-            calendar:  HomeMock.calendar,
-            attention: HomeMock.attention
+            attention: HomeMock.attention,
+            voicePanelOpen: .constant(false)
         )
     }
     .preferredColorScheme(.dark)
@@ -290,16 +263,12 @@ struct HomeView: View {
     LatsBackground {
         HomeView(
             machines:  HomeMock.fleetEmpty,
-            scenes:    HomeMock.scenes,
-            routines:  HomeMock.routines,
             recent:    HomeMock.recent,
-            sync:      HomeMock.sync,
             cloud:     HomeMock.cloud,
             agentFeed: HomeMock.agentFeed,
-            terminal:  HomeMock.terminal,
-            calendar:  HomeMock.calendar,
             attention: HomeMock.attention,
-            onPair: {}
+            onPair: {},
+            voicePanelOpen: .constant(false)
 
         )
     }

--- a/apps/ios/Sources/Home/HomeVoiceOverlay.swift
+++ b/apps/ios/Sources/Home/HomeVoiceOverlay.swift
@@ -51,7 +51,6 @@ struct HomeVoiceOverlay: View {
                 bottomBar
             }
         }
-        .preferredColorScheme(.dark)
     }
 
     // MARK: - Top bar

--- a/apps/ios/Sources/Home/HomeVoicePanel.swift
+++ b/apps/ios/Sources/Home/HomeVoicePanel.swift
@@ -1,18 +1,18 @@
 import DeckKit
 import SwiftUI
 
-/// Inline voice panel — slots into the Home layout above the cloud strip
-/// instead of taking over the screen. The dashboard stays visible above so
-/// the user can see fleet state while dictating.
+/// Inline voice panel — slots into the Home layout above the cloud strip.
 ///
-/// Renders nothing when there's nothing to say (idle, no transcript, no
-/// response, no error, panel not explicitly opened). Hosting view controls
-/// visibility via `isOpen` so an explicit FAB tap can pre-open the panel
-/// before any state arrives from the Mac.
+/// Flow: open panel → pick a Mac → tap mic to start. Nothing arms a host
+/// microphone until both steps are deliberate.
 struct HomeVoicePanel: View {
     let voiceState: DeckVoiceState?
     let macLabel: String
     let isPerforming: Bool
+    var isTargetReachable: Bool = true
+    var machines: [HomeMachine] = []
+    var selectedMachineID: String? = nil
+    var onSelectMachine: ((HomeMachine) -> Void)? = nil
 
     var onStart: () -> Void
     var onStop: () -> Void
@@ -22,6 +22,7 @@ struct HomeVoicePanel: View {
 
     private var phase: DeckVoicePhase { voiceState?.phase ?? .idle }
     private var error: DeckVoiceError? { voiceState?.error }
+    private var hasSelectedTarget: Bool { selectedMachineID != nil }
 
     private var transcript: String? {
         let raw = voiceState?.transcript?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -31,68 +32,93 @@ struct HomeVoicePanel: View {
     private var responseSummary: String? {
         let raw = voiceState?.responseSummary?.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let raw, !raw.isEmpty else { return nil }
-        if raw == "Transcribing..." || raw == "thinking..." { return nil }
+        if DeckVoiceErrorMapper.isProgressMessage(raw) { return nil }
         return raw
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            HStack(alignment: .top, spacing: 14) {
-                // Single round CTA — combines mic icon, phase indicator, and
-                // start/stop action into one tap target. Color + glyph reflect
-                // current phase; tapping advances the state.
-                VoiceCTA(
-                    phase: phase,
-                    severity: error?.severity,
-                    onTap: handlePrimaryTap
-                )
-                .frame(width: 64, height: 64)
+        FleetWell(radius: DeckTheme.radiusWell) {
+            VStack(alignment: .leading, spacing: DeckTheme.Space.sectionGap) {
+                headerRow
 
-                VStack(alignment: .leading, spacing: 8) {
-                    headerRow
+                targetSection
 
-                    Text(caption)
-                        .font(DeckTheme.secondary())
-                        .foregroundStyle(LatsPalette.textDim)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                HStack(alignment: .center, spacing: DeckTheme.Space.sectionGap) {
+                    VoiceCTA(
+                        phase: phase,
+                        severity: error?.severity,
+                        isEnabled: canTapMic,
+                        onTap: handlePrimaryTap
+                    )
+                    .frame(width: 56, height: 56)
 
-                    if let transcript {
-                        transcriptInline(transcript)
-                    }
-                    if let responseSummary {
-                        responseInline(responseSummary)
-                    }
-                    if let error {
-                        errorInline(error)
+                    VStack(alignment: .leading, spacing: 6) {
+                        if showsPhaseLabel {
+                            Text(phaseLabel)
+                                .font(DeckTheme.caption(.semibold))
+                                .foregroundStyle(phaseChipForeground)
+                        }
+
+                        Text(caption)
+                            .font(DeckTheme.secondary())
+                            .foregroundStyle(DeckTheme.textSecondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
+
+                if transcript != nil || responseSummary != nil || error != nil {
+                    VStack(alignment: .leading, spacing: DeckTheme.Space.x8) {
+                        if let transcript {
+                            speechBlock(label: "You said", text: transcript)
+                        }
+                        if let responseSummary {
+                            speechBlock(label: "Result", text: responseSummary, highlighted: true)
+                        }
+                        if let error {
+                            errorInline(error)
+                        }
+                    }
+                }
             }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 12)
-        }
-        .background(Color.black.opacity(0.32))
-        .overlay(alignment: .top) {
-            Rectangle().fill(LatsPalette.hairline2).frame(height: 1)
+            .padding(.horizontal, DeckTheme.Space.wellPad)
+            .padding(.vertical, DeckTheme.Space.cardPadV)
         }
     }
 
-    // MARK: - Header — target label + close
+    // MARK: - Header
 
     private var headerRow: some View {
-        HStack(spacing: 8) {
-            Text(macLabel)
-                .font(DeckTheme.secondary())
-                .foregroundStyle(LatsPalette.textDim)
-                .lineLimit(1)
+        HStack(alignment: .top, spacing: DeckTheme.Space.x8) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Voice")
+                    .font(DeckTheme.secondary(.semibold))
+                    .foregroundStyle(DeckTheme.text)
+                if hasSelectedTarget {
+                    Text(macLabel)
+                        .font(DeckTheme.caption())
+                        .foregroundStyle(isTargetReachable ? DeckTheme.textSecondary : DeckTheme.accent)
+                        .lineLimit(1)
+                } else if machines.count > 1 {
+                    Text("Pick a Mac, then tap the mic")
+                        .font(DeckTheme.caption())
+                        .foregroundStyle(DeckTheme.textTertiary)
+                }
+            }
 
             Spacer(minLength: 8)
 
             Button(action: onClose) {
                 Image(systemName: "chevron.down")
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(LatsPalette.textDim)
-                    .frame(width: 44, height: 44)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(DeckTheme.textTertiary)
+                    .frame(width: 36, height: 36)
+                    .background(DeckTheme.control)
+                    .clipShape(RoundedRectangle(cornerRadius: DeckTheme.radiusSmall, style: .continuous))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: DeckTheme.radiusSmall, style: .continuous)
+                            .strokeBorder(DeckTheme.hairline, lineWidth: 1)
+                    }
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
@@ -100,11 +126,120 @@ struct HomeVoicePanel: View {
         }
     }
 
-    // MARK: - Tap routing for the single CTA
+    private var targetSection: some View {
+        Group {
+            if machines.count > 1 {
+                VStack(alignment: .leading, spacing: DeckTheme.Space.x8) {
+                    Text("Speak to")
+                        .font(DeckTheme.caption())
+                        .foregroundStyle(DeckTheme.textTertiary)
 
-    /// One button, three jobs depending on phase. Idle starts; listening stops;
-    /// transcribing/reasoning/speaking cancels the in-flight turn. Errors with
-    /// remediations route through the remediation handler instead.
+                    if machines.isEmpty {
+                        Text("No paired Macs are reachable right now.")
+                            .font(DeckTheme.secondary())
+                            .foregroundStyle(DeckTheme.textSecondary)
+                    } else {
+                        voiceTargetPicker
+                    }
+                }
+            } else if let only = machines.first {
+                HStack(spacing: 8) {
+                    Image(systemName: only.isForeground ? "laptopcomputer" : "desktopcomputer")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(DeckTheme.textTertiary)
+                    Text(only.name)
+                        .font(DeckTheme.caption(.medium))
+                        .foregroundStyle(DeckTheme.textSecondary)
+                        .lineLimit(1)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 7)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(DeckTheme.control)
+                .clipShape(RoundedRectangle(cornerRadius: DeckTheme.radiusCard, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: DeckTheme.radiusCard, style: .continuous)
+                        .strokeBorder(DeckTheme.hairline, lineWidth: 1)
+                }
+            }
+        }
+    }
+
+    private var voiceTargetPicker: some View {
+        Group {
+            if machines.count <= 2 {
+                HStack(spacing: 8) {
+                    ForEach(machines) { machine in
+                        voiceTargetChip(for: machine)
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        ForEach(machines) { machine in
+                            voiceTargetChip(for: machine)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func voiceTargetChip(for machine: HomeMachine) -> some View {
+        let selected = machine.id == selectedMachineID
+        let reachable = machine.status != .offline
+        return Button {
+            DeckTactileFeedback.shared.rotaryTick()
+            onSelectMachine?(machine)
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: machine.isForeground ? "laptopcomputer" : "desktopcomputer")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(selected ? DeckTheme.text : DeckTheme.textTertiary)
+                    .frame(width: 14, alignment: .center)
+
+                Text(machine.name)
+                    .font(DeckTheme.caption(.medium))
+                    .foregroundStyle(selected ? DeckTheme.text : DeckTheme.textSecondary)
+                    .lineLimit(1)
+
+                if !reachable {
+                    Image(systemName: "wifi.exclamationmark")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(DeckTheme.textTertiary)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .frame(maxWidth: .infinity)
+            .background {
+                RoundedRectangle(cornerRadius: DeckTheme.radiusCard, style: .continuous)
+                    .fill(selected ? DeckTheme.card : DeckTheme.control)
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: DeckTheme.radiusCard, style: .continuous)
+                    .strokeBorder(
+                        selected ? DeckTheme.hairlineStrong : DeckTheme.hairline,
+                        lineWidth: 1
+                    )
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Speak to \(machine.name)")
+        .accessibilityAddTraits(selected ? .isSelected : [])
+    }
+
+    // MARK: - Tap routing
+
+    private var canTapMic: Bool {
+        if error != nil { return true }
+        if phase == .idle {
+            return hasSelectedTarget && isTargetReachable && !machines.isEmpty
+        }
+        return isTargetReachable
+    }
+
     private func handlePrimaryTap() {
         if let err = error, let remediation = err.remediation {
             onRemediate?(remediation)
@@ -112,105 +247,168 @@ struct HomeVoicePanel: View {
         }
         switch phase {
         case .idle:
+            guard hasSelectedTarget else { return }
+            DeckTactileFeedback.shared.tilePress(isAccent: true)
             onStart()
         case .listening:
+            DeckTactileFeedback.shared.buttonPop()
             onStop()
         case .transcribing, .reasoning, .speaking:
+            DeckTactileFeedback.shared.buttonPop()
             onCancel()
         }
     }
 
-    // MARK: - Inline transcript / response / error
+    // MARK: - Content rows
 
-    private func transcriptInline(_ text: String) -> some View {
-        HStack(alignment: .top, spacing: 8) {
-            Text("›")
-                .font(DeckTheme.saidSecondary)
+    private func speechBlock(label: String, text: String, highlighted: Bool = false) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label)
+                .font(DeckTheme.caption())
                 .foregroundStyle(DeckTheme.textTertiary)
             Text(text)
-                .font(DeckTheme.saidSecondary)
-                .foregroundStyle(LatsPalette.text)
+                .font(DeckTheme.body())
+                .foregroundStyle(DeckTheme.text)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .multilineTextAlignment(.leading)
+                .lineSpacing(2)
         }
-    }
-
-    private func responseInline(_ text: String) -> some View {
-        HStack(alignment: .top, spacing: 8) {
-            Image(systemName: "checkmark")
-                .font(.system(size: 10, weight: .bold))
-                .foregroundStyle(LatsPalette.green)
-                .frame(width: 12)
-            Text(text)
-                .font(DeckTheme.saidSecondary)
-                .foregroundStyle(LatsPalette.text)
-                .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(DeckTheme.Space.x12)
+        .background(highlighted ? DeckTheme.accentFill : DeckTheme.card)
+        .clipShape(RoundedRectangle(cornerRadius: DeckTheme.radiusCard, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: DeckTheme.radiusCard, style: .continuous)
+                .strokeBorder(highlighted ? DeckTheme.accent.opacity(0.25) : DeckTheme.hairline, lineWidth: 1)
         }
     }
 
     private func errorInline(_ err: DeckVoiceError) -> some View {
-        let tint = severityTint(err.severity)
-        return VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: DeckTheme.Space.x8) {
             HStack(spacing: 8) {
                 Image(systemName: severityIcon(err.code))
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(tint)
-                Text(err.code.rawValue.uppercased())
-                    .font(LatsFont.mono(9, weight: .bold))
-                    .tracking(1.2)
-                    .foregroundStyle(tint)
-                Spacer()
+                    .foregroundStyle(severityTint(err.severity))
+                Text(err.message)
+                    .font(DeckTheme.secondary())
+                    .foregroundStyle(DeckTheme.text)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .multilineTextAlignment(.leading)
             }
-            Text(err.message)
-                .font(LatsFont.ui(12, weight: .medium))
-                .foregroundStyle(LatsPalette.text)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .multilineTextAlignment(.leading)
             if let remediation = err.remediation {
-                LatsButton(
-                    title: remediationLabel(remediation),
-                    icon: remediationIcon(remediation),
-                    style: .primary(remediationTint(err.severity))
-                ) {
+                Button {
+                    DeckTactileFeedback.shared.tilePress(isAccent: true)
                     onRemediate?(remediation)
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: remediationIcon(remediation))
+                            .font(.system(size: 11, weight: .semibold))
+                        Text(remediationLabel(remediation))
+                            .font(DeckTheme.caption(.semibold))
+                    }
+                    .foregroundStyle(DeckTheme.accent)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 7)
+                    .background(DeckTheme.accentFill)
+                    .clipShape(RoundedRectangle(cornerRadius: DeckTheme.radiusSmall, style: .continuous))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: DeckTheme.radiusSmall, style: .continuous)
+                            .strokeBorder(DeckTheme.accent.opacity(0.35), lineWidth: 1)
+                    }
                 }
+                .buttonStyle(.plain)
             }
         }
-        .padding(10)
-        .background(RoundedRectangle(cornerRadius: 6).fill(tint.opacity(0.08)))
-        .overlay(RoundedRectangle(cornerRadius: 6).stroke(tint.opacity(0.4), lineWidth: 1))
+        .padding(DeckTheme.Space.x12)
+        .background(DeckTheme.errorFill)
+        .clipShape(RoundedRectangle(cornerRadius: DeckTheme.radiusCard, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: DeckTheme.radiusCard, style: .continuous)
+                .strokeBorder(DeckTheme.error.opacity(0.35), lineWidth: 1)
+        }
     }
 
     // MARK: - Phase / severity helpers
 
+    private var showsPhaseLabel: Bool {
+        error != nil || phase != .idle || isPerforming || !hasSelectedTarget || (hasSelectedTarget && !isTargetReachable)
+    }
+
     private var caption: String {
-        if error != nil { return "voice paused — see status above" }
+        if error != nil { return "Voice paused — see below" }
+        if !hasSelectedTarget {
+            return machines.count > 1
+                ? "Choose which Mac should hear you, then tap the mic."
+                : "Tap the mic when you're ready to speak."
+        }
+        if !isTargetReachable {
+            return "Connecting to \(macLabel)… pick another Mac if this takes too long."
+        }
+        if isPerforming && phase == .idle {
+            return "Connecting to voice runtime on \(macLabel)…"
+        }
+        if let status = voiceState?.statusLine, !status.isEmpty {
+            return status
+        }
+        if let kind = voiceState?.turnKind, phase == .reasoning || phase == .speaking {
+            switch kind {
+            case .quick:
+                return "Quick command on \(macLabel)…"
+            case .standard:
+                return "Working on \(macLabel)…"
+            case .conversation:
+                return "Thinking on \(macLabel)…"
+            }
+        }
         switch phase {
-        case .idle:         return "tap to dictate on \(macLabel)"
-        case .listening:    return "listening on \(macLabel) — tap to stop"
-        case .transcribing: return "transcribing…"
-        case .reasoning:    return "matching intent…"
-        case .speaking:     return "responding…"
+        case .idle:         return "Uses \(macLabel)'s microphone — nothing is recorded until you tap."
+        case .listening:    return "Listening on \(macLabel). Tap again to send."
+        case .transcribing: return "Understanding what you said…"
+        case .reasoning:    return "Running on \(macLabel)…"
+        case .speaking:     return "Speaking the reply…"
         }
     }
 
-    private var phaseTint: Color {
-        if let err = error { return severityTint(err.severity) }
+    private var phaseLabel: String {
+        if error != nil { return "Paused" }
+        if !hasSelectedTarget { return "Pick a Mac" }
+        if !isTargetReachable { return "Connecting" }
+        if isPerforming && phase == .idle { return "Connecting" }
+        if let stage = voiceState?.turnStage {
+            switch stage {
+            case .acknowledging: return "Got it"
+            case .understanding: return "Understanding"
+            case .planning: return voiceState?.turnKind == .quick ? "Running" : "Planning"
+            case .narrating: return "Speaking"
+            case .executing: return voiceState?.turnKind == .quick ? "Running" : "Working"
+            case .confirming: return "Done"
+            }
+        }
         switch phase {
-        case .idle:         return LatsPalette.textDim
-        case .listening:    return LatsPalette.green
-        case .transcribing: return LatsPalette.teal
-        case .reasoning:    return LatsPalette.violet
-        case .speaking:     return LatsPalette.blue
+        case .idle:         return "Ready"
+        case .listening:    return "Listening"
+        case .transcribing: return "Understanding"
+        case .reasoning:    return "Working"
+        case .speaking:     return "Speaking"
+        }
+    }
+
+    private var phaseChipForeground: Color {
+        if error != nil { return DeckTheme.error }
+        if !hasSelectedTarget { return DeckTheme.textTertiary }
+        if !isTargetReachable { return DeckTheme.accent }
+        switch phase {
+        case .idle:         return DeckTheme.textSecondary
+        case .listening:    return DeckTheme.accent
+        case .transcribing, .reasoning, .speaking: return DeckTheme.text
         }
     }
 
     private func severityTint(_ severity: DeckErrorSeverity) -> Color {
         switch severity {
-        case .info:    return LatsPalette.blue
-        case .warning: return LatsPalette.amber
+        case .info:    return DeckTheme.textSecondary
+        case .warning: return DeckTheme.accent
         case .error,
-             .blocked: return LatsPalette.red
+             .blocked: return DeckTheme.error
         }
     }
 
@@ -237,10 +435,10 @@ struct HomeVoicePanel: View {
     private func remediationLabel(_ remediation: DeckRemediationAction) -> String {
         switch remediation {
         case .openVox:            return "Open Vox"
-        case .openSystemSettings: return "Open settings"
+        case .openSystemSettings: return "Open Settings"
         case .retryVoice:         return "Retry"
-        case .openDiagnostics:    return "Open diagnostics"
-        case .chooseTarget:       return "Pick target"
+        case .openDiagnostics:    return "Diagnostics"
+        case .chooseTarget:       return "Pick Mac"
         }
     }
 
@@ -250,29 +448,17 @@ struct HomeVoicePanel: View {
         case .openSystemSettings: return "gearshape"
         case .retryVoice:         return "arrow.clockwise"
         case .openDiagnostics:    return "stethoscope"
-        case .chooseTarget:       return "scope"
-        }
-    }
-
-    private func remediationTint(_ severity: DeckErrorSeverity) -> LatsTint {
-        switch severity {
-        case .info:    return .blue
-        case .warning: return .amber
-        case .error,
-             .blocked: return .red
+        case .chooseTarget:       return "laptopcomputer.and.arrow.down"
         }
     }
 }
 
-// MARK: - VoiceCTA — single round button that absorbs orb + phase pill + action
+// MARK: - Voice CTA
 
-/// A round mic button whose color, glyph, and pulse animation reflect the
-/// current voice phase. Replaces the old triple of orb + "READY" pill +
-/// Start/Stop button with one tappable surface — the host wires its tap to
-/// a phase-aware handler that starts, stops, or cancels as appropriate.
 struct VoiceCTA: View {
     let phase: DeckVoicePhase
     let severity: DeckErrorSeverity?
+    var isEnabled: Bool = true
     var onTap: () -> Void
 
     @State private var pulse: Bool = false
@@ -280,8 +466,6 @@ struct VoiceCTA: View {
     var body: some View {
         Button(action: onTap) {
             ZStack {
-                // Outer pulse ring — only animates while listening so the
-                // CTA visually "hears."
                 Circle()
                     .stroke(tint.opacity(0.45), lineWidth: 1.5)
                     .scaleEffect(pulse ? 1.18 : 1.0)
@@ -293,8 +477,8 @@ struct VoiceCTA: View {
                         value: pulse
                     )
 
-                Circle().fill(tint.opacity(0.18))
-                Circle().stroke(tint.opacity(0.55), lineWidth: 1)
+                Circle().fill(tint.opacity(isEnabled ? 0.18 : 0.08))
+                Circle().stroke(tint.opacity(isEnabled ? 0.55 : 0.25), lineWidth: 1)
 
                 if isThinking {
                     ProgressView()
@@ -303,37 +487,39 @@ struct VoiceCTA: View {
                 } else {
                     Image(systemName: glyph)
                         .font(.system(size: 22, weight: .semibold))
-                        .foregroundStyle(tint)
+                        .foregroundStyle(tint.opacity(isEnabled ? 1 : 0.45))
                 }
             }
         }
         .buttonStyle(.plain)
+        .disabled(!isEnabled)
         .contentShape(Circle())
         .onAppear { if isAnimating { pulse = true } }
         .onChange(of: phase) { _, _ in pulse = isAnimating }
         .accessibilityLabel(accessibilityLabel)
     }
 
-    private var isAnimating: Bool { severity == nil && phase == .listening }
+    private var isAnimating: Bool { isEnabled && severity == nil && phase == .listening }
     private var isThinking: Bool {
         severity == nil && (phase == .transcribing || phase == .reasoning || phase == .speaking)
     }
 
     private var tint: Color {
+        if !isEnabled { return DeckTheme.textTertiary }
         if let severity {
             switch severity {
-            case .info:    return LatsPalette.blue
-            case .warning: return LatsPalette.amber
+            case .info:    return DeckTheme.textSecondary
+            case .warning: return DeckTheme.accent
             case .error,
-                 .blocked: return LatsPalette.red
+                 .blocked: return DeckTheme.error
             }
         }
         switch phase {
-        case .idle:         return LatsPalette.violet
-        case .listening:    return LatsPalette.red
-        case .transcribing: return LatsPalette.teal
-        case .reasoning:    return LatsPalette.violet
-        case .speaking:     return LatsPalette.blue
+        case .idle:         return DeckTheme.accent
+        case .listening:    return DeckTheme.accent
+        case .transcribing: return DeckTheme.text
+        case .reasoning:    return DeckTheme.text
+        case .speaking:     return DeckTheme.textSecondary
         }
     }
 
@@ -347,6 +533,7 @@ struct VoiceCTA: View {
     }
 
     private var accessibilityLabel: String {
+        if !isEnabled { return "Select a Mac first" }
         if severity != nil { return "Resolve voice issue" }
         switch phase {
         case .idle:      return "Start dictation"
@@ -354,72 +541,4 @@ struct VoiceCTA: View {
         default:         return "Cancel voice turn"
         }
     }
-}
-
-// MARK: - Previews
-
-#Preview("Panel · listening") {
-    LatsBackground {
-        VStack {
-            Spacer()
-            HomeVoicePanel(
-                voiceState: DeckVoiceState(
-                    phase: .listening,
-                    transcript: "tile chrome two-up right",
-                    provider: "vox"
-                ),
-                macLabel: "arach-laptop",
-                isPerforming: false,
-                onStart: {}, onStop: {}, onCancel: {}, onClose: {}
-            )
-        }
-    }
-    .preferredColorScheme(.dark)
-}
-
-#Preview("Panel · result") {
-    LatsBackground {
-        VStack {
-            Spacer()
-            HomeVoicePanel(
-                voiceState: DeckVoiceState(
-                    phase: .idle,
-                    transcript: "tile chrome two-up right",
-                    responseSummary: "Tiled 3 windows in two columns on display 1",
-                    provider: "vox"
-                ),
-                macLabel: "arach-laptop",
-                isPerforming: false,
-                onStart: {}, onStop: {}, onCancel: {}, onClose: {}
-            )
-        }
-    }
-    .preferredColorScheme(.dark)
-}
-
-#Preview("Panel · error") {
-    LatsBackground {
-        VStack {
-            Spacer()
-            HomeVoicePanel(
-                voiceState: DeckVoiceState(
-                    phase: .idle,
-                    provider: "vox",
-                    error: DeckVoiceError(
-                        code: .voxNotRunning,
-                        severity: .error,
-                        recoverable: true,
-                        retry: .afterLaunch,
-                        source: .mac,
-                        message: "Vox offline — start it to dictate",
-                        remediation: .openVox
-                    )
-                ),
-                macLabel: "arach-laptop",
-                isPerforming: false,
-                onStart: {}, onStop: {}, onCancel: {}, onClose: {}
-            )
-        }
-    }
-    .preferredColorScheme(.dark)
 }


### PR DESCRIPTION
## Summary

- Open voice panel without auto-starting capture; user picks Mac under **Speak to**, then taps mic
- Optional `voiceTargetStore` with **no** fallback to foreground Mac
- `prewarmVoice()` → `voice.runtime.warm` on host selection; fast poll during voice turns
- Phase chips + `statusLine` from `turnKind` / `turnStage`; Mac-mic copy throughout
- Extract `ContentView` helpers (`homeScreen`, `deckCover`, etc.) to fix type-check timeouts

Part of the voice stack — **3/7**. Base: `feat/mac-voice-kokoro`.

**CI deferred** until final merge to `main`.