### PR TITLE
✨ Relay iPad voice commands through HandsOffSession

### DIFF
--- a/apps/mac/Sources/Core/Companion/LatticesDeckHost.swift
+++ b/apps/mac/Sources/Core/Companion/LatticesDeckHost.swift
@@ -1,6 +1,9 @@
 import AppKit
 import DeckKit
 import Foundation
+#if LATTICES_VOICE && canImport(HudsonVoice)
+import HudsonVoice
+#endif
 
 enum LatticesDeckHostError: LocalizedError {
     case unsupportedAction(String)
@@ -276,31 +279,34 @@ private extension LatticesDeckHost {
                 suggestedActions: voiceSuggestions(for: .idle)
             )
 
-        // Single-shot voice command path (transcribe → match intent → execute).
-        // Distinct from voice.toggle / voice.cancel which drive the chat-style
-        // HandsOffSession. Lives here so the iPad companion can fire dictation
-        // on the active Mac via the existing /deck/perform bridge.
+        // iPad companion voice relay — same HandsOff session as the Mac menu
+        // voice mode. The iPad never captures audio; it arms the Mac microphone.
         case "voice.command.start":
             try MainActorSync.run {
-                AudioLayer.shared.startVoiceCommand()
+                self.startRemoteVoiceListening()
             }
             return try voiceOutcome()
 
         case "voice.command.stop":
             try MainActorSync.run {
-                AudioLayer.shared.stopVoiceCommand()
+                self.finishRemoteVoiceListening()
             }
             return try voiceOutcome()
 
         case "voice.command.toggle":
             try MainActorSync.run {
-                if AudioLayer.shared.isListening {
-                    AudioLayer.shared.stopVoiceCommand()
-                } else {
-                    AudioLayer.shared.startVoiceCommand()
-                }
+                HandsOffSession.shared.setAudibleFeedbackEnabled(true)
+                HandsOffSession.shared.toggle()
             }
             return try voiceOutcome()
+
+        case "voice.runtime.warm":
+            warmVoiceRuntime()
+            return ActionOutcome(
+                summary: "Warming voice runtime",
+                detail: "Preparing the Mac voice engine for capture.",
+                suggestedActions: []
+            )
 
         case "talkie.perform":
             guard let shortcutID = request.payload["shortcutID"]?.stringValue else {
@@ -529,6 +535,52 @@ private extension LatticesDeckHost {
         }
     }
 
+
+    func warmVoiceRuntime() {
+        #if LATTICES_VOICE && canImport(HudsonVoice)
+        Task {
+            _ = LatticesVoiceRuntime.ensureRunning()
+            guard let runtime = HudsonVoiceRuntimeResolver.resolve(clientId: "lattices") else { return }
+            do {
+                _ = try await HudVoxProbe.health(
+                    endpoint: runtime.endpoint,
+                    clientId: runtime.options.clientId,
+                    authToken: runtime.options.authToken ?? runtime.authToken
+                )
+            } catch {
+                DiagnosticLog.shared.warn(
+                    "DeckHost: voice runtime warm-up probe failed — \(error.localizedDescription)"
+                )
+            }
+        }
+        #endif
+    }
+
+    @MainActor
+    func startRemoteVoiceListening() {
+        let handsOff = HandsOffSession.shared
+        handsOff.setAudibleFeedbackEnabled(true)
+        switch handsOff.state {
+        case .idle:
+            handsOff.toggle()
+        case .listening:
+            break
+        case .thinking, .connecting:
+            handsOff.cancel()
+            handsOff.toggle()
+        }
+    }
+
+    @MainActor
+    func finishRemoteVoiceListening() {
+        let handsOff = HandsOffSession.shared
+        if handsOff.state == .listening {
+            handsOff.finishListening()
+        } else if handsOff.state == .thinking {
+            handsOff.cancel()
+        }
+    }
+
     func voiceOutcome() throws -> ActionOutcome {
         let phase = try MainActorSync.run { self.currentVoicePhase() }
         let summary: String
@@ -692,13 +744,7 @@ private extension LatticesDeckHost {
         let spacesState = buildSpacesState()
         let currentSpaceIndex = spacesState.currentSpaceIndex
         let currentSpaceName = spacesState.currentSpaceName
-        let voice = DeckVoiceState(
-            phase: currentVoicePhase(),
-            transcript: handsOff.lastTranscript ?? audio.lastTranscript,
-            transcriptLines: buildTranscriptLines(handsOff: handsOff, audio: audio),
-            responseSummary: handsOff.lastResponse ?? audio.executionResult,
-            provider: audio.providerName == "none" ? "voice-runtime" : audio.providerName
-        )
+        let voice = buildDeckVoiceState(handsOff: handsOff, audio: audio)
         let desktop = DeckDesktopSummary(
             activeLayerName: activeLayerName(),
             activeAppName: visibleWindows.first?.app ?? NSWorkspace.shared.frontmostApplication?.localizedName,
@@ -905,18 +951,74 @@ private extension LatticesDeckHost {
     }
 
     @MainActor
+    func buildDeckVoiceState(handsOff: HandsOffSession, audio: AudioLayer) -> DeckVoiceState {
+        let phase = currentVoicePhase(handsOff: handsOff, audio: audio)
+        let rawSummary = handsOff.state == .idle
+            ? (handsOff.lastResponse ?? audio.executionResult)
+            : handsOff.lastResponse
+        let responseSummary = DeckVoiceErrorMapper.isProgressMessage(rawSummary) ? nil : rawSummary
+        let error = DeckVoiceErrorMapper.resolve(
+            phase: phase,
+            executionResult: rawSummary,
+            executionError: audio.executionError,
+            providerError: audio.provider?.lastErrorMessage,
+            isWarmingUp: handsOff.state == .connecting
+        )
+        let summary = error == nil ? responseSummary : nil
+        return DeckVoiceState(
+            phase: phase,
+            transcript: handsOff.lastTranscript ?? audio.lastTranscript,
+            transcriptLines: buildTranscriptLines(handsOff: handsOff, audio: audio),
+            responseSummary: summary,
+            provider: audio.providerName == "none" ? "voice-runtime" : audio.providerName,
+            error: error,
+            lastError: error,
+            turnKind: handsOff.lastTurnKind,
+            turnStage: handsOff.turnStage,
+            statusLine: voiceStatusLine(handsOff: handsOff)
+        )
+    }
+
+    @MainActor
+    func voiceStatusLine(handsOff: HandsOffSession) -> String? {
+        switch handsOff.turnStage {
+        case .acknowledging: return "Got it…"
+        case .understanding: return "Understanding what you said…"
+        case .planning:
+            return handsOff.lastTurnKind == .quick ? "Running command…" : "Planning on your Mac…"
+        case .narrating: return "Explaining what I'll do…"
+        case .executing:
+            return handsOff.lastTurnKind == .quick ? "Running command…" : "Updating your desktop…"
+        case .confirming: return "Done."
+        case .none: return nil
+        }
+    }
+
+    @MainActor
     func currentVoicePhase() -> DeckVoicePhase {
-        let handsOff = HandsOffSession.shared
+        currentVoicePhase(handsOff: HandsOffSession.shared, audio: AudioLayer.shared)
+    }
+
+    @MainActor
+    func currentVoicePhase(handsOff: HandsOffSession, audio: AudioLayer) -> DeckVoicePhase {
         switch handsOff.state {
-        case .idle:
-            break
         case .connecting, .listening:
             return .listening
         case .thinking:
-            return .reasoning
+            switch handsOff.turnStage {
+            case .acknowledging, .narrating, .confirming:
+                return .speaking
+            case .understanding:
+                return .transcribing
+            case .planning, .executing:
+                return .reasoning
+            case .none:
+                return .reasoning
+            }
+        case .idle:
+            break
         }
 
-        let audio = AudioLayer.shared
         if audio.isListening {
             return .listening
         }

--- a/apps/mac/Sources/Core/Voice/AudioProvider.swift
+++ b/apps/mac/Sources/Core/Voice/AudioProvider.swift
@@ -1,4 +1,5 @@
 import AppKit
+import DeckKit
 #if LATTICES_VOICE && canImport(HudsonVoice)
 import HudsonVoice
 #endif
@@ -51,6 +52,8 @@ final class AudioLayer: ObservableObject {
 
     private var pendingVoiceStart = false
     private var voiceConnectionRetry: DispatchWorkItem?
+    /// Capture was requested but the provider is still warming up.
+    var isWarmingUp: Bool { pendingVoiceStart && !isListening }
 
     private init() {
         #if LATTICES_VOICE && canImport(HudsonVoice)
@@ -246,12 +249,11 @@ final class AudioLayer: ObservableObject {
 
         } else if shouldAnswerWithAssistant(text) {
             DiagnosticLog.shared.info("AudioLayer: route → Assistant question")
-            DiagnosticLog.shared.info("AudioLayer: question-like voice request, handing to Assistant")
             matchedIntent = nil
             matchedSlots = [:]
             executionResult = "thinking..."
             executionData = nil
-            handoffToAssistant(prompt: IntentHeuristics.assistantPromptText(text))
+            answerVoiceQuestion(text)
 
         } else {
             // No local match — ask the selected Assistant provider.
@@ -280,11 +282,44 @@ final class AudioLayer: ObservableObject {
             self.agentResponse = response
             if let commentary = response.commentary {
                 DiagnosticLog.shared.info("AudioLayer: Assistant advisor says — \(commentary)")
+                if self.shouldSurfaceAdvisorCommentary() {
+                    self.setFinalResult(commentary)
+                }
             }
             if let suggestion = response.suggestion {
                 DiagnosticLog.shared.info("AudioLayer: Assistant advisor suggests — \(suggestion.label) → \(suggestion.intent)")
             }
         }
+    }
+
+    private func answerVoiceQuestion(_ text: String) {
+        let assistant = WorkspaceAssistantSession.shared
+        guard assistant.isProviderInferenceReady else {
+            DiagnosticLog.shared.info("AudioLayer: Assistant provider not ready for question")
+            handoffToAssistant(prompt: IntentHeuristics.assistantPromptText(text))
+            return
+        }
+
+        assistant.answerVoiceQuestion(text) { [weak self] response in
+            guard let self else { return }
+            if let commentary = response?.commentary?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !commentary.isEmpty {
+                self.agentResponse = response
+                self.setFinalResult(commentary)
+                return
+            }
+            self.handoffToAssistant(prompt: IntentHeuristics.assistantPromptText(text))
+        }
+    }
+
+    private func shouldSurfaceAdvisorCommentary() -> Bool {
+        guard let result = executionResult?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !result.isEmpty else {
+            return true
+        }
+        if result == "ok" { return true }
+        if DeckVoiceErrorMapper.isProgressMessage(result) { return true }
+        return false
     }
 
     private func assistantFallback(transcription: Transcription) {
@@ -410,6 +445,36 @@ final class AudioLayer: ObservableObject {
             DiagnosticLog.shared.warn("AudioLayer: final outcome — \(message)")
         } else {
             DiagnosticLog.shared.info("AudioLayer: final outcome — \(message)")
+            speakVoiceOutcome(message: message)
+        }
+    }
+
+    private func speakVoiceOutcome(message: String) {
+        let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        if DeckVoiceErrorMapper.isProgressMessage(trimmed) { return }
+        if trimmed == "Sent to Assistant" { return }
+
+        if let intent = matchedIntent, let cue = cachedCuePhrase(for: intent) {
+            HandsOffSession.shared.playRemoteCachedCue(cue)
+            return
+        }
+
+        let spoken = trimmed == "ok" ? "Done." : trimmed
+        HandsOffSession.shared.speakRemoteResponse(spoken)
+    }
+
+    private func cachedCuePhrase(for intent: String) -> String? {
+        switch intent {
+        case "tile_window": return "Tiled."
+        case "focus": return "Focused."
+        case "distribute": return "Distributed."
+        case "search": return "Searching."
+        case "switch_layer": return "Switched."
+        case "create_layer": return "Done."
+        case "launch": return "Done."
+        case "kill": return "Done."
+        default: return nil
         }
     }
 

--- a/apps/mac/Sources/Core/Voice/HandsOffSession.swift
+++ b/apps/mac/Sources/Core/Voice/HandsOffSession.swift
@@ -1,4 +1,5 @@
 import AppKit
+import DeckKit
 #if LATTICES_VOICE && canImport(HudsonVoice)
 import HudsonVoice
 #endif
@@ -56,6 +57,10 @@ final class HandsOffSession: ObservableObject {
     @Published private(set) var stateChangedAt: Date = Date()
     @Published var lastTranscript: String?
     @Published var lastResponse: String?
+    /// In-flight turn stage streamed from the worker (ack → plan → narrate → execute).
+    @Published private(set) var turnStage: DeckVoiceTurnStage?
+    /// Kind of the most recently completed turn — drives relay UI copy on the iPad.
+    @Published private(set) var lastTurnKind: DeckVoiceTurnKind?
     @Published var audibleFeedbackEnabled: Bool = false
 
     /// Recently executed actions — shown as playback in the HUD bottom bar
@@ -161,11 +166,26 @@ final class HandsOffSession: ObservableObject {
 
     func playCachedCue(_ phrase: String) {
         guard audibleFeedbackEnabled else { return }
+        playRemoteCachedCue(phrase)
+    }
+
+    /// Cached cue for iPad voice relay and other remote paths outside hands-off.
+    func playRemoteCachedCue(_ phrase: String) {
+        let trimmed = phrase.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
         let now = Date()
         guard now.timeIntervalSince(lastCueAt) >= 0.2 else { return }
         lastCueAt = now
         startWorker()
-        sendToWorker(["cmd": "play_cached", "text": phrase])
+        sendToWorker(["cmd": "play_cached", "text": trimmed])
+    }
+
+    /// Fire-and-forget spoken feedback for remote voice commands (iPad relay).
+    func speakRemoteResponse(_ text: String) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        startWorker()
+        sendToWorker(["cmd": "ack", "text": trimmed])
     }
 
     /// Append a full turn record to the JSONL log
@@ -330,6 +350,19 @@ final class HandsOffSession: ObservableObject {
 
             DiagnosticLog.shared.info("HandsOff: worker response → \(trimmed)")
 
+            // Mid-turn progress — update stage without completing the turn callback.
+            if let progress = json["progress"] as? String {
+                let stage = DeckVoiceTurnStage(rawValue: progress)
+                let kind = (json["turnKind"] as? String).flatMap(DeckVoiceTurnKind.init(rawValue:))
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { return }
+                    if let stage { self.turnStage = stage }
+                    if let kind { self.lastTurnKind = kind }
+                    if self.state != .thinking { self.state = .thinking }
+                }
+                continue
+            }
+
             // Parse everything on the background thread, then do ONE main-queue dispatch
             // to update all @Published properties atomically. Scattered dispatches cause
             // Combine deadlocks (os_unfair_lock contention with SwiftUI rendering).
@@ -374,6 +407,10 @@ final class HandsOffSession: ObservableObject {
                         self.recentActions = actions
                         self.executeActions(actions)
                     }
+                    if let meta = dataObj?["_meta"] as? [String: Any] {
+                        self.lastTurnKind = Self.parseTurnKind(meta)
+                    }
+                    self.turnStage = nil
                     self.state = .idle
                 }
                 cb?(json)
@@ -406,6 +443,7 @@ final class HandsOffSession: ObservableObject {
         turnTimeoutWork?.cancel()
         turnTimeoutWork = nil
         pendingCallback = nil
+        turnStage = nil
         state = .idle
         DiagnosticLog.shared.warn("HandsOff: turn cancelled by user")
         playSound("Funk")
@@ -675,6 +713,8 @@ final class HandsOffSession: ObservableObject {
     // MARK: - Turn processing (delegates to worker)
 
     private func processTurn(_ transcript: String) {
+        turnStage = .understanding
+        lastTurnKind = nil
         state = .thinking
         guard startWorker() else {
             state = .idle
@@ -733,6 +773,16 @@ final class HandsOffSession: ObservableObject {
                 }
             }
         }
+    }
+
+    private static func parseTurnKind(_ meta: [String: Any]) -> DeckVoiceTurnKind? {
+        if let kind = meta["turnKind"] as? String {
+            return DeckVoiceTurnKind(rawValue: kind)
+        }
+        if let path = meta["path"] as? String, path == "quick" {
+            return .quick
+        }
+        return nil
     }
 
     // MARK: - Desktop snapshot (full context — all windows, all screens)


### PR DESCRIPTION
## Summary

- Route `voice.command.start/stop` to `HandsOffSession` (not `AudioLayer`)
- `voice.runtime.warm` preflight + faster runtime resolve retries
- Stream `turnKind` / `turnStage` into `DeckVoiceState`
- Improve `AudioLayer` voice-question handling during companion capture

**Voice stack 3/4**. Base: `feat/handsoff-worker-turns`. Supersedes #108.

**CI deferred** until final merge to `main`.