### PR TITLE
✨ Expand deck tactile catalog and iOS feedback

### DIFF
--- a/apps/ios/Sources/DeckTactileFeedback.swift
+++ b/apps/ios/Sources/DeckTactileFeedback.swift
@@ -1,28 +1,16 @@
 import AVFoundation
-import AudioToolbox
+import DeckKit
 import UIKit
 
-// MARK: - Tactile Feedback & Sound Synthesizer
+// MARK: - Catalog-driven tactile feedback (iOS)
 //
-// Replicates the Dieter Rams / Teenage Engineering mechanical desk controller
-// sound and haptic model from the Lattices experiment page:
-//   - Mechanical Key Switch Thock & Click (linear switch body + keycap noise)
-//   - Rotary Encoder Ratchet Tick (1900Hz -> 300Hz detent click)
-//   - Toggle Switch Clack (solid metal chassis latch)
-//   - Push Button Pop (520Hz -> 120Hz smooth actuation)
-//   - Approval Chime (dual-tone harmonic confirmation)
-//   - Warning Buzz (needs-attention alert)
-//
-// Coupled with iOS Taptic Engine feedback generators:
-//   - .rigid for mechanical switch key travel
-//   - .heavy for accent / signature terracotta keys
-//   - .medium for toggle / latch actions
-//   - .light for micro pops & controls
-//   - .selectionChanged for rotary detents & channel selection
-//   - .success / .warning for agent decision resolutions
+// Sound patches and event bindings live in `deck-tactile-catalog.json` (DeckKit).
+// Customize by merging a JSON overlay: `DeckTactileFeedback.shared.loadTheme(from:)`.
 
 public final class DeckTactileFeedback {
     public static let shared = DeckTactileFeedback()
+
+    public var theme: DeckTactileTheme { DeckTactileTheme.shared }
 
     public var isSoundEnabled: Bool {
         get { UserDefaults.standard.object(forKey: "deck_sound_enabled") as? Bool ?? true }
@@ -34,7 +22,6 @@ public final class DeckTactileFeedback {
         set { UserDefaults.standard.set(newValue, forKey: "deck_haptics_enabled") }
     }
 
-    // MARK: - Haptic Generators
     private let rigidImpact = UIImpactFeedbackGenerator(style: .rigid)
     private let mediumImpact = UIImpactFeedbackGenerator(style: .medium)
     private let heavyImpact = UIImpactFeedbackGenerator(style: .heavy)
@@ -42,102 +29,77 @@ public final class DeckTactileFeedback {
     private let selectionFeedback = UISelectionFeedbackGenerator()
     private let notificationFeedback = UINotificationFeedbackGenerator()
 
-    // MARK: - Audio Players Pool
-    private enum SoundType: String, CaseIterable {
-        case mechanicalOrange = "mech_orange"
-        case mechanicalCream = "mech_cream"
-        case rotaryTick = "rotary_tick"
-        case toggleClack = "toggle_clack"
-        case buttonPop = "button_pop"
-        case approvalChime = "approval_chime"
-        case warningBuzz = "warning_buzz"
-    }
-
-    private var playerPools: [SoundType: [AVAudioPlayer]] = [:]
-    private var poolIndices: [SoundType: Int] = [:]
+    private var playerPools: [String: [AVAudioPlayer]] = [:]
+    private var poolIndices: [String: Int] = [:]
     private var isAudioReady = false
     private let audioQueue = DispatchQueue(label: "dev.lattices.tactile.audio", qos: .userInteractive)
+    private let sampleRate = 44_100
+    private let poolSize = 3
 
     private init() {
         prepareHaptics()
         audioQueue.async { [weak self] in
-            self?.setupAudioSessionAndSynthesize()
+            self?.setupAudioSessionAndWarmPools()
         }
     }
 
-    // MARK: - Public Haptic & Sound Triggers
+    // MARK: - Theme loading
 
-    /// Trigger a mechanical keypress (sculpted mechanical switch thock + contact click).
-    /// `isOrange`: Terracotta "L" keys have a deeper, weightier body (240Hz), cream keys are crisper (340Hz).
+    public func loadTheme(from url: URL) throws {
+        let catalog = try DeckTactileTheme.loadCatalog(from: url)
+        theme.replaceCatalog(catalog)
+        audioQueue.async { [weak self] in
+            self?.rebuildPools()
+        }
+    }
+
+    public func mergeTheme(from url: URL) throws {
+        let overlay = try DeckTactileTheme.loadCatalog(from: url)
+        theme.merge(overlay)
+        audioQueue.async { [weak self] in
+            self?.rebuildPools()
+        }
+    }
+
+    // MARK: - Event playback
+
+    public func play(
+        _ event: DeckTactileEventID,
+        params: [String: DeckTactileParamValue] = [:]
+    ) {
+        play(eventID: event.rawValue, params: params)
+    }
+
+    public func play(
+        eventID: String,
+        params: [String: DeckTactileParamValue] = [:]
+    ) {
+        guard let resolved = theme.resolve(eventID: eventID, params: params) else { return }
+
+        if isHapticsEnabled, let haptic = resolved.haptic {
+            performHaptic(haptic)
+        }
+        if isSoundEnabled, let patch = resolved.patch {
+            playPatch(patch, cacheKey: cacheKey(for: resolved), params: resolved.params)
+        }
+    }
+
+    // MARK: - Legacy convenience (maps to catalog events)
+
     public func mechanicalKey(isOrange: Bool = false, id: Int = 0) {
-        if isHapticsEnabled {
-            if isOrange {
-                heavyImpact.impactOccurred()
-            } else {
-                rigidImpact.impactOccurred()
-            }
-        }
-        if isSoundEnabled {
-            playSound(isOrange ? .mechanicalOrange : .mechanicalCream)
-        }
+        let event: DeckTactileEventID = isOrange ? .deckKeyAccent : .deckKey
+        play(event, params: ["id": .int(id)])
     }
 
-    /// Convenience for command tiles and keys.
     public func tilePress(isAccent: Bool = false) {
         mechanicalKey(isOrange: isAccent)
     }
 
-    /// Stepping channels, cycling layers, or rotating encoder dials.
-    public func rotaryTick() {
-        if isHapticsEnabled {
-            selectionFeedback.selectionChanged()
-        }
-        if isSoundEnabled {
-            playSound(.rotaryTick)
-        }
-    }
-
-    /// Physical toggle switches or transport mode changes.
-    public func toggleClack() {
-        if isHapticsEnabled {
-            mediumImpact.impactOccurred()
-        }
-        if isSoundEnabled {
-            playSound(.toggleClack)
-        }
-    }
-
-    /// Standard micro button clicks (tabs, chips, icon buttons).
-    public func buttonPop() {
-        if isHapticsEnabled {
-            lightImpact.impactOccurred()
-        }
-        if isSoundEnabled {
-            playSound(.buttonPop)
-        }
-    }
-
-    /// Autonomous agent decision approved (e.g. schema migration authorized).
-    public func decisionApproved() {
-        if isHapticsEnabled {
-            notificationFeedback.notificationOccurred(.success)
-        }
-        if isSoundEnabled {
-            playSound(.approvalChime)
-        }
-    }
-
-    /// Decision deferred or rejected (e.g. ask me later / held).
-    public func decisionDeferred() {
-        if isHapticsEnabled {
-            notificationFeedback.notificationOccurred(.warning)
-        }
-        if isSoundEnabled {
-            playSound(.warningBuzz)
-        }
-    }
-
-    // MARK: - Preparation & Warm-up
+    public func rotaryTick() { play(.deckRotary) }
+    public func toggleClack() { play(.deckToggle) }
+    public func buttonPop() { play(.deckButton) }
+    public func decisionApproved() { play(.deckDecisionApproved) }
+    public func decisionDeferred() { play(.deckDecisionDeferred) }
 
     public func prepareHaptics() {
         DispatchQueue.main.async { [weak self] in
@@ -150,226 +112,107 @@ public final class DeckTactileFeedback {
         }
     }
 
-    // MARK: - Sound Synthesis & Playback
+    // MARK: - Audio
 
-    private func playSound(_ type: SoundType) {
-        audioQueue.async { [weak self] in
-            guard let self, self.isAudioReady, let pool = self.playerPools[type], !pool.isEmpty else { return }
-            let index = self.poolIndices[type, default: 0]
-            let player = pool[index % pool.count]
-            self.poolIndices[type] = (index + 1) % pool.count
-            player.currentTime = 0
-            player.play()
-        }
-    }
-
-    private func setupAudioSessionAndSynthesize() {
+    private func setupAudioSessionAndWarmPools() {
         do {
             let session = AVAudioSession.sharedInstance()
             try session.setCategory(.ambient, options: [.mixWithOthers])
             try session.setActive(true)
         } catch {
-            // Audio session setup failed; sound will degrade gracefully
+            // degrade gracefully
         }
-
-        let sampleRate = 44100
-        let poolSize = 3 // 3 overlapping voices per sound for zero cutoff on rapid taps
-
-        for sound in SoundType.allCases {
-            let samples = generateSamples(for: sound, sampleRate: sampleRate)
-            let wavData = makeWavData(samples: samples, sampleRate: sampleRate)
-            var players: [AVAudioPlayer] = []
-            for _ in 0..<poolSize {
-                if let player = try? AVAudioPlayer(data: wavData) {
-                    player.prepareToPlay()
-                    player.volume = 0.85
-                    players.append(player)
-                }
-            }
-            playerPools[sound] = players
-        }
-
+        rebuildPools()
         isAudioReady = true
     }
 
-    // MARK: - Procedural Waveform Synthesizer (Matching Experiment Page)
-
-    private func generateSamples(for type: SoundType, sampleRate: Int) -> [Float] {
-        switch type {
-        case .mechanicalOrange:
-            // Terracotta "L" signature key: deeper 240Hz body + 8ms noise switch contact
-            return synthesizeMechanicalKey(baseFreq: 240.0, filterCutoff: 1200.0, sampleRate: sampleRate)
-
-        case .mechanicalCream:
-            // Cream bone-white key: crisper 340Hz body + 8ms noise switch contact
-            return synthesizeMechanicalKey(baseFreq: 340.0, filterCutoff: 1800.0, sampleRate: sampleRate)
-
-        case .rotaryTick:
-            // 1900Hz -> 300Hz rapid exponential sweep in 15ms
-            let count = Int(0.020 * Double(sampleRate))
-            var samples = [Float]()
-            var phase: Float = 0
-            for i in 0..<count {
-                let t = Float(i) / Float(sampleRate)
-                let freq = 1900.0 * pow(300.0 / 1900.0, min(1.0, t / 0.015))
-                phase += 2.0 * Float.pi * freq / Float(sampleRate)
-                let wave = sin(phase)
-                let gain = 0.22 * pow(0.001 / 0.22, min(1.0, t / 0.016))
-                samples.append(wave * gain)
-            }
-            return samples
-
-        case .toggleClack:
-            // 450Hz -> 90Hz square-wave metal latch in 35ms
-            let count = Int(0.045 * Double(sampleRate))
-            var samples = [Float]()
-            var phase: Float = 0
-            for i in 0..<count {
-                let t = Float(i) / Float(sampleRate)
-                let freq = 450.0 * pow(90.0 / 450.0, min(1.0, t / 0.035))
-                phase += 2.0 * Float.pi * freq / Float(sampleRate)
-                let square = sin(phase) >= 0 ? 0.7 : -0.7
-                let gain = 0.24 * pow(0.001 / 0.24, min(1.0, t / 0.040))
-                samples.append(Float(square) * gain)
-            }
-            return samples
-
-        case .buttonPop:
-            // 520Hz -> 120Hz triangle pop in 25ms
-            let count = Int(0.035 * Double(sampleRate))
-            var samples = [Float]()
-            var phase: Float = 0
-            for i in 0..<count {
-                let t = Float(i) / Float(sampleRate)
-                let freq = 520.0 * pow(120.0 / 520.0, min(1.0, t / 0.025))
-                phase += 2.0 * Float.pi * freq / Float(sampleRate)
-                let tri = 2.0 * abs(2.0 * (phase / (2.0 * Float.pi) - floor(phase / (2.0 * Float.pi) + 0.5))) - 1.0
-                let gain = 0.20 * pow(0.001 / 0.20, min(1.0, t / 0.030))
-                samples.append(tri * gain)
-            }
-            return samples
-
-        case .approvalChime:
-            // Ascending dual-tone harmonic confirmation (587Hz -> 880Hz)
-            let count = Int(0.120 * Double(sampleRate))
-            var samples = [Float]()
-            var phase1: Float = 0
-            var phase2: Float = 0
-            for i in 0..<count {
-                let t = Float(i) / Float(sampleRate)
-                phase1 += 2.0 * Float.pi * 587.33 / Float(sampleRate)
-                phase2 += 2.0 * Float.pi * 880.00 / Float(sampleRate)
-                let wave1 = sin(phase1)
-                let wave2 = sin(phase2)
-                let gain1 = t < 0.06 ? (0.22 * (1.0 - t / 0.06)) : 0.0
-                let gain2 = t >= 0.03 ? (0.26 * (1.0 - (t - 0.03) / 0.09)) : 0.0
-                samples.append(wave1 * gain1 + wave2 * gain2)
-            }
-            return samples
-
-        case .warningBuzz:
-            // Crisp double-pulse alert for needs-attention / defer
-            let count = Int(0.080 * Double(sampleRate))
-            var samples = [Float]()
-            var phase: Float = 0
-            for i in 0..<count {
-                let t = Float(i) / Float(sampleRate)
-                phase += 2.0 * Float.pi * 220.0 / Float(sampleRate)
-                let wave = sin(phase)
-                let envelope: Float
-                if t < 0.035 {
-                    envelope = 0.22 * (1.0 - t / 0.035)
-                } else if t < 0.045 {
-                    envelope = 0.0
-                } else {
-                    envelope = 0.20 * (1.0 - (t - 0.045) / 0.035)
-                }
-                samples.append(wave * envelope)
-            }
-            return samples
+    private func rebuildPools() {
+        playerPools.removeAll()
+        poolIndices.removeAll()
+        let catalog = theme.currentCatalog()
+        for (patchID, patch) in catalog.sounds {
+            let wav = DeckTactileSynthesizer.renderWAV(
+                patch: patch,
+                options: DeckTactileRenderOptions(sampleRate: sampleRate)
+            )
+            playerPools[patchID] = makePlayers(from: wav)
+            poolIndices[patchID] = 0
         }
     }
 
-    private func synthesizeMechanicalKey(baseFreq: Float, filterCutoff: Float, sampleRate: Int) -> [Float] {
-        let count = Int(0.065 * Double(sampleRate))
-        var samples = [Float]()
-        var phase: Float = 0
-        var filtered: Float = 0
-        let fEnd: Float = 55.0
+    private func playPatch(
+        _ patch: DeckSoundPatch,
+        cacheKey: String,
+        params: [String: DeckTactileParamValue]
+    ) {
+        audioQueue.async { [weak self] in
+            guard let self, self.isAudioReady else { return }
 
-        for i in 0..<count {
-            let t = Float(i) / Float(sampleRate)
-            // Frequency drops exponentially to 55Hz
-            let freq = baseFreq * pow(fEnd / baseFreq, min(1.0, t / 0.055))
-            phase += 2.0 * Float.pi * freq / Float(sampleRate)
-
-            // Triangle wave oscillator
-            let tri = 2.0 * abs(2.0 * (phase / (2.0 * Float.pi) - floor(phase / (2.0 * Float.pi) + 0.5))) - 1.0
-
-            // One-pole lowpass filter sweeping to 300Hz
-            let cutoff = filterCutoff * pow(300.0 / filterCutoff, min(1.0, t / 0.050))
-            let rc = 1.0 / (2.0 * Float.pi * cutoff)
-            let dt = 1.0 / Float(sampleRate)
-            let alpha = dt / (rc + dt)
-            filtered = filtered + alpha * (tri - filtered)
-
-            // Gain envelope
-            let gain = 0.32 * pow(0.001 / 0.32, min(1.0, t / 0.060))
-
-            // Short 8ms key switch contact click noise
-            let noise: Float
-            if t < 0.008 {
-                let noiseGain = 0.14 * (1.0 - t / 0.008)
-                noise = Float.random(in: -1.0...1.0) * noiseGain
-            } else {
-                noise = 0
+            if params.isEmpty, let pool = self.playerPools[cacheKey], !pool.isEmpty {
+                self.playFromPool(cacheKey: cacheKey, pool: pool)
+                return
             }
 
-            samples.append(filtered * gain + noise)
+            let wav = DeckTactileSynthesizer.renderWAV(
+                patch: patch,
+                options: DeckTactileRenderOptions(sampleRate: self.sampleRate, params: params)
+            )
+            if let player = try? AVAudioPlayer(data: wav) {
+                player.prepareToPlay()
+                player.volume = Float(patch.volume ?? 0.85)
+                player.play()
+            }
         }
-        return samples
     }
 
-    // MARK: - WAV Encoder
+    private func playFromPool(cacheKey: String, pool: [AVAudioPlayer]) {
+        let index = poolIndices[cacheKey, default: 0]
+        let player = pool[index % pool.count]
+        poolIndices[cacheKey] = (index + 1) % pool.count
+        player.currentTime = 0
+        player.play()
+    }
 
-    private func makeWavData(samples: [Float], sampleRate: Int) -> Data {
-        var data = Data()
-        let numSamples = samples.count
-        let numChannels: UInt16 = 1
-        let bitsPerSample: UInt16 = 16
-        let byteRate = UInt32(sampleRate * Int(numChannels) * Int(bitsPerSample) / 8)
-        let blockAlign = UInt16(numChannels * bitsPerSample / 8)
-        let subchunk2Size = UInt32(numSamples * Int(numChannels) * 2)
-        let chunkSize = 36 + subchunk2Size
-
-        data.append(contentsOf: [0x52, 0x49, 0x46, 0x46]) // "RIFF"
-        var chunkSizeLE = chunkSize.littleEndian
-        data.append(Data(bytes: &chunkSizeLE, count: 4))
-        data.append(contentsOf: [0x57, 0x41, 0x56, 0x45]) // "WAVE"
-        data.append(contentsOf: [0x66, 0x6D, 0x74, 0x20]) // "fmt "
-        var subchunk1Size: UInt32 = 16
-        data.append(Data(bytes: &subchunk1Size, count: 4))
-        var audioFormat: UInt16 = 1 // PCM
-        data.append(Data(bytes: &audioFormat, count: 2))
-        var channels = numChannels.littleEndian
-        data.append(Data(bytes: &channels, count: 2))
-        var sRate = UInt32(sampleRate).littleEndian
-        data.append(Data(bytes: &sRate, count: 4))
-        var bRate = byteRate.littleEndian
-        data.append(Data(bytes: &bRate, count: 4))
-        var bAlign = blockAlign.littleEndian
-        data.append(Data(bytes: &bAlign, count: 2))
-        var bps = bitsPerSample.littleEndian
-        data.append(Data(bytes: &bps, count: 2))
-        data.append(contentsOf: [0x64, 0x61, 0x74, 0x61]) // "data"
-        var s2Size = subchunk2Size.littleEndian
-        data.append(Data(bytes: &s2Size, count: 4))
-
-        for sample in samples {
-            let clamped = max(-1.0, min(1.0, sample))
-            var intSample = Int16(clamped * 32767.0).littleEndian
-            data.append(Data(bytes: &intSample, count: 2))
+    private func makePlayers(from wav: Data) -> [AVAudioPlayer] {
+        var players: [AVAudioPlayer] = []
+        for _ in 0..<poolSize {
+            if let player = try? AVAudioPlayer(data: wav) {
+                player.prepareToPlay()
+                player.volume = 0.85
+                players.append(player)
+            }
         }
-        return data
+        return players
+    }
+
+    private func cacheKey(for resolved: DeckTactileResolvedEvent) -> String {
+        if let sound = theme.currentCatalog().events[resolved.eventID]?.sound {
+            return sound.patchID
+        }
+        return resolved.eventID
+    }
+
+    private func performHaptic(_ style: DeckHapticStyle) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            switch style {
+            case .rigid:
+                self.rigidImpact.impactOccurred()
+            case .heavy:
+                self.heavyImpact.impactOccurred()
+            case .medium:
+                self.mediumImpact.impactOccurred()
+            case .light:
+                self.lightImpact.impactOccurred()
+            case .selection:
+                self.selectionFeedback.selectionChanged()
+            case .success:
+                self.notificationFeedback.notificationOccurred(.success)
+            case .warning:
+                self.notificationFeedback.notificationOccurred(.warning)
+            case .generic, .alignment:
+                self.lightImpact.impactOccurred()
+            }
+        }
     }
 }

--- a/apps/ios/Sources/DeckTactileModifiers.swift
+++ b/apps/ios/Sources/DeckTactileModifiers.swift
@@ -1,0 +1,90 @@
+import DeckKit
+import SwiftUI
+
+// MARK: - Markup-driven tactile bindings
+//
+// Usage:
+//   Button("Approve") { ... }
+//     .deckTactile(.deckDecisionApproved)
+//
+//   KeyView(...)
+//     .deckTactile(.deckKeyAccent, params: ["id": .int(3)])
+//
+//   Button { ... } label: { ... }
+//     .buttonStyle(FleetPressStyle(event: .deckButton))
+
+private struct DeckTactileModifier: ViewModifier {
+    let event: DeckTactileEventID
+    let params: [String: DeckTactileParamValue]
+    let trigger: DeckTactileTrigger
+
+    enum DeckTactileTrigger {
+        case onTap
+    }
+
+    func body(content: Content) -> some View {
+        content.simultaneousGesture(
+            TapGesture().onEnded {
+                DeckTactileFeedback.shared.play(event, params: params)
+            }
+        )
+    }
+}
+
+public extension View {
+    /// Fire a catalog tactile event when the view is tapped.
+    func deckTactile(
+        _ event: DeckTactileEventID,
+        params: [String: DeckTactileParamValue] = [:]
+    ) -> some View {
+        modifier(DeckTactileModifier(event: event, params: params, trigger: .onTap))
+    }
+
+    /// Fire a catalog tactile event by string id (for markup / remote config).
+    func deckTactile(
+        eventID: String,
+        params: [String: DeckTactileParamValue] = [:]
+    ) -> some View {
+        self.onTapGesture {
+            DeckTactileFeedback.shared.play(eventID: eventID, params: params)
+        }
+    }
+}
+
+/// `:active { transform: translateY(1px) }` — every pressable face sinks by a point
+/// and plays a catalog-defined tactile event on press-down.
+public struct FleetPressStyle: ButtonStyle {
+    public var event: DeckTactileEventID
+    public var params: [String: DeckTactileParamValue]
+
+    public init(
+        event: DeckTactileEventID = .deckButton,
+        params: [String: DeckTactileParamValue] = [:]
+    ) {
+        self.event = event
+        self.params = params
+    }
+
+    /// Back-compat: mechanical keys vs micro buttons.
+    public init(isKey: Bool = true, isAccent: Bool = false, id: Int = 0) {
+        if isKey {
+            self.event = isAccent ? .deckKeyAccent : .deckKey
+            self.params = ["id": .int(id)]
+        } else {
+            self.event = .deckButton
+            self.params = [:]
+        }
+    }
+
+    public func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .offset(y: configuration.isPressed ? 1 : 0)
+            .brightness(configuration.isPressed ? 0.04 : 0)
+            .animation(.easeOut(duration: 0.08), value: configuration.isPressed)
+            .onChange(of: configuration.isPressed) { _, isPressed in
+                if isPressed {
+                    DeckTactileFeedback.shared.play(event, params: params)
+                }
+            }
+    }
+}

--- a/apps/site/src/components/ConceptExperimentPage.tsx
+++ b/apps/site/src/components/ConceptExperimentPage.tsx
@@ -1,4 +1,5 @@
-import { useState, useRef } from 'react'
+import { useState } from 'react'
+import { useDeckTactile } from '../lib/deck-tactile'
 import '../styles/concept-experiment.css'
 
 interface FleetHost {
@@ -371,132 +372,14 @@ export default function ConceptExperimentPage() {
   const [toggleMesh, setToggleMesh] = useState<boolean>(false)
   const [lastReceipt, setLastReceipt] = useState<string>('SYS. 01 ONLINE · USB-C HID BUS 12Mbps · Ed25519 Authenticated')
   const [soundEnabled, setSoundEnabled] = useState<boolean>(true)
-  const audioCtxRef = useRef<AudioContext | null>(null)
+  const { play: playTactile } = useDeckTactile(soundEnabled)
 
   const activeHost = FLEET_HOSTS.find((h) => h.id === selectedHostId) || FLEET_HOSTS[0]
   const currentWindows = WINDOWS_BY_HOST[selectedHostId] || WINDOWS_BY_HOST.studio
   const activeWindow = currentWindows.find((w) => w.id === activeWindowId) || currentWindows[3]
 
-  // Web Audio Synthesizer for Physical Mechanical Sounds
-  const getAudioContext = (): AudioContext | null => {
-    if (!soundEnabled) return null
-    try {
-      const AudioCtx = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
-      if (!audioCtxRef.current) {
-        audioCtxRef.current = new AudioCtx()
-      }
-      const ctx = audioCtxRef.current
-      if (ctx.state === 'suspended') {
-        ctx.resume()
-      }
-      return ctx
-    } catch {
-      return null
-    }
-  }
-
-  // Authentic mechanical keyboard "thock"
-  const playMechanicalKey = (isOrange: boolean, id: number) => {
-    const ctx = getAudioContext()
-    if (!ctx) return
-
-    const t = ctx.currentTime
-    const osc = ctx.createOscillator()
-    const gain = ctx.createGain()
-    const filter = ctx.createBiquadFilter()
-
-    // Base frequency: terracotta keys have a deeper, weightier body (240Hz), cream keys are crisper (340Hz)
-    const baseFreq = isOrange ? 230 + (id % 3) * 15 : 320 + (id % 3) * 20
-    osc.type = 'triangle'
-    osc.frequency.setValueAtTime(baseFreq, t)
-    osc.frequency.exponentialRampToValueAtTime(55, t + 0.055)
-
-    filter.type = 'lowpass'
-    filter.frequency.setValueAtTime(isOrange ? 1200 : 1800, t)
-    filter.frequency.exponentialRampToValueAtTime(300, t + 0.05)
-
-    gain.gain.setValueAtTime(0.28, t)
-    gain.gain.exponentialRampToValueAtTime(0.001, t + 0.06)
-
-    osc.connect(filter)
-    filter.connect(gain)
-    gain.connect(ctx.destination)
-
-    osc.start(t)
-    osc.stop(t + 0.065)
-
-    // Short contact click noise
-    const noiseBuffer = ctx.createBuffer(1, ctx.sampleRate * 0.008, ctx.sampleRate)
-    const output = noiseBuffer.getChannelData(0)
-    for (let i = 0; i < noiseBuffer.length; i++) {
-      output[i] = Math.random() * 2 - 1
-    }
-    const noise = ctx.createBufferSource()
-    noise.buffer = noiseBuffer
-    const noiseGain = ctx.createGain()
-    noiseGain.gain.setValueAtTime(0.12, t)
-    noiseGain.gain.exponentialRampToValueAtTime(0.001, t + 0.008)
-    noise.connect(noiseGain)
-    noiseGain.connect(ctx.destination)
-    noise.start(t)
-  }
-
-  // Rotary encoder ratchet tick
-  const playRotaryTick = () => {
-    const ctx = getAudioContext()
-    if (!ctx) return
-    const t = ctx.currentTime
-    const osc = ctx.createOscillator()
-    const gain = ctx.createGain()
-    osc.type = 'sine'
-    osc.frequency.setValueAtTime(1900, t)
-    osc.frequency.exponentialRampToValueAtTime(300, t + 0.015)
-    gain.gain.setValueAtTime(0.18, t)
-    gain.gain.exponentialRampToValueAtTime(0.001, t + 0.016)
-    osc.connect(gain)
-    gain.connect(ctx.destination)
-    osc.start(t)
-    osc.stop(t + 0.02)
-  }
-
-  // Heavy metal toggle switch clack
-  const playToggleClack = () => {
-    const ctx = getAudioContext()
-    if (!ctx) return
-    const t = ctx.currentTime
-    const osc = ctx.createOscillator()
-    const gain = ctx.createGain()
-    osc.type = 'square'
-    osc.frequency.setValueAtTime(450, t)
-    osc.frequency.exponentialRampToValueAtTime(90, t + 0.035)
-    gain.gain.setValueAtTime(0.2, t)
-    gain.gain.exponentialRampToValueAtTime(0.001, t + 0.04)
-    osc.connect(gain)
-    gain.connect(ctx.destination)
-    osc.start(t)
-    osc.stop(t + 0.045)
-  }
-
-  // Micro push button click
-  const playButtonPop = () => {
-    const ctx = getAudioContext()
-    if (!ctx) return
-    const t = ctx.currentTime
-    const osc = ctx.createOscillator()
-    const gain = ctx.createGain()
-    osc.type = 'triangle'
-    osc.frequency.setValueAtTime(520, t)
-    osc.frequency.exponentialRampToValueAtTime(120, t + 0.025)
-    gain.gain.setValueAtTime(0.18, t)
-    gain.gain.exponentialRampToValueAtTime(0.001, t + 0.03)
-    osc.connect(gain)
-    gain.connect(ctx.destination)
-    osc.start(t)
-    osc.stop(t + 0.035)
-  }
-
   const handleKeyClick = (win: SpatialWindow) => {
-    playMechanicalKey(win.isOrange, win.id)
+    playTactile(win.isOrange ? 'deck.key.accent' : 'deck.key', { id: win.id })
     setActiveKeyDepressed(win.id)
     setActiveWindowId(win.id)
     setLastReceipt(`SYS.01 KEY 0${win.id} -> focused ${win.app} (${win.pid}) on ${activeHost.name} [1.8ms]`)
@@ -504,7 +387,7 @@ export default function ConceptExperimentPage() {
   }
 
   const handleKnobClick = () => {
-    playRotaryTick()
+    playTactile('deck.rotary')
     const nextAngle = (knobAngle + 30) % 360
     setKnobAngle(nextAngle)
     const nextWindowId = (activeWindowId % 9) + 1
@@ -514,20 +397,20 @@ export default function ConceptExperimentPage() {
   }
 
   const handleToggleClick = () => {
-    playToggleClack()
+    playTactile('deck.toggle')
     const nextState = !toggleMesh
     setToggleMesh(nextState)
     setLastReceipt(nextState ? 'TOGGLE: Mesh Bonjour Relay Active (_lattices-fleet._tcp.)' : 'TOGGLE: USB-C Direct Zero-Latency HID Mode')
   }
 
   const handleApproveAgent = () => {
-    playButtonPop()
+    playTactile('deck.button')
     setAgentDecisionState('approved')
     setLastReceipt(`SYS.01 [KEY A: APPROVE] -> Authorized Claude Code schema change on ${activeHost.name} · Resuming turn`)
   }
 
   const handleRejectAgent = () => {
-    playButtonPop()
+    playTactile('deck.button')
     setAgentDecisionState('rejected')
     setLastReceipt(`SYS.01 [KEY B: REJECT] -> Blocked schema write on ${activeHost.name} · Agent parked`)
   }
@@ -658,7 +541,7 @@ export default function ConceptExperimentPage() {
                           type="button"
                           className={`concept-exp-host-pill ${isActive ? 'active' : ''}`}
                           onClick={() => {
-                            playButtonPop()
+                            playTactile('deck.button')
                             setSelectedHostId(host.id)
                             setLastReceipt(`SYS.01 HOST SELECT -> switched target host to ${host.name}`)
                           }}
@@ -808,7 +691,7 @@ export default function ConceptExperimentPage() {
                           type="button"
                           className="concept-exp-screen-btn secondary"
                           onClick={() => {
-                            playButtonPop()
+                            playTactile('deck.button')
                             setAgentDecisionState('pending')
                             setLastReceipt('SYS.01 Reset agent attention fixture to pending')
                           }}

--- a/apps/site/src/lib/deck-tactile/catalog.json
+++ b/apps/site/src/lib/deck-tactile/catalog.json
@@ -1,0 +1,412 @@
+{
+  "version": 1,
+  "meta": {
+    "name": "lattices-deck-sys01",
+    "description": "Declarative tactile + acoustic catalog for the Lattices deck controller (SYS.01)."
+  },
+  "sounds": {
+    "mechanicalKey.orange": {
+      "duration": 0.065,
+      "volume": 0.85,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "triangle",
+          "frequency": {
+            "start": {
+              "base": 230,
+              "detune": {
+                "param": "id",
+                "step": 15,
+                "modulo": 3
+              }
+            },
+            "end": 55,
+            "time": 0.055,
+            "curve": "exponential"
+          },
+          "filter": {
+            "type": "lowpass",
+            "start": 1200,
+            "end": 300,
+            "time": 0.05,
+            "curve": "exponential"
+          },
+          "gain": {
+            "start": 0.32,
+            "end": 0.001,
+            "time": 0.06,
+            "curve": "exponential"
+          }
+        },
+        {
+          "kind": "noise",
+          "duration": 0.008,
+          "gain": {
+            "start": 0.14,
+            "end": 0.001,
+            "time": 0.008,
+            "curve": "exponential"
+          }
+        }
+      ]
+    },
+    "mechanicalKey.cream": {
+      "duration": 0.065,
+      "volume": 0.85,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "triangle",
+          "frequency": {
+            "start": {
+              "base": 320,
+              "detune": {
+                "param": "id",
+                "step": 20,
+                "modulo": 3
+              }
+            },
+            "end": 55,
+            "time": 0.055,
+            "curve": "exponential"
+          },
+          "filter": {
+            "type": "lowpass",
+            "start": 1800,
+            "end": 300,
+            "time": 0.05,
+            "curve": "exponential"
+          },
+          "gain": {
+            "start": 0.32,
+            "end": 0.001,
+            "time": 0.06,
+            "curve": "exponential"
+          }
+        },
+        {
+          "kind": "noise",
+          "duration": 0.008,
+          "gain": {
+            "start": 0.14,
+            "end": 0.001,
+            "time": 0.008,
+            "curve": "exponential"
+          }
+        }
+      ]
+    },
+    "rotaryTick": {
+      "duration": 0.02,
+      "volume": 0.85,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 1900,
+            "end": 300,
+            "time": 0.015,
+            "curve": "exponential"
+          },
+          "gain": {
+            "start": 0.22,
+            "end": 0.001,
+            "time": 0.016,
+            "curve": "exponential"
+          }
+        }
+      ]
+    },
+    "toggleClack": {
+      "duration": 0.045,
+      "volume": 0.85,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "square",
+          "frequency": {
+            "start": 450,
+            "end": 90,
+            "time": 0.035,
+            "curve": "exponential"
+          },
+          "gain": {
+            "start": 0.24,
+            "end": 0.001,
+            "time": 0.04,
+            "curve": "exponential"
+          }
+        }
+      ]
+    },
+    "buttonPop": {
+      "duration": 0.035,
+      "volume": 0.85,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "triangle",
+          "frequency": {
+            "start": 520,
+            "end": 120,
+            "time": 0.025,
+            "curve": "exponential"
+          },
+          "gain": {
+            "start": 0.2,
+            "end": 0.001,
+            "time": 0.03,
+            "curve": "exponential"
+          }
+        }
+      ]
+    },
+    "approvalChime": {
+      "duration": 0.12,
+      "volume": 0.85,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 587.33
+          },
+          "gain": {
+            "start": 0.22,
+            "end": 0.0,
+            "time": 0.06,
+            "curve": "linear",
+            "delay": 0.0
+          }
+        },
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 880.0
+          },
+          "gain": {
+            "start": 0.26,
+            "end": 0.0,
+            "time": 0.09,
+            "curve": "linear",
+            "delay": 0.03
+          }
+        }
+      ]
+    },
+    "warningBuzz": {
+      "duration": 0.08,
+      "volume": 0.85,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 220
+          },
+          "gain": {
+            "segments": [
+              {
+                "start": 0.22,
+                "end": 0.0,
+                "time": 0.035,
+                "curve": "linear",
+                "delay": 0.0
+              },
+              {
+                "start": 0.0,
+                "end": 0.0,
+                "time": 0.01,
+                "curve": "linear",
+                "delay": 0.035
+              },
+              {
+                "start": 0.2,
+                "end": 0.0,
+                "time": 0.035,
+                "curve": "linear",
+                "delay": 0.045
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "pointer.tick": {
+      "duration": 0.08,
+      "volume": 0.22,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 920
+          },
+          "gain": {
+            "start": 0.28,
+            "end": 0.001,
+            "time": 0.055,
+            "curve": "exponential"
+          }
+        }
+      ]
+    },
+    "pointer.click": {
+      "duration": 0.09,
+      "volume": 0.26,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 1240
+          },
+          "gain": {
+            "start": 0.34,
+            "end": 0.001,
+            "time": 0.032,
+            "curve": "exponential",
+            "delay": 0.0
+          }
+        },
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 540
+          },
+          "gain": {
+            "start": 0.18,
+            "end": 0.001,
+            "time": 0.055,
+            "curve": "exponential",
+            "delay": 0.018
+          }
+        }
+      ]
+    },
+    "pointer.engage": {
+      "duration": 0.22,
+      "volume": 0.32,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 420
+          },
+          "gain": {
+            "start": 0.2,
+            "end": 0.001,
+            "time": 0.11,
+            "curve": "exponential",
+            "delay": 0.0
+          }
+        },
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 760
+          },
+          "gain": {
+            "start": 0.24,
+            "end": 0.001,
+            "time": 0.13,
+            "curve": "exponential",
+            "delay": 0.055
+          }
+        },
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 1160
+          },
+          "gain": {
+            "start": 0.12,
+            "end": 0.001,
+            "time": 0.06,
+            "curve": "exponential",
+            "delay": 0.12
+          }
+        }
+      ]
+    },
+    "pointer.chime": {
+      "duration": 0.25,
+      "volume": 0.3,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 620
+          },
+          "gain": {
+            "start": 0.18,
+            "end": 0.001,
+            "time": 0.18,
+            "curve": "exponential",
+            "delay": 0.0
+          }
+        },
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 930
+          },
+          "gain": {
+            "start": 0.16,
+            "end": 0.001,
+            "time": 0.2,
+            "curve": "exponential",
+            "delay": 0.03
+          }
+        }
+      ]
+    }
+  },
+  "events": {
+    "deck.key": {
+      "sound": "mechanicalKey.cream",
+      "haptic": "rigid"
+    },
+    "deck.key.accent": {
+      "sound": "mechanicalKey.orange",
+      "haptic": "heavy"
+    },
+    "deck.rotary": {
+      "sound": "rotaryTick",
+      "haptic": "selection"
+    },
+    "deck.toggle": {
+      "sound": "toggleClack",
+      "haptic": "medium"
+    },
+    "deck.button": {
+      "sound": "buttonPop",
+      "haptic": "light"
+    },
+    "deck.decision.approved": {
+      "sound": "approvalChime",
+      "haptic": "success"
+    },
+    "deck.decision.deferred": {
+      "sound": "warningBuzz",
+      "haptic": "warning"
+    },
+    "pointer.aim": {
+      "sound": "pointer.tick",
+      "haptic": "generic"
+    },
+    "pointer.commit": {
+      "sound": "pointer.engage",
+      "haptic": "alignment"
+    }
+  }
+}

--- a/apps/site/src/lib/deck-tactile/index.ts
+++ b/apps/site/src/lib/deck-tactile/index.ts
@@ -1,0 +1,5 @@
+export * from './types'
+export * from './theme'
+export * from './synthesizer'
+export * from './useDeckTactile'
+export { default as deckTactileCatalog } from './catalog.json'

--- a/apps/site/src/lib/deck-tactile/synthesizer.ts
+++ b/apps/site/src/lib/deck-tactile/synthesizer.ts
@@ -1,0 +1,160 @@
+import type {
+  DeckCurve,
+  DeckEnvelope,
+  DeckFrequencySpec,
+  DeckFrequencyValue,
+  DeckGainSpec,
+  DeckOscillatorLayer,
+  DeckSoundPatch,
+  DeckTactileParamValue,
+  DeckWaveform,
+} from './types'
+
+export interface RenderOptions {
+  sampleRate?: number
+  params?: Record<string, DeckTactileParamValue>
+}
+
+function envelopes(spec: DeckGainSpec): DeckEnvelope[] {
+  if ('segments' in spec) return spec.segments
+  return [spec]
+}
+
+function paramInt(params: Record<string, DeckTactileParamValue>, key: string): number {
+  const value = params[key]
+  if (typeof value === 'number') return value
+  if (typeof value === 'boolean') return value ? 1 : 0
+  if (typeof value === 'string') return Number.parseInt(value, 10) || 0
+  return 0
+}
+
+function resolvedFrequency(value: DeckFrequencyValue, params: Record<string, DeckTactileParamValue>): number {
+  if (typeof value === 'number') return value
+  const mod = value.detune.modulo > 0 ? paramInt(params, value.detune.param) % value.detune.modulo : paramInt(params, value.detune.param)
+  return value.base + mod * value.detune.step
+}
+
+function interpolate(start: number, end: number, progress: number, curve: DeckCurve = 'linear'): number {
+  const t = Math.min(1, Math.max(0, progress))
+  if (curve === 'exponential' && start > 0 && end > 0) {
+    return start * Math.pow(end / start, t)
+  }
+  return start + (end - start) * t
+}
+
+function envelopeGain(time: number, spec: DeckGainSpec): number {
+  return envelopes(spec).reduce((total, envelope) => {
+    const delay = envelope.delay ?? 0
+    const local = time - delay
+    if (local < 0) return total
+    const progress = Math.min(1, local / Math.max(envelope.time, 0.0001))
+    return total + interpolate(envelope.start, envelope.end, progress, envelope.curve ?? 'linear')
+  }, 0)
+}
+
+function frequencyAt(time: number, spec: DeckFrequencySpec, params: Record<string, DeckTactileParamValue>): number {
+  const start = resolvedFrequency(spec.start, params)
+  if (spec.end == null || spec.time == null) return start
+  const progress = Math.min(1, time / Math.max(spec.time, 0.0001))
+  return interpolate(start, spec.end, progress, spec.curve ?? 'exponential')
+}
+
+function waveformValue(waveform: DeckWaveform, phase: number): number {
+  if (waveform === 'sine') return Math.sin(phase)
+  if (waveform === 'square') return Math.sin(phase) >= 0 ? 0.7 : -0.7
+  const normalized = phase / (2 * Math.PI)
+  return 2 * Math.abs(2 * (normalized - Math.floor(normalized + 0.5))) - 1
+}
+
+function renderOscillator(layer: DeckOscillatorLayer, buffer: Float32Array, sampleRate: number, params: Record<string, DeckTactileParamValue>) {
+  let phase = 0
+  let filtered = 0
+  for (let index = 0; index < buffer.length; index += 1) {
+    const time = index / sampleRate
+    const freq = frequencyAt(time, layer.frequency, params)
+    phase += (2 * Math.PI * freq) / sampleRate
+    let sample = waveformValue(layer.waveform, phase)
+    if (layer.filter) {
+      const cutoff = interpolate(layer.filter.start, layer.filter.end, Math.min(1, time / Math.max(layer.filter.time, 0.0001)), layer.filter.curve ?? 'exponential')
+      const rc = 1 / (2 * Math.PI * Math.max(cutoff, 1))
+      const dt = 1 / sampleRate
+      const alpha = dt / (rc + dt)
+      filtered += alpha * (sample - filtered)
+      sample = filtered
+    }
+    buffer[index] += sample * envelopeGain(time, layer.gain)
+  }
+}
+
+function renderNoise(layer: { duration: number; gain: DeckGainSpec }, buffer: Float32Array, sampleRate: number) {
+  const count = Math.min(buffer.length, Math.floor(layer.duration * sampleRate))
+  for (let index = 0; index < count; index += 1) {
+    const time = index / sampleRate
+    buffer[index] += (Math.random() * 2 - 1) * envelopeGain(time, layer.gain)
+  }
+}
+
+export function renderPatch(patch: DeckSoundPatch, options: RenderOptions = {}): Float32Array {
+  const sampleRate = options.sampleRate ?? 44_100
+  const params = options.params ?? {}
+  const count = Math.max(1, Math.floor(patch.duration * sampleRate))
+  const buffer = new Float32Array(count)
+  for (const layer of patch.layers) {
+    if (layer.kind === 'oscillator') renderOscillator(layer, buffer, sampleRate, params)
+    else renderNoise(layer, buffer, sampleRate)
+  }
+  const volume = patch.volume ?? 1
+  if (volume !== 1) {
+    for (let i = 0; i < buffer.length; i += 1) buffer[i] *= volume
+  }
+  return buffer
+}
+
+export function playPatch(ctx: AudioContext, patch: DeckSoundPatch, params: Record<string, DeckTactileParamValue> = {}) {
+  const t = ctx.currentTime
+  for (const layer of patch.layers) {
+    if (layer.kind === 'noise') {
+      const noiseBuffer = ctx.createBuffer(1, Math.max(1, Math.floor(ctx.sampleRate * layer.duration)), ctx.sampleRate)
+      const output = noiseBuffer.getChannelData(0)
+      for (let i = 0; i < output.length; i += 1) output[i] = Math.random() * 2 - 1
+      const noise = ctx.createBufferSource()
+      noise.buffer = noiseBuffer
+      const gain = ctx.createGain()
+      const env = envelopes(layer.gain)[0]
+      gain.gain.setValueAtTime(Math.max(env.start, 0.0001), t + (env.delay ?? 0))
+      gain.gain.exponentialRampToValueAtTime(Math.max(env.end, 0.0001), t + (env.delay ?? 0) + env.time)
+      noise.connect(gain)
+      gain.connect(ctx.destination)
+      noise.start(t + (env.delay ?? 0))
+      continue
+    }
+
+    const osc = ctx.createOscillator()
+    const gain = ctx.createGain()
+    const filter = layer.filter ? ctx.createBiquadFilter() : null
+    osc.type = layer.waveform
+    const startFreq = resolvedFrequency(layer.frequency.start, params)
+    osc.frequency.setValueAtTime(startFreq, t)
+    if (layer.frequency.end != null && layer.frequency.time != null) {
+      osc.frequency.exponentialRampToValueAtTime(Math.max(layer.frequency.end, 1), t + layer.frequency.time)
+    }
+    if (filter && layer.filter) {
+      filter.type = 'lowpass'
+      filter.frequency.setValueAtTime(layer.filter.start, t)
+      filter.frequency.exponentialRampToValueAtTime(Math.max(layer.filter.end, 1), t + layer.filter.time)
+    }
+    for (const env of envelopes(layer.gain)) {
+      gain.gain.setValueAtTime(Math.max(env.start, 0.0001), t + (env.delay ?? 0))
+      gain.gain.exponentialRampToValueAtTime(Math.max(env.end, 0.0001), t + (env.delay ?? 0) + env.time)
+    }
+    if (filter) {
+      osc.connect(filter)
+      filter.connect(gain)
+    } else {
+      osc.connect(gain)
+    }
+    gain.connect(ctx.destination)
+    osc.start(t)
+    osc.stop(t + patch.duration + 0.01)
+  }
+}

--- a/apps/site/src/lib/deck-tactile/theme.ts
+++ b/apps/site/src/lib/deck-tactile/theme.ts
@@ -1,0 +1,67 @@
+import catalogJSON from './catalog.json'
+import type {
+  DeckSoundPatch,
+  DeckTactileCatalog,
+  DeckTactileEventBinding,
+  DeckTactileParamValue,
+  DeckTactileSoundRef,
+} from './types'
+
+export interface ResolvedTactileEvent {
+  eventID: string
+  patch?: DeckSoundPatch
+  haptic?: DeckTactileEventBinding['haptic']
+  params: Record<string, DeckTactileParamValue>
+}
+
+function soundRefID(ref: DeckTactileSoundRef): string {
+  return typeof ref === 'string' ? ref : ref.ref
+}
+
+function soundRefParams(ref: DeckTactileSoundRef): Record<string, DeckTactileParamValue> {
+  return typeof ref === 'string' ? {} : (ref.params ?? {})
+}
+
+export class DeckTactileTheme {
+  private catalog: DeckTactileCatalog
+
+  constructor(catalog: DeckTactileCatalog = catalogJSON as DeckTactileCatalog) {
+    this.catalog = catalog
+  }
+
+  replaceCatalog(catalog: DeckTactileCatalog) {
+    this.catalog = catalog
+  }
+
+  merge(overlay: DeckTactileCatalog) {
+    this.catalog = {
+      ...this.catalog,
+      ...overlay,
+      sounds: { ...this.catalog.sounds, ...overlay.sounds },
+      events: { ...this.catalog.events, ...overlay.events },
+    }
+  }
+
+  resolve(eventID: string, params: Record<string, DeckTactileParamValue> = {}): ResolvedTactileEvent | null {
+    const binding = this.catalog.events[eventID]
+    if (!binding) return null
+
+    const mergedParams = { ...params }
+    let patch: DeckSoundPatch | undefined
+    if (binding.sound && binding.hapticOnly !== true) {
+      const ref = binding.sound
+      const patchID = soundRefID(ref)
+      Object.assign(mergedParams, soundRefParams(ref))
+      patch = this.catalog.sounds[patchID]
+    }
+
+    return {
+      eventID,
+      patch,
+      haptic: binding.soundOnly === true ? undefined : binding.haptic,
+      params: mergedParams,
+    }
+  }
+}
+
+export const defaultDeckTactileTheme = new DeckTactileTheme()

--- a/apps/site/src/lib/deck-tactile/types.ts
+++ b/apps/site/src/lib/deck-tactile/types.ts
@@ -1,0 +1,96 @@
+export type DeckCurve = 'linear' | 'exponential'
+
+export type DeckWaveform = 'sine' | 'triangle' | 'square'
+
+export type DeckHapticStyle =
+  | 'rigid'
+  | 'heavy'
+  | 'medium'
+  | 'light'
+  | 'selection'
+  | 'success'
+  | 'warning'
+  | 'generic'
+  | 'alignment'
+
+export type DeckTactileParamValue = boolean | number | string
+
+export interface DeckEnvelope {
+  start: number
+  end: number
+  time: number
+  curve?: DeckCurve
+  delay?: number
+}
+
+export type DeckGainSpec = DeckEnvelope | { segments: DeckEnvelope[] }
+
+export type DeckFrequencyValue =
+  | number
+  | { base: number; detune: { param: string; step: number; modulo: number } }
+
+export interface DeckFrequencySpec {
+  start: DeckFrequencyValue
+  end?: number
+  time?: number
+  curve?: DeckCurve
+}
+
+export interface DeckFilterSpec {
+  type: string
+  start: number
+  end: number
+  time: number
+  curve?: DeckCurve
+}
+
+export interface DeckOscillatorLayer {
+  kind: 'oscillator'
+  waveform: DeckWaveform
+  frequency: DeckFrequencySpec
+  gain: DeckGainSpec
+  filter?: DeckFilterSpec
+}
+
+export interface DeckNoiseLayer {
+  kind: 'noise'
+  duration: number
+  gain: DeckGainSpec
+}
+
+export type DeckSoundLayer = DeckOscillatorLayer | DeckNoiseLayer
+
+export interface DeckSoundPatch {
+  duration: number
+  volume?: number
+  layers: DeckSoundLayer[]
+}
+
+export type DeckTactileSoundRef =
+  | string
+  | { ref: string; params?: Record<string, DeckTactileParamValue> }
+
+export interface DeckTactileEventBinding {
+  sound?: DeckTactileSoundRef
+  haptic?: DeckHapticStyle
+  hapticOnly?: boolean
+  soundOnly?: boolean
+}
+
+export interface DeckTactileCatalog {
+  version: number
+  meta?: { name?: string; description?: string }
+  sounds: Record<string, DeckSoundPatch>
+  events: Record<string, DeckTactileEventBinding>
+}
+
+export type DeckTactileEventID =
+  | 'deck.key'
+  | 'deck.key.accent'
+  | 'deck.rotary'
+  | 'deck.toggle'
+  | 'deck.button'
+  | 'deck.decision.approved'
+  | 'deck.decision.deferred'
+  | 'pointer.aim'
+  | 'pointer.commit'

--- a/apps/site/src/lib/deck-tactile/useDeckTactile.ts
+++ b/apps/site/src/lib/deck-tactile/useDeckTactile.ts
@@ -1,0 +1,36 @@
+import { useCallback, useMemo, useRef } from 'react'
+import catalogJSON from './catalog.json'
+import { playPatch } from './synthesizer'
+import { DeckTactileTheme } from './theme'
+import type { DeckTactileCatalog, DeckTactileEventID, DeckTactileParamValue } from './types'
+
+export function useDeckTactile(enabled: boolean, catalog?: DeckTactileCatalog) {
+  const theme = useMemo(() => new DeckTactileTheme(catalog ?? (catalogJSON as DeckTactileCatalog)), [catalog])
+  const audioCtxRef = useRef<AudioContext | null>(null)
+
+  const getAudioContext = useCallback((): AudioContext | null => {
+    if (!enabled) return null
+    try {
+      const AudioCtx = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
+      if (!audioCtxRef.current) audioCtxRef.current = new AudioCtx()
+      const ctx = audioCtxRef.current
+      if (ctx.state === 'suspended') void ctx.resume()
+      return ctx
+    } catch {
+      return null
+    }
+  }, [enabled])
+
+  const play = useCallback(
+    (eventID: DeckTactileEventID | string, params: Record<string, DeckTactileParamValue> = {}) => {
+      const ctx = getAudioContext()
+      if (!ctx) return
+      const resolved = theme.resolve(eventID, params)
+      if (!resolved?.patch) return
+      playPatch(ctx, resolved.patch, resolved.params)
+    },
+    [getAudioContext, theme]
+  )
+
+  return { play, theme }
+}

--- a/design/deck-tactile/README.md
+++ b/design/deck-tactile/README.md
@@ -1,0 +1,48 @@
+# Deck tactile catalog
+
+Declarative sound + haptic definitions for the Lattices SYS.01 deck controller.
+
+## Canonical file
+
+`swift/Sources/DeckKit/Resources/deck-tactile-catalog.json`
+
+Copies are kept in sync for web consumption:
+
+- `apps/site/src/lib/deck-tactile/catalog.json`
+- `design/deck-tactile/catalog.json`
+
+## Schema
+
+- **`sounds`**: named synthesis patches (oscillator + noise layers, envelopes, filters)
+- **`events`**: semantic bindings (`deck.key`, `deck.rotary`, …) → sound patch + haptic style
+
+### Extensibility
+
+1. **New sounds** — add a patch under `sounds`, reference it from an `events` entry
+2. **Runtime params** — pass `id`, `accent`, etc. when firing an event; frequency detune uses `{ "base": 320, "detune": { "param": "id", "step": 20, "modulo": 3 } }`
+3. **Theme overlays** — merge JSON at runtime:
+   - iOS: `DeckTactileFeedback.shared.mergeTheme(from: url)`
+   - Web: `theme.merge(overlayCatalog)`
+   - Swift: `DeckTactileTheme.shared.merge(overlay)`
+
+## Markup
+
+### SwiftUI
+
+```swift
+Button("Approve") { approve() }
+  .deckTactile(.deckDecisionApproved)
+
+Button { } label: { Keycap() }
+  .buttonStyle(FleetPressStyle(event: .deckKeyAccent, params: ["id": .int(3)]))
+```
+
+### React
+
+```tsx
+const { play } = useDeckTactile(soundEnabled)
+// ...
+onClick={() => play('deck.key.accent', { id: win.id })}
+```
+
+Or `data-deck-tactile="deck.button"` with a small attribute handler (hook exports `theme.resolve`).

--- a/design/deck-tactile/catalog.json
+++ b/design/deck-tactile/catalog.json
@@ -1,0 +1,412 @@
+{
+  "version": 1,
+  "meta": {
+    "name": "lattices-deck-sys01",
+    "description": "Declarative tactile + acoustic catalog for the Lattices deck controller (SYS.01)."
+  },
+  "sounds": {
+    "mechanicalKey.orange": {
+      "duration": 0.065,
+      "volume": 0.85,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "triangle",
+          "frequency": {
+            "start": {
+              "base": 230,
+              "detune": {
+                "param": "id",
+                "step": 15,
+                "modulo": 3
+              }
+            },
+            "end": 55,
+            "time": 0.055,
+            "curve": "exponential"
+          },
+          "filter": {
+            "type": "lowpass",
+            "start": 1200,
+            "end": 300,
+            "time": 0.05,
+            "curve": "exponential"
+          },
+          "gain": {
+            "start": 0.32,
+            "end": 0.001,
+            "time": 0.06,
+            "curve": "exponential"
+          }
+        },
+        {
+          "kind": "noise",
+          "duration": 0.008,
+          "gain": {
+            "start": 0.14,
+            "end": 0.001,
+            "time": 0.008,
+            "curve": "exponential"
+          }
+        }
+      ]
+    },
+    "mechanicalKey.cream": {
+      "duration": 0.065,
+      "volume": 0.85,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "triangle",
+          "frequency": {
+            "start": {
+              "base": 320,
+              "detune": {
+                "param": "id",
+                "step": 20,
+                "modulo": 3
+              }
+            },
+            "end": 55,
+            "time": 0.055,
+            "curve": "exponential"
+          },
+          "filter": {
+            "type": "lowpass",
+            "start": 1800,
+            "end": 300,
+            "time": 0.05,
+            "curve": "exponential"
+          },
+          "gain": {
+            "start": 0.32,
+            "end": 0.001,
+            "time": 0.06,
+            "curve": "exponential"
+          }
+        },
+        {
+          "kind": "noise",
+          "duration": 0.008,
+          "gain": {
+            "start": 0.14,
+            "end": 0.001,
+            "time": 0.008,
+            "curve": "exponential"
+          }
+        }
+      ]
+    },
+    "rotaryTick": {
+      "duration": 0.02,
+      "volume": 0.85,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 1900,
+            "end": 300,
+            "time": 0.015,
+            "curve": "exponential"
+          },
+          "gain": {
+            "start": 0.22,
+            "end": 0.001,
+            "time": 0.016,
+            "curve": "exponential"
+          }
+        }
+      ]
+    },
+    "toggleClack": {
+      "duration": 0.045,
+      "volume": 0.85,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "square",
+          "frequency": {
+            "start": 450,
+            "end": 90,
+            "time": 0.035,
+            "curve": "exponential"
+          },
+          "gain": {
+            "start": 0.24,
+            "end": 0.001,
+            "time": 0.04,
+            "curve": "exponential"
+          }
+        }
+      ]
+    },
+    "buttonPop": {
+      "duration": 0.035,
+      "volume": 0.85,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "triangle",
+          "frequency": {
+            "start": 520,
+            "end": 120,
+            "time": 0.025,
+            "curve": "exponential"
+          },
+          "gain": {
+            "start": 0.2,
+            "end": 0.001,
+            "time": 0.03,
+            "curve": "exponential"
+          }
+        }
+      ]
+    },
+    "approvalChime": {
+      "duration": 0.12,
+      "volume": 0.85,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 587.33
+          },
+          "gain": {
+            "start": 0.22,
+            "end": 0.0,
+            "time": 0.06,
+            "curve": "linear",
+            "delay": 0.0
+          }
+        },
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 880.0
+          },
+          "gain": {
+            "start": 0.26,
+            "end": 0.0,
+            "time": 0.09,
+            "curve": "linear",
+            "delay": 0.03
+          }
+        }
+      ]
+    },
+    "warningBuzz": {
+      "duration": 0.08,
+      "volume": 0.85,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 220
+          },
+          "gain": {
+            "segments": [
+              {
+                "start": 0.22,
+                "end": 0.0,
+                "time": 0.035,
+                "curve": "linear",
+                "delay": 0.0
+              },
+              {
+                "start": 0.0,
+                "end": 0.0,
+                "time": 0.01,
+                "curve": "linear",
+                "delay": 0.035
+              },
+              {
+                "start": 0.2,
+                "end": 0.0,
+                "time": 0.035,
+                "curve": "linear",
+                "delay": 0.045
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "pointer.tick": {
+      "duration": 0.08,
+      "volume": 0.22,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 920
+          },
+          "gain": {
+            "start": 0.28,
+            "end": 0.001,
+            "time": 0.055,
+            "curve": "exponential"
+          }
+        }
+      ]
+    },
+    "pointer.click": {
+      "duration": 0.09,
+      "volume": 0.26,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 1240
+          },
+          "gain": {
+            "start": 0.34,
+            "end": 0.001,
+            "time": 0.032,
+            "curve": "exponential",
+            "delay": 0.0
+          }
+        },
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 540
+          },
+          "gain": {
+            "start": 0.18,
+            "end": 0.001,
+            "time": 0.055,
+            "curve": "exponential",
+            "delay": 0.018
+          }
+        }
+      ]
+    },
+    "pointer.engage": {
+      "duration": 0.22,
+      "volume": 0.32,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 420
+          },
+          "gain": {
+            "start": 0.2,
+            "end": 0.001,
+            "time": 0.11,
+            "curve": "exponential",
+            "delay": 0.0
+          }
+        },
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 760
+          },
+          "gain": {
+            "start": 0.24,
+            "end": 0.001,
+            "time": 0.13,
+            "curve": "exponential",
+            "delay": 0.055
+          }
+        },
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 1160
+          },
+          "gain": {
+            "start": 0.12,
+            "end": 0.001,
+            "time": 0.06,
+            "curve": "exponential",
+            "delay": 0.12
+          }
+        }
+      ]
+    },
+    "pointer.chime": {
+      "duration": 0.25,
+      "volume": 0.3,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 620
+          },
+          "gain": {
+            "start": 0.18,
+            "end": 0.001,
+            "time": 0.18,
+            "curve": "exponential",
+            "delay": 0.0
+          }
+        },
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 930
+          },
+          "gain": {
+            "start": 0.16,
+            "end": 0.001,
+            "time": 0.2,
+            "curve": "exponential",
+            "delay": 0.03
+          }
+        }
+      ]
+    }
+  },
+  "events": {
+    "deck.key": {
+      "sound": "mechanicalKey.cream",
+      "haptic": "rigid"
+    },
+    "deck.key.accent": {
+      "sound": "mechanicalKey.orange",
+      "haptic": "heavy"
+    },
+    "deck.rotary": {
+      "sound": "rotaryTick",
+      "haptic": "selection"
+    },
+    "deck.toggle": {
+      "sound": "toggleClack",
+      "haptic": "medium"
+    },
+    "deck.button": {
+      "sound": "buttonPop",
+      "haptic": "light"
+    },
+    "deck.decision.approved": {
+      "sound": "approvalChime",
+      "haptic": "success"
+    },
+    "deck.decision.deferred": {
+      "sound": "warningBuzz",
+      "haptic": "warning"
+    },
+    "pointer.aim": {
+      "sound": "pointer.tick",
+      "haptic": "generic"
+    },
+    "pointer.commit": {
+      "sound": "pointer.engage",
+      "haptic": "alignment"
+    }
+  }
+}

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -12,7 +12,12 @@ let package = Package(
         .library(name: "LatticesTerminalKit", targets: ["LatticesTerminalKit"])
     ],
     targets: [
-        .target(name: "DeckKit"),
+        .target(
+            name: "DeckKit",
+            resources: [
+                .copy("Resources/deck-tactile-catalog.json")
+            ]
+        ),
         .target(name: "LatticesTerminalKit"),
         .testTarget(
             name: "DeckKitTests",

--- a/swift/Sources/DeckKit/Resources/deck-tactile-catalog.json
+++ b/swift/Sources/DeckKit/Resources/deck-tactile-catalog.json
@@ -1,0 +1,412 @@
+{
+  "version": 1,
+  "meta": {
+    "name": "lattices-deck-sys01",
+    "description": "Declarative tactile + acoustic catalog for the Lattices deck controller (SYS.01)."
+  },
+  "sounds": {
+    "mechanicalKey.orange": {
+      "duration": 0.065,
+      "volume": 0.85,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "triangle",
+          "frequency": {
+            "start": {
+              "base": 230,
+              "detune": {
+                "param": "id",
+                "step": 15,
+                "modulo": 3
+              }
+            },
+            "end": 55,
+            "time": 0.055,
+            "curve": "exponential"
+          },
+          "filter": {
+            "type": "lowpass",
+            "start": 1200,
+            "end": 300,
+            "time": 0.05,
+            "curve": "exponential"
+          },
+          "gain": {
+            "start": 0.32,
+            "end": 0.001,
+            "time": 0.06,
+            "curve": "exponential"
+          }
+        },
+        {
+          "kind": "noise",
+          "duration": 0.008,
+          "gain": {
+            "start": 0.14,
+            "end": 0.001,
+            "time": 0.008,
+            "curve": "exponential"
+          }
+        }
+      ]
+    },
+    "mechanicalKey.cream": {
+      "duration": 0.065,
+      "volume": 0.85,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "triangle",
+          "frequency": {
+            "start": {
+              "base": 320,
+              "detune": {
+                "param": "id",
+                "step": 20,
+                "modulo": 3
+              }
+            },
+            "end": 55,
+            "time": 0.055,
+            "curve": "exponential"
+          },
+          "filter": {
+            "type": "lowpass",
+            "start": 1800,
+            "end": 300,
+            "time": 0.05,
+            "curve": "exponential"
+          },
+          "gain": {
+            "start": 0.32,
+            "end": 0.001,
+            "time": 0.06,
+            "curve": "exponential"
+          }
+        },
+        {
+          "kind": "noise",
+          "duration": 0.008,
+          "gain": {
+            "start": 0.14,
+            "end": 0.001,
+            "time": 0.008,
+            "curve": "exponential"
+          }
+        }
+      ]
+    },
+    "rotaryTick": {
+      "duration": 0.02,
+      "volume": 0.85,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 1900,
+            "end": 300,
+            "time": 0.015,
+            "curve": "exponential"
+          },
+          "gain": {
+            "start": 0.22,
+            "end": 0.001,
+            "time": 0.016,
+            "curve": "exponential"
+          }
+        }
+      ]
+    },
+    "toggleClack": {
+      "duration": 0.045,
+      "volume": 0.85,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "square",
+          "frequency": {
+            "start": 450,
+            "end": 90,
+            "time": 0.035,
+            "curve": "exponential"
+          },
+          "gain": {
+            "start": 0.24,
+            "end": 0.001,
+            "time": 0.04,
+            "curve": "exponential"
+          }
+        }
+      ]
+    },
+    "buttonPop": {
+      "duration": 0.035,
+      "volume": 0.85,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "triangle",
+          "frequency": {
+            "start": 520,
+            "end": 120,
+            "time": 0.025,
+            "curve": "exponential"
+          },
+          "gain": {
+            "start": 0.2,
+            "end": 0.001,
+            "time": 0.03,
+            "curve": "exponential"
+          }
+        }
+      ]
+    },
+    "approvalChime": {
+      "duration": 0.12,
+      "volume": 0.85,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 587.33
+          },
+          "gain": {
+            "start": 0.22,
+            "end": 0.0,
+            "time": 0.06,
+            "curve": "linear",
+            "delay": 0.0
+          }
+        },
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 880.0
+          },
+          "gain": {
+            "start": 0.26,
+            "end": 0.0,
+            "time": 0.09,
+            "curve": "linear",
+            "delay": 0.03
+          }
+        }
+      ]
+    },
+    "warningBuzz": {
+      "duration": 0.08,
+      "volume": 0.85,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 220
+          },
+          "gain": {
+            "segments": [
+              {
+                "start": 0.22,
+                "end": 0.0,
+                "time": 0.035,
+                "curve": "linear",
+                "delay": 0.0
+              },
+              {
+                "start": 0.0,
+                "end": 0.0,
+                "time": 0.01,
+                "curve": "linear",
+                "delay": 0.035
+              },
+              {
+                "start": 0.2,
+                "end": 0.0,
+                "time": 0.035,
+                "curve": "linear",
+                "delay": 0.045
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "pointer.tick": {
+      "duration": 0.08,
+      "volume": 0.22,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 920
+          },
+          "gain": {
+            "start": 0.28,
+            "end": 0.001,
+            "time": 0.055,
+            "curve": "exponential"
+          }
+        }
+      ]
+    },
+    "pointer.click": {
+      "duration": 0.09,
+      "volume": 0.26,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 1240
+          },
+          "gain": {
+            "start": 0.34,
+            "end": 0.001,
+            "time": 0.032,
+            "curve": "exponential",
+            "delay": 0.0
+          }
+        },
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 540
+          },
+          "gain": {
+            "start": 0.18,
+            "end": 0.001,
+            "time": 0.055,
+            "curve": "exponential",
+            "delay": 0.018
+          }
+        }
+      ]
+    },
+    "pointer.engage": {
+      "duration": 0.22,
+      "volume": 0.32,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 420
+          },
+          "gain": {
+            "start": 0.2,
+            "end": 0.001,
+            "time": 0.11,
+            "curve": "exponential",
+            "delay": 0.0
+          }
+        },
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 760
+          },
+          "gain": {
+            "start": 0.24,
+            "end": 0.001,
+            "time": 0.13,
+            "curve": "exponential",
+            "delay": 0.055
+          }
+        },
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 1160
+          },
+          "gain": {
+            "start": 0.12,
+            "end": 0.001,
+            "time": 0.06,
+            "curve": "exponential",
+            "delay": 0.12
+          }
+        }
+      ]
+    },
+    "pointer.chime": {
+      "duration": 0.25,
+      "volume": 0.3,
+      "layers": [
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 620
+          },
+          "gain": {
+            "start": 0.18,
+            "end": 0.001,
+            "time": 0.18,
+            "curve": "exponential",
+            "delay": 0.0
+          }
+        },
+        {
+          "kind": "oscillator",
+          "waveform": "sine",
+          "frequency": {
+            "start": 930
+          },
+          "gain": {
+            "start": 0.16,
+            "end": 0.001,
+            "time": 0.2,
+            "curve": "exponential",
+            "delay": 0.03
+          }
+        }
+      ]
+    }
+  },
+  "events": {
+    "deck.key": {
+      "sound": "mechanicalKey.cream",
+      "haptic": "rigid"
+    },
+    "deck.key.accent": {
+      "sound": "mechanicalKey.orange",
+      "haptic": "heavy"
+    },
+    "deck.rotary": {
+      "sound": "rotaryTick",
+      "haptic": "selection"
+    },
+    "deck.toggle": {
+      "sound": "toggleClack",
+      "haptic": "medium"
+    },
+    "deck.button": {
+      "sound": "buttonPop",
+      "haptic": "light"
+    },
+    "deck.decision.approved": {
+      "sound": "approvalChime",
+      "haptic": "success"
+    },
+    "deck.decision.deferred": {
+      "sound": "warningBuzz",
+      "haptic": "warning"
+    },
+    "pointer.aim": {
+      "sound": "pointer.tick",
+      "haptic": "generic"
+    },
+    "pointer.commit": {
+      "sound": "pointer.engage",
+      "haptic": "alignment"
+    }
+  }
+}

--- a/swift/Sources/DeckKit/Tactile/DeckTactileCatalog.swift
+++ b/swift/Sources/DeckKit/Tactile/DeckTactileCatalog.swift
@@ -1,0 +1,383 @@
+import Foundation
+
+// MARK: - Catalog root
+
+/// Declarative tactile catalog: named sound patches + semantic event bindings.
+public struct DeckTactileCatalog: Codable, Equatable, Sendable {
+    public var version: Int
+    public var meta: DeckTactileMeta?
+    public var sounds: [String: DeckSoundPatch]
+    public var events: [String: DeckTactileEventBinding]
+
+    public init(
+        version: Int = 1,
+        meta: DeckTactileMeta? = nil,
+        sounds: [String: DeckSoundPatch] = [:],
+        events: [String: DeckTactileEventBinding] = [:]
+    ) {
+        self.version = version
+        self.meta = meta
+        self.sounds = sounds
+        self.events = events
+    }
+}
+
+public struct DeckTactileMeta: Codable, Equatable, Sendable {
+    public var name: String?
+    public var description: String?
+}
+
+// MARK: - Event bindings
+
+public struct DeckTactileEventBinding: Codable, Equatable, Sendable {
+    public var sound: DeckTactileSoundRef?
+    public var haptic: DeckHapticStyle?
+    public var hapticOnly: Bool?
+    public var soundOnly: Bool?
+
+    public init(
+        sound: DeckTactileSoundRef? = nil,
+        haptic: DeckHapticStyle? = nil,
+        hapticOnly: Bool? = nil,
+        soundOnly: Bool? = nil
+    ) {
+        self.sound = sound
+        self.haptic = haptic
+        self.hapticOnly = hapticOnly
+        self.soundOnly = soundOnly
+    }
+}
+
+public enum DeckTactileSoundRef: Codable, Equatable, Sendable {
+    case id(String)
+    case resolved(ref: String, params: [String: DeckTactileParamValue])
+
+    public init(from decoder: Decoder) throws {
+        if let single = try? decoder.singleValueContainer(),
+           let id = try? single.decode(String.self) {
+            self = .id(id)
+            return
+        }
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let ref = try container.decode(String.self, forKey: .ref)
+        let params = try container.decodeIfPresent([String: DeckTactileParamValue].self, forKey: .params) ?? [:]
+        self = .resolved(ref: ref, params: params)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .id(let id):
+            var container = encoder.singleValueContainer()
+            try container.encode(id)
+        case .resolved(let ref, let params):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(ref, forKey: .ref)
+            if !params.isEmpty {
+                try container.encode(params, forKey: .params)
+            }
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case ref, params
+    }
+
+    public var patchID: String {
+        switch self {
+        case .id(let id): return id
+        case .resolved(let ref, _): return ref
+        }
+    }
+
+    public var params: [String: DeckTactileParamValue] {
+        switch self {
+        case .id: return [:]
+        case .resolved(_, let params): return params
+        }
+    }
+}
+
+public enum DeckTactileParamValue: Codable, Equatable, Sendable {
+    case bool(Bool)
+    case int(Int)
+    case double(Double)
+    case string(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Int.self) {
+            self = .int(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .double(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported tactile param value")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .bool(let value): try container.encode(value)
+        case .int(let value): try container.encode(value)
+        case .double(let value): try container.encode(value)
+        case .string(let value): try container.encode(value)
+        }
+    }
+
+    public var intValue: Int? {
+        switch self {
+        case .bool(let value): return value ? 1 : 0
+        case .int(let value): return value
+        case .double(let value): return Int(value)
+        case .string(let value): return Int(value)
+        }
+    }
+
+    public var boolValue: Bool? {
+        switch self {
+        case .bool(let value): return value
+        case .int(let value): return value != 0
+        case .double(let value): return value != 0
+        case .string(let value):
+            switch value.lowercased() {
+            case "true", "yes", "1": return true
+            case "false", "no", "0": return false
+            default: return nil
+            }
+        }
+    }
+}
+
+public enum DeckHapticStyle: String, Codable, CaseIterable, Sendable {
+    case rigid
+    case heavy
+    case medium
+    case light
+    case selection
+    case success
+    case warning
+    case generic
+    case alignment
+}
+
+// MARK: - Sound patches
+
+public struct DeckSoundPatch: Codable, Equatable, Sendable {
+    public var duration: Double
+    public var volume: Double?
+    public var layers: [DeckSoundLayer]
+
+    public init(duration: Double, volume: Double? = nil, layers: [DeckSoundLayer]) {
+        self.duration = duration
+        self.volume = volume
+        self.layers = layers
+    }
+}
+
+public enum DeckSoundLayer: Codable, Equatable, Sendable {
+    case oscillator(DeckOscillatorLayer)
+    case noise(DeckNoiseLayer)
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(String.self, forKey: .kind)
+        switch kind {
+        case "oscillator":
+            self = .oscillator(try DeckOscillatorLayer(from: decoder))
+        case "noise":
+            self = .noise(try DeckNoiseLayer(from: decoder))
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "Unknown layer kind: \(kind)")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .oscillator(let layer):
+            try layer.encode(to: encoder)
+        case .noise(let layer):
+            try layer.encode(to: encoder)
+        }
+    }
+}
+
+public struct DeckOscillatorLayer: Codable, Equatable, Sendable {
+    public var kind: String = "oscillator"
+    public var waveform: DeckWaveform
+    public var frequency: DeckFrequencySpec
+    public var gain: DeckGainSpec
+    public var filter: DeckFilterSpec?
+
+    public init(
+        waveform: DeckWaveform,
+        frequency: DeckFrequencySpec,
+        gain: DeckGainSpec,
+        filter: DeckFilterSpec? = nil
+    ) {
+        self.waveform = waveform
+        self.frequency = frequency
+        self.gain = gain
+        self.filter = filter
+    }
+}
+
+public struct DeckNoiseLayer: Codable, Equatable, Sendable {
+    public var kind: String = "noise"
+    public var duration: Double
+    public var gain: DeckGainSpec
+
+    public init(duration: Double, gain: DeckGainSpec) {
+        self.duration = duration
+        self.gain = gain
+    }
+}
+
+public enum DeckWaveform: String, Codable, Sendable {
+    case sine
+    case triangle
+    case square
+}
+
+public struct DeckFrequencySpec: Codable, Equatable, Sendable {
+    public var start: DeckFrequencyValue
+    public var end: Double?
+    public var time: Double?
+    public var curve: DeckCurve?
+
+    public init(start: DeckFrequencyValue, end: Double? = nil, time: Double? = nil, curve: DeckCurve? = nil) {
+        self.start = start
+        self.end = end
+        self.time = time
+        self.curve = curve
+    }
+}
+
+public enum DeckFrequencyValue: Codable, Equatable, Sendable {
+    case fixed(Double)
+    case parameterized(base: Double, detune: DeckFrequencyDetune)
+
+    public init(from decoder: Decoder) throws {
+        if let value = try? decoder.singleValueContainer().decode(Double.self) {
+            self = .fixed(value)
+            return
+        }
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let base = try container.decode(Double.self, forKey: .base)
+        let detune = try container.decode(DeckFrequencyDetune.self, forKey: .detune)
+        self = .parameterized(base: base, detune: detune)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .fixed(let value):
+            var container = encoder.singleValueContainer()
+            try container.encode(value)
+        case .parameterized(let base, let detune):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(base, forKey: .base)
+            try container.encode(detune, forKey: .detune)
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case base, detune
+    }
+}
+
+public struct DeckFrequencyDetune: Codable, Equatable, Sendable {
+    public var param: String
+    public var step: Double
+    public var modulo: Int
+
+    public init(param: String, step: Double, modulo: Int) {
+        self.param = param
+        self.step = step
+        self.modulo = modulo
+    }
+}
+
+public struct DeckFilterSpec: Codable, Equatable, Sendable {
+    public var type: String
+    public var start: Double
+    public var end: Double
+    public var time: Double
+    public var curve: DeckCurve?
+
+    public init(type: String = "lowpass", start: Double, end: Double, time: Double, curve: DeckCurve? = nil) {
+        self.type = type
+        self.start = start
+        self.end = end
+        self.time = time
+        self.curve = curve
+    }
+}
+
+public enum DeckGainSpec: Codable, Equatable, Sendable {
+    case envelope(DeckEnvelope)
+    case segments([DeckEnvelope])
+
+    public init(from decoder: Decoder) throws {
+        if let envelope = try? DeckEnvelope(from: decoder) {
+            self = .envelope(envelope)
+            return
+        }
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let segments = try container.decode([DeckEnvelope].self, forKey: .segments)
+        self = .segments(segments)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .envelope(let envelope):
+            try envelope.encode(to: encoder)
+        case .segments(let segments):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(segments, forKey: .segments)
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case segments
+    }
+}
+
+public struct DeckEnvelope: Codable, Equatable, Sendable {
+    public var start: Double
+    public var end: Double
+    public var time: Double
+    public var curve: DeckCurve?
+    public var delay: Double?
+
+    public init(start: Double, end: Double, time: Double, curve: DeckCurve? = nil, delay: Double? = nil) {
+        self.start = start
+        self.end = end
+        self.time = time
+        self.curve = curve
+        self.delay = delay
+    }
+}
+
+public enum DeckCurve: String, Codable, Sendable {
+    case linear
+    case exponential
+}
+
+public enum DeckTactileEventID: String, CaseIterable, Sendable {
+    case deckKey = "deck.key"
+    case deckKeyAccent = "deck.key.accent"
+    case deckRotary = "deck.rotary"
+    case deckToggle = "deck.toggle"
+    case deckButton = "deck.button"
+    case deckDecisionApproved = "deck.decision.approved"
+    case deckDecisionDeferred = "deck.decision.deferred"
+    case pointerAim = "pointer.aim"
+    case pointerCommit = "pointer.commit"
+}

--- a/swift/Sources/DeckKit/Tactile/DeckTactileSynthesizer.swift
+++ b/swift/Sources/DeckKit/Tactile/DeckTactileSynthesizer.swift
@@ -1,0 +1,233 @@
+import Foundation
+
+public struct DeckTactileRenderOptions: Equatable, Sendable {
+    public var sampleRate: Int
+    public var params: [String: DeckTactileParamValue]
+
+    public init(sampleRate: Int = 44_100, params: [String: DeckTactileParamValue] = [:]) {
+        self.sampleRate = sampleRate
+        self.params = params
+    }
+}
+
+public enum DeckTactileSynthesizer {
+    public static func render(patch: DeckSoundPatch, options: DeckTactileRenderOptions = DeckTactileRenderOptions()) -> [Float] {
+        let sampleRate = options.sampleRate
+        let sampleCount = max(1, Int(patch.duration * Double(sampleRate)))
+        var buffer = [Float](repeating: 0, count: sampleCount)
+
+        for layer in patch.layers {
+            switch layer {
+            case .oscillator(let osc):
+                renderOscillator(osc, into: &buffer, sampleRate: sampleRate, params: options.params)
+            case .noise(let noise):
+                renderNoise(noise, into: &buffer, sampleRate: sampleRate, params: options.params)
+            }
+        }
+
+        let volume = Float(patch.volume ?? 1.0)
+        if volume != 1 {
+            for index in buffer.indices {
+                buffer[index] *= volume
+            }
+        }
+        return buffer
+    }
+
+    public static func renderWAV(patch: DeckSoundPatch, options: DeckTactileRenderOptions = DeckTactileRenderOptions()) -> Data {
+        let samples = render(patch: patch, options: options)
+        return encodeWAV(samples: samples, sampleRate: options.sampleRate)
+    }
+
+    // MARK: - Layers
+
+    private static func renderOscillator(
+        _ layer: DeckOscillatorLayer,
+        into buffer: inout [Float],
+        sampleRate: Int,
+        params: [String: DeckTactileParamValue]
+    ) {
+        let envelopes = envelopes(for: layer.gain)
+        var phase: Float = 0
+        var filtered: Float = 0
+
+        for index in buffer.indices {
+            let time = Float(index) / Float(sampleRate)
+            let frequency = frequency(at: time, spec: layer.frequency, params: params)
+            phase += 2 * Float.pi * frequency / Float(sampleRate)
+            let wave = waveformValue(layer.waveform, phase: phase)
+
+            var sample = wave
+            if let filter = layer.filter {
+                let cutoff = interpolate(
+                    start: Float(filter.start),
+                    end: Float(filter.end),
+                    time: time,
+                    duration: Float(filter.time),
+                    curve: filter.curve ?? .exponential
+                )
+                let rc = 1 / (2 * Float.pi * max(cutoff, 1))
+                let dt = 1 / Float(sampleRate)
+                let alpha = dt / (rc + dt)
+                filtered += alpha * (wave - filtered)
+                sample = filtered
+            }
+
+            let gain = envelopeGain(at: time, envelopes: envelopes)
+            buffer[index] += sample * gain
+        }
+    }
+
+    private static func renderNoise(
+        _ layer: DeckNoiseLayer,
+        into buffer: inout [Float],
+        sampleRate: Int,
+        params: [String: DeckTactileParamValue]
+    ) {
+        let envelopes = envelopes(for: layer.gain)
+        let count = min(buffer.count, Int(layer.duration * Double(sampleRate)))
+        for index in 0..<count {
+            let time = Float(index) / Float(sampleRate)
+            let gain = envelopeGain(at: time, envelopes: envelopes)
+            buffer[index] += Float.random(in: -1...1) * gain
+        }
+    }
+
+    // MARK: - Envelopes & frequency
+
+    private static func envelopes(for spec: DeckGainSpec) -> [DeckEnvelope] {
+        switch spec {
+        case .envelope(let envelope):
+            return [envelope]
+        case .segments(let segments):
+            return segments
+        }
+    }
+
+    private static func envelopeGain(at time: Float, envelopes: [DeckEnvelope]) -> Float {
+        var total: Float = 0
+        for envelope in envelopes {
+            let delay = Float(envelope.delay ?? 0)
+            let local = time - delay
+            guard local >= 0 else { continue }
+            let duration = max(Float(envelope.time), 0.0001)
+            let progress = min(1, local / duration)
+            let gain = interpolate(
+                start: Float(envelope.start),
+                end: Float(envelope.end),
+                progress: progress,
+                curve: envelope.curve ?? .linear
+            )
+            total += gain
+        }
+        return total
+    }
+
+    private static func frequency(
+        at time: Float,
+        spec: DeckFrequencySpec,
+        params: [String: DeckTactileParamValue]
+    ) -> Float {
+        let start = resolvedFrequency(spec.start, params: params)
+        guard let end = spec.end, let duration = spec.time, duration > 0 else {
+            return start
+        }
+        return interpolate(
+            start: start,
+            end: Float(end),
+            time: time,
+            duration: Float(duration),
+            curve: spec.curve ?? .exponential
+        )
+    }
+
+    private static func resolvedFrequency(_ value: DeckFrequencyValue, params: [String: DeckTactileParamValue]) -> Float {
+        switch value {
+        case .fixed(let hz):
+            return Float(hz)
+        case .parameterized(let base, let detune):
+            let raw = params[detune.param]?.intValue ?? 0
+            let mod = detune.modulo > 0 ? raw % detune.modulo : raw
+            return Float(base + Double(mod) * detune.step)
+        }
+    }
+
+    private static func interpolate(
+        start: Float,
+        end: Float,
+        time: Float,
+        duration: Float,
+        curve: DeckCurve
+    ) -> Float {
+        let progress = min(1, max(0, time / max(duration, 0.0001)))
+        return interpolate(start: start, end: end, progress: progress, curve: curve)
+    }
+
+    private static func interpolate(start: Float, end: Float, progress: Float, curve: DeckCurve) -> Float {
+        switch curve {
+        case .linear:
+            return start + (end - start) * progress
+        case .exponential:
+            guard start > 0, end > 0 else {
+                return start + (end - start) * progress
+            }
+            let ratio = end / start
+            return start * pow(ratio, progress)
+        }
+    }
+
+    private static func waveformValue(_ waveform: DeckWaveform, phase: Float) -> Float {
+        switch waveform {
+        case .sine:
+            return sin(phase)
+        case .triangle:
+            let normalized = phase / (2 * Float.pi)
+            return 2 * abs(2 * (normalized - floor(normalized + 0.5))) - 1
+        case .square:
+            return sin(phase) >= 0 ? 0.7 : -0.7
+        }
+    }
+
+    // MARK: - WAV
+
+    public static func encodeWAV(samples: [Float], sampleRate: Int) -> Data {
+        var data = Data()
+        let numSamples = samples.count
+        let numChannels: UInt16 = 1
+        let bitsPerSample: UInt16 = 16
+        let byteRate = UInt32(sampleRate * Int(numChannels) * Int(bitsPerSample) / 8)
+        let blockAlign = UInt16(numChannels * bitsPerSample / 8)
+        let subchunk2Size = UInt32(numSamples * Int(numChannels) * 2)
+        let chunkSize = 36 + subchunk2Size
+
+        data.append(contentsOf: [0x52, 0x49, 0x46, 0x46])
+        var chunkSizeLE = chunkSize.littleEndian
+        data.append(Data(bytes: &chunkSizeLE, count: 4))
+        data.append(contentsOf: [0x57, 0x41, 0x56, 0x45])
+        data.append(contentsOf: [0x66, 0x6D, 0x74, 0x20])
+        var subchunk1Size: UInt32 = 16
+        data.append(Data(bytes: &subchunk1Size, count: 4))
+        var audioFormat: UInt16 = 1
+        data.append(Data(bytes: &audioFormat, count: 2))
+        var channels = numChannels.littleEndian
+        data.append(Data(bytes: &channels, count: 2))
+        var sRate = UInt32(sampleRate).littleEndian
+        data.append(Data(bytes: &sRate, count: 4))
+        var bRate = byteRate.littleEndian
+        data.append(Data(bytes: &bRate, count: 4))
+        var bAlign = blockAlign.littleEndian
+        data.append(Data(bytes: &bAlign, count: 2))
+        var bps = bitsPerSample.littleEndian
+        data.append(Data(bytes: &bps, count: 2))
+        data.append(contentsOf: [0x64, 0x61, 0x74, 0x61])
+        var s2Size = subchunk2Size.littleEndian
+        data.append(Data(bytes: &s2Size, count: 4))
+
+        for sample in samples {
+            let clamped = max(-1.0, min(1.0, sample))
+            var intSample = Int16(clamped * 32767).littleEndian
+            data.append(Data(bytes: &intSample, count: 2))
+        }
+        return data
+    }
+}

--- a/swift/Sources/DeckKit/Tactile/DeckTactileTheme.swift
+++ b/swift/Sources/DeckKit/Tactile/DeckTactileTheme.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+public struct DeckTactileResolvedEvent: Equatable, Sendable {
+    public var eventID: String
+    public var patch: DeckSoundPatch?
+    public var haptic: DeckHapticStyle?
+    public var params: [String: DeckTactileParamValue]
+
+    public init(
+        eventID: String,
+        patch: DeckSoundPatch? = nil,
+        haptic: DeckHapticStyle? = nil,
+        params: [String: DeckTactileParamValue] = [:]
+    ) {
+        self.eventID = eventID
+        self.patch = patch
+        self.haptic = haptic
+        self.params = params
+    }
+}
+
+public final class DeckTactileTheme: @unchecked Sendable {
+    public static let shared = DeckTactileTheme()
+
+    private var catalog: DeckTactileCatalog
+    private let lock = NSLock()
+
+    public init(catalog: DeckTactileCatalog = DeckTactileTheme.loadBuiltinCatalog()) {
+        self.catalog = catalog
+    }
+
+    public func currentCatalog() -> DeckTactileCatalog {
+        lock.lock()
+        defer { lock.unlock() }
+        return catalog
+    }
+
+    /// Replace the active catalog wholesale (e.g. after loading a custom theme file).
+    public func replaceCatalog(_ catalog: DeckTactileCatalog) {
+        lock.lock()
+        self.catalog = catalog
+        lock.unlock()
+    }
+
+    /// Merge sounds/events from an overlay catalog. Existing keys are replaced.
+    public func merge(_ overlay: DeckTactileCatalog) {
+        lock.lock()
+        catalog.sounds.merge(overlay.sounds) { _, new in new }
+        catalog.events.merge(overlay.events) { _, new in new }
+        if let meta = overlay.meta {
+            catalog.meta = meta
+        }
+        if overlay.version > 0 {
+            catalog.version = overlay.version
+        }
+        lock.unlock()
+    }
+
+    public func resolve(
+        eventID: String,
+        params: [String: DeckTactileParamValue] = [:]
+    ) -> DeckTactileResolvedEvent? {
+        lock.lock()
+        let binding = catalog.events[eventID]
+        let sounds = catalog.sounds
+        lock.unlock()
+
+        guard let binding else { return nil }
+
+        var mergedParams = params
+        var patchID: String?
+        if let sound = binding.sound {
+            patchID = sound.patchID
+            for (key, value) in sound.params {
+                mergedParams[key] = value
+            }
+        }
+
+        let patch = patchID.flatMap { sounds[$0] }
+        let soundPatch = binding.hapticOnly == true ? nil : patch
+        let hapticStyle = binding.soundOnly == true ? nil : binding.haptic
+
+        return DeckTactileResolvedEvent(
+            eventID: eventID,
+            patch: soundPatch,
+            haptic: hapticStyle,
+            params: mergedParams
+        )
+    }
+
+    public func resolve(_ event: DeckTactileEventID, params: [String: DeckTactileParamValue] = [:]) -> DeckTactileResolvedEvent? {
+        resolve(eventID: event.rawValue, params: params)
+    }
+
+    public func renderWAV(
+        eventID: String,
+        params: [String: DeckTactileParamValue] = [:],
+        sampleRate: Int = 44_100
+    ) -> Data? {
+        guard let resolved = resolve(eventID: eventID, params: params),
+              let patch = resolved.patch else { return nil }
+        return DeckTactileSynthesizer.renderWAV(
+            patch: patch,
+            options: DeckTactileRenderOptions(sampleRate: sampleRate, params: resolved.params)
+        )
+    }
+
+    public static func loadBuiltinCatalog() -> DeckTactileCatalog {
+        if let url = Bundle.module.url(forResource: "deck-tactile-catalog", withExtension: "json"),
+           let data = try? Data(contentsOf: url),
+           let catalog = try? JSONDecoder().decode(DeckTactileCatalog.self, from: data) {
+            return catalog
+        }
+        return DeckTactileCatalog()
+    }
+
+    public static func loadCatalog(from url: URL) throws -> DeckTactileCatalog {
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(DeckTactileCatalog.self, from: data)
+    }
+
+    public static func loadCatalog(fromJSON data: Data) throws -> DeckTactileCatalog {
+        try JSONDecoder().decode(DeckTactileCatalog.self, from: data)
+    }
+}

--- a/swift/Tests/DeckKitTests/DeckTactileTests.swift
+++ b/swift/Tests/DeckKitTests/DeckTactileTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import DeckKit
+
+final class DeckTactileTests: XCTestCase {
+    func testBuiltinCatalogLoads() {
+        let catalog = DeckTactileTheme.loadBuiltinCatalog()
+        XCTAssertEqual(catalog.version, 1)
+        XCTAssertFalse(catalog.sounds.isEmpty)
+        XCTAssertFalse(catalog.events.isEmpty)
+        XCTAssertNotNil(catalog.sounds["buttonPop"])
+        XCTAssertNotNil(catalog.events[DeckTactileEventID.deckButton.rawValue])
+    }
+
+    func testResolveEventWithParams() throws {
+        let theme = DeckTactileTheme()
+        let resolved = theme.resolve(eventID: "deck.key.accent", params: ["id": .int(2)])
+        XCTAssertNotNil(resolved)
+        XCTAssertEqual(resolved?.haptic, .heavy)
+        XCTAssertEqual(resolved?.params["id"]?.intValue, 2)
+    }
+
+    func testSynthesizerProducesNonSilentWAV() throws {
+        let catalog = DeckTactileTheme.loadBuiltinCatalog()
+        let patch = try XCTUnwrap(catalog.sounds["buttonPop"])
+        let wav = DeckTactileSynthesizer.renderWAV(patch: patch)
+        XCTAssertGreaterThan(wav.count, 44)
+        XCTAssertEqual(String(data: wav.prefix(4), encoding: .ascii), "RIFF")
+    }
+
+    func testMergeOverlayReplacesSounds() throws {
+        let theme = DeckTactileTheme()
+        let overlay = DeckTactileCatalog(
+            version: 1,
+            sounds: [
+                "buttonPop": DeckSoundPatch(
+                    duration: 0.01,
+                    layers: [
+                        .oscillator(
+                            DeckOscillatorLayer(
+                                waveform: .sine,
+                                frequency: DeckFrequencySpec(start: .fixed(440)),
+                                gain: .envelope(DeckEnvelope(start: 0.1, end: 0.0, time: 0.01))
+                            )
+                        )
+                    ]
+                )
+            ],
+            events: [:]
+        )
+        theme.merge(overlay)
+        let merged = theme.currentCatalog().sounds["buttonPop"]
+        XCTAssertEqual(merged?.duration, 0.01)
+    }
+}


### PR DESCRIPTION
## Summary

- Add DeckKit tactile module with bundled `deck-tactile-catalog.json`
- Refine iOS `DeckTactileFeedback` + new `DeckTactileModifiers` for event routing
- Mirror tactile catalog on concept experiment page for design review

**Note:** Supersedes / extends #104 (`feat/tactile-deck-acoustics`). Close #104 when this lands.

Part of the integration stack — **5/7**. Base: `feat/fleet-deck-remote-first`.

**CI deferred** until final merge to `main`.