### PR TITLE
✨ Add Hudson Kokoro TTS client and engine loader

### DIFF
--- a/apps/mac/Sources/Core/Voice/LatticesVoiceEngineLoader.swift
+++ b/apps/mac/Sources/Core/Voice/LatticesVoiceEngineLoader.swift
@@ -1,0 +1,162 @@
+#if LATTICES_VOICE && canImport(HudsonVoice)
+import Foundation
+import HudsonSpeechEngine
+import VoxCore
+import VoxService
+
+/// Boots the embedded Vox engines with Kokoro TTS + Parakeet ASR for Lattices voice.
+enum LatticesVoiceEngineLoader {
+    static let kokoroModelId = "mlx-community/Kokoro-82M-bf16"
+    static let kokoroVoiceId = "af_heart"
+
+    static func loadEngines(runtimeHome: URL) throws -> (EngineManager, TTSEngineManager, String) {
+        try seedRuntimeHome(runtimeHome)
+
+        let configURL = runtimeHome.appendingPathComponent("providers.json")
+        if FileManager.default.fileExists(atPath: configURL.path) {
+            do {
+                let config = try ProvidersConfig.load(from: configURL)
+                let asrConfig = config.providers.contains(where: { $0.resolvedKind == .asr })
+                    ? config
+                    : defaultASRConfig()
+                let ttsConfig = config.providers.contains(where: { $0.resolvedKind == .tts })
+                    ? config.mergingMissingTTSDefaults()
+                    : defaultTTSConfig()
+                return (
+                    EngineManager(provider: ProviderRegistry(config: asrConfig)),
+                    TTSEngineManager(provider: TTSProviderRegistry(config: ttsConfig)),
+                    resolveDefaultSynthesisModelId(for: ttsConfig)
+                )
+            } catch {
+                DiagnosticLog.shared.warn(
+                    "HudsonVoice: failed to parse providers.json — \(error.localizedDescription); using defaults"
+                )
+            }
+        }
+
+        let ttsConfig = defaultTTSConfig()
+        return (
+            EngineManager(provider: ProviderRegistry(config: defaultASRConfig())),
+            TTSEngineManager(provider: TTSProviderRegistry(config: ttsConfig)),
+            resolveDefaultSynthesisModelId(for: ttsConfig)
+        )
+    }
+
+    private static func resolveDefaultSynthesisModelId(for config: ProvidersConfig) -> String {
+        let models = config.providers
+            .filter { $0.resolvedKind == .tts }
+            .flatMap { $0.models ?? [] }
+        if models.contains(kokoroModelId) {
+            return kokoroModelId
+        }
+        return TTSDefaultModelSelector.defaultModelId(for: config)
+    }
+
+    private static func seedRuntimeHome(_ runtimeHome: URL) throws {
+        try FileManager.default.createDirectory(at: runtimeHome, withIntermediateDirectories: true)
+
+        let providersURL = runtimeHome.appendingPathComponent("providers.json")
+        if !FileManager.default.fileExists(atPath: providersURL.path) {
+            let userProviders = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".vox/providers.json")
+            if FileManager.default.fileExists(atPath: userProviders.path) {
+                try FileManager.default.copyItem(at: userProviders, to: providersURL)
+            } else {
+                try writeDefaultProviders(to: providersURL)
+            }
+        }
+
+        let preferencesURL = runtimeHome.appendingPathComponent("preferences.json")
+        var preferences = (try? VoxPreferences.load(from: preferencesURL)) ?? VoxPreferences()
+        if preferences.speech.preferredSynthesisModelId?.isEmpty != false {
+            preferences.speech.preferredSynthesisModelId = kokoroModelId
+        }
+        if preferences.speech.preferredSynthesisVoiceId?.isEmpty != false {
+            preferences.speech.preferredSynthesisVoiceId = kokoroVoiceId
+        }
+        try preferences.save(to: preferencesURL)
+    }
+
+    private static func writeDefaultProviders(to url: URL) throws {
+        let payload: [String: Any] = [
+            "providers": [
+                [
+                    "id": "parakeet",
+                    "kind": "asr",
+                    "builtin": true,
+                    "models": ["parakeet:v3"],
+                ],
+                [
+                    "id": "mlx-audio",
+                    "kind": "tts",
+                    "builtin": true,
+                    "models": [kokoroModelId],
+                    "env": [
+                        "VOX_MLX_AUDIO_USE_UV": "1",
+                        "VOX_MLX_AUDIO_TTS_MODELS": kokoroModelId,
+                        "VOX_MLX_AUDIO_TTS_DEFAULT_VOICE": kokoroVoiceId,
+                        "VOX_PROVIDER_CALL_TIMEOUT_SECONDS": "300",
+                    ],
+                ],
+                [
+                    "id": "avspeech",
+                    "kind": "tts",
+                    "builtin": true,
+                    "models": [AVSpeechSynthesizerProvider.modelID],
+                ],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: url, options: .atomic)
+    }
+
+    static func defaultASRConfig() -> ProvidersConfig {
+        ProvidersConfig(providers: [
+            ProviderEntry(
+                id: "parakeet",
+                kind: .asr,
+                builtin: true,
+                models: ["parakeet:v3"]
+            ),
+        ])
+    }
+
+    static func defaultTTSConfig() -> ProvidersConfig {
+        ProvidersConfig(providers: [
+            ProviderEntry(
+                id: "mlx-audio",
+                kind: .tts,
+                builtin: true,
+                models: [kokoroModelId],
+                env: [
+                    "VOX_MLX_AUDIO_USE_UV": "1",
+                    "VOX_MLX_AUDIO_TTS_MODELS": kokoroModelId,
+                    "VOX_MLX_AUDIO_TTS_DEFAULT_VOICE": kokoroVoiceId,
+                    "VOX_PROVIDER_CALL_TIMEOUT_SECONDS": "300",
+                ]
+            ),
+            ProviderEntry(
+                id: "avspeech",
+                kind: .tts,
+                builtin: true,
+                models: [AVSpeechSynthesizerProvider.modelID]
+            ),
+        ])
+    }
+}
+
+private extension ProvidersConfig {
+    func mergingMissingTTSDefaults() -> ProvidersConfig {
+        let existingProviderIds = Set(
+            providers
+                .filter { $0.resolvedKind == .tts }
+                .map { $0.id.lowercased() }
+        )
+        let additionalProviders = LatticesVoiceEngineLoader.defaultTTSConfig().providers.filter { entry in
+            entry.resolvedKind == .tts && !existingProviderIds.contains(entry.id.lowercased())
+        }
+        guard !additionalProviders.isEmpty else { return self }
+        return ProvidersConfig(providers: providers + additionalProviders)
+    }
+}
+#endif

--- a/apps/mac/Sources/Core/Voice/LatticesVoiceRuntime.swift
+++ b/apps/mac/Sources/Core/Voice/LatticesVoiceRuntime.swift
@@ -57,6 +57,15 @@ enum LatticesVoiceRuntime {
         #endif
     }
 
+    /// Drop any orphaned live capture session owned by the embedded runtime.
+    /// Used when Vox reports `live_session_busy` after a dropped client handle.
+    static func resetEmbeddedRuntime() {
+        #if LATTICES_VOICE && canImport(HudsonVoice)
+        stop()
+        _ = ensureRunning()
+        #endif
+    }
+
     #if LATTICES_VOICE && canImport(HudsonVoice)
     /// True when this process is currently hosting the voice WebSocket.
     static var isRunning: Bool { Host.shared.isRunning }
@@ -121,9 +130,19 @@ private final class Host: @unchecked Sendable {
         try configureEnvironment(authToken: authToken)
         try persistPreferences()
 
+        let (asrEngine, ttsEngine, defaultSynthesisModelId) = try LatticesVoiceEngineLoader.loadEngines(
+            runtimeHome: runtimeHomeURL
+        )
+        DiagnosticLog.shared.info(
+            "HudsonVoice: synthesis default \(defaultSynthesisModelId) (\(LatticesVoiceEngineLoader.kokoroVoiceId))"
+        )
+
         let service = VoxRuntimeService(
             port: port,
             bindAddress: bindAddress,
+            engine: asrEngine,
+            ttsEngine: ttsEngine,
+            defaultSynthesisModelId: defaultSynthesisModelId,
             authToken: authToken
         )
         do {
@@ -166,7 +185,10 @@ private final class Host: @unchecked Sendable {
     }
 
     private func persistPreferences() throws {
-        let preferences = (try? HudsonVoicePreferences.load()) ?? HudsonVoicePreferences()
+        var preferences = (try? HudsonVoicePreferences.load()) ?? HudsonVoicePreferences()
+        if preferences.preferredSynthesisModelId?.isEmpty != false {
+            preferences.preferredSynthesisModelId = LatticesVoiceEngineLoader.kokoroModelId
+        }
         try preferences.normalized().save()
     }
 

--- a/bin/vox-tts.ts
+++ b/bin/vox-tts.ts
@@ -1,0 +1,236 @@
+/**
+ * Hudson / Vox on-device TTS client for Lattices workers.
+ *
+ * Speaks through the embedded Lattices voice runtime (Kokoro via mlx-audio by default).
+ */
+
+import { existsSync, readFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+import { spawn } from "child_process";
+
+export const KOKORO_MODEL_ID = "mlx-community/Kokoro-82M-bf16";
+export const KOKORO_VOICE_ID = "af_heart";
+export const AVSPEECH_MODEL_ID = "avspeech:system";
+
+const DEFAULT_CAPABILITY_PATH = join(
+  homedir(),
+  "Library/Application Support/Lattices/Voice/hudson-voice-runtime.json"
+);
+
+type Capability = {
+  webSocketUrl?: string;
+  host?: string;
+  port?: number;
+  authToken?: string;
+};
+
+type VoxRuntime = {
+  capability: Capability;
+  wsUrl: string;
+  authToken: string;
+};
+
+let cachedRuntime: VoxRuntime | null | undefined;
+let requestCounter = 0;
+
+function resolveCapabilityPath(): string {
+  return process.env.LATTICES_VOICE_CAPABILITY?.trim() || DEFAULT_CAPABILITY_PATH;
+}
+
+function loadCapability(): Capability | null {
+  const path = resolveCapabilityPath();
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as Capability;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveVoxRuntime(): VoxRuntime | null {
+  if (cachedRuntime !== undefined) return cachedRuntime;
+
+  const capability = loadCapability();
+  if (!capability) {
+    cachedRuntime = null;
+    return null;
+  }
+
+  const wsUrl =
+    capability.webSocketUrl?.trim() ||
+    (capability.host && capability.port
+      ? `ws://${capability.host}:${capability.port}`
+      : process.env.LATTICES_VOICE_WS_URL?.trim() || "ws://127.0.0.1:9398");
+
+  const authToken = capability.authToken?.trim() || process.env.VOX_AUTH_TOKEN?.trim() || "";
+  if (!authToken) {
+    cachedRuntime = null;
+    return null;
+  }
+
+  cachedRuntime = { capability, wsUrl, authToken };
+  return cachedRuntime;
+}
+
+export function resetVoxRuntimeCache() {
+  cachedRuntime = undefined;
+}
+
+function playWavFile(filePath: string): Promise<number> {
+  const start = performance.now();
+  return new Promise((resolve, reject) => {
+    const player = spawn("/usr/bin/afplay", [filePath], {
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let stderr = "";
+    player.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    player.on("close", (code) => {
+      const ms = Math.round(performance.now() - start);
+      if (code === 0) resolve(ms);
+      else reject(new Error(`afplay failed (${code ?? "unknown"}): ${stderr.slice(0, 160)}`));
+    });
+    player.on("error", reject);
+  });
+}
+
+async function voxRpc(
+  runtime: VoxRuntime,
+  method: string,
+  params: Record<string, unknown>,
+  timeoutMs = 120_000
+): Promise<Record<string, unknown>> {
+  const id = `handsoff-${++requestCounter}`;
+  const ws = new WebSocket(runtime.wsUrl);
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      try {
+        ws.close();
+      } catch {}
+      reject(new Error(`Vox ${method} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    const cleanup = () => clearTimeout(timer);
+
+    ws.addEventListener("open", () => {
+      ws.send(
+        JSON.stringify({
+          id,
+          method,
+          authToken: runtime.authToken,
+          params: {
+            clientId: "handsoff-worker",
+            ...params,
+          },
+        })
+      );
+    });
+
+    ws.addEventListener("message", (event) => {
+      let payload: any;
+      try {
+        payload = JSON.parse(String(event.data));
+      } catch {
+        return;
+      }
+      if (payload.id !== id) return;
+
+      cleanup();
+      try {
+        ws.close();
+      } catch {}
+
+      if (payload.error) {
+        reject(new Error(String(payload.error)));
+        return;
+      }
+      resolve((payload.result ?? {}) as Record<string, unknown>);
+    });
+
+    ws.addEventListener("error", () => {
+      cleanup();
+      reject(new Error(`Could not connect to Hudson voice runtime at ${runtime.wsUrl}`));
+    });
+  });
+}
+
+export async function synthesizeWithVox(
+  text: string,
+  options: {
+    modelId?: string;
+    voiceId?: string;
+    format?: string;
+  } = {}
+): Promise<{ wav: Buffer; elapsedMs: number; modelId: string; voiceId: string }> {
+  const runtime = resolveVoxRuntime();
+  if (!runtime) {
+    throw new Error("Hudson voice runtime capability is unavailable");
+  }
+
+  const result = await voxRpc(runtime, "synthesize.generate", {
+    text,
+    modelId: options.modelId,
+    voiceId: options.voiceId,
+    format: options.format ?? "wav",
+  });
+
+  const audioBase64 = String(result.audioBase64 ?? "");
+  if (!audioBase64) {
+    throw new Error("Vox synthesize.generate returned no audio");
+  }
+
+  const wav = Buffer.from(audioBase64, "base64");
+  return {
+    wav,
+    elapsedMs: Number(result.elapsedMs ?? 0),
+    modelId: String(result.modelId ?? options.modelId ?? KOKORO_MODEL_ID),
+    voiceId: String(result.voiceId ?? options.voiceId ?? KOKORO_VOICE_ID),
+  };
+}
+
+export async function speakWithVox(
+  text: string,
+  options: {
+    modelId?: string;
+    voiceId?: string;
+    cachePath?: string;
+  } = {}
+): Promise<number> {
+  const { wav, elapsedMs } = await synthesizeWithVox(text, {
+    modelId: options.modelId,
+    voiceId: options.voiceId,
+  });
+
+  if (options.cachePath) {
+    const { writeFileSync } = await import("fs");
+    writeFileSync(options.cachePath, wav);
+    return elapsedMs;
+  }
+
+  const { mkdtempSync, writeFileSync, rmSync } = await import("fs");
+  const { tmpdir } = await import("os");
+  const dir = mkdtempSync(join(tmpdir(), "lattices-vox-tts-"));
+  const filePath = join(dir, "speech.wav");
+  writeFileSync(filePath, wav);
+  try {
+    const playbackMs = await playWavFile(filePath);
+    return Math.max(playbackMs, elapsedMs);
+  } finally {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {}
+  }
+}
+
+export async function playCachedWav(filePath: string): Promise<number> {
+  return playWavFile(filePath);
+}
+
+export function describeVoxRuntime(): string {
+  const runtime = resolveVoxRuntime();
+  if (!runtime) return "unavailable";
+  return runtime.wsUrl;
+}


### PR DESCRIPTION
## Summary

- `vox-tts.ts` WebSocket client for `synthesize.generate` (Kokoro `af_heart`)
- `LatticesVoiceEngineLoader` seeds mlx-audio providers into embedded Vox runtime
- Wire Kokoro ASR/TTS engines in `LatticesVoiceRuntime`
- `resetEmbeddedRuntime()` for `live_session_busy` recovery

**Voice stack 1/4**. Base: `feat/deckkit-voice-metadata`.

**CI deferred** until final merge to `main`.