### PR TITLE
✨ Add tile pointer keyboard for rapid window placement

### DIFF
--- a/apps/mac/Sources/Core/Desktop/TilePointerController.swift
+++ b/apps/mac/Sources/Core/Desktop/TilePointerController.swift
@@ -4,16 +4,28 @@ import CoreGraphics
 /// Hold Ctrl+Option and move the mouse to aim. Dead-center is cancel;
 /// the rest of the center cell is maximize; outer cells are sectors.
 /// Release Ctrl+Option to apply the current aim, or stay in the dead
-/// zone to do nothing. A key chord during the hold cancels the picker.
+/// zone to do nothing.
+///
+/// Keyboard aim (while Ctrl+Option is held):
+/// - Numpad 1–9 map to the 3×3 matrix (5 = maximize)
+/// - Number row 1–9 use the same matrix layout
+/// - Arrow keys tile to an edge; hold two arrows for a corner (e.g. ← + ↓ = bottom-left)
+/// Other keys during the hold still cancel the picker.
 final class TilePointerController {
     static let shared = TilePointerController()
 
     private var flagsMonitor: Any?
     private var mouseMonitor: Any?
     private var keyMonitor: Any?
+    private var keyUpMonitor: Any?
     private var localFlagsMonitor: Any?
     private var localMouseMonitor: Any?
     private var localKeyMonitor: Any?
+    private var localKeyUpMonitor: Any?
+    private var heldArrows = Set<TilePointerKeyboard.Arrow>()
+    /// True after an arrow chord set the aim; keeps that cell until modifiers release
+    /// even if the arrow keys come up before Ctrl+Option.
+    private var arrowAimLocked = false
 
     private var armed = false
     private var origin: NSPoint?
@@ -58,8 +70,15 @@ final class TilePointerController {
         keyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
             self?.handleKeyDown(event)
         }
+        keyUpMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyUp) { [weak self] event in
+            self?.handleKeyUp(event)
+        }
         localKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            self?.handleKeyDown(event)
+            guard let self else { return event }
+            return self.handleKeyDown(event) ? nil : event
+        }
+        localKeyUpMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyUp) { [weak self] event in
+            self?.handleKeyUp(event)
             return event
         }
 
@@ -67,15 +86,20 @@ final class TilePointerController {
     }
 
     func stop() {
-        for monitor in [flagsMonitor, mouseMonitor, keyMonitor, localFlagsMonitor, localMouseMonitor, localKeyMonitor] {
+        for monitor in [
+            flagsMonitor, mouseMonitor, keyMonitor, keyUpMonitor,
+            localFlagsMonitor, localMouseMonitor, localKeyMonitor, localKeyUpMonitor,
+        ] {
             if let monitor { NSEvent.removeMonitor(monitor) }
         }
         flagsMonitor = nil
         mouseMonitor = nil
         keyMonitor = nil
+        keyUpMonitor = nil
         localFlagsMonitor = nil
         localMouseMonitor = nil
         localKeyMonitor = nil
+        localKeyUpMonitor = nil
         pendingArm?.cancel()
         pendingArm = nil
         pendingDisarm?.cancel()
@@ -84,13 +108,55 @@ final class TilePointerController {
     }
 
     /// Keyboard chords and other Ctrl+Option hotkeys own the hold.
+    var isAiming: Bool { armed }
+
+    /// While the Ctrl+Option HUD is actively using arrow aim, defer global tiling
+    /// hotkeys that share the same chord. Quick Ctrl+Option+arrow chords must still
+    /// tile immediately via the registered hotkey path.
+    func shouldSuppressTilingHotkey(_ action: HotkeyAction) -> Bool {
+        guard armed, arrowAimLocked || !heldArrows.isEmpty else { return false }
+        switch action {
+        case .tileLeft, .tileRight, .tileTop, .tileBottom,
+             .tileTopLeft, .tileTopRight, .tileBottomLeft, .tileBottomRight,
+             .tileMaximize, .tileLeftThird, .tileCenterThird, .tileRightThird:
+            return true
+        default:
+            return false
+        }
+    }
+
     func cancelApply() {
         dismiss(apply: false)
     }
 
-    private func handleKeyDown(_ event: NSEvent) {
-        guard !Self.modifierKeyCodes.contains(event.keyCode) else { return }
+    /// Returns true when the key was consumed for a keyboard tile.
+    @discardableResult
+    private func handleKeyDown(_ event: NSEvent) -> Bool {
+        guard !Self.modifierKeyCodes.contains(event.keyCode) else { return false }
+        guard Self.ctrlOptionHeld(event.modifierFlags) else {
+            cancelApply()
+            return false
+        }
+
+        if let position = TilePointerKeyboard.tilePosition(forMatrixKeyCode: event.keyCode) {
+            applyKeyboardTile(to: position)
+            return true
+        }
+        if let arrow = TilePointerKeyboard.Arrow.from(keyCode: event.keyCode) {
+            // Before the HUD arms, leave Ctrl+Option+arrow to the global tiling hotkeys.
+            guard armed else { return false }
+            heldArrows.insert(arrow)
+            updateArrowAim()
+            return true
+        }
+
         cancelApply()
+        return false
+    }
+
+    private func handleKeyUp(_ event: NSEvent) {
+        guard let arrow = TilePointerKeyboard.Arrow.from(keyCode: event.keyCode) else { return }
+        heldArrows.remove(arrow)
     }
 
     private func handleFlags(_ flags: NSEvent.ModifierFlags) {
@@ -106,6 +172,10 @@ final class TilePointerController {
                 dismiss(apply: false)
             }
             return
+        }
+
+        if !Self.ctrlOptionHeld(flags) {
+            heldArrows.removeAll()
         }
 
         if Self.ctrlOptionHeld(flags) {
@@ -149,7 +219,7 @@ final class TilePointerController {
     }
 
     private func handleMouseMoved(_ event: NSEvent? = nil) {
-        guard armed, !WindowDragSnapController.shared.isSnapping else { return }
+        guard armed, heldArrows.isEmpty, !arrowAimLocked, !WindowDragSnapController.shared.isSnapping else { return }
         if origin == nil {
             origin = NSEvent.mouseLocation
         }
@@ -175,6 +245,26 @@ final class TilePointerController {
         } else {
             TileZoneOverlay.shared.dismiss()
         }
+    }
+
+    private func updateArrowAim() {
+        guard armed, let origin else { return }
+        guard let position = TilePointerKeyboard.tilePosition(forArrows: heldArrows) else {
+            return
+        }
+        arrowAimLocked = true
+
+        guard let screen = NSScreen.screens.first(where: { $0.frame.contains(origin) })
+                ?? NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) })
+                ?? NSScreen.main else { return }
+        currentScreen = screen
+        showHUD(at: origin, position: position)
+        guard position != currentPosition else { return }
+        currentPosition = position
+        if Preferences.shared.tilePointerSoundEffectsEnabled {
+            AppFeedback.shared.aimTick()
+        }
+        TileZoneOverlay.shared.show(position: position, on: screen)
     }
 
     /// When the origin sits against a display edge, macOS pins the cursor.
@@ -219,6 +309,7 @@ final class TilePointerController {
 
     private func arm() {
         armed = true
+        arrowAimLocked = false
         origin = NSEvent.mouseLocation
         aimPoint = origin
         currentPosition = nil
@@ -250,6 +341,8 @@ final class TilePointerController {
         pollTimer = nil
         let position = currentPosition
         let screen = currentScreen
+        heldArrows.removeAll()
+        arrowAimLocked = false
         armed = false
         origin = nil
         aimPoint = nil
@@ -258,18 +351,42 @@ final class TilePointerController {
 
         hideHUD()
         if apply, let position {
-            // Land: same tactile commit the other window-placement paths use.
-            if Preferences.shared.tilePointerSoundEffectsEnabled {
-                AppFeedback.shared.commitTactile()
-            }
-            if WindowMotionMode.shared.tileCurrentTarget(to: position) {
-                return
-            }
-            TileZoneOverlay.shared.show(position: position, on: screen, autoHideAfter: 0.28)
-            WindowTiler.tileFrontmostViaAX(to: position)
+            commitTile(to: position, on: screen)
             return
         }
         TileZoneOverlay.shared.dismiss()
+    }
+
+    private func applyKeyboardTile(to position: TilePosition) {
+        pendingArm?.cancel()
+        pendingArm = nil
+        pendingDisarm?.cancel()
+        pendingDisarm = nil
+        pollTimer?.invalidate()
+        pollTimer = nil
+        heldArrows.removeAll()
+        arrowAimLocked = false
+        armed = false
+        origin = nil
+        aimPoint = nil
+        currentPosition = nil
+        let screen = currentScreen
+            ?? NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) })
+            ?? NSScreen.main
+        currentScreen = nil
+        hideHUD()
+        commitTile(to: position, on: screen)
+    }
+
+    private func commitTile(to position: TilePosition, on screen: NSScreen?) {
+        if Preferences.shared.tilePointerSoundEffectsEnabled {
+            AppFeedback.shared.commitTactile()
+        }
+        if WindowMotionMode.shared.tileCurrentTarget(to: position) {
+            return
+        }
+        TileZoneOverlay.shared.show(position: position, on: screen, autoHideAfter: 0.28)
+        WindowTiler.tileFrontmostViaAX(to: position)
     }
 
     private var hudStyle: TilePointerHUDStyle {

--- a/apps/mac/Sources/Core/Desktop/TilePointerKeyboard.swift
+++ b/apps/mac/Sources/Core/Desktop/TilePointerKeyboard.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Keyboard aim targets for the Ctrl+Option tile pointer.
+///
+/// Numpad layout mirrors `TilePointerMatrixHUD.cells`:
+/// ```
+/// 7 8 9
+/// 4 5 6
+/// 1 2 3
+/// ```
+/// The number row (1–9) uses the same matrix when Ctrl+Option is held.
+/// Arrow keys tile to an edge; hold two arrows (e.g. ← + ↓) for a corner.
+enum TilePointerKeyboard {
+    enum Arrow: UInt16, Hashable, CaseIterable {
+        case left = 123
+        case right = 124
+        case down = 125
+        case up = 126
+
+        static func from(keyCode: UInt16) -> Arrow? {
+            Arrow(rawValue: keyCode)
+        }
+    }
+
+    /// Numpad and number-row keys that map to the 3×3 matrix.
+    static func tilePosition(forMatrixKeyCode keyCode: UInt16) -> TilePosition? {
+        switch keyCode {
+        // Numpad (HIToolbox kVK_Keypad*)
+        case 89: return .topLeft      // keypad 7
+        case 91: return .top          // keypad 8
+        case 92: return .topRight     // keypad 9
+        case 86: return .left         // keypad 4
+        case 87: return .maximize     // keypad 5
+        case 88: return .right        // keypad 6
+        case 83: return .bottomLeft   // keypad 1
+        case 84: return .bottom       // keypad 2
+        case 85: return .bottomRight  // keypad 3
+        // Number row (kVK_ANSI_1–9)
+        case 26: return .topLeft      // 7
+        case 28: return .top          // 8
+        case 25: return .topRight     // 9
+        case 21: return .left         // 4
+        case 23: return .maximize     // 5
+        case 22: return .right        // 6
+        case 18: return .bottomLeft   // 1
+        case 19: return .bottom       // 2
+        case 20: return .bottomRight  // 3
+        default: return nil
+        }
+    }
+
+    static func tilePosition(forArrows arrows: Set<Arrow>) -> TilePosition? {
+        let left = arrows.contains(.left)
+        let right = arrows.contains(.right)
+        let up = arrows.contains(.up)
+        let down = arrows.contains(.down)
+
+        switch (left, right, up, down) {
+        case (true, false, true, false):   return .topLeft
+        case (false, true, true, false):   return .topRight
+        case (true, false, false, true):  return .bottomLeft
+        case (false, true, false, true):  return .bottomRight
+        case (true, false, false, false): return .left
+        case (false, true, false, false): return .right
+        case (false, false, true, false): return .top
+        case (false, false, false, true): return .bottom
+        default: return nil
+        }
+    }
+}

--- a/apps/mac/Tests/TilePointerKeyboardTests.swift
+++ b/apps/mac/Tests/TilePointerKeyboardTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import Lattices
+
+final class TilePointerKeyboardTests: XCTestCase {
+    func testNumpadMapsToMatrix() {
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forMatrixKeyCode: 89), .topLeft)
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forMatrixKeyCode: 91), .top)
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forMatrixKeyCode: 92), .topRight)
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forMatrixKeyCode: 86), .left)
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forMatrixKeyCode: 87), .maximize)
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forMatrixKeyCode: 88), .right)
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forMatrixKeyCode: 83), .bottomLeft)
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forMatrixKeyCode: 84), .bottom)
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forMatrixKeyCode: 85), .bottomRight)
+    }
+
+    func testNumberRowMapsToMatrix() {
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forMatrixKeyCode: 26), .topLeft)
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forMatrixKeyCode: 28), .top)
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forMatrixKeyCode: 25), .topRight)
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forMatrixKeyCode: 21), .left)
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forMatrixKeyCode: 23), .maximize)
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forMatrixKeyCode: 22), .right)
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forMatrixKeyCode: 18), .bottomLeft)
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forMatrixKeyCode: 19), .bottom)
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forMatrixKeyCode: 20), .bottomRight)
+    }
+
+    func testArrowEdgesAndCorners() {
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forArrows: [.left]), .left)
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forArrows: [.right]), .right)
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forArrows: [.up]), .top)
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forArrows: [.down]), .bottom)
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forArrows: [.left, .down]), .bottomLeft)
+        XCTAssertEqual(TilePointerKeyboard.tilePosition(forArrows: [.right, .up]), .topRight)
+    }
+}


### PR DESCRIPTION
## Summary

- Add `TilePointerKeyboard` with grid navigation and placement shortcuts
- Wire keyboard handling through `TilePointerController`
- Unit tests for keyboard layout and action mapping

Part of the integration stack — **6/7**. Base: `feat/deck-tactile-expansion`.

**CI deferred** until final merge to `main`.