### PR TITLE
🔧 Make hosted CI and releases opt in

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,20 @@
+# Hosted CI is opt in
+
+All checked-in GitHub Actions workflows run only through `workflow_dispatch`.
+Pushes, pull requests, labels, and release tags do not start hosted jobs.
+This applies to build checks, package checks, releases, and site deployment
+where present. Run routine validation and release builds locally.
+
+To request a hosted run, open **Actions**, select the workflow, choose
+**Run workflow**, and select the branch or tag to check. The selected ref must
+contain the manual-only workflow version. Old refs can still contain historical
+automatic triggers; merge or rebase the current default branch before pushing
+older branches or creating release tags from them.
+
+Publishing or uploading a release requires its explicit input (`publish`,
+`publish_release`, or `upload`); leave it false for validation or artifact-only
+runs. The Pages deployment workflow, where present, deploys when manually run.
+Signing, notarization, and artifact verification remain part of release jobs.
+
+Do not add automatic push, PR, schedule, or tag triggers without explicit
+operator approval. A manual run opts in to that run only.

--- a/.github/workflows/action-guards.yml
+++ b/.github/workflows/action-guards.yml
@@ -3,17 +3,8 @@ name: Action Guards
 # Rules that are cheap to check and expensive to regress. Each one exists because it
 # already went wrong once.
 
+# Hosted runner usage is opt in. Start this workflow manually from Actions.
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'products/action/**'
-      - '.github/workflows/action-guards.yml'
-  pull_request:
-    paths:
-      - 'products/action/**'
-      - '.github/workflows/action-guards.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/blink-guards.yml
+++ b/.github/workflows/blink-guards.yml
@@ -1,18 +1,7 @@
 name: Blink Guards
 
+# Hosted runner usage is opt in. Start this workflow manually from Actions.
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'products/blink/**'
-      - 'package.json'
-      - '.github/workflows/blink-guards.yml'
-  pull_request:
-    paths:
-      - 'products/blink/**'
-      - 'package.json'
-      - '.github/workflows/blink-guards.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,9 +1,7 @@
 name: Deploy site to GitHub Pages
 
+# Hosted runner usage is opt in. Start this workflow manually from Actions.
 on:
-  push:
-    branches: [main]
-    paths: [apps/site/**, docs/**, products/action/docs/**, products/blink/docs/**, products/blink/landing/public/**]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release-action-macos.yml
+++ b/.github/workflows/release-action-macos.yml
@@ -1,9 +1,7 @@
 name: Release Action macOS
 
+# Hosted runner usage is opt in. Start this workflow manually from Actions.
 on:
-  push:
-    tags:
-      - 'action-v*'
   workflow_dispatch:
     inputs:
       version:
@@ -68,7 +66,7 @@ jobs:
               exit 1
             fi
             version="${tag#action-v}"
-            publish_release="true"
+            publish_release="${{ inputs.publish_release }}"
           else
             version="${{ inputs.version }}"
             publish_release="${{ inputs.publish_release }}"

--- a/.github/workflows/release-app-ios.yml
+++ b/.github/workflows/release-app-ios.yml
@@ -1,9 +1,7 @@
 name: Release App iOS
 
+# Hosted runner usage is opt in. Start this workflow manually from Actions.
 on:
-  push:
-    tags:
-      - 'app-ios-v*'
   workflow_dispatch:
     inputs:
       upload:
@@ -18,7 +16,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 75
     env:
-      SHOULD_UPLOAD: ${{ (github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && inputs.upload)) && '1' || '0' }}
+      SHOULD_UPLOAD: ${{ (github.event_name == 'workflow_dispatch' && inputs.upload) && '1' || '0' }}
       ASC_API_KEY_ID: ${{ vars.APP_STORE_CONNECT_KEY_ID || secrets.APP_STORE_CONNECT_KEY_ID }}
       ASC_API_ISSUER_ID: ${{ vars.APP_STORE_CONNECT_ISSUER_ID || secrets.APP_STORE_CONNECT_ISSUER_ID }}
     steps:

--- a/.github/workflows/release-app-macos.yml
+++ b/.github/workflows/release-app-macos.yml
@@ -1,9 +1,7 @@
 name: Release App macOS
 
+# Hosted runner usage is opt in. Start this workflow manually from Actions.
 on:
-  push:
-    tags:
-      - 'app-macos-v*'
   workflow_dispatch:
     inputs:
       version:
@@ -27,8 +25,8 @@ jobs:
     timeout-minutes: 60
 
     env:
-      SHOULD_PUBLISH: ${{ (github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && inputs.publish)) && '1' || '0' }}
-      REQUESTED_PUBLISH: ${{ (github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && inputs.publish)) && '1' || '0' }}
+      SHOULD_PUBLISH: ${{ (github.event_name == 'workflow_dispatch' && inputs.publish) && '1' || '0' }}
+      REQUESTED_PUBLISH: ${{ (github.event_name == 'workflow_dispatch' && inputs.publish) && '1' || '0' }}
       HUDSON_READ_TOKEN: ${{ secrets.HUDSON_READ_TOKEN }}
 
     steps:

--- a/.github/workflows/release-blink-macos.yml
+++ b/.github/workflows/release-blink-macos.yml
@@ -1,9 +1,7 @@
 name: Release Blink macOS
 
+# Hosted runner usage is opt in. Start this workflow manually from Actions.
 on:
-  push:
-    tags:
-      - 'blink-v*'
   workflow_dispatch:
     inputs:
       version:
@@ -83,7 +81,7 @@ jobs:
               exit 1
             fi
             version="${tag#blink-v}"
-            publish_release="true"
+            publish_release="${{ inputs.publish_release }}"
           else
             version="${{ inputs.version }}"
             publish_release="${{ inputs.publish_release }}"

--- a/.github/workflows/release-blink-npm.yml
+++ b/.github/workflows/release-blink-npm.yml
@@ -1,9 +1,7 @@
 name: Release Blink npm
 
+# Hosted runner usage is opt in. Start this workflow manually from Actions.
 on:
-  push:
-    tags:
-      - 'blink-npm-v*'
   workflow_dispatch:
     inputs:
       publish:

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,9 +1,7 @@
 name: Release Candidate
 
+# Hosted runner usage is opt in. Start this workflow manually from Actions.
 on:
-  push:
-    tags:
-      - 'candidate-v*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release-package-npm.yml
+++ b/.github/workflows/release-package-npm.yml
@@ -1,9 +1,7 @@
 name: Release Package npm
 
+# Hosted runner usage is opt in. Start this workflow manually from Actions.
 on:
-  push:
-    tags:
-      - 'npm-v*'
   workflow_dispatch:
     inputs:
       publish:


### PR DESCRIPTION
Hosted builds currently start from release tags and selected PR or push events, consuming runner quota without a separate CI request. Make every checked-in workflow manual-only through Actions → Run workflow, including checks, releases, and site deployment where present.

Preserve release validation and explicit publication inputs. Lattices tag-selected manual runs now honor publish/upload=false. Document how to opt in and the need to update old refs before pushing them.

Validation: actionlint passed for every workflow; YAML inspection confirmed workflow_dispatch is the sole trigger for all 17 workflows across both repositories; git diff --check passed. No hosted workflow was dispatched.
